### PR TITLE
Improve SoundFont configuration options

### DIFF
--- a/Client/Client.Config.cs
+++ b/Client/Client.Config.cs
@@ -4,6 +4,7 @@ using Helion.Util.Configs.Components;
 using Helion.World.Entities.Players;
 using OpenTK.Windowing.Common;
 using System;
+using System.IO;
 
 namespace Helion.Client;
 
@@ -14,7 +15,6 @@ public partial class Client
         m_config.Audio.MusicVolume.OnChanged += MusicVolume_OnChanged;
         m_config.Audio.SoundVolume.OnChanged += SoundVolume_OnChanged;
         m_config.Audio.Volume.OnChanged += Volume_OnChanged;
-        m_config.Audio.SoundFontFolder.OnChanged += SoundFont_OnChanged;
         m_config.Audio.SoundFontFile.OnChanged += SoundFont_OnChanged;
         m_config.Mouse.Look.OnChanged += Look_OnChanged;
 
@@ -113,7 +113,7 @@ public partial class Client
         }
     }
 
-    private void SoundFont_OnChanged(object? sender, string e)
+    private void SoundFont_OnChanged(object? sender, FileInfo e)
     {
         (m_audioSystem.Music as MusicPlayer)?.ChangeSoundFont();
     }

--- a/Client/Client.Config.cs
+++ b/Client/Client.Config.cs
@@ -14,7 +14,8 @@ public partial class Client
         m_config.Audio.MusicVolume.OnChanged += MusicVolume_OnChanged;
         m_config.Audio.SoundVolume.OnChanged += SoundVolume_OnChanged;
         m_config.Audio.Volume.OnChanged += Volume_OnChanged;
-        m_config.Audio.SoundFont.OnChanged += SoundFont_OnChanged;
+        m_config.Audio.SoundFontFolder.OnChanged += SoundFont_OnChanged;
+        m_config.Audio.SoundFontFile.OnChanged += SoundFont_OnChanged;
         m_config.Mouse.Look.OnChanged += Look_OnChanged;
 
         m_config.Window.State.OnChanged += WindowState_OnChanged;
@@ -114,6 +115,6 @@ public partial class Client
 
     private void SoundFont_OnChanged(object? sender, string e)
     {
-        (m_audioSystem.Music as MusicPlayer)?.Restart();
+        (m_audioSystem.Music as MusicPlayer)?.ChangeSoundFont();
     }
 }

--- a/Client/Client.Config.cs
+++ b/Client/Client.Config.cs
@@ -1,3 +1,4 @@
+using Helion.Client.Music;
 using Helion.Geometry;
 using Helion.Util.Configs.Components;
 using Helion.World.Entities.Players;
@@ -13,6 +14,7 @@ public partial class Client
         m_config.Audio.MusicVolume.OnChanged += MusicVolume_OnChanged;
         m_config.Audio.SoundVolume.OnChanged += SoundVolume_OnChanged;
         m_config.Audio.Volume.OnChanged += Volume_OnChanged;
+        m_config.Audio.SoundFont.OnChanged += SoundFont_OnChanged;
         m_config.Mouse.Look.OnChanged += Look_OnChanged;
 
         m_config.Window.State.OnChanged += WindowState_OnChanged;
@@ -108,5 +110,10 @@ public partial class Client
             m_audioSystem.Music.SetVolume(musicVolume);
             m_audioSystem.SetVolume(soundVolume);
         }
+    }
+
+    private void SoundFont_OnChanged(object? sender, string e)
+    {
+        (m_audioSystem.Music as MusicPlayer)?.Restart();
     }
 }

--- a/Client/Client.cs
+++ b/Client/Client.cs
@@ -484,7 +484,7 @@ public partial class Client : IDisposable, IInputManagement
             ArchiveCollection archiveCollection = new(new FilesystemArchiveLocator(config), config, ArchiveCollection.StaticDataCache);
             using HelionConsole console = new(archiveCollection.DataCache, config, commandLineArgs);
             LogClientInfo();
