### PR TITLE
wad envvars fix and utility class

### DIFF
--- a/Core/Resources/Archives/Locator/FilesystemArchiveLocator.cs
+++ b/Core/Resources/Archives/Locator/FilesystemArchiveLocator.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using Helion.Resources.Archives.Directories;
 using Helion.Resources.Archives.Entries;
 using Helion.Util.Configs;
@@ -49,7 +48,7 @@ public class FilesystemArchiveLocator : IArchiveLocator
     public FilesystemArchiveLocator(IConfig config)
     {
         List<string> paths = config.Files.Directories.Value;
-        var envPaths = GetWadDirsFromEnvVars();
+        var envPaths = WadPaths.GetFromEnvVars();
         foreach (string path in paths.Concat(envPaths).Where(p => !p.Empty()).Select(EnsureEndsWithDirectorySeparator).Distinct())
             m_paths.Add(path);
     }
@@ -123,24 +122,5 @@ public class FilesystemArchiveLocator : IArchiveLocator
     private static string EnsureEndsWithDirectorySeparator(string path)
     {
         return path.EndsWith(Path.DirectorySeparatorChar) ? path : path + Path.DirectorySeparatorChar;
-    }
-
-    /// <remarks>
-    /// https://doomwiki.org/wiki/Environment_variables
-    /// </remarks>
-    public static List<string> GetWadDirsFromEnvVars()
-    {
-        List<string> envPaths = [];
-        string? envDOOMWADDIR = Environment.GetEnvironmentVariable("DOOMWADDIR");
-        if (envDOOMWADDIR != null)
-            envPaths.Add(envDOOMWADDIR);
-        string? envDOOMWADPATH = Environment.GetEnvironmentVariable("DOOMWADPATH");
-        if (envDOOMWADPATH != null)
-        {
-            char separator = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ';' : ':';
-            foreach (string path in envDOOMWADPATH.Split(separator))
-                envPaths.Add(path);
-        }
-        return envPaths;
     }
 }

--- a/Core/Resources/Archives/WadPaths.cs
+++ b/Core/Resources/Archives/WadPaths.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Microsoft.Win32;
+
+namespace Helion.Resources.Archives;
+
+/// <summary>
+/// Utility class for getting WAD paths.
+/// </summary>
+public static class WadPaths
+{
+    private static readonly string[] SteamDoomDirs = [
+        "steamapps/common/Ultimate Doom/base",
+        "steamapps/common/Doom 2/base",
+        "steamapps/common/Doom 2/masterbase",
+        "steamapps/common/Doom 2/finaldoombase",
+        "steamapps/common/Final Doom/base",
+        "steamapps/common/DOOM 3 BFG Edition/base/wads",
+    ];
+
+    private static readonly string[] LinuxDoomDirs = [
+        "/usr/local/share/doom",
+        "/usr/local/share/games/doom",
+        "/usr/share/doom",
+        "/usr/share/games/doom",
+        "/usr/share/games/doom3bfg/base/wads",
+    ];
+
+    /// <remarks>
+    /// https://doomwiki.org/wiki/Environment_variables
+    /// </remarks>
+    public static List<string> GetFromEnvVars()
+    {
+        List<string> paths = [];
+        string? envDOOMWADDIR = Environment.GetEnvironmentVariable("DOOMWADDIR");
+        if (!string.IsNullOrEmpty(envDOOMWADDIR))
+            paths.Add(envDOOMWADDIR);
+        string? envDOOMWADPATH = Environment.GetEnvironmentVariable("DOOMWADPATH");
+        if (envDOOMWADPATH != null)
+        {
+            char separator = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ';' : ':';
+            foreach (string path in envDOOMWADPATH.Split(separator).Where(x => !string.IsNullOrEmpty(x)))
+                paths.Add(path);
+        }
+        return paths;
+    }
+
+    public static List<string> GetFromSteamAndLinuxDirs()
+    {
+        List<string> paths = [];
+
+        var steamPath = GetSteamPath();
+        if (Directory.Exists(steamPath))
+        {
+            foreach (var dir in SteamDoomDirs)
+                paths.Add(Path.Combine(steamPath, dir));
+        }
+
+        if (OperatingSystem.IsLinux())
+        {
+            paths.AddRange(LinuxDoomDirs);
+            paths.AddRange(GetLinuxUserPaths());
+        }
+
+        return paths;
+    }
+
+    private static string? GetSteamPath()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            try
+            {
+                return Registry.GetValue(@"HKEY_CURRENT_USER\Software\Valve\Steam", "SteamPath", null) as string;
+            }
+            catch (Exception)
+            {
+                return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Steam/");
+            }
+        }
+
+        if (OperatingSystem.IsLinux())
+        {
+            var home = Environment.GetEnvironmentVariable("HOME");
+
+            if (!string.IsNullOrWhiteSpace(home))
+                return $"{home}/.local/share/Steam";
+        }
+
+        return null;
+    }
+
+    private static List<string> GetLinuxUserPaths()
+    {
+        var paths = new List<string>();
+
+        var xdgConfigHome = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
+
+        if (!string.IsNullOrWhiteSpace(xdgConfigHome))
+            paths.Add($"{xdgConfigHome}/helion");
+
+        var xdgDataHome = Environment.GetEnvironmentVariable("XDG_DATA_HOME");
+
+        if (!string.IsNullOrWhiteSpace(xdgDataHome))
+        {
+            paths.Add($"{xdgDataHome}/doom");
+            paths.Add($"{xdgDataHome}/games/doom");
+        }
+
+        var home = Environment.GetEnvironmentVariable("HOME");
+
+        if (!string.IsNullOrWhiteSpace(home))
+        {
+            paths.Add($"{home}/.config/helion");
+            paths.Add($"{home}/.local/share/doom");
+            paths.Add($"{home}/.local/share/games/doom");
+        }
+
+        return paths;
+    }
+}

