### PR TITLE
parser: don't strip empty lines in quoted strings

### DIFF
--- a/Core/Util/Parser/SimpleParser.cs
+++ b/Core/Util/Parser/SimpleParser.cs
@@ -66,7 +66,7 @@ public class SimpleParser
     public void Parse(string data, bool keepEmptyLines = false, bool parseQuotes = true)
     {
         m_index = 0;
-        m_lines = data.Split(SplitLines, keepEmptyLines ?  StringSplitOptions.None : StringSplitOptions.RemoveEmptyEntries);
+        m_lines = data.Split(SplitLines, StringSplitOptions.None);
         bool multiLineComment = false;
         int lineCount = 0;
         int startLine = 0;
@@ -79,9 +79,10 @@ public class SimpleParser
 
         foreach (string line in m_lines)
         {
-            if (line.Length == 0 && keepEmptyLines)
+            if (line.Length == 0)
             {
-                m_tokens.Add(new ParserToken(lineCount, 0, 0));
+                if (keepEmptyLines || quotedString)
+                    m_tokens.Add(new ParserToken(lineCount, 0, 0));
                 lineCount++;
                 continue;
             }


### PR DESCRIPTION
Fixes missing linebreaks in text screens

Before:
![nobreaks](https://github.com/user-attachments/assets/7eb05069-2c5d-482f-a48d-d070f3080a77)

After:
![breaks](https://github.com/user-attachments/assets/9ae7b1ad-9c88-4b57-bb13-1bd15a979fe4)
