### PR TITLE
fullscreen backgrounds: always use 1/1.2 ratio, support larger images for cast/credits

### DIFF
--- a/Core/Layer/EndGame/EndGameLayer.Render.cs
+++ b/Core/Layer/EndGame/EndGameLayer.Render.cs
@@ -72,12 +72,12 @@ public partial class EndGameLayer
         ctx.ClearDepth();
         hud.Clear(Color.Black);
 
+        hud.RenderFullscreenImage("BOSSBACK");
         hud.DoomVirtualResolution(m_virtualDrawCast, hud);
     }
 
     private void VirtualDrawCast(IHudRenderContext hud)
     {
-        hud.Image("BOSSBACK", Vec2I.Zero);
         DrawCastMonsterText(hud);
 
         if (m_castEntity == null)

--- a/Core/Layer/EndGame/EndGameLayer.Render.cs
+++ b/Core/Layer/EndGame/EndGameLayer.Render.cs
@@ -168,6 +168,11 @@ public partial class EndGameLayer
         ctx.ClearDepth();
         hud.Clear(Color.Black);
 
+        if (m_drawState == EndGameDrawState.Complete && images.Count == 1)
+        {
+            hud.RenderFullscreenImage(images[0]);
+            return;
+        }
         for (int i = 0; i < images.Count; i++)
         {
             string image = images[i];

--- a/Core/Util/Extensions/HudExtensions.cs
+++ b/Core/Util/Extensions/HudExtensions.cs
@@ -14,14 +14,7 @@ public static class HudExtensions
         if (!hud.Textures.TryGet(image, out var handle))
             return false;
 
-        if (handle.Dimension.AspectRatio == 1.6f)
-        {
-            hud.VirtualDimension(handle.Dimension, ResolutionScale.Center, Constants.DoomVirtualAspectRatio, HudVirtualFullscreenImage,
-                new HudImage(hud, image, handle, window, anchor, alpha));
-            return true;
-        }
-
-        hud.VirtualDimension(handle.Dimension, ResolutionScale.Center, handle.Dimension.AspectRatio, HudVirtualFullscreenImage,
+        hud.VirtualDimension(handle.Dimension, ResolutionScale.Center, handle.Dimension.AspectRatio / 1.2f, HudVirtualFullscreenImage,
             new HudImage(hud, image, handle, window, anchor, alpha));
         return true;
     }


### PR DESCRIPTION
- always use 1/1.2 pixel ratio in RenderFullscreenImage() regardless of texture aspect ratio
- centers credits background (#614, for large images; this conditional may need tweaking)
- centers cast background (#617, for large images)

![aa-cast-4x3](https://github.com/user-attachments/assets/a0b064e4-adca-4c45-9c1a-a99d2fbfaf43)
![aa-cast-16x9](https://github.com/user-attachments/assets/136291c2-a149-49d3-b27e-0da1e554dc01)
![aa-cast-ultrawide](https://github.com/user-attachments/assets/a13875d1-3782-4a55-923a-74720484dda3)
![aa-credits-4x3](https://github.com/user-attachments/assets/a23f4a5c-76e4-42a3-9ad5-efb729964777)
![aa-credits-16x9](https://github.com/user-attachments/assets/67ee081f-2102-4456-80ab-911763ced601)
![aa-credits-ultrawide](https://github.com/user-attachments/assets/396f9263-7c7c-415e-b7de-8c786f353e98)
![aa-intermission-4x3](https://github.com/user-attachments/assets/86f79fbf-6e5f-4b18-b206-5b0e3608353d)
![aa-intermission-16x9](https://github.com/user-attachments/assets/eac2fa20-c3af-4688-946a-02667f175a26)
![aa-intermission-ultrawide](https://github.com/user-attachments/assets/44fff663-b35a-4c2d-a859-0864d10d4b0f)
![aa-text-4x3](https://github.com/user-attachments/assets/48cae930-da1b-4848-a99e-a5610e717c71)
![aa-text-16x9](https://github.com/user-attachments/assets/3764510f-97b8-4319-b4a2-ceca78db4dec)
![aa-text-ultrawide](https://github.com/user-attachments/assets/d0ccf4e4-9f2f-4563-854e-6210790eac5a)
![aa-title-4x3](https://github.com/user-attachments/assets/a9adc128-cce6-4428-b955-729892e89c9b)
![aa-title-16x9](https://github.com/user-attachments/assets/9a66fee4-28f0-42bc-b5a6-97831b165a07)

Sanity checks:

![eviternity-intermission-4x3](https://github.com/user-attachments/assets/70940a84-6b69-4373-a12c-50be468d65cf)
![eviternity-intermission-16x9](https://github.com/user-attachments/assets/e5a2cc70-53ff-4a51-869e-f7faf7df07a6)
![eviternity-title-4x3](https://github.com/user-attachments/assets/109c59d3-290e-4b78-a65d-f51c4cc358c9)
![eviternity-title-16x9](https://github.com/user-attachments/assets/c0e8f844-06c3-4eda-8c19-fdd5bb8c2cb5)

![d2-text-4x3](https://github.com/user-attachments/assets/06f9389a-3e30-4ed0-9dc4-54b186fe09d8)
![d2-text-16x9](https://github.com/user-attachments/assets/35cc4919-e866-43fb-a088-08ef01f1f503)
![d2-cast-4x3](https://github.com/user-attachments/assets/a6baa0e8-2a33-45a2-8fd5-0257416b71b2)
![d2-cast-16x9](https://github.com/user-attachments/assets/7c9d0da9-dd9c-4e20-8454-4086f74eeea8)
![d1-title-4x3](https://github.com/user-attachments/assets/848d8b67-b7ed-4ab5-9684-3210450a2cfa)
![d1-title-16x9](https://github.com/user-attachments/assets/24968368-2cec-4f07-9ce6-3b7454dee953)
![d1-credits-4x3](https://github.com/user-attachments/assets/4eef4369-efa2-4b86-a6af-3433ad49217c)
![d1-credits-16x9](https://github.com/user-attachments/assets/669bb675-af9a-46cb-8aa0-f7ce90b36890)
![d1-intermission-4x3](https://github.com/user-attachments/assets/531a00f1-d5ff-4fdb-92b9-71232ce39dca)
![d1-intermission-16x9](https://github.com/user-attachments/assets/9c8df827-46aa-485c-89e2-bc65b081ae72)
