### PR TITLE
Fixed being unable to load readonly pk3s

### DIFF
--- a/Core/Resources/Archives/PK3/PK3.cs
+++ b/Core/Resources/Archives/PK3/PK3.cs
@@ -16,7 +16,7 @@ public class PK3 : Archive, IDisposable
 
     public PK3(IEntryPath path, IIndexGenerator indexGenerator) : base(path)
     {
-        m_zipArchive = new ZipArchive(File.Open(Path.FullPath, FileMode.Open));
+        m_zipArchive = new(File.Open(Path.FullPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite));
         m_indexGenerator = indexGenerator;
         Pk3EntriesFromData();
     }


### PR DESCRIPTION
File.Open(string, FileMode) opens files with both read and write access which prevented loading readonly PK3s.