### PR TITLE
Fix incorrect music selection in E1M6 of DOOM

### DIFF
--- a/Assets/Assets/MapInfo/Doom1.txt
+++ b/Assets/Assets/MapInfo/Doom1.txt
@@ -120,7 +120,7 @@ map E1M6 lookup "HUSTR_E1M6"
 	sky1 = "SKY1"
 	cluster = 1
 	par = 180
-	music = "$MUSIC_E1M7"
+	music = "$MUSIC_E1M6"
 }
 
 map E1M7 lookup "HUSTR_E1M7"


### PR DESCRIPTION
Currently, E1M6 plays the song that is supposed to play on E1M7.  Probably a typo?