### PR TITLE
Minor feature: saved game organizer

### DIFF
--- a/Client/Client.Commands.cs
+++ b/Client/Client.Commands.cs
@@ -290,14 +290,16 @@ public partial class Client
     private async Task CommandLoadGame(ConsoleCommandEventArgs args)
     {
         string fileName = args.Args[0];
+        string? baseDir = args.Args.Count == 2 ? args.Args[1] : null;
+
         HelionLog.Info($"Loading save file {fileName}");
-        if (!m_saveGameManager.SaveFileExists(fileName))
+        if (!m_saveGameManager.SaveFileExists(baseDir, fileName))
         {
             LogError($"Save file {fileName} not found.");
             return;
         }
 
-        SaveGame saveGame = m_saveGameManager.ReadSaveGame(fileName);
+        SaveGame saveGame = m_saveGameManager.ReadSaveGame(baseDir ?? m_saveGameManager.GetSaveDir(), fileName);
         if (saveGame.Model == null)
         {
             LogError("Corrupt save game.");

--- a/Core/Resources/Archives/Collection/ArchiveCollection.cs
+++ b/Core/Resources/Archives/Collection/ArchiveCollection.cs
@@ -520,7 +520,7 @@ public class ArchiveCollection : IResources, IPathResolver
             Definitions.Track(archive);
 
             if (archive.ArchiveType == ArchiveType.Assets && GetIWadInfo(iwadArchive, out IWadInfo? info))
-            {                
+            {
                 Definitions.LoadMapInfo(archive, info.MapInfoResource);
                 Definitions.LoadDecorate(archive, info.DecorateResource);
             }
@@ -544,5 +544,25 @@ public class ArchiveCollection : IResources, IPathResolver
 
         info = null;
         return false;
+    }
+
+    /// <summary>
+    /// Get a list of string tokens that uniquely identify the IWAD and any loaded PWADs
+    /// </summary>
+    /// <returns>A list of strings, in the format "{Name}_{MD5}", that identify the current IWAD and any PWADS added to it</returns>
+    public List<string> GetIdentifiers()
+    {
+        // Always include the IWAD first
+        List<string> idStrings = this.IWad != null
+            ? new List<string>() { $"{this.IWad.IWadInfo.IWadType}_{this.IWad.MD5}" }
+            : new List<string>();
+
+        // Add the rest of the loaded archives in name order, ignoring the IWAD and Helion's own asset file
+        idStrings.AddRange(m_archives
+            .OrderBy(archive => archive.Path.Name)
+            .Where(archive => archive.MD5 != this.IWad?.MD5 && archive.Path.FullPath != "assets.pk3")
+            .Select(archive => $"{archive.Path.Name}_{archive.MD5}"));
+
+        return idStrings;
     }
 }

--- a/Core/Util/Configs/Components/ConfigGame.cs
+++ b/Core/Util/Configs/Components/ConfigGame.cs
@@ -40,6 +40,10 @@ public class ConfigGame
     [OptionMenu(OptionSectionType.General, "Confirm Quick Save")]
     public readonly ConfigValue<bool> QuickSaveConfirm = new(true);
 
+    [ConfigInfo("Store saved games in subdirectories per WAD file.")]
+    [OptionMenu(OptionSectionType.General, "Organize Saved Games")]
+    public readonly ConfigValue<bool> UseSavedGameOrganizer = new(true);
+
     [ConfigInfo("Enable fast monsters.", save: false, demo: true, serialize: true)]
     [OptionMenu(OptionSectionType.General, "Fast Monsters", spacer: true)]
     public readonly ConfigValue<bool> FastMonsters = new(false);


### PR DESCRIPTION
Currently, Helion writes all of its saved games to the default saved game directory.  This is normally either a directory specified as a command-line argument, or the current directory (if no such argument is provided).  Unless a user passes a different set of command line arguments each time they use a new set of PWADs, this can result in a pretty large number of saved games accumulating in the default directory.  On my own machine, I have 40+ saved games in my Helion directory, and I have no idea what any of them are.  😆 

In this change, I propose a saved game organizer, which can be turned on or off.  When the organizer is turned on, I attempt to create subdirectories based on the name and MD5 hash of each loaded IWAD and PWAD.  The IWAD is listed first, then PWADs are listed in alphabetical order by file name:
`{savedir}\{IWAD Type}_{IWAD MD5}\{PWAD 1 Name}_{PWAD 1 MD5}\...   ...\{PWAD N Name}_{PWAD N MD5}\savegameX.hsg`, e.g.

For example, here's one of my saves from BTSX E1 (two PWADs):
`C:\HelionSaves\Doom2_25e1459ca71d321525f84628f45ca8cd\btsx_e1a_96530f7e149ab838b3a80c29570cd275\btsx_e1b_667a7b6160ab0f64d853a5142a9a31de\savegame0.hsg`

And here's a Doom II saved game with no PWADs loaded:
`C:\HelionSaves\Doom2_25e1459ca71d321525f84628f45ca8cd\savegame0.hsg`

When the organizer is enabled, the basic save/load functions behave as follows:

* Saved game list menu:  List all compatible saved games in the root of the save directory, and all saved games in the "organized" directory (as described above)
* Load:  Allows loading saved games either from the root of the save directory or from the "organized" directory
* Save new game:  Writes to the "organized" directory
* Save over existing game:  Overwrites the save in its existing path (regardless of whether it's in the root or in the "organized" directory)

When the organizer is turned off, the saved game list reverts to just listing whatever's in the root of the save directory, rather than attempting to enumerate the contents of all subdirectories.  I figured that turning the organizer on is probably a "one way trip" for users that want to use it, but they'll probably want to maintain the ability to load their old saved games.


As always, I'm open to feedback, particularly around the following:
1.  I'm not sure whether having the MD5 stuff in there is desirable or not.  On the upside, it makes it VERY clear what files are supposed to be loaded to use a given saved game, but it does produce some pretty long paths, which may cause trouble if people have a lot of PWADs loaded (Windows can get pretty weird with paths > 260 chars).
2.  The code could be simplified a bit if I weren't trying to maintain backwards compatibility with loading files from the root of the savedir.  I could remove this capability (and set the feature _off_ by default, to avoid upsetting users with existing saved games),
3.  I am not sure if the average user would want this on or off by default.