### PR TITLE
Update SixLabors.ImageSharp to latest stable release version

### DIFF
--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="OpenTK.Graphics" Version="4.7.4" />
     <PackageReference Include="OpenTK.OpenAL" Version="4.7.4" />
     <PackageReference Include="OpenTK.Windowing.Common" Version="4.7.4" />
-	<PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta0007" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.3" />
     <PackageReference Include="TextCopy" Version="6.2.1" />
     <PackageReference Include="zdbspSharp" Version="1.0.2" />
   </ItemGroup>

--- a/Core/Graphics/Fonts/TrueTypeFont.cs
+++ b/Core/Graphics/Fonts/TrueTypeFont.cs
@@ -46,19 +46,22 @@ public static class TrueTypeFont
                 string text = ComposeRenderableCharacters();
                 Dictionary<char, Image> charImages = new Dictionary<char, Image>();
 
+                // Use this to compute the maximum height needed for the entire font, so that all of the character
+                // bitmaps can have the same height dimension.
+                FontRectangle fontBounds = TextMeasurer.MeasureBounds(text, richTextOptions);
+
                 foreach (char c in text)
                 {
                     string charString = $"{c}";
-                    // Character advance seems to be the best measurement of the pixel size required to render
-                    // a character, as it measures how far over the image library would need to "move" in order to draw
-                    // the next character in a string.  However, it seems like it doesn't _quite_ capture the height of
-                    // characters that "dangle" under the line, like 'g'.  For now, we're adding a 4px fudge factor, but
-                    // this may need to be revisited.
+                    // To measure the amount of room we need to render each character, we are using character advance
+                    // for the width dimension.  Advance is how far "over" the renderer needs to move before drawing the
+                    // next character.
+                    // For height, we are using the maximum height dimension of the entire font, as computed above.
                     FontRectangle charAdvance = TextMeasurer.MeasureAdvance(charString, richTextOptions);
 
                     using (Image<Rgba32> charImage = new(
                         (int)Math.Ceiling(charAdvance.X + charAdvance.Width),
-                        (int)Math.Ceiling(charAdvance.Y + charAdvance.Height + 4)))
+                        (int)Math.Ceiling(fontBounds.Y + fontBounds.Height)))
                     {
                         charImage.Mutate(ctx =>
                         {

--- a/Core/Resources/Images/ArchiveImageRetriever.cs
+++ b/Core/Resources/Images/ArchiveImageRetriever.cs
@@ -1,5 +1,3 @@
-using System;
-using System.IO;
 using Helion.Graphics;
 using Helion.Graphics.Palettes;
 using Helion.Resources.Archives.Collection;
@@ -9,6 +7,8 @@ using NLog;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.PixelFormats;
+using System;
+using System.IO;
 using Image = Helion.Graphics.Image;
 
 namespace Helion.Resources.Images;
@@ -155,17 +155,19 @@ public class ArchiveImageRetriever : IImageRetriever
                 using MemoryStream inputStream = new MemoryStream(data);
                 using Image<Rgba32> img = SixLabors.ImageSharp.Image.Load<Rgba32>(inputStream);
 
-                Span<Rgba32> pixelSpans = img.GetPixelSpan<Rgba32>();
-                byte[] argbData = new byte[pixelSpans.Length * 4];
+                byte[] argbData = new byte[img.Height * img.Width * 4];
                 int offset = 0;
-
-                foreach (Rgba32 rgba in pixelSpans)
+                for (int y = 0; y < img.Height; y++)
                 {
-                    argbData[offset] = rgba.A;
-                    argbData[offset + 1] = rgba.R;
-                    argbData[offset + 2] = rgba.G;
-                    argbData[offset + 3] = rgba.B;
-                    offset += 4;
+                    Span<Rgba32> pixelRow = img.DangerousGetPixelRowMemory(y).Span;
+                    foreach (ref Rgba32 pixel in pixelRow)
+                    {
+                        argbData[offset] = pixel.A;
+                        argbData[offset + 1] = pixel.R;
+                        argbData[offset + 2] = pixel.G;
+                        argbData[offset + 3] = pixel.B;
+                        offset += 4;
+                    }
                 }
 
                 image = Image.FromArgbBytes((img.Width, img.Height), argbData, (0, 0), entry.Namespace);


### PR DESCRIPTION
In this change, I'm updating Helion onto a stable release version of the SixLabors.ImageSharp.Drawing library that is used for some image conversions (JPEG/PNG loading) and console font rendering.  It is currently using a very old pre-1.0 beta of this library.

This involved reworking a couple of image loading/conversion methods, as well as the TTF font conversion method used to generate fonts for the IWAD picker, IWAD error splash screen, and console.

This eliminates the offset math and magic-number vertical/horizontal padding applied to the font graphics, and doesn't seem to clip pixels off the rendered characters or lose the descenders on letters like 'g'.

I verified that this produces reasonable results on default settings on my 1920x1080 resolution monitor; the console, IWAD picker, and "can't find an IWAD" error screen (which uses both a converted TTF font _and_ a converted JPEG) all look good to me.  If there are other cases I need to test, please let me know which ones and how, as I'm not fully versed in all the ways Helion might load these types of resources.