### PR TITLE
Add help-text footer to Options menu

### DIFF
--- a/Core/Layer/Options/IOptionSection.cs
+++ b/Core/Layer/Options/IOptionSection.cs
@@ -49,9 +49,6 @@ public interface IOptionSection
     public event EventHandler<RowEvent>? OnRowChanged;
     public event EventHandler<string>? OnError;
 
-    public int CurrentRowIndex { get; }
-    public int MaxRowIndex { get; }
-
     public OptionSectionType OptionType { get; }
 
     void OnShow();

--- a/Core/Layer/Options/IOptionSection.cs
+++ b/Core/Layer/Options/IOptionSection.cs
@@ -49,6 +49,9 @@ public interface IOptionSection
     public event EventHandler<RowEvent>? OnRowChanged;
     public event EventHandler<string>? OnError;
 
+    public int CurrentRowIndex { get; }
+    public int MaxRowIndex { get; }
+
     public OptionSectionType OptionType { get; }
 
     void OnShow();

--- a/Core/Layer/Options/IOptionSection.cs
+++ b/Core/Layer/Options/IOptionSection.cs
@@ -34,9 +34,12 @@ public struct RowEvent
 {
     public readonly int Index;
 
-    public RowEvent(int index)
+    public readonly string SelectedRowDescription;
+
+    public RowEvent(int index, string selectedRowDescription)
     {
         Index = index;
+        SelectedRowDescription = selectedRowDescription;
     }
 }
 

--- a/Core/Layer/Options/OptionsLayer.cs
+++ b/Core/Layer/Options/OptionsLayer.cs
@@ -540,28 +540,25 @@ public class OptionsLayer : IGameLayer
             return;
 
         int scrollHeight = section.GetRenderHeight() + m_headerHeight;
-        if (scrollHeight <= hud.Dimension.Height - m_footerHeight)
+        int maxScrollOffset = scrollHeight - hud.Dimension.Height;
+
+        if (maxScrollOffset < 0)
+        {
             return;
+        }
+
+        int actualScrollOffset = Math.Abs(m_scrollOffset);
+        int barPosition = (int)((actualScrollOffset / (float)maxScrollOffset) * hud.Dimension.Height);
 
         const string Bar = "|";
         var textDimension = hud.MeasureText(Bar, Fonts.Small, fontSize);
 
-        int scrollAmount = GetScrollAmount();
-        int scrollDiff = scrollHeight - (hud.Dimension.Height - m_headerHeight) ;
-        int total = scrollDiff / scrollAmount;
-        if (scrollDiff % scrollAmount != 0)
-            total++;
+        if (barPosition + textDimension.Height > hud.Dimension.Height)
+        {
+            barPosition = hud.Dimension.Height - textDimension.Height;
+        }
 
-        if (total == 0)
-            return;
-
-        int screenScrollAmount = hud.Dimension.Height / total;
-
-        int y = -(total - (total - (m_scrollOffset / scrollAmount))) * screenScrollAmount;
-        if (y + textDimension.Height > hud.Dimension.Height)
-            y = hud.Dimension.Height - textDimension.Height;
-
-        hud.Text(Bar, Fonts.Small, fontSize, (0, y), both: Align.TopRight);
+        hud.Text(Bar, Fonts.Small, fontSize, (0, barPosition), both: Align.TopRight);
     }
 
     private bool ScrollRequired(int windowHeight, IOptionSection section) =>

--- a/Core/Layer/Options/OptionsLayer.cs
+++ b/Core/Layer/Options/OptionsLayer.cs
@@ -17,7 +17,6 @@ using Helion.Util.Configs.Components;
 using Helion.Util.Configs.Extensions;
 using Helion.Util.Configs.Options;
 using Helion.Util.Configs.Values;
-using Helion.Util.Parser;
 using Helion.Util.Timing;
 using Helion.Window;
 using Helion.Window.Input;
@@ -548,7 +547,7 @@ public class OptionsLayer : IGameLayer
         }
 
         int actualScrollOffset = Math.Abs(m_scrollOffset);
