### PR TITLE
always map buffer in GLBufferTextureStorage

### DIFF
--- a/Core/Render/OpenGL/Textures/GLBufferTextureStorage.cs
+++ b/Core/Render/OpenGL/Textures/GLBufferTextureStorage.cs
@@ -53,9 +53,6 @@ public class GLBufferTextureStorage
 
     public void Map(Action<IntPtr> action)
     {
-        if (!m_bufferTexture.PersistentBufferStorage)
-            return;
-
         m_bufferTexture.Map(action);
     }
 


### PR DESCRIPTION
fixes GPUs that do not support map persistent bit

fixed #645