-            using IMusicPlayer musicPlayer = commandLineArgs.NoMusic ? new MockMusicPlayer() : new MusicPlayer();
+            using IMusicPlayer musicPlayer = commandLineArgs.NoMusic ? new MockMusicPlayer() : new MusicPlayer(config);
             using IAudioSystem audioPlayer = new OpenALAudioSystem(config, archiveCollection, musicPlayer);
 
             using Client client = new(commandLineArgs, config, console, audioPlayer, archiveCollection);

--- a/Client/Client.cs
+++ b/Client/Client.cs
@@ -484,7 +484,7 @@ public partial class Client : IDisposable, IInputManagement
             ArchiveCollection archiveCollection = new(new FilesystemArchiveLocator(config), config, ArchiveCollection.StaticDataCache);
             using HelionConsole console = new(archiveCollection.DataCache, config, commandLineArgs);
             LogClientInfo();
-            using IMusicPlayer musicPlayer = commandLineArgs.NoMusic ? new MockMusicPlayer() : new MusicPlayer(config);
+            using IMusicPlayer musicPlayer = commandLineArgs.NoMusic ? new MockMusicPlayer() : new MusicPlayer(config.Audio);
             using IAudioSystem audioPlayer = new OpenALAudioSystem(config, archiveCollection, musicPlayer);
 
             using Client client = new(commandLineArgs, config, console, audioPlayer, archiveCollection);

--- a/Client/Music/FluidSynthMusicPlayer.cs
+++ b/Client/Music/FluidSynthMusicPlayer.cs
@@ -20,7 +20,7 @@ public class FluidSynthMusicPlayer : IMusicPlayer
     private float m_volume = 1;
     private uint m_soundFontCounter = 0;
 
-    public FluidSynthMusicPlayer(string soundFontFile)
+    public FluidSynthMusicPlayer(FileInfo soundFontFile)
     {
         m_settings = new Settings();
         m_settings[ConfigurationKeys.SynthAudioChannels].IntValue = 2;
@@ -87,7 +87,7 @@ public class FluidSynthMusicPlayer : IMusicPlayer
         return false;
     }
 
