### PR TITLE
Fix build break in test due to missing args

### DIFF
--- a/Tests/Unit/GameLayer/GameLayerInput.cs
+++ b/Tests/Unit/GameLayer/GameLayerInput.cs
@@ -37,7 +37,7 @@ public class GameLayerInput
         World = WorldAllocator.LoadMap("Resources/playermovement.zip", "playermovement.wad", "MAP01", GetType().Name, WorldInit, IWadType.Doom2);
         InputManager = new InputManager();
         MockWindow window = new(InputManager);
-        HelionConsole console = new(World.Config);
+        HelionConsole console = new(new DataCache(), World.Config);
         SaveGameManager saveGameManager = new(World.Config, null);
         GameLayerManager = new(World.Config, window, console, new(), World.ArchiveCollection, World.SoundManager, saveGameManager, new());
 

--- a/Tests/Unit/Util/Consoles/HelionConsoleTest.cs
+++ b/Tests/Unit/Util/Consoles/HelionConsoleTest.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Helion.Util;
 using Helion.Util.Consoles;
 using Xunit;
 
@@ -9,7 +10,7 @@ public class HelionConsoleTest
     [Fact(DisplayName = "Can add messages to the console")]
     public void AddMessages()
     {
-        using HelionConsole console = new();
+        using HelionConsole console = new(new DataCache());
 
         console.AddMessage("hello!");
 
@@ -20,7 +21,7 @@ public class HelionConsoleTest
     [Fact(DisplayName = "Add input to console")]
     public void AddInput()
     {
-        using HelionConsole console = new();
+        using HelionConsole console = new(new DataCache());
 
         console.AddInput("yes hi");
 
@@ -30,7 +31,7 @@ public class HelionConsoleTest
     [Fact(DisplayName = "Submit console input with new lines")]
     public void SubmitInputWithNewlines()
     {
-        using HelionConsole console = new();
+        using HelionConsole console = new(new DataCache());
         using var monitor = console.Monitor();
 
         console.AddInput("stuff a b\n");
@@ -49,7 +50,7 @@ public class HelionConsoleTest
     [Fact(DisplayName = "Submit console input manually")]
     public void SubmitInput()
     {
-        using HelionConsole console = new();
+        using HelionConsole console = new(new DataCache());
         using var monitor = console.Monitor();
 
         console.AddInput("stuff a b");
@@ -69,7 +70,7 @@ public class HelionConsoleTest
     [Fact(DisplayName = "Clear console input")]
     public void ClearInput()
     {
-        using HelionConsole console = new();
+        using HelionConsole console = new(new DataCache());
         using var monitor = console.Monitor();
 
         console.AddInput("stuff a b");


### PR DESCRIPTION
Commit 60fe0b75bf1f98c909b5db091f60eb6f152cec7c broke build over in the Test project.

I'm not sure if this is the fix you'd ideally _want_, but this at least gets the unit tests building and passing again.