### PR TITLE
Fix save/load menu quirks

### DIFF
--- a/Core/Layer/GameLayerManager.cs
+++ b/Core/Layer/GameLayerManager.cs
@@ -137,6 +137,8 @@ public class GameLayerManager : IGameLayerManager
 
     public bool OptionsLock => OptionsLayer != null && OptionsLayer.Animation.State != InterpolationAnimationState.Out;
 
+    public bool CanSave => EndGameLayer == null && IntermissionLayer == null;
+
     public bool ShouldFocus()
     {
         if (ConsoleLock || MenuLock)
@@ -531,6 +533,9 @@ public class GameLayerManager : IGameLayerManager
 
     public void GoToSaveOrLoadMenu(bool isSave)
     {
+        if (isSave && !CanSave)
+            return;
+
         if (MenuLayer == null)
             CreateMenuLayer();
 
@@ -548,6 +553,9 @@ public class GameLayerManager : IGameLayerManager
 
     public void QuickSave()
     {
+        if (!CanSave)
+            return;
+
         if (WorldLayer == null  || !LastSave.HasValue)
         {
             GoToSaveOrLoadMenu(true);
@@ -579,10 +587,10 @@ public class GameLayerManager : IGameLayerManager
 
     private void WriteQuickSave()
     {
-        if (WorldLayer == null || LastSave == null)
+        if (WorldLayer == null || LastSave == null || !CanSave)
             return;
 
-        var world = WorldLayer.World;
+        var world = WorldLayer!.World;
         var save = LastSave.Value;
         m_saveGameManager.WriteSaveGame(world, world.MapInfo.GetMapNameWithPrefix(world.ArchiveCollection), save.SaveGame);
         world.DisplayMessage(world.Player, null, SaveMenu.SaveMessage);

--- a/Core/Layer/Menus/MenuLayer.Input.cs
+++ b/Core/Layer/Menus/MenuLayer.Input.cs
@@ -39,6 +39,9 @@ public partial class MenuLayer
 
         if (MenuNotChanged(menu))
             HandleInputForMenu(menu, input);
+
+        // Consume all remaining input--when menu layer is on top, users are not expecting input to fall through into other layers.
+        input.ConsumeAll();
     }
 
     private void InvokeAndPushMenu(Func<Menu?> action)

--- a/Core/Layer/Worlds/WorldLayer.Input.cs
+++ b/Core/Layer/Worlds/WorldLayer.Input.cs
@@ -1,4 +1,3 @@
-using Helion.Layer.IwadSelection;
 using Helion.Util;
 using Helion.Util.Configs.Impl;
 using Helion.Util.Configs.Values;
@@ -114,6 +113,12 @@ public partial class WorldLayer
         if ((m_parent.LoadingLayer != null || World.Paused) && InGameCommands.Contains(cmd.Command))
             return;
 
+        // This layer should eat all regular base commands whenever it's on top, to prevent things like "move automap"
+        // commands from getting passed down to the console when the automap isn't raised (it'll always be on top and
+        // thus will have had a chance to consume its inputs first).
+        if (BaseCommands.Contains(cmd.Command))
+            return;
+
         m_parent.SubmitConsoleText(cmd.Command);
     }
 
@@ -168,7 +173,7 @@ public partial class WorldLayer
     }
 
     private void ChangeAutoMapSize(int amount)
-    {       
+    {
         if (m_autoMapScale > 0.5)
             m_autoMapScale += amount * 0.2;
         else


### PR DESCRIPTION
In this change, I am attempting to fix the following issues, all of which impact usability around save, load, and quicksave.

I want to playtest this for a bit to make sure I didn't break anything, before I merge this.

1.  The user can save while the game is displaying an intermission or endgame sequence.  This results in a save that, when reloaded, is _functionally useless_--the player is locked in place and cannot move because the intermission/endgame stuff is _supposed_ to be playing, but I'm guessing that's not serialized in the save.

My proposed fix is to block this scenario entirely.

2.  If the user currently has a menu on top, and presses a bound key that the menu cannot consume, it falls through to the command processor and sometimes produces errors.  A good example of this would be pressing the Load key while the Load menu is already open--there's a log message about missing arguments to the "load" console command.

My proposed fix is for the menu layer to consume all inputs when it's on top.  The user can still open the console while in this state, and console commands still seem to work normally.

3.  On the console, if the user types something that _isn't_ a console command, but _is_ a valid "game action", then this results in no response.  For example, if the user types "hello" at the console, they get an error telling them that there is no such command.  However, if they type "save" at the console, it just...doesn't do anything.

My proposed fix is to create dummy commands for all command constants that aren't implemented by the console.  These commands simply print the same error message as when the user types an invalid command.