-    public void ChangeSoundFont(string soundFontPath)
+    public void ChangeSoundFont(FileInfo soundFontPath)
     {
         if (m_soundFontLoaded)
         {
@@ -97,7 +97,7 @@ public class FluidSynthMusicPlayer : IMusicPlayer
 
         try
         {
-            m_synth.LoadSoundFont(soundFontPath, true);
+            m_synth.LoadSoundFont(soundFontPath.FullName, true);
             for (int i = 0; i < 16; i++)
                 m_synth.SoundFontSelect(i, 0);
 

--- a/Client/Music/FluidSynthMusicPlayer.cs
+++ b/Client/Music/FluidSynthMusicPlayer.cs
@@ -4,12 +4,14 @@ using Helion.Audio;
 using Helion.Util;
 using Helion.Util.Extensions;
 using NFluidsynth;
+using NLog;
 using static Helion.Util.Assertion.Assert;
 
 namespace Helion.Client.Music;
 
 public class FluidSynthMusicPlayer : IMusicPlayer
 {
+    private static readonly NLog.Logger Log = LogManager.GetCurrentClassLogger();
     private readonly string m_soundFontFile;
     private readonly Settings m_settings;
     private string m_lastFile = string.Empty;
@@ -55,36 +57,45 @@ public class FluidSynthMusicPlayer : IMusicPlayer
         if (m_disposed)
             return false;
 
-        Stop();
-
-        if (!string.IsNullOrEmpty(m_lastFile))
-            TempFileManager.DeleteFile(m_lastFile);
-
-        m_lastFile = TempFileManager.GetFile();
-        File.WriteAllBytes(m_lastFile, data);
-
-        using (Synth synth = new(m_settings))
+        try
         {
-            synth.LoadSoundFont(m_soundFontFile, true);
-            for (int i = 0; i < 16; i++)
-                synth.SoundFontSelect(i, 0);
+            Stop();
 
-            using (m_player = new Player(synth))
+            if (!string.IsNullOrEmpty(m_lastFile))
+                TempFileManager.DeleteFile(m_lastFile);
+
+            m_lastFile = TempFileManager.GetFile();
+            File.WriteAllBytes(m_lastFile, data);
+
+            using (Synth synth = new(m_settings))
             {
-                using var adriver = new AudioDriver(synth.Settings, synth);
-                if (options.HasFlag(MusicPlayerOptions.Loop))
-                    m_player.SetLoop(-1);
+                synth.LoadSoundFont(m_soundFontFile, true);
+                for (int i = 0; i < 16; i++)
+                    synth.SoundFontSelect(i, 0);
 
-                SetVolumeInternal();
+                using (m_player = new Player(synth))
+                {
+                    using var adriver = new AudioDriver(synth.Settings, synth);
+                    if (options.HasFlag(MusicPlayerOptions.Loop))
+                        m_player.SetLoop(-1);
 
-                m_player.Add(m_lastFile);
-                m_player.Play();
-                m_player.Join();
+                    SetVolumeInternal();
+
+                    m_player.Add(m_lastFile);
+                    m_player.Play();
+                    m_player.Join();
+                }
             }
+
+            m_player = null;
+            return true;
+        }
+        catch
+        {
+            Log.Warn("Error starting FluidSynth music playback.");
         }
 
-        m_player = null;
-        return true;
+        return false;
     }
 
     public void Stop()

--- a/Client/Music/MusicPlayer.cs
+++ b/Client/Music/MusicPlayer.cs
@@ -118,7 +118,7 @@ public class MusicPlayer : IMusicPlayer
         switch(musicType)
         {
             case MusicType.MIDI:
-                m_musicPlayer = new FluidSynthMusicPlayer(Path.Combine(m_configAudio.SoundFontFolder, m_configAudio.SoundFontFile));
+                m_musicPlayer = new FluidSynthMusicPlayer(m_configAudio.SoundFontFile);
                 break;
             case MusicType.OGG:
                 m_musicPlayer = new NAudioMusicPlayer(NAudioMusicType.Ogg);
@@ -133,7 +133,7 @@ public class MusicPlayer : IMusicPlayer
 
     public void ChangeSoundFont()
     {
-        (m_musicPlayer as FluidSynthMusicPlayer)?.ChangeSoundFont(Path.Combine(m_configAudio.SoundFontFolder, m_configAudio.SoundFontFile));
+        (m_musicPlayer as FluidSynthMusicPlayer)?.ChangeSoundFont(m_configAudio.SoundFontFile);
     }
 
     private void PlayThread(object? param)

--- a/Core/Util/Configs/Components/ConfigAudio.cs
+++ b/Core/Util/Configs/Components/ConfigAudio.cs
@@ -1,6 +1,7 @@
 using Helion.Audio;
 using Helion.Util.Configs.Options;
 using Helion.Util.Configs.Values;
+using System.IO;
 using static Helion.Util.Configs.Values.ConfigFilters;
 
 namespace Helion.Util.Configs.Components;
@@ -37,11 +38,7 @@ public class ConfigAudio
     [ConfigInfo("Main device to use for audio.")]
     public readonly ConfigValue<string> Device = new(IAudioSystem.DefaultAudioDevice);
 
-    [ConfigInfo("Folder to use for SoundFonts.")]
-    [OptionMenu(OptionSectionType.Audio, "SoundFont Folder")]
-    public readonly ConfigValue<string> SoundFontFolder = new("SoundFonts");
-
     [ConfigInfo("SoundFont file to use for MIDI/MUS music playback.")]
     [OptionMenu(OptionSectionType.Audio, "SoundFont File")]
-    public readonly ConfigValue<string> SoundFontFile = new($"Default.sf2");
+    public readonly ConfigValue<FileInfo> SoundFontFile = new(new($"SoundFonts{Path.DirectorySeparatorChar}Default.sf2"));
 }

--- a/Core/Util/Configs/Components/ConfigAudio.cs
+++ b/Core/Util/Configs/Components/ConfigAudio.cs
@@ -37,7 +37,11 @@ public class ConfigAudio
     [ConfigInfo("Main device to use for audio.")]
     public readonly ConfigValue<string> Device = new(IAudioSystem.DefaultAudioDevice);
 
+    [ConfigInfo("Folder to use for SoundFonts.")]
+    [OptionMenu(OptionSectionType.Audio, "SoundFont Folder")]
+    public readonly ConfigValue<string> SoundFontFolder = new("SoundFonts");
+
     [ConfigInfo("SoundFont file to use for MIDI/MUS music playback.")]
-    [OptionMenu(OptionSectionType.Audio, "SoundFont")]
-    public readonly ConfigValue<string> SoundFont = new($"SoundFonts{System.IO.Path.DirectorySeparatorChar}Default.sf2");
+    [OptionMenu(OptionSectionType.Audio, "SoundFont File")]
+    public readonly ConfigValue<string> SoundFontFile = new($"Default.sf2");
 }

--- a/Core/Util/Configs/Components/ConfigAudio.cs
+++ b/Core/Util/Configs/Components/ConfigAudio.cs
@@ -36,4 +36,8 @@ public class ConfigAudio
 
     [ConfigInfo("Main device to use for audio.")]
     public readonly ConfigValue<string> Device = new(IAudioSystem.DefaultAudioDevice);
+
+    [ConfigInfo("SoundFont file to use for MIDI/MUS music playback.")]
+    [OptionMenu(OptionSectionType.Audio, "SoundFont")]
+    public readonly ConfigValue<string> SoundFont = new($"SoundFonts{System.IO.Path.DirectorySeparatorChar}Default.sf2");
 }

--- a/Core/Util/Configs/Values/ConfigConverters.cs
+++ b/Core/Util/Configs/Values/ConfigConverters.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Text.Json;
@@ -26,6 +27,8 @@ public static class ConfigConverters
             return MakeThrowableEnumConverter<T>();
         if (typeof(T) == typeof(List<string>))
             return MakeThrowableStringListConverter<T>();
+        if (typeof(T) == typeof(FileInfo))
+            return MakeThrowableFileInfoConverter<T>();
 
         // Last ditch attempt at a converter.
         MethodInfo? method = typeof(T).GetMethod("FromConfigString", BindingFlags.Static | BindingFlags.Public);
@@ -135,5 +138,15 @@ public static class ConfigConverters
         }
 
         return ThrowableStringListConverter;
