### PR TITLE
Fix minor controls-related issues

### DIFF
--- a/Core/Layer/Options/Sections/ListedConfigSection.cs
+++ b/Core/Layer/Options/Sections/ListedConfigSection.cs
@@ -71,10 +71,13 @@ public class ListedConfigSection : IOptionSection
     private void SetDisableStates()
     {
         m_config.Window.Dimension.OptionDisabled = m_config.Window.State != RenderWindowState.Normal;
+
         bool paletteMode = m_config.Window.ColorMode.Value == RenderColorMode.Palette;
         m_config.Render.Filter.Texture.OptionDisabled = paletteMode;
         m_config.Render.Anisotropy.OptionDisabled = paletteMode;
         m_config.Render.LightMode.OptionDisabled = paletteMode;
+
+        m_config.Mouse.ForwardBackwardSpeed.OptionDisabled = m_config.Mouse.Look.Value == true;
     }
 
     public void ResetSelection() => m_currentRowIndex = 0;
@@ -402,6 +405,7 @@ public class ListedConfigSection : IOptionSection
 
         Log.ConditionalTrace($"Config value with '{newValue}'for update result: {result}");
         m_currentEditValue = null;
+        SetDisableStates();
     }
 
     private void AdvanceToValidRow(int direction)

--- a/Core/Layer/Worlds/WorldLayer.Input.cs
+++ b/Core/Layer/Worlds/WorldLayer.Input.cs
@@ -195,7 +195,7 @@ public partial class WorldLayer
 
         cmd.WeaponScroll = weaponScroll;
         int yMove = input.GetMouseMove().Y;
-        if (m_config.Mouse.ForwardBackwardSpeed > 0 && yMove != 0)
+        if (!m_config.Mouse.Look && m_config.Mouse.ForwardBackwardSpeed > 0 && yMove != 0)
             cmd.ForwardMoveSpeed += yMove * (m_config.Mouse.ForwardBackwardSpeed / 128);
     }
 

--- a/Core/Util/Configs/Components/ConfigMouse.cs
+++ b/Core/Util/Configs/Components/ConfigMouse.cs
@@ -10,7 +10,7 @@ public class ConfigMouse
     [OptionMenu(OptionSectionType.Mouse, "Mouse Look")]
     public readonly ConfigValue<bool> Look = new(true);
     
-    [ConfigInfo("Forward/backward movement speed.")]
+    [ConfigInfo("Forward/backward movement speed when mouse look is disabled.")]
     [OptionMenu(OptionSectionType.Mouse, "Movement Speed")]
     public readonly ConfigValue<double> ForwardBackwardSpeed = new(0, GreaterOrEqual(0.0));
 

--- a/Core/Util/Constants.cs
+++ b/Core/Util/Constants.cs
@@ -115,8 +115,8 @@ public static class Constants
     public static class Input
     {
         public const string Forward = "Forward";
-        public const string Left = "Left";
         public const string Backward = "Backward";
+        public const string Left = "Left";
         public const string Right = "Right";
         public const string Use = "Use";
         public const string Run = "Run";
@@ -181,8 +181,8 @@ public static class Constants
     public static readonly HashSet<string> BaseCommands = new(StringComparer.OrdinalIgnoreCase)
     {
         Input.Forward,
-        Input.Left,
         Input.Backward,
+        Input.Left,
         Input.Right,
         Input.Use,
         Input.Run,
@@ -226,8 +226,8 @@ public static class Constants
     public static readonly HashSet<string> InGameCommands = new(StringComparer.OrdinalIgnoreCase)
     {
         Input.Forward,
-        Input.Left,
         Input.Backward,
+        Input.Left,
         Input.Right,
         Input.Use,
         Input.Run,


### PR DESCRIPTION
1.  Reorder Forward/Left/Backward/Right to Forward/Backward/Left/Right in the keybind menu.  This matches the Up/Down/Left/Right ordering for map bindings, and brings the behavior in line with most other FPS.
2.  Don't allow forward/backward movement via mouse when mouselook is enabled.  I have no idea why anyone would _intentionally_ do this, but setting a large movement scale value and turning mouselook on produces some truly nonsensical (and motion sickness inducing) results.