### PR TITLE
store prev weapon offsets before AnimationWeapon tick (#551)

### DIFF
--- a/Core/World/Entities/Players/Player.cs
+++ b/Core/World/Entities/Players/Player.cs
@@ -610,6 +610,9 @@ public class Player : Entity
             Flags.JustAttacked = false;
         }
 
+        PrevWeaponOffset = WeaponOffset;
+        PrevWeaponBobOffset = WeaponBobOffset;
+
         Inventory.Tick();
         AnimationWeapon?.Tick();
         StatusBar.Tick();
@@ -623,9 +626,6 @@ public class Player : Entity
         PrevAngle = AngleRadians;
         m_prevPitch = PitchRadians;
         m_prevViewZ = m_viewZ;
-
-        PrevWeaponOffset = WeaponOffset;
-        PrevWeaponBobOffset = WeaponBobOffset;
 
         if (m_jumpTics > 0)
             m_jumpTics--;


### PR DESCRIPTION
#551 

`PrevWeaponOffset` was being set after `WeaponOffset` was updated in `AnimationWeapon?.Tick();`, so it was interpolating against itself. Not sure if I've missed anything here.