+    }
+
+    private static Func<object, T> MakeThrowableFileInfoConverter<T>() where T : notnull
+    {
+        static T ThrowableFileInfoConverter(object obj)
+        {
+            return (T)(object)new FileInfo(obj?.ToString() ?? string.Empty);
+        }
+
+        return ThrowableFileInfoConverter;
     }
 }


### PR DESCRIPTION
This change should work as-is, although it requires the user to enter file names (either absolute or relative paths) into the config option that I added.  I am expecting to do some follow-up work to add a rudimentary file browser as an Options dialog.  I would like to do that as a separate change, since the important stuff here already works, it's just not a great UX.

1. Add a config option to the Audio options group, to control the default SoundFont file.  I chose to create a config converter type for FileInfo, which is a little silly, but the intent is to add a specific type of Options control for editing options of that type, so I wanted to differentiate it from other strings (since existing specialized Options dialogs like the color picker all key off the underlying type).
2. Make the main MusicPlayer class reuse the current FluidSynthPlayer if it already has one.  When using a large SoundFont (especially if compressed), this noticeably decreases loading time between levels.
3. Enable FluidSynthPlayer to change SoundFonts.  It can actually do this on-the-fly while playing, which is kind of neat.

I have tested:
1. Switch to a new _valid_ SoundFont
2. Switch back to a previously loaded SoundFont after (1)
3. Switch to an invalid SoundFont (currently possible because I'm not testing the file path, just handling the exception if we pick a bad one)
4. Recover from (4) by switching back to a valid SoundFont
5. With a valid SoundFont loaded, switch tracks by starting a new game in a different episode than the one currently selected
6. Verify that reasonable values are written to and loaded from the config file
7. Verify that the default works correctly when there is no value stored in the config file