### PR TITLE
Fix app-restart behavior for single-file publish

### DIFF
--- a/Client/Client.Commands.cs
+++ b/Client/Client.Commands.cs
@@ -64,11 +64,8 @@ public partial class Client
     [ConsoleCommand("restart", "Restarts the application.")]
     private void Restart(ConsoleCommandEventArgs args)
     {
-        var assembly = System.Reflection.Assembly.GetEntryAssembly();
-        if (assembly == null)
-            return;
+        var path = AppContext.BaseDirectory;
 
-        var path = Path.GetDirectoryName(assembly.Location);
         if (path == null)
             return;
 

--- a/Client/Client.cs
+++ b/Client/Client.cs
@@ -423,7 +423,7 @@ public partial class Client : IDisposable, IInputManagement
         if (assembly == null)
             return;
 
-        string? dir = Path.GetDirectoryName(assembly.Location);
+        string? dir = AppContext.BaseDirectory;
         if (dir == null)
             return;
 


### PR DESCRIPTION
I typically build Helion using the following command-line options, and the resulting program cannot execute the `restart` console command (which also means the "you just changed color mode, do you want to restart now?" dialog is also broken for me):
`dotnet publish -c Release -r win-x64 -p:PublishSingleFile=true --self-contained=true`

When publishing `DEBUG` in the same manner, the build process emits this handy warning:
```
client\Client.Commands.cs(71,42): warning IL3000: 'System.Reflection.Assembly.Location' always returns
an empty string for assemblies embedded in a single-file app. If the path to the app directory is needed, consider call
ing 'System.AppContext.BaseDirectory'.
```

I tried it, and it seems to work on my environment, both when just building, and when publishing (single-file or otherwise).