-        int barPosition = (int)((actualScrollOffset / (float)maxScrollOffset) * hud.Dimension.Height);
+        int barPosition = (int)(actualScrollOffset / (float)maxScrollOffset * hud.Dimension.Height);
 
         const string Bar = "|";
         var textDimension = hud.MeasureText(Bar, Fonts.Small, fontSize);

--- a/Core/Layer/Options/OptionsLayer.cs
+++ b/Core/Layer/Options/OptionsLayer.cs
@@ -538,25 +538,12 @@ public class OptionsLayer : IGameLayer
         if (!ScrollRequired(hud.Dimension.Height, section))
             return;
 
-        int scrollHeight = section.GetRenderHeight() + m_headerHeight;
-        int maxScrollOffset = scrollHeight - hud.Dimension.Height;
-
-        if (maxScrollOffset < 0)
-        {
-            return;
-        }
-
-        int actualScrollOffset = Math.Abs(m_scrollOffset);
-        int barPosition = (int)(actualScrollOffset / (float)maxScrollOffset * hud.Dimension.Height);
-
         const string Bar = "|";
-        var textDimension = hud.MeasureText(Bar, Fonts.Small, fontSize);
 
-        if (barPosition + textDimension.Height > hud.Dimension.Height)
-        {
-            barPosition = hud.Dimension.Height - textDimension.Height;
-        }
+        // Figure out how low we can put the bar before it clips off the bottom of the screen
+        int lowestBarPosition = hud.Dimension.Height - hud.MeasureText(Bar, Fonts.Small, fontSize).Height;
 
+        int barPosition = (int)(Math.Abs(section.CurrentRowIndex) / (float)Math.Max(section.MaxRowIndex, 1) * lowestBarPosition);
         hud.Text(Bar, Fonts.Small, fontSize, (0, barPosition), both: Align.TopRight);
     }
 

--- a/Core/Layer/Options/OptionsLayer.cs
+++ b/Core/Layer/Options/OptionsLayer.cs
@@ -538,12 +538,25 @@ public class OptionsLayer : IGameLayer
         if (!ScrollRequired(hud.Dimension.Height, section))
             return;
 
+        int scrollHeight = section.GetRenderHeight() + m_headerHeight;
+        int maxScrollOffset = scrollHeight - hud.Dimension.Height;
+
+        if (maxScrollOffset < 0)
+        {
+            return;
+        }
+
+        int actualScrollOffset = Math.Abs(m_scrollOffset);
+        int barPosition = (int)(actualScrollOffset / (float)maxScrollOffset * hud.Dimension.Height);
+
         const string Bar = "|";
+        var textDimension = hud.MeasureText(Bar, Fonts.Small, fontSize);
 
-        // Figure out how low we can put the bar before it clips off the bottom of the screen
-        int lowestBarPosition = hud.Dimension.Height - hud.MeasureText(Bar, Fonts.Small, fontSize).Height;
+        if (barPosition + textDimension.Height > hud.Dimension.Height)
+        {
+            barPosition = hud.Dimension.Height - textDimension.Height;
+        }
 
-        int barPosition = (int)(Math.Abs(section.CurrentRowIndex) / (float)Math.Max(section.MaxRowIndex, 1) * lowestBarPosition);
         hud.Text(Bar, Fonts.Small, fontSize, (0, barPosition), both: Align.TopRight);
     }
 

--- a/Core/Layer/Options/Sections/KeyBindingSection.cs
+++ b/Core/Layer/Options/Sections/KeyBindingSection.cs
@@ -81,9 +81,6 @@ public class KeyBindingSection : IOptionSection
     private bool m_updateMouse;
     private bool m_configUpdated;
 
