### PR TITLE
Updated default config path for Linux

### DIFF
--- a/Core/Util/Configs/Impl/FileConfig.cs
+++ b/Core/Util/Configs/Impl/FileConfig.cs
@@ -19,7 +19,33 @@ namespace Helion.Util.Configs.Impl;
 /// </summary>
 public class FileConfig : Config
 {
-    public const string DefaultConfigPath = "config.ini";
+    public string DefaultConfigPath
+    {
+        get
+        {
+            // On Linux, default to "$XDG_CONFIG_HOME/helion/config.ini"
+            if (OperatingSystem.IsLinux())
+            {
+                var xdgConfigHome = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
+
+                if (!string.IsNullOrWhiteSpace(xdgConfigHome))
+                {
+                   return $"{xdgConfigHome}/helion/config.ini";
+                }
+
+                // Fallback to "$HOME/.config/helion/config.ini"
+                var home = Environment.GetEnvironmentVariable("HOME");
+
+                if (!string.IsNullOrWhiteSpace(home))
+                {
+                   return $"{home}/.config/helion/config.ini";
+                }
+            }
+
+            return "config.ini";
+        }
+    }
+
     public const string EngineSectionName = "engine";
     public const string KeysSectionName = "keys";
     private static readonly Logger Log = LogManager.GetCurrentClassLogger();

--- a/Core/Util/Configs/Impl/FileConfig.cs
+++ b/Core/Util/Configs/Impl/FileConfig.cs
@@ -19,7 +19,7 @@ namespace Helion.Util.Configs.Impl;
 /// </summary>
 public class FileConfig : Config
 {
-    public string DefaultConfigPath
+    public static string DefaultConfigPath
     {
         get
         {


### PR DESCRIPTION
Updated the default config path for Linux to comply with the XDG Base Directory Specification which is to save config files using `$XDG_CONFIG_HOME` and, if empty or not set, fallback to `$HOME/.config`.

If neither environment variables are usable, the config is saved to the current directory.