### PR TITLE
Fixed keybind config saves ignoring the config command line argument

### DIFF
--- a/Core/Layer/Options/Sections/KeyBindingSection.cs
+++ b/Core/Layer/Options/Sections/KeyBindingSection.cs
@@ -229,7 +229,7 @@ public class KeyBindingSection : IOptionSection
     private void WriteConfigFile()
     {
         if (m_config is FileConfig fileConfig)
-            fileConfig.Write(FileConfig.DefaultConfigPath);
+            fileConfig.Write();
     }
 
     private bool TryConsumeAnyKey(IConsumableInput input, out Key key)


### PR DESCRIPTION
My apologies for this one, I overlooked keybind saves when I put together the config command line argument PR.