### PR TITLE
Nodebuilder now uses full filepaths when building

### DIFF
--- a/Core/Maps/Bsp/Zdbsp/Zdbsp.cs
+++ b/Core/Maps/Bsp/Zdbsp/Zdbsp.cs
@@ -35,9 +35,9 @@ namespace Helion.Maps.Bsp.Zdbsp
 
                 CleanZdbspData(outputFile);
 
-                Log.Info($"Building nodes [{map.Archive.OriginalFilePath}]...");
+                Log.Info($"Building nodes [{map.Archive.Path}]...");
                 m_stopwatch.Restart();
-                if (!RunZdbsp(map.Archive.OriginalFilePath, mapName, outputFile))
+                if (!RunZdbsp(map.Archive.Path.FullPath, mapName, outputFile))
                     return false;
 
                 m_stopwatch.Stop();


### PR DESCRIPTION
Files in alternate content directories can be loaded with just their filenames instead of a path, e.g. `wads/DOOM2.WAD` can be loaded with just `-iwad DOOM2.WAD`. However, in this scenario, only the filename is passed to the nodebuilder and it attempts to open files in the current directory causing errors like these:

```
map map01
Building nodes [DOOM2.WAD]...
Zdbsp critical failure: Could not find file '/mnt/Storage/Projects/Helion/Client/bin/Debug/net7.0/DOOM2.WAD'.
Failed to run zdbsp.
```

The full filepath is now passed to the nodebuilder instead of just the filename to ensure that the right file is found and loaded.