### PR TITLE
Try to handle FluidSynth crash

### DIFF
--- a/Client/Music/FluidSynthMusicPlayer.cs
+++ b/Client/Music/FluidSynthMusicPlayer.cs
@@ -79,9 +79,10 @@ public class FluidSynthMusicPlayer : IMusicPlayer
             m_player = null;
             return true;
         }
-        catch
+        catch (Exception ex)
         {
             Log.Warn("Error starting FluidSynth music playback.");
+            Log.Info(ex.ToString());
         }
 
         return false;
@@ -104,9 +105,10 @@ public class FluidSynthMusicPlayer : IMusicPlayer
             m_soundFontCounter++;
             m_soundFontLoaded = true;
         }
-        catch
+        catch (Exception ex)
         {
             Log.Warn($"Could not load SoundFont {soundFontPath}.");
+            Log.Info(ex.ToString());
         }
     }
 
@@ -136,9 +138,10 @@ public class FluidSynthMusicPlayer : IMusicPlayer
             m_settings.Dispose();
             m_synth.Dispose();
         }
-        catch
+        catch (Exception ex)
         {
             Log.Warn("Error unloading FluidSynth music player");
+            Log.Info(ex.ToString());
         }
         m_disposed = true;
     }

--- a/Client/Music/FluidSynthMusicPlayer.cs
+++ b/Client/Music/FluidSynthMusicPlayer.cs
@@ -131,8 +131,15 @@ public class FluidSynthMusicPlayer : IMusicPlayer
             return;
 
         Stop();
-        m_settings.Dispose();
-        m_synth.Dispose();
+        try
+        {
+            m_settings.Dispose();
+            m_synth.Dispose();
+        }
+        catch(Exception ex)
+        {
+            Log.Warn("Error unloading FluidSynth music player");
+        }
         m_disposed = true;
     }
 }

--- a/Client/Music/FluidSynthMusicPlayer.cs
+++ b/Client/Music/FluidSynthMusicPlayer.cs
@@ -136,7 +136,7 @@ public class FluidSynthMusicPlayer : IMusicPlayer
             m_settings.Dispose();
             m_synth.Dispose();
         }
-        catch(Exception ex)
+        catch
         {
             Log.Warn("Error unloading FluidSynth music player");
         }


### PR DESCRIPTION
On some machines, it seems possible to hit this exception, which crashes the whole application.  It's kind of a hit-or-miss thing; I have a machine that shows this issue just often enough to keep me in suspense.

1.  I suspect that disposing the synth before the settings _might_ help to avoid this
2.  Let's see if we can catch and log it.

```
Application: Helion.exe
CoreCLR Version: 8.0.824.36612
.NET Version: 8.0.8
Description: The process was terminated due to an unhandled exception.
Exception Info: System.AccessViolationException: Attempted to read or write protected memory. This is often an indication that other memory is corrupt.
Stack:
   at NFluidsynth.Native.LibFluidsynth.delete_fluid_synth(IntPtr)
   at NFluidsynth.Native.LibFluidsynth.delete_fluid_synth(IntPtr)
   at NFluidsynth.Synth.Dispose(Boolean)
   at NFluidsynth.FluidsynthObject.Dispose()
   at Helion.Client.Music.FluidSynthMusicPlayer.PerformDispose()
   at Helion.Client.Music.FluidSynthMusicPlayer.Dispose()
   at Helion.Client.Music.MusicPlayer.Play(Byte[], Helion.Audio.MusicPlayerOptions)
   at Helion.World.Impl.SinglePlayer.SinglePlayerWorld.Start(Helion.Models.WorldModel)
   at Helion.Client.Client.CheckLoadMapComplete()
   at Helion.Client.Client.Window_MainLoop(OpenTK.Windowing.Common.FrameEventArgs)
   at OpenTK.Windowing.Desktop.GameWindow.DispatchRenderFrame()
   at OpenTK.Windowing.Desktop.GameWindow.Run()
   at Helion.Client.Client.Run()
   at Helion.Client.Client.Run(Helion.Util.CommandLine.CommandLineArgs)
   at Helion.Client.Client.RunRelease(Helion.Util.CommandLine.CommandLineArgs)
   at Helion.Client.Client.Main(System.String[])
   ```