### PR TITLE
Improve incremental build behavior

### DIFF
--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -47,20 +47,28 @@
       <!-- Runtime unspecified; copy native files into runtimes\(runtimeID)\native  -->
       <NativeFiles Include="$(ProjectDir)Unmanaged\win-x64\**\*" Destination="runtimes\win-x64\native\%(RecursiveDir)" Condition="'$(RuntimeIdentifier)' == ''" />
       <NativeFiles Include="$(ProjectDir)Unmanaged\win-x64\**\*" Destination="runtimes\win-x86\native\%(RecursiveDir)" Condition="'$(RuntimeIdentifier)' == ''" />
+
+      <!-- Files used to determine whether the "copy support files" targets need to run  -->
+      <TargetAssetsFile Include="$(TargetDir)assets.pk3" />
+      <PublishAssetsFile Include="$(PublishDir)assets.pk3" />
+      <AllSupportFiles Include="@(NativeFiles)" />
+      <AllSupportFiles Include="@(SoundFonts)" />
+      <AllSupportFiles Include="$(HelionRootDir)Assets\Assets\**\*" />
     </ItemGroup>
   </Target>
 
-  <Target Name="CopySupportFilesForBuild" AfterTargets="Build" DependsOnTargets="GetSupportFiles" >
+  <Target Name="CopySupportFilesForBuild" AfterTargets="Build" DependsOnTargets="GetSupportFiles" Inputs="@(AllSupportFiles)" Outputs="@(TargetAssetsFile)">
     <!-- Copy SoundFont for FluidSynth, create assets.pk3 -->
     <Copy SourceFiles="@(SoundFonts)" DestinationFolder="$(TargetDir)SoundFonts\%(RecursiveDir)" SkipUnchangedFiles="true" />
     <Copy SourceFiles="@(NativeFiles)" DestinationFolder="$(TargetDir)%(Destination)" SkipUnchangedFiles="true" />
-    <ZipDirectory SourceDirectory="$(HelionRootDir)Assets\Assets" DestinationFile="$(TargetDir)assets.pk3" Overwrite="true" />
+    <ZipDirectory SourceDirectory="$(HelionRootDir)Assets\Assets" DestinationFile="@(TargetAssetsFile)" Overwrite="true" />
   </Target>
 
-  <Target Name="CopySupportFilesForPublish" AfterTargets="Publish" DependsOnTargets="GetSupportFiles">
+  <Target Name="CopySupportFilesForPublish" AfterTargets="Publish" DependsOnTargets="GetSupportFiles" Inputs="@(AllSupportFiles)" Outputs="@(PublishAssetsFile)">
     <!-- The previous steps that copy support files to the target directory do NOT copy on publish, so we have to handle that again. -->
     <Copy SourceFiles="@(SoundFonts)" DestinationFolder="$(PublishDir)SoundFonts\%(RecursiveDir)" SkipUnchangedFiles="true" />
     <Copy SourceFiles="@(NativeFiles)" DestinationFolder="$(PublishDir)%(Destination)" SkipUnchangedFiles="true" />
-    <ZipDirectory SourceDirectory="$(HelionRootDir)Assets\Assets" DestinationFile="$(PublishDir)assets.pk3" Overwrite="true" />
+    <Copy SourceFiles="@(TargetAssetsFile)" DestinationFolder="$(PublishDir)" SkipUnchangedFiles="true" />
   </Target>
+
 </Project>

--- a/README.adoc
+++ b/README.adoc
@@ -55,7 +55,7 @@ Once any platform-specific prerequisites are installed, you can build or publish
 
 Note that it only makes sense to run the following from the `/Client` subdirectory, as this is the only one that actually builds an executable (and can therefore be published).
 
-Common parameters:
+.Common Build Parameters
 * `-r <runtimeID>`:  Build an executable for the specific runtime.  Tested choices include `win-x64`, `win-x86`, and `linux-x64`.
 * `--self-contained=true`:  Includes support files for the specified runtime, so that you do not need to install the .NET runtime onto the machine where you're going to run this (helps to make installs more portable)
 * `-p:PublishSingleFile=true`:  Bundles all of the .NET dependencies into a single file, resulting in fewer files in the output directory.  Can be combined with `--self-contained=true`.

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -34,9 +34,17 @@
     <None Update ="Resources\*" CopyToOutputDirectory="PreserveNewest"/>
   </ItemGroup>
 
-  <Target Name="MakeAssetsZip" AfterTargets="PostBuildEvent">
+  <Target Name="GetSupportFiles">
+    <ItemGroup>
+      <!-- Source files used for input into "zip" task  -->
+      <CompressedAssetSources Include="$(HelionRootDir)Assets\Assets\**\*" />
+      <TargetAssetsFile Include="$(TargetDir)assets.pk3" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="MakeAssetsZip" AfterTargets="PostBuildEvent" DependsOnTargets="GetSupportFiles" Inputs="@(CompressedAssetSources)" Outputs="@(TargetAssetsFile)">
     <!-- Zip the (Root)\Assets directory to a .pk3 file in the target directory -->
-    <ZipDirectory SourceDirectory="$(HelionRootDir)Assets\Assets" DestinationFile="$(TargetDir)assets.pk3" Overwrite="true" />
+    <ZipDirectory SourceDirectory="$(HelionRootDir)Assets\Assets" DestinationFile="@(TargetAssetsFile)" Overwrite="true" />
   </Target>
 
 </Project>


### PR DESCRIPTION
This is a minor update to some previous work I did to use MSBuild's integrated build tasks to copy support files and generate the assets.pk3 file.  In this change, I am:

1.  Modifying the preconditions for those build steps, so they only execute if one or more input files are newer than the assets.pk3 file in the output (or publish) directory.  This means that the assets.pk3 file will be left alone and _not_ repacked unless one or more support files change.  I have manually verified that MSBuild _will_ repack assets.pk3 if I edit a file in the /Assets directory of the repo.

2.  Updating the readme to fix a previous mistake of mine.  Apparently the .adoc format is _mostly_ like Markdown, except where it isn't (in this case, in handling bulleted lists).  Whoops.

This is more of a cleanliness/best-practices kind of change than anything else.  At present, the assets.pk3 file only contains around 80 files, and is only about one megabyte, so repacking or overwriting it is not a big deal on modern systems.  If the assets ever grow to include more graphics or sound effects, repacking it on every build would get pretty annoying.