### PR TITLE
Refactor dialog logic

### DIFF
--- a/Core/Layer/Options/ColorDialog.cs
+++ b/Core/Layer/Options/ColorDialog.cs
@@ -1,5 +1,4 @@
-﻿using Helion.Geometry;
-using Helion.Geometry.Vectors;
+﻿using Helion.Geometry.Vectors;
 using Helion.Graphics;
 using Helion.Layer.Options.Sections;
 using Helion.Render.Common.Enums;
@@ -72,9 +71,9 @@ internal class ColorDialog : DialogBase
         m_sliders[m_row].HandleInput(input);
     }
 
-    protected override void RenderImpl(IRenderableSurfaceContext ctx, IHudRenderContext hud)
+    protected override void RenderDialogContents(IRenderableSurfaceContext ctx, IHudRenderContext hud)
     {
-        PrintMessage(hud, m_attr.Name, windowAlign: Align.TopMiddle, anchorAlign: Align.TopMiddle);
+        RenderDialogText(hud, m_attr.Name, windowAlign: Align.TopMiddle, anchorAlign: Align.TopMiddle);
         m_valueStartX = hud.MeasureText("Green", Font, m_fontSize).Width + m_padding * 4;
 
         int boxSize = m_config.GetScaled(24);

--- a/Core/Layer/Options/ColorDialog.cs
+++ b/Core/Layer/Options/ColorDialog.cs
@@ -16,8 +16,6 @@ namespace Helion.Layer.Options;
 
 internal class ColorDialog : DialogBase
 {
-    const string Selector = ">";
-
     private readonly IConfigValue m_configValue;
     private readonly OptionMenuAttribute m_attr;
     private readonly Slider m_redSlider;
@@ -26,9 +24,7 @@ internal class ColorDialog : DialogBase
     private readonly Slider[] m_sliders;
     private readonly BoxList m_cursorPosList = new();
     private int m_row;
-    private int m_rowHeight;
     private int m_valueStartX;
-    private Dimension m_selectorSize;
     private Vec3I m_color;
 
     public Vec3I SelectedColor => m_color;
@@ -76,43 +72,19 @@ internal class ColorDialog : DialogBase
         m_sliders[m_row].HandleInput(input);
     }
 
-    public override void Render(IRenderableSurfaceContext ctx, IHudRenderContext hud)
+    protected override void RenderImpl(IRenderableSurfaceContext ctx, IHudRenderContext hud)
     {
-        base.Render(ctx, hud);
-
-        m_cursorPosList.Clear();
-        m_fontSize = m_config.GetSmallFontSize();
-        m_padding = m_config.GetScaled(8);
-        int border = m_config.GetScaled(1);
-        var size = new Dimension(Math.Max(hud.Width / 2, 320), Math.Max(hud.Height / 2, 200));
-        hud.FillBox((0, 0, hud.Width, hud.Height), Color.Black, alpha: 0.5f);
-
-        hud.FillBox((0, 0, size.Width, size.Height), Color.Gray, window: Align.Center, anchor: Align.Center);
-        hud.FillBox((0, 0, size.Width - (border * 2), size.Height - (border * 2)), Color.Black, window: Align.Center, anchor: Align.Center);
-
-        m_selectorSize = hud.MeasureText(Selector, Font, m_fontSize);
-        m_rowHeight = hud.MeasureText("I", Font, m_fontSize).Height;
+        PrintMessage(hud, m_attr.Name, windowAlign: Align.TopMiddle, anchorAlign: Align.TopMiddle);
         m_valueStartX = hud.MeasureText("Green", Font, m_fontSize).Width + m_padding * 4;
 
-        hud.PushOffset((0, m_dialogOffset.Y + m_padding));
-
-        hud.Text(m_attr.Name, Font, m_fontSize, (0, 0), window: Align.TopMiddle, anchor: Align.TopMiddle);
-        hud.AddOffset((0, m_rowHeight + m_padding));
         int boxSize = m_config.GetScaled(24);
         RenderColorBox(hud, 0, 0, boxSize);
-
         hud.AddOffset((m_dialogOffset.X + m_padding, boxSize + m_rowHeight));
+
         hud.Text(Selector, Font, m_fontSize, (0, m_row * (m_rowHeight + m_padding)));
         RenderSlider(ctx, hud, "Red", m_redSlider, 0);
         RenderSlider(ctx, hud, "Green", m_greenSlider, 1);
         RenderSlider(ctx, hud, "Blue", m_blueSlider, 2);
-        hud.PopOffset();
-
-        hud.PushOffset((m_dialogOffset.X + m_box.Width - m_padding, m_dialogOffset.Y + m_box.Height - m_rowHeight));
-        RenderButton(ctx, hud, "OK", 0);
-        hud.AddOffset((-m_padding, 0));
-        RenderButton(ctx, hud, "Cancel", 1);
-        hud.PopOffset();
     }
 
     private void RenderSlider(IRenderableSurfaceContext ctx, IHudRenderContext hud, string text, Slider slider, int row)

--- a/Core/Layer/Options/DialogBase.cs
+++ b/Core/Layer/Options/DialogBase.cs
@@ -65,7 +65,7 @@ internal abstract class DialogBase(ConfigHud config, string? acceptButton, strin
     public virtual bool OnClickableItem(Vec2I mousePosition) =>
         m_buttonPosList.GetIndex(mousePosition, out _);
 
-    public virtual void Render(IRenderableSurfaceContext ctx, IHudRenderContext hud)
+    public void Render(IRenderableSurfaceContext ctx, IHudRenderContext hud)
     {
         m_buttonPosList.Clear();
 
@@ -102,19 +102,22 @@ internal abstract class DialogBase(ConfigHud config, string? acceptButton, strin
         }
 
         hud.PushOffset((0, m_dialogOffset.Y + m_padding));
-        this.RenderImpl(ctx, hud);
+        // When dialog contents are rendered, vertical offset is at a point suitable for rendering new elements.
+        // Horizontal offset is set to the left side of the screen in case we need to draw something centered on the screen,
+        // as in the color picker dialog.
+        this.RenderDialogContents(ctx, hud);
         hud.PopOffset();
     }
-    
-    /// <summary>
-    /// Render the contents of the dialog (the Accept/Cancel buttons, box outline, and title row are already rendered)
-    /// </summary>
-    protected abstract void RenderImpl(IRenderableSurfaceContext ctx, IHudRenderContext hud);
 
     /// <summary>
-    /// Print a line of text, with line wrapping applied if needed
+    /// Render the contents of the dialog.
     /// </summary>
-    protected void PrintMessage(
+    protected abstract void RenderDialogContents(IRenderableSurfaceContext ctx, IHudRenderContext hud);
+
+    /// <summary>
+    /// Print a string of text, with line wrapping applied if needed, auto-incrementing the vertical offset after each line.
+    /// </summary>
+    protected void RenderDialogText(
         IHudRenderContext hud,
         string message,
         Color? color = null,
@@ -138,7 +141,6 @@ internal abstract class DialogBase(ConfigHud config, string? acceptButton, strin
 
     public virtual void RunLogic(TickerInfo tickerInfo)
     {
-
     }
 
     protected void RenderButton(IRenderableSurfaceContext ctx, IHudRenderContext hud, string text, int index)

--- a/Core/Layer/Options/MessageDialog.cs
+++ b/Core/Layer/Options/MessageDialog.cs
@@ -1,27 +1,25 @@
 ﻿using Helion.Graphics;
 using Helion.Render.Common.Renderers;
 using Helion.Util.Configs.Components;
-using Helion.World.Geometry.Lines;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Helion.Layer.Options;
 
-internal class MessageDialog(ConfigHud config, string title, IList<string> message, string? acceptButton, string? cancelButton) 
+internal class MessageDialog(ConfigHud config, string title, IList<string> message, string? acceptButton, string? cancelButton)
     : DialogBase(config, acceptButton, cancelButton)
 {
     private readonly string m_title = title;
     private readonly IList<string> m_message = message;
 
-    protected override void RenderImpl(IRenderableSurfaceContext ctx, IHudRenderContext hud)
+    protected override void RenderDialogContents(IRenderableSurfaceContext ctx, IHudRenderContext hud)
     {
-        hud.PushOffset((m_dialogOffset.X + m_padding, m_dialogOffset.Y + m_padding));
+        hud.AddOffset((m_dialogOffset.X + m_padding, 0));
 
-        PrintMessage(hud, m_title, Color.Red);
+        RenderDialogText(hud, m_title, Color.Red);
 
         foreach (var message in m_message)
         {
-            PrintMessage(hud, message);
+            RenderDialogText(hud, message);
         }
     }
 }

--- a/Core/Layer/Options/MessageDialog.cs
+++ b/Core/Layer/Options/MessageDialog.cs
@@ -13,38 +13,15 @@ internal class MessageDialog(ConfigHud config, string title, IList<string> messa
     private readonly string m_title = title;
     private readonly IList<string> m_message = message;
 
-    private readonly List<string> m_lines = [];
-    private readonly StringBuilder m_builder = new();
-
-    public override void Render(IRenderableSurfaceContext ctx, IHudRenderContext hud)
+    protected override void RenderImpl(IRenderableSurfaceContext ctx, IHudRenderContext hud)
     {
-        base.Render(ctx, hud);
-
-        int height = hud.MeasureText("I", Font, m_fontSize).Height;
         hud.PushOffset((m_dialogOffset.X + m_padding, m_dialogOffset.Y + m_padding));
 
-        LineWrap.Calculate(m_title, Font, m_fontSize, m_box.Width, hud, m_lines, m_builder, out _);
-        foreach (var line in m_lines)
-        {
-            hud.Text(line, Font, m_fontSize, (0, 0), color: Color.Red);
-            hud.AddOffset((0, height + m_padding));
-        }
-
-        hud.AddOffset((0, height));
+        PrintMessage(hud, m_title, Color.Red);
 
         foreach (var message in m_message)
         {
-            if (message.Length == 0)
-                hud.AddOffset((0, height));
-
-            LineWrap.Calculate(message, Font, m_fontSize, m_box.Width, hud, m_lines, m_builder, out _);
-            foreach (var line in m_lines)
-            {
-                hud.Text(line, Font, m_fontSize, (0, 0));
-                hud.AddOffset((0, height + m_padding));
-            }
+            PrintMessage(hud, message);
         }
-
-        hud.PopOffset();
     }
 }


### PR DESCRIPTION
In this change, I am refactoring "options dialog" classes:

1.  Remove redundant initialization and draw operations (for example, the Color dialog was drawing the OK and Cancel buttons again, even though the base class had already drawn them)
2.  Push common operations down into the base class
3.  Add a method that does the basic stuff we're _usually_ going to want to do when writing multiline text (wrap when needed, keep incrementing the vertical offset so we can write more lines after that)

I think this makes it clearer what's really going on in the derived classes--what they add beyond a box with some OK/Cancel buttons.

My intent is to use this as a base for implementing a "list picker" type control.