### PR TITLE
Adjust options menu text and verbiage

### DIFF
--- a/Core/Layer/Options/Sections/KeyBindingSection.cs
+++ b/Core/Layer/Options/Sections/KeyBindingSection.cs
@@ -364,7 +364,7 @@ public class KeyBindingSection : IOptionSection
         int xOffset = m_config.Hud.GetScaled(4) * 2;
         int smallPad = m_config.Hud.GetScaled(1);
 
-        hud.Text("Scroll with the mouse wheel or holding up/down", Font, fontSize, (0, y), out Dimension scrollArea, 
+        hud.Text("Scroll with the mouse wheel or hold up/down arrows", Font, fontSize, (0, y), out Dimension scrollArea, 
             both: Align.TopMiddle, color: Color.Firebrick);
         y += scrollArea.Height + smallPad;
         

--- a/Core/Util/Configs/Components/ConfigAudio.cs
+++ b/Core/Util/Configs/Components/ConfigAudio.cs
@@ -7,15 +7,15 @@ namespace Helion.Util.Configs.Components;
 
 public class ConfigAudio
 {
-    [ConfigInfo("The volume of the music. 0.0 is off, 1.0 is max.")]
+    [ConfigInfo("Music volume. 0.0 is off, 1.0 is max.")]
     [OptionMenu(OptionSectionType.Audio, "Music Volume")]
     public readonly ConfigValue<double> MusicVolume = new(1.0, ClampNormalized);
 
-    [ConfigInfo("The volume of the sounds. 0.0 is off, 1.0 is max.")]
+    [ConfigInfo("Sound effect volume. 0.0 is off, 1.0 is max.")]
     [OptionMenu(OptionSectionType.Audio, "Sound Volume")]
     public readonly ConfigValue<double> SoundVolume = new(1.0, ClampNormalized);
 
-    [ConfigInfo("The volume of the sounds. 0.0 is off, 1.0 is max.")]
+    [ConfigInfo("Overall volume. 0.0 is off, 1.0 is max.")]
     public readonly ConfigValue<double> Volume = new(1.0, ClampNormalized);
 
     [ConfigInfo("Randomize sound pitch.")]
@@ -31,9 +31,9 @@ public class ConfigAudio
     public readonly ConfigValue<double> Pitch = new(1, Clamp(0.1, 10));
 
     [ConfigInfo("Log sound errors.")]
-    [OptionMenu(OptionSectionType.Audio, "Log sound errors", spacer: true)]
+    [OptionMenu(OptionSectionType.Audio, "Log Sound Errors", spacer: true)]
     public readonly ConfigValue<bool> LogErrors = new(false);
 
-    [ConfigInfo("The main device to use for audio.")]
+    [ConfigInfo("Main device to use for audio.")]
     public readonly ConfigValue<string> Device = new(IAudioSystem.DefaultAudioDevice);
 }

--- a/Core/Util/Configs/Components/ConfigAudio.cs
+++ b/Core/Util/Configs/Components/ConfigAudio.cs
@@ -26,7 +26,7 @@ public class ConfigAudio
     [OptionMenu(OptionSectionType.Audio, "Random Pitch Scale")]
     public readonly ConfigValue<double> RandomPitchScale = new(1, Clamp(0.1, 10));
 
-    [ConfigInfo("Scale sound pitch.")]
+    [ConfigInfo("Scale for sound pitch.")]
     [OptionMenu(OptionSectionType.Audio, "Pitch Scale")]
     public readonly ConfigValue<double> Pitch = new(1, Clamp(0.1, 10));
 

--- a/Core/Util/Configs/Components/ConfigAudio.cs
+++ b/Core/Util/Configs/Components/ConfigAudio.cs
@@ -7,15 +7,15 @@ namespace Helion.Util.Configs.Components;
 
 public class ConfigAudio
 {
-    [ConfigInfo("Music volume. 0.0 is off, 1.0 is max.")]
+    [ConfigInfo("Music volume. 0.0 is Off, 1.0 is Maximum.")]
     [OptionMenu(OptionSectionType.Audio, "Music Volume")]
     public readonly ConfigValue<double> MusicVolume = new(1.0, ClampNormalized);
 
-    [ConfigInfo("Sound effect volume. 0.0 is off, 1.0 is max.")]
+    [ConfigInfo("Sound effect volume. 0.0 is Off, 1.0 is Maximum.")]
     [OptionMenu(OptionSectionType.Audio, "Sound Volume")]
     public readonly ConfigValue<double> SoundVolume = new(1.0, ClampNormalized);
 
-    [ConfigInfo("Overall volume. 0.0 is off, 1.0 is max.")]
+    [ConfigInfo("Overall volume. 0.0 is Off, 1.0 is Maximum.")]
     public readonly ConfigValue<double> Volume = new(1.0, ClampNormalized);
 
     [ConfigInfo("Randomize sound pitch.")]

--- a/Core/Util/Configs/Components/ConfigCompat.cs
+++ b/Core/Util/Configs/Components/ConfigCompat.cs
@@ -37,11 +37,11 @@ public class ConfigCompat
     [OptionMenu(OptionSectionType.Compatibility, "Vanilla Missile Height Collision")]
     public readonly ConfigValue<bool> MissileClip = new(false);
 
-    [ConfigInfo("Limits lost souls spawned by pain elementals to 21.", serialize: true, demo: true)]
+    [ConfigInfo("Limit lost souls spawned by pain elementals to 21.", serialize: true, demo: true)]
     [OptionMenu(OptionSectionType.Compatibility, "Limit Pain Elemental Lost Souls to 21")]
     public readonly ConfigValue<bool> PainElementalLostSoulLimit = new(false);
 
-    [ConfigInfo("Disables item drop tossing.", serialize: true, demo: true)]
+    [ConfigInfo("Disable item drop tossing.", serialize: true, demo: true)]
     [OptionMenu(OptionSectionType.Compatibility, "Disable Item Drop Tossing")]
     public readonly ConfigValue<bool> NoTossDrops = new(false);
 

--- a/Core/Util/Configs/Components/ConfigCompat.cs
+++ b/Core/Util/Configs/Components/ConfigCompat.cs
@@ -9,7 +9,7 @@ public class ConfigCompat
     [OptionMenu(OptionSectionType.Compatibility, "Find Shortest Texture")]
     public readonly ConfigValue<bool> VanillaShortestTexture = new(true);
 
-    [ConfigInfo("If DeHackEd should be preferred over DECORATE in the same archive.", demo: true)]
+    [ConfigInfo("Use DeHackEd over DECORATE if both are available.", demo: true)]
     [OptionMenu(OptionSectionType.Compatibility, "Use DeHackEd over DECORATE")]
     public readonly ConfigValue<bool> PreferDehacked = new(true);
 

--- a/Core/Util/Configs/Components/ConfigCompat.cs
+++ b/Core/Util/Configs/Components/ConfigCompat.cs
@@ -5,68 +5,68 @@ namespace Helion.Util.Configs.Components;
 
 public class ConfigCompat
 {
-    [ConfigInfo("Vanilla method for finding shortest texture. Emulates bug with AASHITTY.", save: false, serialize: true, demo: true)]
-    [OptionMenu(OptionSectionType.Compatibility, "Find shortest texture")]
+    [ConfigInfo("Use vanilla method for finding shortest texture. Emulates bug with AASHITTY.", save: false, serialize: true, demo: true)]
+    [OptionMenu(OptionSectionType.Compatibility, "Find Shortest Texture")]
     public readonly ConfigValue<bool> VanillaShortestTexture = new(true);
 
-    [ConfigInfo("If dehacked should be preferred over decorate in the same archive.", demo: true)]
-    [OptionMenu(OptionSectionType.Compatibility, "Use dehacked over decorate")]
+    [ConfigInfo("If DeHackEd should be preferred over DECORATE in the same archive.", demo: true)]
+    [OptionMenu(OptionSectionType.Compatibility, "Use DeHackEd over DECORATE")]
     public readonly ConfigValue<bool> PreferDehacked = new(true);
 
-    [ConfigInfo("Allow items to dropoff tall ledges.", serialize: true, demo: true)]
-    [OptionMenu(OptionSectionType.Compatibility, "Items drop off ledges")]
+    [ConfigInfo("Allow items to drop off tall ledges.", serialize: true, demo: true)]
+    [OptionMenu(OptionSectionType.Compatibility, "Items Drop Off Ledges")]
     public readonly ConfigValue<bool> AllowItemDropoff = new(true);
 
-    [ConfigInfo("Use vanilla sector physics. Floors can move through ceiling. Only one move special per sector at a time.", serialize: true, demo: true)]
-    [OptionMenu(OptionSectionType.Compatibility, "Vanilla sector physics")]
+    [ConfigInfo("Use vanilla sector physics. Floors can move through ceilings. Only one move special per sector at a time.", serialize: true, demo: true)]
+    [OptionMenu(OptionSectionType.Compatibility, "Vanilla Sector Physics")]
     public readonly ConfigValue<bool> VanillaSectorPhysics = new(false);
 
     [ConfigInfo("Use vanilla movement physics. Velocity is maintained when hitting things.", serialize: true, demo: true)]
-    [OptionMenu(OptionSectionType.Compatibility, "Vanilla movement physics")]
+    [OptionMenu(OptionSectionType.Compatibility, "Vanilla Movement Physics")]
     public readonly ConfigValue<bool> VanillaMovementPhysics = new(false);
 
-    [ConfigInfo("Use vanilla sector sound calculation. Sound is calculated from the center of the sectors bounding box.", serialize: true, demo: true)]
-    [OptionMenu(OptionSectionType.Compatibility, "Vanilla sector sound")]
+    [ConfigInfo("Use vanilla sector sound calculation. Sound is calculated from the center of the sector's bounding box.", serialize: true, demo: true)]
+    [OptionMenu(OptionSectionType.Compatibility, "Vanilla Sector Sound")]
     public readonly ConfigValue<bool> VanillaSectorSound = new(false);
 
     [ConfigInfo("Emulate vanilla infinitely tall things.", serialize: true, demo: true)]
-    [OptionMenu(OptionSectionType.Compatibility, "Infinitely tall things")]
+    [OptionMenu(OptionSectionType.Compatibility, "Infinitely Tall Things")]
     public readonly ConfigValue<bool> InfinitelyTallThings = new(false);
 
     [ConfigInfo("Things use their original vanilla heights for projectile collision checks.", serialize: true, demo: true)]
-    [OptionMenu(OptionSectionType.Compatibility, "Vanilla missile height collision")]
+    [OptionMenu(OptionSectionType.Compatibility, "Vanilla Missile Height Collision")]
     public readonly ConfigValue<bool> MissileClip = new(false);
 
-    [ConfigInfo("Limits lost souls spawn by pain elementals to 21.", serialize: true, demo: true)]
-    [OptionMenu(OptionSectionType.Compatibility, "Limit pain elemental lost souls to 21")]
+    [ConfigInfo("Limits lost souls spawned by pain elementals to 21.", serialize: true, demo: true)]
+    [OptionMenu(OptionSectionType.Compatibility, "Limit Pain Elemental Lost Souls to 21")]
     public readonly ConfigValue<bool> PainElementalLostSoulLimit = new(false);
 
     [ConfigInfo("Disables item drop tossing.", serialize: true, demo: true)]
-    [OptionMenu(OptionSectionType.Compatibility, "Disable item drop tossing")]
+    [OptionMenu(OptionSectionType.Compatibility, "Disable Item Drop Tossing")]
     public readonly ConfigValue<bool> NoTossDrops = new(false);
 
     [ConfigInfo("Use Doom's bugged stair building.", serialize: true, demo: true)]
-    [OptionMenu(OptionSectionType.Compatibility, "Use bugged stair building")]
+    [OptionMenu(OptionSectionType.Compatibility, "Use Bugged Stair Building")]
     public readonly ConfigValue<bool> Stairs = new(false);
 
-    [ConfigInfo("Enable Doom 2 projectiles triggering walk specials", serialize: true, demo: true)]
-    [OptionMenu(OptionSectionType.Compatibility, "Doom 2 projectiles trigger walk specials")]
+    [ConfigInfo("Enable Doom 2 projectiles triggering walk specials.", serialize: true, demo: true)]
+    [OptionMenu(OptionSectionType.Compatibility, "Doom 2 Projectiles Trigger Walk Specials")]
     public readonly ConfigValue<bool> Doom2ProjectileWalkTriggers = new(false);
 
-    [ConfigInfo("Use original doom explosion behavior", serialize: true, demo: true)]
-    [OptionMenu(OptionSectionType.Compatibility, "Use original doom explosion behavior")]
+    [ConfigInfo("Use original Doom explosion behavior.", serialize: true, demo: true)]
+    [OptionMenu(OptionSectionType.Compatibility, "Use Original Doom Explosion Behavior")]
     public readonly ConfigValue<bool> OriginalExplosion = new(false);
 
     [ConfigInfo("Enable vile ghosts.", serialize: true, demo: true)]
-    [OptionMenu(OptionSectionType.Compatibility, "Vile ghosts")]
+    [OptionMenu(OptionSectionType.Compatibility, "Vile Ghosts")]
     public readonly ConfigValue<bool> VileGhosts = new(false);
 
-    [ConfigInfo("Enable final doom teleports. Disables forcing to floor.", serialize: true, demo: true)]
-    [OptionMenu(OptionSectionType.Compatibility, "Final Doom teleport")]
+    [ConfigInfo("Enable Final Doom teleports. Disables forcing to floor.", serialize: true, demo: true)]
+    [OptionMenu(OptionSectionType.Compatibility, "Final Doom Teleport")]
     public readonly ConfigValue<bool> FinalDoomTeleport = new(false);
 
-    [ConfigInfo("Enable mbf21 features.", serialize: true, demo: true)]
-    [OptionMenu(OptionSectionType.Compatibility, "Enable mbf21 features")]
+    [ConfigInfo("Enable MBF21 features.", serialize: true, demo: true)]
+    [OptionMenu(OptionSectionType.Compatibility, "Enable MBF21 Features")]
     public readonly ConfigValue<bool> Mbf21 = new(true);
 
     public void ResetToUserValues()

--- a/Core/Util/Configs/Components/ConfigConsole.cs
+++ b/Core/Util/Configs/Components/ConfigConsole.cs
@@ -6,12 +6,12 @@ namespace Helion.Util.Configs.Components;
 
 public class ConfigConsole
 {
-    [ConfigInfo("The number of messages the console buffer holds before discarding old ones.")]
-    [OptionMenu(OptionSectionType.Console, "Max messages")]
+    [ConfigInfo("Number of messages the console buffer holds before discarding old ones.")]
+    [OptionMenu(OptionSectionType.Console, "Max Messages")]
     public readonly ConfigValue<int> MaxMessages = new(256, Greater(0));
 
     [ConfigInfo("Font size.")]
-    [OptionMenu(OptionSectionType.Console, "Font size")]
+    [OptionMenu(OptionSectionType.Console, "Font Size")]
     public readonly ConfigValue<int> FontSize = new(32, Greater(15));
 
     [ConfigInfo("Transparency.")]

--- a/Core/Util/Configs/Components/ConfigDemo.cs
+++ b/Core/Util/Configs/Components/ConfigDemo.cs
@@ -6,6 +6,6 @@ namespace Helion.Util.Configs.Components;
 public class ConfigDemo
 {
     [ConfigInfo("Playback tick multiplier rounded to the nearest tick. (0.5 = half speed, 2 = double speed)", save: true)]
-    [OptionMenu(OptionSectionType.Demo, "Playback speed")]
+    [OptionMenu(OptionSectionType.Demo, "Playback Speed")]
     public readonly ConfigValue<double> PlaybackSpeed = new(1);
 }

--- a/Core/Util/Configs/Components/ConfigDeveloper.cs
+++ b/Core/Util/Configs/Components/ConfigDeveloper.cs
@@ -4,7 +4,7 @@ namespace Helion.Util.Configs.Components;
 
 public class ConfigDeveloperRender
 {
-    [ConfigInfo("If rendering should have debugging information drawn.", save: false)]
+    [ConfigInfo("Draw rendering debug information.", save: false)]
     public readonly ConfigValue<bool> Debug = new(false);
 
     [ConfigInfo("Draw the tracers from autoaim and shooting for the player.", save: false)]
@@ -15,18 +15,18 @@ public class ConfigDeveloper
 {
     public readonly ConfigDeveloperRender Render = new();
 
-    [ConfigInfo("Marks flooded areas on the automap.", save: true)]
+    [ConfigInfo("Mark flooded areas on the automap.", save: true)]
     public readonly ConfigValue<bool> MarkFlood = new(false);
 
-    [ConfigInfo("Logs marked special info.", save: true)]
+    [ConfigInfo("Log marked special info.", save: true)]
     public readonly ConfigValue<bool> LogMarkSpecials = new(false);
 
     [ConfigInfo("Flood opposing testing.", save: true)]
     public readonly ConfigValue<bool> FloodOpposing = new(false);
 
-    [ConfigInfo("If ReversedZ should be used.", save: true, restartRequired: true)]
+    [ConfigInfo("Use ReversedZ.", save: true, restartRequired: true)]
     public readonly ConfigValue<bool> UseReversedZ = new(false);
 
-    [ConfigInfo("Forces usage of ReversedZ. Only used if Developer.ReversedZ is set.", save: true, restartRequired: true)]
+    [ConfigInfo("Force usage of ReversedZ. Only used if Developer.ReversedZ is set.", save: true, restartRequired: true)]
     public readonly ConfigValue<bool> ReversedZ = new(false);
 }

--- a/Core/Util/Configs/Components/ConfigGame.cs
+++ b/Core/Util/Configs/Components/ConfigGame.cs
@@ -24,7 +24,7 @@ public class ConfigGame
     [OptionMenu(OptionSectionType.General, "Pain Intensity")]
     public readonly ConfigValue<double> PainIntensity = new(1.0);
 
-    [ConfigInfo("Player can use lines by bumping into them.", demo: true)]
+    [ConfigInfo("Player can use lines (doors, switches) by bumping into them.", demo: true)]
     [OptionMenu(OptionSectionType.General, "Bump Use", spacer: true)]
     public readonly ConfigValue<bool> BumpUse = new(false);
 

--- a/Core/Util/Configs/Components/ConfigGame.cs
+++ b/Core/Util/Configs/Components/ConfigGame.cs
@@ -8,15 +8,15 @@ namespace Helion.Util.Configs.Components;
 
 public class ConfigGame
 {
-    [ConfigInfo("Player always runs.", demo: true)]
+    [ConfigInfo("Always run.", demo: true)]
     [OptionMenu(OptionSectionType.General, "Always Run")]
     public readonly ConfigValue<bool> AlwaysRun = new(true);
 
-    [ConfigInfo("Enable autoaiming.", demo: true)]
+    [ConfigInfo("Enable vertical autoaiming.", demo: true)]
     [OptionMenu(OptionSectionType.General, "Autoaim")]
     public readonly ConfigValue<bool> AutoAim = new(true);
 
-    [ConfigInfo("Horizontal autoaiming enabled for projectiles (rockets, plasma).", demo: true)]
+    [ConfigInfo("Enable horizontal autoaiming for projectiles (rockets, plasma).  Only applies if vertical autoaiming is enabled.", demo: true)]
     [OptionMenu(OptionSectionType.General, "Horizontal Autoaim")]
     public readonly ConfigValue<bool> HorizontalAutoAim = new(false);
 

--- a/Core/Util/Configs/Components/ConfigGame.cs
+++ b/Core/Util/Configs/Components/ConfigGame.cs
@@ -8,27 +8,27 @@ namespace Helion.Util.Configs.Components;
 
 public class ConfigGame
 {
-    [ConfigInfo("If the player should always run.", demo: true)]
+    [ConfigInfo("Player always runs.", demo: true)]
     [OptionMenu(OptionSectionType.General, "Always Run")]
     public readonly ConfigValue<bool> AlwaysRun = new(true);
 
-    [ConfigInfo("If autoaiming should be used.", demo: true)]
+    [ConfigInfo("Enable autoaiming.", demo: true)]
     [OptionMenu(OptionSectionType.General, "Autoaim")]
     public readonly ConfigValue<bool> AutoAim = new(true);
 
-    [ConfigInfo("If horizontal autoaiming should be used for projectiles.", demo: true)]
+    [ConfigInfo("Horizontal autoaiming enabled for projectiles (rockets, plasma).", demo: true)]
     [OptionMenu(OptionSectionType.General, "Horizontal Autoaim")]
     public readonly ConfigValue<bool> HorizontalAutoAim = new(false);
 
-    [ConfigInfo("Scales red amount drawn to screen when the player takes damage.")]
+    [ConfigInfo("Scale red amount drawn to screen when the player takes damage.")]
     [OptionMenu(OptionSectionType.General, "Pain Intensity")]
     public readonly ConfigValue<double> PainIntensity = new(1.0);
 
-    [ConfigInfo("If the player should automatically use lines when bumping.", demo: true)]
+    [ConfigInfo("Player can use lines by bumping into them.", demo: true)]
     [OptionMenu(OptionSectionType.General, "Bump Use", spacer: true)]
     public readonly ConfigValue<bool> BumpUse = new(false);
 
-    [ConfigInfo("Use the last loaded world state on death.")]
+    [ConfigInfo("Attempt to load latest saved game on death.")]
     [OptionMenu(OptionSectionType.General, "Load Latest on Death")]
     public readonly ConfigValue<bool> LoadLatestOnDeath = new(true);
 
@@ -36,35 +36,35 @@ public class ConfigGame
     [OptionMenu(OptionSectionType.General, "Autosave")]
     public readonly ConfigValue<bool> AutoSave = new(false);
 
-    [ConfigInfo("Confirm overwriting when quick saving.")]
+    [ConfigInfo("Confirm overwrite when quick saving.")]
     [OptionMenu(OptionSectionType.General, "Confirm Quick Save")]
     public readonly ConfigValue<bool> QuickSaveConfirm = new(true);
 
-    [ConfigInfo("Enables fast monsters.", save: false, demo: true, serialize: true)]
+    [ConfigInfo("Enable fast monsters.", save: false, demo: true, serialize: true)]
     [OptionMenu(OptionSectionType.General, "Fast Monsters", spacer: true)]
     public readonly ConfigValue<bool> FastMonsters = new(false);
 
-    [ConfigInfo("Enables monster closet detection and limited monster AI.", mapRestartRequired: true, demo: true)]
+    [ConfigInfo("Enable monster closet detection and limited monster AI.", mapRestartRequired: true, demo: true)]
     [OptionMenu(OptionSectionType.General, "Monster Closet Detection")]
     public readonly ConfigValue<bool> MonsterCloset = new(true);
 
     [ConfigInfo("Skill level to use when starting a map.", save: false, demo: true)]
     public readonly ConfigValue<SkillLevel> Skill = new(SkillLevel.Medium, ConfigSetFlags.OnNewWorld, OnlyValidEnums<SkillLevel>());
 
-    [ConfigInfo("If stats should be written to levelstat.txt.", save: false)]
+    [ConfigInfo("Write stats to levelstat.txt.", save: false)]
     public readonly ConfigValue<bool> LevelStat = new(false);
 
     [ConfigInfo("Whether no monsters should be spawned.", save: false, serialize: true)]
     public readonly ConfigValue<bool> NoMonsters = new(false);
 
-    [ConfigInfo("Resets the player's inventory at the start of each map.", save: false, serialize: true)]
+    [ConfigInfo("Reset the player's inventory at the start of each map.", save: false, serialize: true)]
     public readonly ConfigValue<bool> PistolStart = new(false);
 
-    [ConfigInfo("Marks lines and sectors that are activated by a special in the automap.")]
+    [ConfigInfo("Mark lines and sectors that are activated by a special in the automap.")]
     [OptionMenu(OptionSectionType.General, "Mark Specials", spacer: true)]
     public readonly ConfigValue<bool> MarkSpecials = new(false);
 
-    [ConfigInfo("Marks secret sectors in the automap.")]
+    [ConfigInfo("Mark secret sectors in the automap.")]
     [OptionMenu(OptionSectionType.General, "Mark Secrets")]
     public readonly ConfigValue<bool> MarkSecrets = new(false);
 

--- a/Core/Util/Configs/Components/ConfigGame.cs
+++ b/Core/Util/Configs/Components/ConfigGame.cs
@@ -20,7 +20,7 @@ public class ConfigGame
     [OptionMenu(OptionSectionType.General, "Horizontal Autoaim")]
     public readonly ConfigValue<bool> HorizontalAutoAim = new(false);
 
-    [ConfigInfo("Scales red amount draw to screen when the player takes damage.")]
+    [ConfigInfo("Scales red amount drawn to screen when the player takes damage.")]
     [OptionMenu(OptionSectionType.General, "Pain Intensity")]
     public readonly ConfigValue<double> PainIntensity = new(1.0);
 
@@ -28,27 +28,27 @@ public class ConfigGame
     [OptionMenu(OptionSectionType.General, "Bump Use", spacer: true)]
     public readonly ConfigValue<bool> BumpUse = new(false);
 
-    [ConfigInfo("The last loaded world state on death.")]
-    [OptionMenu(OptionSectionType.General, "Load latest on death")]
+    [ConfigInfo("Use the last loaded world state on death.")]
+    [OptionMenu(OptionSectionType.General, "Load Latest on Death")]
     public readonly ConfigValue<bool> LoadLatestOnDeath = new(true);
 
-    [ConfigInfo("Automatically saves at level start.", save: false)]
+    [ConfigInfo("Automatically save at level start.", save: false)]
     [OptionMenu(OptionSectionType.General, "Autosave")]
     public readonly ConfigValue<bool> AutoSave = new(false);
 
     [ConfigInfo("Confirm overwriting when quick saving.")]
-    [OptionMenu(OptionSectionType.General, "Confirm quick save")]
+    [OptionMenu(OptionSectionType.General, "Confirm Quick Save")]
     public readonly ConfigValue<bool> QuickSaveConfirm = new(true);
 
     [ConfigInfo("Enables fast monsters.", save: false, demo: true, serialize: true)]
-    [OptionMenu(OptionSectionType.General, "Fast monsters", spacer: true)]
+    [OptionMenu(OptionSectionType.General, "Fast Monsters", spacer: true)]
     public readonly ConfigValue<bool> FastMonsters = new(false);
 
     [ConfigInfo("Enables monster closet detection and limited monster AI.", mapRestartRequired: true, demo: true)]
-    [OptionMenu(OptionSectionType.General, "Monster closet detection")]
+    [OptionMenu(OptionSectionType.General, "Monster Closet Detection")]
     public readonly ConfigValue<bool> MonsterCloset = new(true);
 
-    [ConfigInfo("The skill level to use when starting a map.", save: false, demo: true)]
+    [ConfigInfo("Skill level to use when starting a map.", save: false, demo: true)]
     public readonly ConfigValue<SkillLevel> Skill = new(SkillLevel.Medium, ConfigSetFlags.OnNewWorld, OnlyValidEnums<SkillLevel>());
 
     [ConfigInfo("If stats should be written to levelstat.txt.", save: false)]
@@ -57,15 +57,15 @@ public class ConfigGame
     [ConfigInfo("Whether no monsters should be spawned.", save: false, serialize: true)]
     public readonly ConfigValue<bool> NoMonsters = new(false);
 
-    [ConfigInfo("Resets the players inventory at the start of each map.", save: false, serialize: true)]
+    [ConfigInfo("Resets the player's inventory at the start of each map.", save: false, serialize: true)]
     public readonly ConfigValue<bool> PistolStart = new(false);
 
-    [ConfigInfo("Marks lines and secctors that are activated by a special in the automap.")]
-    [OptionMenu(OptionSectionType.General, "Mark specials", spacer: true)]
+    [ConfigInfo("Marks lines and sectors that are activated by a special in the automap.")]
+    [OptionMenu(OptionSectionType.General, "Mark Specials", spacer: true)]
     public readonly ConfigValue<bool> MarkSpecials = new(false);
 
     [ConfigInfo("Marks secret sectors in the automap.")]
-    [OptionMenu(OptionSectionType.General, "Mark secrets")]
+    [OptionMenu(OptionSectionType.General, "Mark Secrets")]
     public readonly ConfigValue<bool> MarkSecrets = new(false);
 
     public SkillDef? SelectedSkillDefinition { get; set; }

--- a/Core/Util/Configs/Components/ConfigHud.cs
+++ b/Core/Util/Configs/Components/ConfigHud.cs
@@ -34,19 +34,19 @@ public class ConfigHudAutoMap
     public readonly ConfigValue<bool> Rotate = new(true);
 
     [ConfigInfo("Background color for the default automap.")]
-    [OptionMenu(OptionSectionType.Automap, "Background color")]
+    [OptionMenu(OptionSectionType.Automap, "Background Color")]
     public readonly ConfigValue<Vec3I> BackgroundColor = new((0, 0, 0), ClampColor);
 
     [ConfigInfo("Backdrop color for the overlay automap.")]
-    [OptionMenu(OptionSectionType.Automap, "Backdrop color")]
+    [OptionMenu(OptionSectionType.Automap, "Backdrop Color")]
     public readonly ConfigValue<Vec3I> OverlayBackdropColor = new((0, 0, 0), ClampColor);
 
     [ConfigInfo("Background color transparency when using overlay.")]
-    [OptionMenu(OptionSectionType.Automap, "Backdrop transparency")]
+    [OptionMenu(OptionSectionType.Automap, "Backdrop Transparency")]
     public readonly ConfigValue<double> OverlayBackdropTransparency = new(0.7, ClampNormalized);
 
     [ConfigInfo("Shows map title on the automap.")]
-    [OptionMenu(OptionSectionType.Automap, "Show map title")]
+    [OptionMenu(OptionSectionType.Automap, "Show Map Title")]
     public readonly ConfigValue<bool> MapTitle = new(true);
 
     public AutomapLineColors DefaultColors = new(false);
@@ -60,54 +60,54 @@ public class AutomapLineColors(bool overlay)
     public readonly ConfigValueHeader Header = new(overlay ? "Overlay Colors" : "Default Colors");
 
     [ConfigInfo("One-sided wall color for the automap.")]
-    [OptionMenu(OptionSectionType.Automap, "Wall color")]
+    [OptionMenu(OptionSectionType.Automap, "Wall Color")]
     public readonly ConfigValue<Vec3I> WallColor = new(overlay ? (0, 0xFF, 0) : (0xFF, 0xFF, 0xFF), ClampColor);
 
     [ConfigInfo("One-sided wall color for the automap.")]
-    [OptionMenu(OptionSectionType.Automap, "Two-sided wall color")]
+    [OptionMenu(OptionSectionType.Automap, "Two-sided Wall Color")]
     public readonly ConfigValue<Vec3I> TwoSidedWallColor = new(overlay ? (0, 0x80, 0) : (0x80, 0x80, 0x80), ClampColor);
 
     [ConfigInfo("Unseen wall color for the automap.")]
-    [OptionMenu(OptionSectionType.Automap, "Unseen wall color")]
+    [OptionMenu(OptionSectionType.Automap, "Unseen Wall Color")]
     public readonly ConfigValue<Vec3I> UnseenWallColor = new(overlay ? (0, 0x80, 0) : (0x80, 0x80, 0x80), ClampColor);
 
     [ConfigInfo("Teleport line color for the automap.")]
-    [OptionMenu(OptionSectionType.Automap, "Teleport line color")]
+    [OptionMenu(OptionSectionType.Automap, "Teleport Line Color")]
     public readonly ConfigValue<Vec3I> TeleportLineColor = new(overlay ? (0xFF, 0x00, 0xFF) : (0x00, 0xFF, 0x00), ClampColor);
 
     [ConfigInfo("Player color for the automap.")]
-    [OptionMenu(OptionSectionType.Automap, "Player color")]
+    [OptionMenu(OptionSectionType.Automap, "Player Color")]
     public readonly ConfigValue<Vec3I> PlayerColor = new(overlay ? (0xFF, 0xFF, 0xFF) : (0x00, 0xFF, 0x00), ClampColor);
 
     [ConfigInfo("Thing color for the automap.")]
-    [OptionMenu(OptionSectionType.Automap, "Thing color")]
+    [OptionMenu(OptionSectionType.Automap, "Thing Color")]
     public readonly ConfigValue<Vec3I> ThingColor = new((0xFF, 0xFF, 0x00), ClampColor);
 
     [ConfigInfo("Pickup thing color for the automap.")]
-    [OptionMenu(OptionSectionType.Automap, "Pickup color")]
+    [OptionMenu(OptionSectionType.Automap, "Pickup Color")]
     public readonly ConfigValue<Vec3I> PickupColor = new(overlay ? (0x00, 0x00, 0xFF) : (0x00, 0xFF, 0x00), ClampColor);
 
     [ConfigInfo("Monster color for the automap.")]
-    [OptionMenu(OptionSectionType.Automap, "Monster color")]
+    [OptionMenu(OptionSectionType.Automap, "Monster Color")]
     public readonly ConfigValue<Vec3I> MonsterColor = new((0xFF, 0x00, 0x00), ClampColor);
 
     [ConfigInfo("Dead monster color for the automap.")]
-    [OptionMenu(OptionSectionType.Automap, "Dead monster color")]
+    [OptionMenu(OptionSectionType.Automap, "Dead Monster Color")]
     public readonly ConfigValue<Vec3I> DeadMonsterColor = new((0x80, 0x80, 0x80), ClampColor);
 
     [ConfigInfo("Marker color for the automap.")]
-    [OptionMenu(OptionSectionType.Automap, "Marker color")]
+    [OptionMenu(OptionSectionType.Automap, "Marker Color")]
     public readonly ConfigValue<Vec3I> MakerColor = new((0x80, 0x00, 0x80), ClampColor);
 
     [ConfigInfo("Alt marker color for the automap.")]
-    [OptionMenu(OptionSectionType.Automap, "Marker color alt")]
+    [OptionMenu(OptionSectionType.Automap, "Marker Color Alt")]
     public readonly ConfigValue<Vec3I> AltMakerColor = new((0xAD, 0xD8, 0xE6), ClampColor);
 }
 
 public class ConfigHud
 {
     [ConfigInfo("Shows crosshair.")]
-    [OptionMenu(OptionSectionType.Hud, "Crosshair enabled")]
+    [OptionMenu(OptionSectionType.Hud, "Crosshair Enabled")]
     public readonly ConfigValue<bool> Crosshair = new(true);
 
     [ConfigInfo("Crosshair type.")]
@@ -115,35 +115,35 @@ public class ConfigHud
     public readonly ConfigValue<CrosshairStyle> CrosshairType = new(CrosshairStyle.Cross1);
 
     [ConfigInfo("Crosshair color.")]
-    [OptionMenu(OptionSectionType.Hud, "Crosshair color")]
+    [OptionMenu(OptionSectionType.Hud, "Crosshair Color")]
     public readonly ConfigValue<CrossColor> CrosshairColor = new(CrossColor.Green);
 
     [ConfigInfo("Crosshair target color.")]
-    [OptionMenu(OptionSectionType.Hud, "Crosshair target color")]
+    [OptionMenu(OptionSectionType.Hud, "Crosshair Target Color")]
     public readonly ConfigValue<CrossColor> CrosshairTargetColor = new(CrossColor.Red);
 
     [ConfigInfo("Crosshair transparency.")]
-    [OptionMenu(OptionSectionType.Hud, "Crosshair transparency")]
+    [OptionMenu(OptionSectionType.Hud, "Crosshair Transparency")]
     public readonly ConfigValue<double> CrosshairTransparency = new(0.5, ClampNormalized);
 
     [ConfigInfo("Crosshair scale.")]
-    [OptionMenu(OptionSectionType.Hud, "Crosshair scale")]
+    [OptionMenu(OptionSectionType.Hud, "Crosshair Scale")]
     public readonly ConfigValue<double> CrosshairScale = new(1.0);
 
     [ConfigInfo("The amount of view bobbing. 0.0 is off, 1.0 is normal.")]
-    [OptionMenu(OptionSectionType.Hud, "View bob", spacer: true)]
+    [OptionMenu(OptionSectionType.Hud, "View Bob", spacer: true)]
     public readonly ConfigValue<double> ViewBob = new(1.0, ClampNormalized);
 
     [ConfigInfo("The amount of weapon bobbing. 0.0 is off, 1.0 is normal.")]
-    [OptionMenu(OptionSectionType.Hud, "Weapon bob")]
+    [OptionMenu(OptionSectionType.Hud, "Weapon Bob")]
     public readonly ConfigValue<double> WeaponBob = new(1.0, ClampNormalized);
 
     [ConfigInfo("The size of the status bar.")]
-    [OptionMenu(OptionSectionType.Hud, "Status bar size", spacer: true)]
+    [OptionMenu(OptionSectionType.Hud, "Status Bar Size", spacer: true)]
     public readonly ConfigValue<StatusBarSizeType> StatusBarSize = new(StatusBarSizeType.Minimal, OnlyValidEnums<StatusBarSizeType>());
 
     [ConfigInfo("Background texture for status bar when it doesn't fill the screen.")]
-    [OptionMenu(OptionSectionType.Hud, "Status bar texture")]
+    [OptionMenu(OptionSectionType.Hud, "Status Bar Texture")]
     public readonly ConfigValue<string> BackgroundTexture = new("W94_1");
 
     [ConfigInfo("If average frames per second should be rendered.")]
@@ -155,27 +155,27 @@ public class ConfigHud
     public readonly ConfigValue<bool> ShowMinMaxFPS = new(false);
 
     [ConfigInfo("If the world stats should be rendered.")]
-    [OptionMenu(OptionSectionType.Hud, "Show world stats")]
+    [OptionMenu(OptionSectionType.Hud, "Show World Stats")]
     public readonly ConfigValue<bool> ShowStats = new(false);
 
-    [ConfigInfo("If the hud should be autoscaled.")]
-    [OptionMenu(OptionSectionType.Hud, "Autoscale hud", spacer: true)]
+    [ConfigInfo("If the HUD should be autoscaled.")]
+    [OptionMenu(OptionSectionType.Hud, "Autoscale HUD", spacer: true)]
     public readonly ConfigValue<bool> AutoScale = new(true);
 
-    [ConfigInfo("Amount to scale the hud.")]
-    [OptionMenu(OptionSectionType.Hud, "Hud scale")]
+    [ConfigInfo("Amount to scale the HUD.")]
+    [OptionMenu(OptionSectionType.Hud, "HUD Scale")]
     public readonly ConfigValue<double> Scale = new(2.0, Greater(0.0));
 
-    [ConfigInfo("Amount of hud transparency.")]
-    [OptionMenu(OptionSectionType.Hud, "Hud transparency")]
+    [ConfigInfo("Amount of HUD transparency.")]
+    [OptionMenu(OptionSectionType.Hud, "HUD Transparency")]
     public readonly ConfigValue<double> Transparency = new(0.0, ClampNormalized);
 
-    [ConfigInfo("Max hud messages.")]
-    [OptionMenu(OptionSectionType.Hud, "Max hud messages")]
+    [ConfigInfo("Max HUD messages.")]
+    [OptionMenu(OptionSectionType.Hud, "Max HUD Messages")]
     public readonly ConfigValue<int> MaxMessages = new(4, GreaterOrEqual(0));
 
-    [ConfigInfo("Horizontal hud margin percentage.")]
-    [OptionMenu(OptionSectionType.Hud, "Horizontal margin percent (0.0 - 1.0)")]
+    [ConfigInfo("Horizontal HUD margin percentage  (0.0 - 1.0).")]
+    [OptionMenu(OptionSectionType.Hud, "Horizontal Margin Percent")]
     public readonly ConfigValue<double> HorizontalMargin = new(0, ClampNormalized);
 
     public readonly ConfigHudAutoMap AutoMap = new();

--- a/Core/Util/Configs/Components/ConfigHud.cs
+++ b/Core/Util/Configs/Components/ConfigHud.cs
@@ -45,7 +45,7 @@ public class ConfigHudAutoMap
     [OptionMenu(OptionSectionType.Automap, "Backdrop Transparency")]
     public readonly ConfigValue<double> OverlayBackdropTransparency = new(0.7, ClampNormalized);
 
-    [ConfigInfo("Shows map title on the automap.")]
+    [ConfigInfo("Show map title on the automap.")]
     [OptionMenu(OptionSectionType.Automap, "Show Map Title")]
     public readonly ConfigValue<bool> MapTitle = new(true);
 

--- a/Core/Util/Configs/Components/ConfigHud.cs
+++ b/Core/Util/Configs/Components/ConfigHud.cs
@@ -130,15 +130,15 @@ public class ConfigHud
     [OptionMenu(OptionSectionType.Hud, "Crosshair Scale")]
     public readonly ConfigValue<double> CrosshairScale = new(1.0);
 
-    [ConfigInfo("The amount of view bobbing. 0.0 is off, 1.0 is normal.")]
+    [ConfigInfo("Amount of view bobbing. 0.0 is off, 1.0 is normal.")]
     [OptionMenu(OptionSectionType.Hud, "View Bob", spacer: true)]
     public readonly ConfigValue<double> ViewBob = new(1.0, ClampNormalized);
 
-    [ConfigInfo("The amount of weapon bobbing. 0.0 is off, 1.0 is normal.")]
+    [ConfigInfo("Amount of weapon bobbing. 0.0 is off, 1.0 is normal.")]
     [OptionMenu(OptionSectionType.Hud, "Weapon Bob")]
     public readonly ConfigValue<double> WeaponBob = new(1.0, ClampNormalized);
 
-    [ConfigInfo("The size of the status bar.")]
+    [ConfigInfo("Size of the status bar.")]
     [OptionMenu(OptionSectionType.Hud, "Status Bar Size", spacer: true)]
     public readonly ConfigValue<StatusBarSizeType> StatusBarSize = new(StatusBarSizeType.Minimal, OnlyValidEnums<StatusBarSizeType>());
 
@@ -146,19 +146,19 @@ public class ConfigHud
     [OptionMenu(OptionSectionType.Hud, "Status Bar Texture")]
     public readonly ConfigValue<string> BackgroundTexture = new("W94_1");
 
-    [ConfigInfo("If average frames per second should be rendered.")]
+    [ConfigInfo("Render average frames per second in corner of display.")]
     [OptionMenu(OptionSectionType.Hud, "Show FPS", spacer: true)]
     public readonly ConfigValue<bool> ShowFPS = new(false);
 
-    [ConfigInfo("If min/max frames per second should be rendered.")]
+    [ConfigInfo("Render min/max frames per second in corner of display.")]
     [OptionMenu(OptionSectionType.Hud, "Show Min/Max FPS")]
     public readonly ConfigValue<bool> ShowMinMaxFPS = new(false);
 
-    [ConfigInfo("If the world stats should be rendered.")]
+    [ConfigInfo("Render world statistics (kills, secrets, items, time) in corner of display.")]
     [OptionMenu(OptionSectionType.Hud, "Show World Stats")]
     public readonly ConfigValue<bool> ShowStats = new(false);
 
-    [ConfigInfo("If the HUD should be autoscaled.")]
+    [ConfigInfo("Automatically scale HUD.")]
     [OptionMenu(OptionSectionType.Hud, "Autoscale HUD", spacer: true)]
     public readonly ConfigValue<bool> AutoScale = new(true);
 
@@ -181,6 +181,6 @@ public class ConfigHud
     public readonly ConfigHudAutoMap AutoMap = new();
 
     // Legacy stuff
-    [ConfigInfo("The amount of view and weapon bobbing. 0.0 is off, 1.0 is normal.", legacy: true)]
+    [ConfigInfo("Amount of view and weapon bobbing. 0.0 is off, 1.0 is normal.", legacy: true)]
     public readonly ConfigValue<double> MoveBob = new(1.0, ClampNormalized);
 }

--- a/Core/Util/Configs/Components/ConfigMouse.cs
+++ b/Core/Util/Configs/Components/ConfigMouse.cs
@@ -6,7 +6,7 @@ namespace Helion.Util.Configs.Components;
 
 public class ConfigMouse
 {
-    [ConfigInfo("If the player can look up and down with the mouse.", demo: true)]
+    [ConfigInfo("Player can look up and down with the mouse.", demo: true)]
     [OptionMenu(OptionSectionType.Mouse, "Mouse Look")]
     public readonly ConfigValue<bool> Look = new(true);
     
@@ -14,7 +14,7 @@ public class ConfigMouse
     [OptionMenu(OptionSectionType.Mouse, "Movement Speed")]
     public readonly ConfigValue<double> ForwardBackwardSpeed = new(0, GreaterOrEqual(0.0));
 
-    [ConfigInfo("A scale for both the pitch and yaw, meaning this affects both axes.")]
+    [ConfigInfo("Scale for both the pitch and yaw (affects both axes).")]
     [OptionMenu(OptionSectionType.Mouse, "Overall Sensitivity", spacer: true)]
     public readonly ConfigValue<double> Sensitivity = new(1.0);
 
@@ -30,14 +30,14 @@ public class ConfigMouse
     [OptionMenu(OptionSectionType.Mouse, "Invert Y", spacer: true)]
     public readonly ConfigValue<bool> InvertY = new(false);
 
-    [ConfigInfo("If mouse input should be interpolated.")]
+    [ConfigInfo("Interpolate mouse input.")]
     [OptionMenu(OptionSectionType.Mouse, "Interpolate")]
     public readonly ConfigValue<bool> Interpolate = new(false);
 
-    [ConfigInfo("If the mouse should be focused on the window or not.")]
+    [ConfigInfo("Application window steals mouse focus when active.")]
     [OptionMenu(OptionSectionType.Mouse, "Focus")]
     public readonly ConfigValue<bool> Focus = new(true);
 
-    [ConfigInfo("A scaling divisor that allows other sensitivities to be reasonable values.")]
+    [ConfigInfo("Scaling divisor that allows other sensitivities to be reasonable values.")]
     public readonly ConfigValue<double> PixelDivisor = new(1024.0, Greater(0.0));
 }

--- a/Core/Util/Configs/Components/ConfigMouse.cs
+++ b/Core/Util/Configs/Components/ConfigMouse.cs
@@ -6,23 +6,23 @@ namespace Helion.Util.Configs.Components;
 
 public class ConfigMouse
 {
-    [ConfigInfo("If we should be able to look around the level with the mouse.", demo: true)]
-    [OptionMenu(OptionSectionType.Mouse, "Mouse look")]
+    [ConfigInfo("If the player can look up and down with the mouse.", demo: true)]
+    [OptionMenu(OptionSectionType.Mouse, "Mouse Look")]
     public readonly ConfigValue<bool> Look = new(true);
     
     [ConfigInfo("Forward/backward movement speed.")]
-    [OptionMenu(OptionSectionType.Mouse, "Movement speed")]
+    [OptionMenu(OptionSectionType.Mouse, "Movement Speed")]
     public readonly ConfigValue<double> ForwardBackwardSpeed = new(0, GreaterOrEqual(0.0));
 
-    [ConfigInfo("A scale for both the pitch and yaw, meaning this affects both axis.")]
-    [OptionMenu(OptionSectionType.Mouse, "Sensitivity", spacer: true)]
+    [ConfigInfo("A scale for both the pitch and yaw, meaning this affects both axes.")]
+    [OptionMenu(OptionSectionType.Mouse, "Overall Sensitivity", spacer: true)]
     public readonly ConfigValue<double> Sensitivity = new(1.0);
 
-    [ConfigInfo("The vertical sensitivity. This is multiplied by the sensitivity value for a final calculation.")]
+    [ConfigInfo("Vertical sensitivity. This is multiplied by the overall sensitivity value.")]
     [OptionMenu(OptionSectionType.Mouse, "Vertical Sensitivity")]
     public readonly ConfigValue<double> Pitch = new(1.0);
 
-    [ConfigInfo("The horizontal sensitivity. This is multiplied by the sensitivity value for a final calculation.")]
+    [ConfigInfo("Horizontal sensitivity. This is multiplied by the overall sensitivity value.")]
     [OptionMenu(OptionSectionType.Mouse, "Horizontal Sensitivity")]
     public readonly ConfigValue<double> Yaw = new(1.0);
     
@@ -30,7 +30,7 @@ public class ConfigMouse
     [OptionMenu(OptionSectionType.Mouse, "Invert Y", spacer: true)]
     public readonly ConfigValue<bool> InvertY = new(false);
 
-    [ConfigInfo("If the mouse should interpolate.")]
+    [ConfigInfo("If mouse input should be interpolated.")]
     [OptionMenu(OptionSectionType.Mouse, "Interpolate")]
     public readonly ConfigValue<bool> Interpolate = new(false);
 

--- a/Core/Util/Configs/Components/ConfigPlayer.cs
+++ b/Core/Util/Configs/Components/ConfigPlayer.cs
@@ -7,11 +7,11 @@ namespace Helion.Util.Configs.Components;
 
 public class ConfigPlayer
 {
-    [ConfigInfo("The name of the player.")]
+    [ConfigInfo("Name of the player.")]
     [OptionMenu(OptionSectionType.General, "Player Name", spacer: true)]
     public readonly ConfigValue<string> Name = new("Player", IfEmptyDefaultTo("Player"));
 
-    [ConfigInfo("The gender of the player.")]
+    [ConfigInfo("Gender of the player.")]
     [OptionMenu(OptionSectionType.General, "Player Gender")]
     public readonly ConfigValue<PlayerGender> Gender = new(default, OnlyValidEnums<PlayerGender>());
 }

--- a/Core/Util/Configs/Components/ConfigRender.cs
+++ b/Core/Util/Configs/Components/ConfigRender.cs
@@ -40,7 +40,7 @@ public class ConfigRenderFilter
 
 public class ConfigRender
 {
-    [ConfigInfo("Vertical synchronization. Prevents tearing, but affects input processing (unless you have g-sync).")]
+    [ConfigInfo("Vertical synchronization. Prevents tearing, but affects input processing (unless you have G-Sync).")]
     [OptionMenu(OptionSectionType.Render, "VSync")]
     public readonly ConfigValue<RenderVsyncMode> VSync = new(RenderVsyncMode.On);
 

--- a/Core/Util/Configs/Components/ConfigRender.cs
+++ b/Core/Util/Configs/Components/ConfigRender.cs
@@ -101,7 +101,7 @@ public class ConfigRender
     [OptionMenu(OptionSectionType.Render, "Light Mode", spacer: true)]
     public readonly ConfigValue<RenderLightMode> LightMode = new(RenderLightMode.Smooth);
 
-    [ConfigInfo("Adds to the rendering light level offset.")]
+    [ConfigInfo("Added light level offset.")]
     [OptionMenu(OptionSectionType.Render, "Extra Lighting")]
     public readonly ConfigValue<int> ExtraLight = new(0);
 
@@ -109,7 +109,7 @@ public class ConfigRender
     [OptionMenu(OptionSectionType.Render, "Full Brightness")]
     public readonly ConfigValue<bool> Fullbright = new(false);
 
-    [ConfigInfo("Traverse the BSP in a separate thread to mark lines seen for automap. Ignored if using BSP rendering.")]
+    [ConfigInfo("Traverse the BSP tree in a separate thread to mark lines seen for automap. If disabled, automap always shows all lines.")]
     [OptionMenu(OptionSectionType.Render, "Automap on Separate Thread")]
     public readonly ConfigValue<bool> AutomapBspThread = new(true);
 

--- a/Core/Util/Configs/Components/ConfigRender.cs
+++ b/Core/Util/Configs/Components/ConfigRender.cs
@@ -28,23 +28,23 @@ public enum RenderLightMode
 
 public class ConfigRenderFilter
 {
-    [ConfigInfo("Kind of filter applied to fonts.")]
+    [ConfigInfo("Filter applied to fonts.")]
     // TODO need to implement to take effect
     //[OptionMenu(OptionSectionType.Render, "Font filtering")]
     public readonly ConfigValue<FilterType> Font = new(FilterType.Nearest, OnlyValidEnums<FilterType>());
 
-    [ConfigInfo("Filter to be applied to textures. True color required.")]
+    [ConfigInfo("Filter applied to textures. True color required.")]
     [OptionMenu(OptionSectionType.Render, "Texture Filtering", spacer: true)]
     public readonly ConfigValue<FilterType> Texture = new(FilterType.Nearest, OnlyValidEnums<FilterType>());
 }
 
 public class ConfigRender
 {
-    [ConfigInfo("If VSync should be on or off. Prevents tearing, but affects input processing (unless you have g-sync).")]
+    [ConfigInfo("Vertical synchronization. Prevents tearing, but affects input processing (unless you have g-sync).")]
     [OptionMenu(OptionSectionType.Render, "VSync")]
     public readonly ConfigValue<RenderVsyncMode> VSync = new(RenderVsyncMode.On);
 
-    [ConfigInfo("A cap on the maximum amount of frames per second. Zero is equivalent to no cap.")]
+    [ConfigInfo("Maximum frames per second. Zero is equivalent to no cap.")]
     [OptionMenu(OptionSectionType.Render, "Max FPS")]
     public readonly ConfigValue<int> MaxFPS = new(250, fps =>
     {
@@ -82,7 +82,7 @@ public class ConfigRender
     [OptionMenu(OptionSectionType.Render, "Emulate Vanilla Contrast")]
     public readonly ConfigValue<bool> FakeContrast = new(true);
 
-    [ConfigInfo("If true, forces the pipeline to be flushed after rendering a frame. May fix a laggy buffered feeling on lower end computers.")]
+    [ConfigInfo("Force pipeline flush after rendering each frame. May fix a laggy buffered feeling on lower end computers.")]
     [OptionMenu(OptionSectionType.Render, "Pipeline Flush (for old GPUs)")]
     public readonly ConfigValue<bool> ForcePipelineFlush = new(false);
 
@@ -93,11 +93,11 @@ public class ConfigRender
     [OptionMenu(OptionSectionType.Render, "Cache All Sprites")]
     public readonly ConfigValue<bool> CacheSprites = new(true);
 
-    [ConfigInfo("Renders sprites over floors/ceilings. Sprites always clipped to walls.", mapRestartRequired: true)]
+    [ConfigInfo("Render sprites over floors/ceilings. Sprites always clipped to walls.", mapRestartRequired: true)]
     [OptionMenu(OptionSectionType.Render, "Emulate Vanilla Rendering", spacer: true)]
     public readonly ConfigValue<bool> VanillaRender = new(false);
 
-    [ConfigInfo("Sets light projection to banded or smooth. Smooth only supported with true color rendering.")]
+    [ConfigInfo("Set light projection to banded or smooth. Smooth only supported with true color rendering.")]
     [OptionMenu(OptionSectionType.Render, "Light Mode", spacer: true)]
     public readonly ConfigValue<RenderLightMode> LightMode = new(RenderLightMode.Smooth);
 
@@ -105,15 +105,15 @@ public class ConfigRender
     [OptionMenu(OptionSectionType.Render, "Extra Lighting")]
     public readonly ConfigValue<int> ExtraLight = new(0);
 
-    [ConfigInfo("Draws everything at full brightness.")]
+    [ConfigInfo("Draw everything at full brightness.")]
     [OptionMenu(OptionSectionType.Render, "Full Brightness")]
     public readonly ConfigValue<bool> Fullbright = new(false);
 
-    [ConfigInfo("Traverses the BSP in a separate thread to mark lines seen for automap. Ignored if using BSP rendering.")]
+    [ConfigInfo("Traverse the BSP in a separate thread to mark lines seen for automap. Ignored if using BSP rendering.")]
     [OptionMenu(OptionSectionType.Render, "Automap on Separate Thread")]
     public readonly ConfigValue<bool> AutomapBspThread = new(true);
 
-    [ConfigInfo("Renders missing textures as a red/black checkered texture.", mapRestartRequired: true)]
+    [ConfigInfo("Render missing textures as a red/black checkered texture.", mapRestartRequired: true)]
     [OptionMenu(OptionSectionType.Render, "Render Null Textures")]
     public readonly ConfigValue<bool> NullTexture = new(false);
 
@@ -121,7 +121,7 @@ public class ConfigRender
     [OptionMenu(OptionSectionType.Render, "Fuzz Amount")]
     public readonly ConfigValue<double> FuzzAmount = new(1);
 
-    [ConfigInfo("If any sprite should clip the floor.")]
+    [ConfigInfo("Clip sprites against the floor.")]
     [OptionMenu(OptionSectionType.Render, "Sprite Floor Clip", spacer: true)]
     public readonly ConfigValue<bool> SpriteClip = new(true);
 
@@ -133,7 +133,7 @@ public class ConfigRender
     [OptionMenu(OptionSectionType.Render, "Clip Min Height")]
     public readonly ConfigValue<int> SpriteClipMin = new(16, GreaterOrEqual(0));
 
-    [ConfigInfo("Checks if sprites will overlap and Z-fight.")]
+    [ConfigInfo("Prevent sprites from overlapping and Z-fighting.")]
     [OptionMenu(OptionSectionType.Render, "Sprite Z-fighting Check")]
     public readonly ConfigValue<bool> SpriteZCheck = new(true);
 }

--- a/Core/Util/Configs/Components/ConfigRender.cs
+++ b/Core/Util/Configs/Components/ConfigRender.cs
@@ -28,13 +28,13 @@ public enum RenderLightMode
 
 public class ConfigRenderFilter
 {
-    [ConfigInfo("The kind of filter applied to fonts.")]
+    [ConfigInfo("Kind of filter applied to fonts.")]
     // TODO need to implement to take effect
     //[OptionMenu(OptionSectionType.Render, "Font filtering")]
     public readonly ConfigValue<FilterType> Font = new(FilterType.Nearest, OnlyValidEnums<FilterType>());
 
-    [ConfigInfo("The filter to be applied to textures. True color required.")]
-    [OptionMenu(OptionSectionType.Render, "Texture filtering", spacer: true)]
+    [ConfigInfo("Filter to be applied to textures. True color required.")]
+    [OptionMenu(OptionSectionType.Render, "Texture Filtering", spacer: true)]
     public readonly ConfigValue<FilterType> Texture = new(FilterType.Nearest, OnlyValidEnums<FilterType>());
 }
 
@@ -57,83 +57,83 @@ public class ConfigRender
     });
 
     [ConfigInfo("Field of view. Default = 90")]
-    [OptionMenu(OptionSectionType.Render, "Field of view")]
+    [OptionMenu(OptionSectionType.Render, "Field Of View")]
     public readonly ConfigValue<double> FieldOfView = new(90, Clamp(60.0, 120.0));
 
     [ConfigInfo("Max render distance.")]
-    [OptionMenu(OptionSectionType.Render, "Max rendering distance")]
+    [OptionMenu(OptionSectionType.Render, "Max Rendering Distance")]
     public readonly ConfigValue<int> MaxDistance = new(0);
 
     public readonly ConfigRenderFilter Filter = new();
 
-    [ConfigInfo("The anisotropic filtering amount. A value of 1 is the same as being off. True color required.")]
+    [ConfigInfo("Anisotropic filtering amount. A value of 1 is the same as being off. True color required.")]
     [OptionMenu(OptionSectionType.Render, "Anisotropy")]
     public readonly ConfigValue<int> Anisotropy = new(8, GreaterOrEqual(1));
 
     [ConfigInfo("Enable sprite transparency.")]
-    [OptionMenu(OptionSectionType.Render, "Sprite transparency", spacer: true)]
+    [OptionMenu(OptionSectionType.Render, "Sprite Transparency", spacer: true)]
     public readonly ConfigValue<bool> SpriteTransparency = new(true);
 
     [ConfigInfo("Enable texture transparency.")]
-    [OptionMenu(OptionSectionType.Render, "Texture transparency")]
+    [OptionMenu(OptionSectionType.Render, "Texture Transparency")]
     public readonly ConfigValue<bool> TextureTransparency = new(true);
 
     [ConfigInfo("Emulate fake contrast like vanilla Doom.")]
-    [OptionMenu(OptionSectionType.Render, "Emulate vanilla contrast")]
+    [OptionMenu(OptionSectionType.Render, "Emulate Vanilla Contrast")]
     public readonly ConfigValue<bool> FakeContrast = new(true);
 
     [ConfigInfo("If true, forces the pipeline to be flushed after rendering a frame. May fix a laggy buffered feeling on lower end computers.")]
-    [OptionMenu(OptionSectionType.Render, "Pipeline flush (for old GPUs)")]
+    [OptionMenu(OptionSectionType.Render, "Pipeline Flush (for old GPUs)")]
     public readonly ConfigValue<bool> ForcePipelineFlush = new(false);
 
-    [ConfigInfo("The multisampling amount. A value of 1 is the same as being off.")]
+    [ConfigInfo("Multisampling amount. A value of 1 is the same as being off.")]
     public readonly ConfigValue<int> Multisample = new(1, GreaterOrEqual(1));
 
     [ConfigInfo("Cache all sprites. Prevents stuttering compared to loading them at runtime.", restartRequired: true)]
-    [OptionMenu(OptionSectionType.Render, "Cache all sprites")]
+    [OptionMenu(OptionSectionType.Render, "Cache All Sprites")]
     public readonly ConfigValue<bool> CacheSprites = new(true);
 
     [ConfigInfo("Renders sprites over floors/ceilings. Sprites always clipped to walls.", mapRestartRequired: true)]
-    [OptionMenu(OptionSectionType.Render, "Emulate vanilla rendering", spacer: true)]
+    [OptionMenu(OptionSectionType.Render, "Emulate Vanilla Rendering", spacer: true)]
     public readonly ConfigValue<bool> VanillaRender = new(false);
 
     [ConfigInfo("Sets light projection to banded or smooth. Smooth only supported with true color rendering.")]
-    [OptionMenu(OptionSectionType.Render, "Light mode", spacer: true)]
+    [OptionMenu(OptionSectionType.Render, "Light Mode", spacer: true)]
     public readonly ConfigValue<RenderLightMode> LightMode = new(RenderLightMode.Smooth);
 
     [ConfigInfo("Adds to the rendering light level offset.")]
-    [OptionMenu(OptionSectionType.Render, "Extra lighting")]
+    [OptionMenu(OptionSectionType.Render, "Extra Lighting")]
     public readonly ConfigValue<int> ExtraLight = new(0);
 
     [ConfigInfo("Draws everything at full brightness.")]
-    [OptionMenu(OptionSectionType.Render, "Full brightness")]
+    [OptionMenu(OptionSectionType.Render, "Full Brightness")]
     public readonly ConfigValue<bool> Fullbright = new(false);
 
     [ConfigInfo("Traverses the BSP in a separate thread to mark lines seen for automap. Ignored if using BSP rendering.")]
-    [OptionMenu(OptionSectionType.Render, "Automap on separate thread")]
+    [OptionMenu(OptionSectionType.Render, "Automap on Separate Thread")]
     public readonly ConfigValue<bool> AutomapBspThread = new(true);
 
-    [ConfigInfo("Enable rendering missing textures as a red/black checkered texture.", mapRestartRequired: true)]
-    [OptionMenu(OptionSectionType.Render, "Render null textures")]
+    [ConfigInfo("Renders missing textures as a red/black checkered texture.", mapRestartRequired: true)]
+    [OptionMenu(OptionSectionType.Render, "Render Null Textures")]
     public readonly ConfigValue<bool> NullTexture = new(false);
 
-    [ConfigInfo("Fuzz amount.")]
-    [OptionMenu(OptionSectionType.Render, "Fuzz amount")]
+    [ConfigInfo("Fuzz amount for partial invisibility effect.")]
+    [OptionMenu(OptionSectionType.Render, "Fuzz Amount")]
     public readonly ConfigValue<double> FuzzAmount = new(1);
 
     [ConfigInfo("If any sprite should clip the floor.")]
-    [OptionMenu(OptionSectionType.Render, "Sprite floor clip", spacer: true)]
+    [OptionMenu(OptionSectionType.Render, "Sprite Floor Clip", spacer: true)]
     public readonly ConfigValue<bool> SpriteClip = new(true);
 
     [ConfigInfo("Max percentage of height allowed to clip the floor for corpses.")]
-    [OptionMenu(OptionSectionType.Render, "Clip max height percentage")]
+    [OptionMenu(OptionSectionType.Render, "Clip Max Height Percentage")]
     public readonly ConfigValue<double> SpriteClipFactorMax = new(0.02, ClampNormalized);
 
-    [ConfigInfo("The minimum sprite height to allow to clip the floor.")]
-    [OptionMenu(OptionSectionType.Render, "Clip min height")]
+    [ConfigInfo("Minimum sprite height to allow to clip the floor.")]
+    [OptionMenu(OptionSectionType.Render, "Clip Min Height")]
     public readonly ConfigValue<int> SpriteClipMin = new(16, GreaterOrEqual(0));
 
-    [ConfigInfo("Checks if sprites will overlap and z-fight.")]
-    [OptionMenu(OptionSectionType.Render, "Sprite Z-fighting check")]
+    [ConfigInfo("Checks if sprites will overlap and Z-fight.")]
+    [OptionMenu(OptionSectionType.Render, "Sprite Z-fighting Check")]
     public readonly ConfigValue<bool> SpriteZCheck = new(true);
 }

--- a/Core/Util/Configs/Components/ConfigSlowTick.cs
+++ b/Core/Util/Configs/Components/ConfigSlowTick.cs
@@ -12,23 +12,23 @@ public class ConfigSlowTick
     [OptionMenu(OptionSectionType.SlowTick, "Enable")]
     public readonly ConfigValue<bool> Enabled = new(false);
 
-    [ConfigInfo("Distance to start slow ticking things for A_Look and A_Chase. 0 = disabled.", demo: true)]
+    [ConfigInfo("Distance to start slow ticking things for A_Look and A_Chase. 0 = Disabled.", demo: true)]
     [OptionMenu(OptionSectionType.SlowTick, "Distance")]
     public readonly ConfigValue<int> Distance = new(2000, Clamp(0, int.MaxValue));
 
-    [ConfigInfo("Number of times to skip setting a new chase direction on movement failures. 0 = disabled.", demo: true)]
-    [OptionMenu(OptionSectionType.SlowTick, "Chase failure skip count", spacer: true)]
+    [ConfigInfo("Number of times to skip setting a new chase direction on movement failures. 0 = Disabled.", demo: true)]
+    [OptionMenu(OptionSectionType.SlowTick, "Chase Failure Skip Count", spacer: true)]
     public readonly ConfigValue<int> ChaseFailureSkipCount = new(4, Clamp(0, SlowTickMultiplierMax));
 
-    [ConfigInfo("How much to multiply the ticks for chase with SlowTickDistance. 0 = disabled.", demo: true)]
-    [OptionMenu(OptionSectionType.SlowTick, "Chase multiplier")]
+    [ConfigInfo("How much to multiply the ticks for chase with SlowTickDistance. 0 = Disabled.", demo: true)]
+    [OptionMenu(OptionSectionType.SlowTick, "Chase Multiplier")]
     public readonly ConfigValue<int> ChaseMultiplier = new(4, Clamp(0, SlowTickMultiplierMax));
 
-    [ConfigInfo("How much to multiply the ticks for look with SlowTickDistance. 0 = disabled.", demo: true)]
-    [OptionMenu(OptionSectionType.SlowTick, "Look multiplier")]
+    [ConfigInfo("How much to multiply the ticks for look with SlowTickDistance. 0 = Disabled.", demo: true)]
+    [OptionMenu(OptionSectionType.SlowTick, "Look Multiplier")]
     public readonly ConfigValue<int> LookMultiplier = new(2, Clamp(0, SlowTickMultiplierMax));
 
-    [ConfigInfo("How much to multiply the ticks for tracers with SlowTickDistance. 0 = disabled.", demo: true)]
-    [OptionMenu(OptionSectionType.SlowTick, "Tracer multiplier")]
+    [ConfigInfo("How much to multiply the ticks for tracers with SlowTickDistance. 0 = Disabled.", demo: true)]
+    [OptionMenu(OptionSectionType.SlowTick, "Tracer Multiplier")]
     public readonly ConfigValue<int> TracerMultiplier = new(4, Clamp(0, SlowTickMultiplierMax));
 }

--- a/Core/Util/Configs/Components/ConfigSlowTick.cs
+++ b/Core/Util/Configs/Components/ConfigSlowTick.cs
@@ -8,27 +8,27 @@ public class ConfigSlowTick
 {
     private const int SlowTickMultiplierMax = 10;
 
-    [ConfigInfo("Enables slow ticking properties.", demo: true)]
+    [ConfigInfo("Enables slow ticking; reduces overhead by updating distant actors less frequently. ", demo: true)]
     [OptionMenu(OptionSectionType.SlowTick, "Enable")]
     public readonly ConfigValue<bool> Enabled = new(false);
 
-    [ConfigInfo("Distance to start slow ticking things for A_Look and A_Chase. 0 = Disabled.", demo: true)]
-    [OptionMenu(OptionSectionType.SlowTick, "Distance")]
+    [ConfigInfo("Distance threshold for A_Look and A_Chase. Actors beyond this distance threshold are updated less frequently. 0 = Disabled.", demo: true)]
+    [OptionMenu(OptionSectionType.SlowTick, "Distance Threshold")]
     public readonly ConfigValue<int> Distance = new(2000, Clamp(0, int.MaxValue));
 
-    [ConfigInfo("Number of times to skip setting a new chase direction on movement failures. 0 = Disabled.", demo: true)]
+    [ConfigInfo("Number of times to skip setting a new chase direction when an actor fails to move due to an obstruction. 0 = Disabled.", demo: true)]
     [OptionMenu(OptionSectionType.SlowTick, "Chase Failure Skip Count", spacer: true)]
     public readonly ConfigValue<int> ChaseFailureSkipCount = new(4, Clamp(0, SlowTickMultiplierMax));
 
-    [ConfigInfo("How much to multiply the ticks for chase with SlowTickDistance. 0 = Disabled.", demo: true)]
+    [ConfigInfo("Tick multiplier for chase beyond distance threshold. 0 = Disabled.", demo: true)]
     [OptionMenu(OptionSectionType.SlowTick, "Chase Multiplier")]
     public readonly ConfigValue<int> ChaseMultiplier = new(4, Clamp(0, SlowTickMultiplierMax));
 
-    [ConfigInfo("How much to multiply the ticks for look with SlowTickDistance. 0 = Disabled.", demo: true)]
+    [ConfigInfo("Tick multiplier for look beyond distance threshold. 0 = Disabled.", demo: true)]
     [OptionMenu(OptionSectionType.SlowTick, "Look Multiplier")]
     public readonly ConfigValue<int> LookMultiplier = new(2, Clamp(0, SlowTickMultiplierMax));
 
-    [ConfigInfo("How much to multiply the ticks for tracers with SlowTickDistance. 0 = Disabled.", demo: true)]
+    [ConfigInfo("Tick multiplier for tracers beyond distance threshold. 0 = Disabled.", demo: true)]
     [OptionMenu(OptionSectionType.SlowTick, "Tracer Multiplier")]
     public readonly ConfigValue<int> TracerMultiplier = new(4, Clamp(0, SlowTickMultiplierMax));
 }

--- a/Core/Util/Configs/Components/ConfigWindow.cs
+++ b/Core/Util/Configs/Components/ConfigWindow.cs
@@ -17,39 +17,39 @@ public enum RenderWindowState
 public class ConfigWindowVirtual
 {
     [ConfigInfo("The width and height of the virtual dimension.")]
-    [OptionMenu(OptionSectionType.Video, "Virtual size", spacer: true)]
+    [OptionMenu(OptionSectionType.Video, "Virtual Size", spacer: true)]
     public readonly ConfigValue<Dimension> Dimension = new((800, 600), (_, dim) => dim.Width >= 320 && dim.Height >= 200);
 
     [ConfigInfo("Whether virtual dimensions should be used or not.")]
-    [OptionMenu(OptionSectionType.Video, "Use virutal size")]
+    [OptionMenu(OptionSectionType.Video, "Use Virtual Size")]
     public readonly ConfigValue<bool> Enable = new(false);
 
     [ConfigInfo("Will stretch the image if widescreen, otherwise will render black bars on the side.")]
-    [OptionMenu(OptionSectionType.Video, "Stretch virtual size")]
+    [OptionMenu(OptionSectionType.Video, "Stretch Virtual Size")]
     public readonly ConfigValue<bool> Stretch = new(false);
 }
 
 public class ConfigWindow
 {
-    [ConfigInfo("The state of the window, such as if it is fullscreen or windowed.")]
+    [ConfigInfo("Whether display should be fullscreen or windowed.")]
     [OptionMenu(OptionSectionType.Video, "Fullscreen/Window")]
     public readonly ConfigValue<RenderWindowState> State = new(RenderWindowState.Fullscreen, OnlyValidEnums<RenderWindowState>());
 
-    [ConfigInfo("The border of the window.")]
+    [ConfigInfo("Window border.")]
     [OptionMenu(OptionSectionType.Video, "Border")]
     public readonly ConfigValue<WindowBorder> Border = new(WindowBorder.Resizable, OnlyValidEnums<WindowBorder>());
 
-    [ConfigInfo("The width and height of the window.")]
-    [OptionMenu(OptionSectionType.Video, "Window size")]
+    [ConfigInfo("Width and height of the window.")]
+    [OptionMenu(OptionSectionType.Video, "Window Size")]
     public readonly ConfigValue<Dimension> Dimension = new((1024, 768), (_, dim) => dim.Width >= 320 && dim.Height >= 200);
 
     public readonly ConfigWindowVirtual Virtual = new();
 
-    [ConfigInfo("The display number for the window. (0 = default. Use command ListDisplays for display numbers).")]
+    [ConfigInfo("Display number for the window. (0 = default. Use command ListDisplays for display numbers).")]
     [OptionMenu(OptionSectionType.Video, "Display Number", spacer: true)]
     public readonly ConfigValue<int> Display = new(0, GreaterOrEqual(0));
 
-    [ConfigInfo("Palette uses Doom's colormaps. True color is calculated from the base palette and interpolated. Disables texture filtering. Application restart required.", restartRequired: true)]
-    [OptionMenu(OptionSectionType.Video, "Color mode")]
+    [ConfigInfo("Palette uses Doom's colormaps and disables texture filtering, producing output that resembles software rendering. True Color interpolates color values. Application restart required.", restartRequired: true)]
+    [OptionMenu(OptionSectionType.Video, "Color Mode")]
     public readonly ConfigValue<RenderColorMode> ColorMode = new(RenderColorMode.TrueColor);
 }

--- a/Core/Util/Configs/Components/ConfigWindow.cs
+++ b/Core/Util/Configs/Components/ConfigWindow.cs
@@ -16,22 +16,22 @@ public enum RenderWindowState
 
 public class ConfigWindowVirtual
 {
-    [ConfigInfo("The width and height of the virtual dimension.")]
+    [ConfigInfo("Virtual screen size.")]
     [OptionMenu(OptionSectionType.Video, "Virtual Size", spacer: true)]
     public readonly ConfigValue<Dimension> Dimension = new((800, 600), (_, dim) => dim.Width >= 320 && dim.Height >= 200);
 
-    [ConfigInfo("Whether virtual dimensions should be used or not.")]
+    [ConfigInfo("Use virtual screen size.")]
     [OptionMenu(OptionSectionType.Video, "Use Virtual Size")]
     public readonly ConfigValue<bool> Enable = new(false);
 
-    [ConfigInfo("Will stretch the image if widescreen, otherwise will render black bars on the side.")]
+    [ConfigInfo("Stretch the image if widescreen, or render black bars on the sides.")]
     [OptionMenu(OptionSectionType.Video, "Stretch Virtual Size")]
     public readonly ConfigValue<bool> Stretch = new(false);
 }
 
 public class ConfigWindow
 {
-    [ConfigInfo("Whether display should be fullscreen or windowed.")]
+    [ConfigInfo("Display fullscreen or windowed.")]
     [OptionMenu(OptionSectionType.Video, "Fullscreen/Window")]
     public readonly ConfigValue<RenderWindowState> State = new(RenderWindowState.Fullscreen, OnlyValidEnums<RenderWindowState>());
 
@@ -39,17 +39,17 @@ public class ConfigWindow
     [OptionMenu(OptionSectionType.Video, "Border")]
     public readonly ConfigValue<WindowBorder> Border = new(WindowBorder.Resizable, OnlyValidEnums<WindowBorder>());
 
-    [ConfigInfo("Width and height of the window.")]
+    [ConfigInfo("Window width and height.")]
     [OptionMenu(OptionSectionType.Video, "Window Size")]
     public readonly ConfigValue<Dimension> Dimension = new((1024, 768), (_, dim) => dim.Width >= 320 && dim.Height >= 200);
 
     public readonly ConfigWindowVirtual Virtual = new();
 
-    [ConfigInfo("Display number for the window. (0 = default. Use command ListDisplays for display numbers).")]
+    [ConfigInfo("Display number for the window. (0 = default. Use command ListDisplays for display numbers.)")]
     [OptionMenu(OptionSectionType.Video, "Display Number", spacer: true)]
     public readonly ConfigValue<int> Display = new(0, GreaterOrEqual(0));
 
-    [ConfigInfo("Palette uses Doom's colormaps and disables texture filtering, producing output that resembles software rendering. True Color interpolates color values. Application restart required.", restartRequired: true)]
+    [ConfigInfo("Color rendering mode: Palette uses Doom's colormaps and disables texture filtering, producing output that resembles software rendering. True Color interpolates color values. Application restart required.", restartRequired: true)]
     [OptionMenu(OptionSectionType.Video, "Color Mode")]
     public readonly ConfigValue<RenderColorMode> ColorMode = new(RenderColorMode.TrueColor);
 }


### PR DESCRIPTION
There should be no real "code" changes in this PR, only changes that impact menu and console text for various configuration options.

Let me know if you'd prefer a more conservative approach, but this was a best-effort attempt to improve the user experience in the Options menus.  It's all, unfortunately, very subjective.  😄 

In this change, I've attempted to:

1. Fix misspellings
2. Use consistent capitalization patterns, including "preferred" capitalization patterns for proper names.  This doesn't matter for the option _names_ displayed in the menus (at least, unless you switch to a font that has capital and lower-case letters), but it does matter for the help text displayed in the caption at the bottom.
3. Use consistent verbiage and tone
4. Use consistent verb tense and number
5. Remove unnecessary words-- "if X" or "whether X" can just be "X" if the values for an option are only Enabled and Disabled
6. Explain options in a clearer, less-technical way where possible.