--- a/Core/Resources/IWad/IWadLocator.cs
+++ b/Core/Resources/IWad/IWadLocator.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Helion.Resources.Archives.Locator;
 
 namespace Helion.Resources.IWad;
 
@@ -31,7 +32,7 @@ public class IWadLocator
 
     public static IWadLocator CreateDefault(IEnumerable<string> configDirectories)
     {
-        List<string> paths = [Directory.GetCurrentDirectory(), .. configDirectories];
+        List<string> paths = [Directory.GetCurrentDirectory(), .. configDirectories, .. FilesystemArchiveLocator.GetWadDirsFromEnvVars()];
 
         var steamPath = GetSteamPath();
 

--- a/Core/Resources/IWad/IWadLocator.cs
+++ b/Core/Resources/IWad/IWadLocator.cs
@@ -1,53 +1,19 @@
-using Microsoft.Win32;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Helion.Resources.Archives.Locator;
+using Helion.Resources.Archives;
 
 namespace Helion.Resources.IWad;
 
 public class IWadLocator
 {
-    private static readonly string[] SteamDoomDirs = new[]
-    {
-        "steamapps/common/Ultimate Doom/base",
-        "steamapps/common/Doom 2/base",
-        "steamapps/common/Doom 2/masterbase",
-        "steamapps/common/Doom 2/finaldoombase",
-        "steamapps/common/Final Doom/base",
-        "steamapps/common/DOOM 3 BFG Edition/base/wads",
-    };
-
-    private static readonly string[] LinuxDoomDirs = new[]
-    {
-        "/usr/local/share/doom",
-        "/usr/local/share/games/doom",
-        "/usr/share/doom",
-        "/usr/share/games/doom",
-        "/usr/share/games/doom3bfg/base/wads",
-    };
-
     private readonly List<string> m_directories;
 
     public static IWadLocator CreateDefault(IEnumerable<string> configDirectories)
     {
-        List<string> paths = [Directory.GetCurrentDirectory(), .. configDirectories, .. FilesystemArchiveLocator.GetWadDirsFromEnvVars()];
-
-        var steamPath = GetSteamPath();
-
-        if (Directory.Exists(steamPath))
-        {
-            foreach (var dir in SteamDoomDirs)
-                paths.Add(Path.Combine(steamPath, dir));
-        }
-
-        if (OperatingSystem.IsLinux())
-        {
-            paths.AddRange(LinuxDoomDirs);
-            paths.AddRange(GetLinuxUserPaths());
-        }
-
+        List<string> paths = [Directory.GetCurrentDirectory(), .. configDirectories,
+            .. WadPaths.GetFromSteamAndLinuxDirs(), .. WadPaths.GetFromEnvVars()];
         return new IWadLocator(paths);
     }
 
@@ -89,59 +55,5 @@ public class IWadLocator
             }
         }
         catch { }
-    }
-
-    private static string? GetSteamPath()
-    {
-        if (OperatingSystem.IsWindows())
-        {
-            try
-            {
-                return Registry.GetValue(@"HKEY_CURRENT_USER\Software\Valve\Steam", "SteamPath", null) as string;
-            }
-            catch (Exception)
-            {
-                return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Steam/");
-            }
-        }
-
-        if (OperatingSystem.IsLinux())
-        {
-            var home = Environment.GetEnvironmentVariable("HOME");
-
-            if (!string.IsNullOrWhiteSpace(home))
-                return $"{home}/.local/share/Steam";
-        }
-
-        return null;
-    }
-
-    private static IEnumerable<string> GetLinuxUserPaths()
-    {
-        var paths = new List<string>();
-
-        var xdgConfigHome = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
-
-        if (!string.IsNullOrWhiteSpace(xdgConfigHome))
-            paths.Add($"{xdgConfigHome}/helion");
-
-        var xdgDataHome = Environment.GetEnvironmentVariable("XDG_DATA_HOME");
-
-        if (!string.IsNullOrWhiteSpace(xdgDataHome))
-        {
-            paths.Add($"{xdgDataHome}/doom");
-            paths.Add($"{xdgDataHome}/games/doom");
-        }
-
-        var home = Environment.GetEnvironmentVariable("HOME");
-
-        if (!string.IsNullOrWhiteSpace(home))
-        {
-            paths.Add($"{home}/.config/helion");
-            paths.Add($"{home}/.local/share/doom");
-            paths.Add($"{home}/.local/share/games/doom");
-        }
-
-        return paths;
     }
 }


### PR DESCRIPTION
#641 created a bug that spammed config.ini with the WAD path envvars, this fixes it and moves the shared logic to a new utility class