-    public int CurrentRowIndex => m_currentRow;
-    public int MaxRowIndex => m_commandToKeys?.Count ?? 0;
-
     public KeyBindingSection(IConfig config, SoundManager soundManager)
     {
         m_config = config;

--- a/Core/Layer/Options/Sections/KeyBindingSection.cs
+++ b/Core/Layer/Options/Sections/KeyBindingSection.cs
@@ -81,6 +81,9 @@ public class KeyBindingSection : IOptionSection
     private bool m_updateMouse;
     private bool m_configUpdated;
 
+    public int CurrentRowIndex => m_currentRow;
+    public int MaxRowIndex => m_commandToKeys?.Count ?? 0;
+
     public KeyBindingSection(IConfig config, SoundManager soundManager)
     {
         m_config = config;

--- a/Core/Layer/Options/Sections/KeyBindingSection.cs
+++ b/Core/Layer/Options/Sections/KeyBindingSection.cs
@@ -91,6 +91,7 @@ public class KeyBindingSection : IOptionSection
 
     public void OnShow()
     {
+        OnRowChanged?.Invoke(this, new(m_currentRow, string.Empty));
         m_configUpdated = true;
     }
 
@@ -445,7 +446,7 @@ public class KeyBindingSection : IOptionSection
 
         if (m_updateRow)
         {
-            OnRowChanged?.Invoke(this, new(m_currentRow));
+            OnRowChanged?.Invoke(this, new(m_currentRow, string.Empty));
             m_updateRow = false;
         }
     }

--- a/Core/Layer/Options/Sections/ListedConfigSection.cs
+++ b/Core/Layer/Options/Sections/ListedConfigSection.cs
@@ -53,6 +53,9 @@ public class ListedConfigSection : IOptionSection
     private bool m_updateMouse;
     private IConfigValue? m_currentEditValue;
 
+    public int CurrentRowIndex => m_currentRowIndex;
+    public int MaxRowIndex => m_configValues?.Count ?? 0;
+
     public ListedConfigSection(IConfig config, OptionSectionType optionType, SoundManager soundManager)
     {
         m_config = config;

--- a/Core/Layer/Options/Sections/ListedConfigSection.cs
+++ b/Core/Layer/Options/Sections/ListedConfigSection.cs
@@ -484,7 +484,7 @@ public class ListedConfigSection : IOptionSection
 
         if (m_updateRow)
         {
-            OnRowChanged?.Invoke(this, new(m_currentRowIndex));
+            OnRowChanged?.Invoke(this, new(m_currentRowIndex, this.m_configValues[m_currentRowIndex].ConfigAttr.Description));
             m_updateRow = false;
         }
     }
@@ -514,8 +514,12 @@ public class ListedConfigSection : IOptionSection
         (IConfigValue cfgValue, OptionMenuAttribute attr, _) = m_configValues[rowIndex];
         return cfgValue.OptionDisabled || attr.Disabled;
     }
-    
-    public void OnShow() { }
+
+    public void OnShow()
+    {
+        OnRowChanged?.Invoke(this, new(m_currentRowIndex, m_configValues[m_currentRowIndex].ConfigAttr.Description));
+    }
+
     public int GetRenderHeight() => m_renderHeight;
     public (int, int) GetSelectedRenderY() => m_selectedRender;
     public void SetToFirstSelection() => m_currentRowIndex = 0;

--- a/Core/Layer/Options/Sections/ListedConfigSection.cs
+++ b/Core/Layer/Options/Sections/ListedConfigSection.cs
@@ -53,9 +53,6 @@ public class ListedConfigSection : IOptionSection
     private bool m_updateMouse;
     private IConfigValue? m_currentEditValue;
 
-    public int CurrentRowIndex => m_currentRowIndex;
-    public int MaxRowIndex => m_configValues?.Count ?? 0;
-
     public ListedConfigSection(IConfig config, OptionSectionType optionType, SoundManager soundManager)
     {
         m_config = config;


### PR DESCRIPTION
On all options sections _except_ key bindings, add a footer that explains the currently-selected option, based on the description of the underlying config item.

Note that this doesn't "reserve" an area at the bottom of the screen, so it is possible for a long Options section to run over the footer.  However, this is currently only a risk for the key bindings section, because none of the others are anywhere near long  enough for this to be a problem, at typical modern display resolutions.