### PR TITLE
Lemming104/fluid synth re init

### DIFF
--- a/Client/Music/MusicPlayer.cs
+++ b/Client/Music/MusicPlayer.cs
@@ -59,7 +59,7 @@ public class MusicPlayer : IMusicPlayer
 
         if (MusToMidi.TryConvert(data, out var converted))
         {
-            m_musicPlayer = new FluidSynthMusicPlayer(m_configAudio.SoundFontFile);
+            m_musicPlayer = CreateFluidSynthPlayer();
             data = converted;
         }
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -77,7 +77,7 @@ public class MusicPlayer : IMusicPlayer
         }
         else if (MusToMidi.TryConvertNoHeader(data, out converted))
         {
-            m_musicPlayer = new FluidSynthMusicPlayer(m_configAudio.SoundFontFile);
+            m_musicPlayer = CreateFluidSynthPlayer();
             data = converted;
         }
 
@@ -88,11 +88,14 @@ public class MusicPlayer : IMusicPlayer
             return true;
         }
 
-        Log.Warn("Unsupported music format");
+        Log.Warn("Unknown/unsupported music format");
         return false;
     }
 
     public bool ChangesMasterVolume() => m_musicPlayer is NAudioMusicPlayer;
+
+    private IMusicPlayer CreateFluidSynthPlayer() =>
+        new FluidSynthMusicPlayer(m_configAudio.SoundFontFile);
 
     public void ChangeSoundFont()
     {

--- a/Client/Music/MusicPlayer.cs
+++ b/Client/Music/MusicPlayer.cs
@@ -4,7 +4,6 @@ using Helion.Util.Extensions;
 using Helion.Util.Sounds.Mus;
 using NLog;
 using System;
-using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
 
@@ -21,15 +20,6 @@ public class MusicPlayer : IMusicPlayer
     private ConfigAudio m_configAudio;
     private Thread? m_thread;
     private IMusicPlayer? m_musicPlayer;
-    private MusicType? m_lastMusicType;
-
-    private enum MusicType
-    {
-        MIDI,
-        MP3,
-        OGG,
-        NONE
-    };
 
     private class PlayParams
     {
@@ -64,10 +54,12 @@ public class MusicPlayer : IMusicPlayer
         m_lastDataHash = hash ?? data.CalculateCrc32();
 
         Stop();
+        m_musicPlayer?.Dispose();
+        m_musicPlayer = null;
 
         if (MusToMidi.TryConvert(data, out var converted))
         {
-            SelectMusicPlayer(MusicType.MIDI);
+            m_musicPlayer = new FluidSynthMusicPlayer(m_configAudio.SoundFontFile);
             data = converted;
         }
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -75,22 +67,18 @@ public class MusicPlayer : IMusicPlayer
             // Ogg/mp3 currently only works in Windows
             if (NAudioMusicPlayer.IsOgg(data))
             {
-                SelectMusicPlayer(MusicType.OGG);
+                m_musicPlayer = new NAudioMusicPlayer(NAudioMusicType.Ogg);
             }
             else if (NAudioMusicPlayer.IsMp3(data))
             {
-                SelectMusicPlayer(MusicType.MP3);
+                m_musicPlayer = new NAudioMusicPlayer(NAudioMusicType.Mp3);
             }
 
         }
         else if (MusToMidi.TryConvertNoHeader(data, out converted))
         {
-            SelectMusicPlayer(MusicType.MIDI);
+            m_musicPlayer = new FluidSynthMusicPlayer(m_configAudio.SoundFontFile);
             data = converted;
-        }
-        else
-        {
-            SelectMusicPlayer(MusicType.NONE);
         }
 
         if (m_musicPlayer != null)
@@ -100,36 +88,11 @@ public class MusicPlayer : IMusicPlayer
             return true;
         }
 
-        Log.Warn("Unknown/unsupported music format");
+        Log.Warn("Unsupported music format");
         return false;
     }
 
     public bool ChangesMasterVolume() => m_musicPlayer is NAudioMusicPlayer;
-
-    private void SelectMusicPlayer(MusicType musicType)
-    {
-        if (musicType == MusicType.MIDI && m_musicPlayer is FluidSynthMusicPlayer)
-        {
-            // We already have a FluidSynth player; avoid reloading it, so it can cache SoundFonts.
-            return;
-        }
-
-        m_musicPlayer?.Dispose();
-        switch(musicType)
-        {
-            case MusicType.MIDI:
-                m_musicPlayer = new FluidSynthMusicPlayer(m_configAudio.SoundFontFile);
-                break;
-            case MusicType.OGG:
-                m_musicPlayer = new NAudioMusicPlayer(NAudioMusicType.Ogg);
-                break;
-            case MusicType.MP3:
-                m_musicPlayer = new NAudioMusicPlayer(NAudioMusicType.Mp3);
-                break;
-            default:
-                break;
-        }
-    }
 
     public void ChangeSoundFont()
     {


### PR DESCRIPTION
The previous optimization really saved on loading time with large SoundFonts, but it caused some weird issues where instruments would sound wrong after going through several maps.  I may revisit that optimization later; maybe we're just missing a reset signal we need to send or something.

Compared to the 0.9.4.0 release, the main MusicPlayer.cs file now has only the changes needed to plumb SoundFont changes and allow selection of something other than "Default.sf2".  It's back to disposing and re-creating the player on every track change.

I've left my changes in the FluidSynthPlayer.cs file as-is, so it's still possible to cycle SoundFonts while the music is playing.  I think this will allow for a better user experience when I implement some kind of picker/browser control.
