### PR TITLE
Improve IWAD search

### DIFF
--- a/Client/Client.Initialize.cs
+++ b/Client/Client.Initialize.cs
@@ -77,7 +77,7 @@ public partial class Client
 
     private void FindInstalledIWads()
     {
-        var iwadLocator = IWadLocator.CreateDefault();
+        var iwadLocator = IWadLocator.CreateDefault(m_config.Files.Directories.Value);
         m_iwads.AddRange(iwadLocator.Locate());
     }
 

--- a/Core/Resources/IWad/IWadLocator.cs
+++ b/Core/Resources/IWad/IWadLocator.cs
@@ -94,9 +94,14 @@ public class IWadLocator
     {
         if (OperatingSystem.IsWindows())
         {
-            return
-                Registry.GetValue(@"HKEY_CURRENT_USER\Software\Valve\Steam", "SteamPath", null) as string ??
-                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Steam/");
+            try
+            {
+                return Registry.GetValue(@"HKEY_CURRENT_USER\Software\Valve\Steam", "SteamPath", null) as string;
+            }
+            catch (Exception)
+            {
+                return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Steam/");
+            }
         }
 
         if (OperatingSystem.IsLinux())

--- a/Core/Resources/IWad/IWadLocator.cs
+++ b/Core/Resources/IWad/IWadLocator.cs
@@ -1,3 +1,4 @@
+using Microsoft.Win32;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -28,9 +29,9 @@ public class IWadLocator
 
     private readonly List<string> m_directories;
 
-    public static IWadLocator CreateDefault()
+    public static IWadLocator CreateDefault(IEnumerable<string> configDirectories)
     {
-        List<string> paths = new() { Directory.GetCurrentDirectory() };
+        List<string> paths = [Directory.GetCurrentDirectory(), .. configDirectories];
 
         var steamPath = GetSteamPath();
 
@@ -92,7 +93,11 @@ public class IWadLocator
     private static string? GetSteamPath()
     {
         if (OperatingSystem.IsWindows())
-            return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Steam/");
+        {
+            return
+                Registry.GetValue(@"HKEY_CURRENT_USER\Software\Valve\Steam", "SteamPath", null) as string ??
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Steam/");
+        }
 
         if (OperatingSystem.IsLinux())
         {


### PR DESCRIPTION
A couple attempts to improve IWAD detection for users who have multiple different Doom source ports on their machines and don't want to make multiple copies of their IWADs:

1.  On Windows, attempt to read the actual installed registry path for Steam, rather than just assuming it is in `Program Files (x86)`.  It is possible to install Steam to another path (I use `C:\Steam` on my own machine).

2.  Pass the contents of the "files.directories" element of the config file to the IWAD search method.  I've verified that both absolute and relative (to current working directory) paths seem to work as expected.  I don't know if that's what this config item was _originally_ intended to do, so if this is wrong, I'll add a new config item instead (let me know).