### PR TITLE
Automated release support

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -1,0 +1,60 @@
+# This workflow will build, publish, and release Helion.
+# Release detail text is copied from RELEASENOTES.md.
+# Release files will include source snapshots, and ZIP files with prebuilt executables for Linux and Windows (both single-file and runtime-dependent)
+
+# Release checklist:
+# 1.  Update RELEASENOTES.md
+# 2.  Update version info in Directory.Build.props
+# 3.  Ensure you are synced to a commit that includes the updated state of (1) and (2); run `git pull` if needed
+# 4.  Create a new tag, e.g. `git tag 0.9.5.0`
+# 5.  Push the new tag, e.g. `git push origin 0.9.5.0`
+
+name: Make .NET Release
+
+on:
+  push:
+    tags:
+    - '*'
+
+jobs:
+  buildRelease:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore
+    - name: Dotnet Publish Linux
+      run: dotnet publish -c Release -r linux-x64 Client/Client.csproj
+    - name: Dotnet Publish Windows
+      run: dotnet publish -c Release -r win-x64 Client/Client.csproj
+    - name: Dotnet Publish Linux Self-Contained
+      run: dotnet publish -c Release -r linux-x64 -p:SelfContainedRelease=true Client/Client.csproj
+    - name: Dotnet Publish Windows Self-Contained
+      run: dotnet publish -c Release -r win-x64 -p:SelfContainedRelease=true Client/Client.csproj
+    - name: Install zip
+      uses: montudor/action-zip@v1
+    - name: Zip Linux
+      run: zip -r ../../Helion-${{ github.ref_name }}-linux-x64.zip *
+      working-directory: Publish/linux-x64
+    - name: Zip Linux Self-Contained
+      run: zip -r ../../Helion-${{ github.ref_name }}-linux-x64_SelfContained.zip *
+      working-directory: Publish/linux-x64_SelfContained
+    - name: Zip Windows
+      run: zip -r ../../Helion-${{ github.ref_name }}-win-x64.zip *
+      working-directory: Publish/win-x64
+    - name: Zip Windows Self-Contained
+      run: zip -r ../../Helion-${{ github.ref_name }}-win-x64_SelfContained.zip *
+      working-directory: Publish/win-x64_SelfContained
+    - name: Make Release
+      uses: ncipollo/release-action@v1
+      with:
+        artifacts: "*.zip"
+        bodyFile: "RELEASENOTES.md"

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,0 +1,12 @@
+# 0.9.5.0 (Pre-release)
+
+## Bug fixes:
+  - Fix various issues with intermission screen and end-game screen formatting, including use of widescreen assets
+  - Interpolate weapon raise/lower animation
+  - Prevent mouse vertical movement from causing the player to move when mouselook is enabled
+  - Fix issues related to building on case-sensitive file systems (Linux)
+
+## Features:
+  - Initial id24 specification support
+  - SoundFont picker dialog
+  


### PR DESCRIPTION
This will create a new release in the Releases section whenever you push a tag.  This replaces creating Releases manually.  Releases include a release description (whatever is in RELEASENOTES.md) and ZIP files that contain prebuilt executables for Windows and Linux, both "self-contained", and "runtime-dependent".

To create a tag, you can either tag the current head commit on your remote branch:
`git tag 0.9.5.0`

Or you can tag a specific SHA:
`git tag 0.9.5.0 7b984de106b92c01532ab2475bd7423faa13bae9`

Then push your tag:
`git push origin 0.9.5.0`

Since this runs automation that includes a build, it will take several minutes to complete.  You can monitor the progress from the Actions tab at the top of the GitHub web UI.