### PR TITLE
A_WeaponReady: lower for pending weapon before setting ReadyToFire = true (#609)

### DIFF
--- a/Core/World/Entities/Definition/States/EntityActionFunctions.cs
+++ b/Core/World/Entities/Definition/States/EntityActionFunctions.cs
@@ -1832,14 +1832,14 @@ public static class EntityActionFunctions
         var player = entity.PlayerObj;
         player.Weapon.ReadyState = true;
         player.WeaponOffset.Y = Constants.WeaponTop;
-        if (!player.Weapon.Definition.Flags.WeaponNoAutofire || !player.AttackDown)
-            entity.PlayerObj.Weapon.ReadyToFire = true;
 
         if (entity.PlayerObj.PendingWeapon != null || player.IsDead)
         {
             entity.PlayerObj.LowerWeapon();
             return;
         }
+        if (!player.Weapon.Definition.Flags.WeaponNoAutofire || !player.AttackDown)
+            entity.PlayerObj.Weapon.ReadyToFire = true;
 
         if (player.TickCommand.Has(TickCommands.Attack))
         {


### PR DESCRIPTION
#609

It seems safe to wait to set `ReadyToFire`, since it's only checked when attempting to fire and when calculating the bob, and just below these swapped blocks is the check to fire, so it would never happen with a pending weapon or death anyway.