### PR TITLE
Implement status bar texture picker

### DIFF
--- a/Client/Client.Config.cs
+++ b/Client/Client.Config.cs
@@ -113,7 +113,7 @@ public partial class Client
         }
     }
 
-    private void SoundFont_OnChanged(object? sender, FileInfo e)
+    private void SoundFont_OnChanged(object? sender, string _)
     {
         (m_audioSystem.Music as MusicPlayer)?.ChangeSoundFont();
     }

--- a/Client/Music/MusicPlayer.cs
+++ b/Client/Music/MusicPlayer.cs
@@ -6,6 +6,7 @@ using NLog;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -55,11 +56,11 @@ public class MusicPlayer : IMusicPlayer
     public bool ChangesMasterVolume() => m_musicPlayer is NAudioMusicPlayer;
 
     private FluidSynthMusicPlayer CreateFluidSynthPlayer() =>
-        new(m_configAudio.SoundFontFile);
+        new(new FileInfo(m_configAudio.SoundFontFile));
 
     public void ChangeSoundFont()
     {
-        (m_musicPlayer as FluidSynthMusicPlayer)?.ChangeSoundFont(m_configAudio.SoundFontFile);
+        (m_musicPlayer as FluidSynthMusicPlayer)?.ChangeSoundFont(new FileInfo(m_configAudio.SoundFontFile));
     }
 
     private void PlayQueueTask()

--- a/Core/Layer/Options/Dialogs/ColorDialog.cs
+++ b/Core/Layer/Options/Dialogs/ColorDialog.cs
@@ -11,7 +11,7 @@ using Helion.Window;
 using Helion.Window.Input;
 using System;
 
-namespace Helion.Layer.Options;
+namespace Helion.Layer.Options.Dialogs;
 
 internal class ColorDialog : DialogBase
 {

--- a/Core/Layer/Options/Dialogs/DialogBase.cs
+++ b/Core/Layer/Options/Dialogs/DialogBase.cs
@@ -157,7 +157,6 @@ internal abstract class DialogBase(ConfigHud config, string? acceptButton, strin
         Align windowAlign = Align.TopLeft,
         Align anchorAlign = Align.TopLeft)
     {
-        //hud.Image(imageName, )
         hud.Image(imageName, new HudBox((0, 0), desiredSize), window: windowAlign, anchor: anchorAlign);
         hud.AddOffset((0, desiredSize.Y + m_padding));
     }

--- a/Core/Layer/Options/Dialogs/DialogBase.cs
+++ b/Core/Layer/Options/Dialogs/DialogBase.cs
@@ -2,6 +2,7 @@
 using Helion.Geometry.Boxes;
 using Helion.Geometry.Vectors;
 using Helion.Graphics;
+using Helion.Render.Common;
 using Helion.Render.Common.Enums;
 using Helion.Render.Common.Renderers;
 using Helion.Util;
@@ -147,6 +148,18 @@ internal abstract class DialogBase(ConfigHud config, string? acceptButton, strin
 
         hud.Text(message, Font, m_fontSize, (0, 0), color: color, textAlign: textAlign, window: windowAlign, anchor: anchorAlign, maxWidth: m_box.Width);
         hud.AddOffset((0, m_rowHeight + m_padding));
+    }
+
+    protected void RenderDialogImage(
+        IHudRenderContext hud,
+        string imageName,
+        Vec2I desiredSize,
+        Align windowAlign = Align.TopLeft,
+        Align anchorAlign = Align.TopLeft)
+    {
+        //hud.Image(imageName, )
+        hud.Image(imageName, new HudBox((0, 0), desiredSize), window: windowAlign, anchor: anchorAlign);
+        hud.AddOffset((0, desiredSize.Y + m_padding));
     }
 
     protected string TruncateTextToDialogWidth(string text, IHudRenderContext hud)

--- a/Core/Layer/Options/Dialogs/DialogBase.cs
+++ b/Core/Layer/Options/Dialogs/DialogBase.cs
@@ -14,7 +14,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace Helion.Layer.Options;
+namespace Helion.Layer.Options.Dialogs;
 
 internal abstract class DialogBase(ConfigHud config, string? acceptButton, string? cancelButton) : IDialog
 {
@@ -97,7 +97,7 @@ internal abstract class DialogBase(ConfigHud config, string? acceptButton, strin
         m_dialogBox = new(m_dialogOffset, (m_dialogOffset.X + m_box.Width, m_dialogOffset.Y + m_box.Height));
 
         hud.FillBox((0, 0, size.Width, size.Height), Color.Gray, window: Align.Center, anchor: Align.Center);
-        hud.FillBox((0, 0, size.Width - (border * 2), size.Height - (border * 2)), Color.Black, window: Align.Center, anchor: Align.Center);
+        hud.FillBox((0, 0, size.Width - border * 2, size.Height - border * 2), Color.Black, window: Align.Center, anchor: Align.Center);
 
         if (m_acceptButton != null && m_cancelButton != null)
         {
@@ -119,7 +119,7 @@ internal abstract class DialogBase(ConfigHud config, string? acceptButton, strin
         // When dialog contents are rendered, vertical offset is at a point suitable for rendering new elements.
         // Horizontal offset is set to the left side of the screen in case we need to draw something centered on the screen,
         // as in the color picker dialog.
-        this.RenderDialogContents(ctx, hud, !m_box.Equals(lastBox));
+        RenderDialogContents(ctx, hud, !m_box.Equals(lastBox));
         hud.PopOffset();
     }
 

--- a/Core/Layer/Options/Dialogs/FileListDialog.cs
+++ b/Core/Layer/Options/Dialogs/FileListDialog.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
-namespace Helion.Layer.Options;
+namespace Helion.Layer.Options.Dialogs;
 
 internal class FileListDialog : ListDialog
 {

--- a/Core/Layer/Options/Dialogs/FileListDialog.cs
+++ b/Core/Layer/Options/Dialogs/FileListDialog.cs
@@ -77,8 +77,10 @@ internal class FileListDialog : ListDialog
         m_listsNeedUpdate = true;
     }
 
-    protected override void ModifyListElements(List<string> valuesList, IHudRenderContext hud, bool sizeChanged)
+    protected override void ModifyListElements(List<string> valuesList, IHudRenderContext hud, bool sizeChanged, out bool didChange)
     {
+        didChange = false;
+
         if (m_listsNeedUpdate || sizeChanged)
         {
             m_header = TruncateTextToDialogWidth($"Directory: {m_path}", hud);
@@ -86,6 +88,7 @@ internal class FileListDialog : ListDialog
 
             m_valuesListRaw.Clear();
             valuesList.Clear();
+            didChange = true;
 
             DirectoryInfo directory = new DirectoryInfo(m_path.Length > 0 ? m_path : AppContext.BaseDirectory);
 

--- a/Core/Layer/Options/Dialogs/IDialog.cs
+++ b/Core/Layer/Options/Dialogs/IDialog.cs
@@ -2,7 +2,7 @@
 using Helion.Render.Common.Renderers;
 using System;
 
-namespace Helion.Layer.Options;
+namespace Helion.Layer.Options.Dialogs;
 
 public record struct DialogCloseArgs(bool Accepted);
 

--- a/Core/Layer/Options/Dialogs/ListDialog.cs
+++ b/Core/Layer/Options/Dialogs/ListDialog.cs
@@ -11,7 +11,7 @@ using Helion.Window.Input;
 using System;
 using System.Collections.Generic;
 
-namespace Helion.Layer.Options;
+namespace Helion.Layer.Options.Dialogs;
 internal abstract class ListDialog : DialogBase
 {
     private const string ScrollIndicator = "|";

--- a/Core/Layer/Options/Dialogs/MessageDialog.cs
+++ b/Core/Layer/Options/Dialogs/MessageDialog.cs
@@ -3,7 +3,7 @@ using Helion.Render.Common.Renderers;
 using Helion.Util.Configs.Components;
 using System.Collections.Generic;
 
-namespace Helion.Layer.Options;
+namespace Helion.Layer.Options.Dialogs;
 
 internal class MessageDialog(ConfigHud config, string title, IList<string> message, string? acceptButton, string? cancelButton)
     : DialogBase(config, acceptButton, cancelButton)

--- a/Core/Layer/Options/Dialogs/TexturePickerDialog.cs
+++ b/Core/Layer/Options/Dialogs/TexturePickerDialog.cs
@@ -1,0 +1,33 @@
+﻿namespace Helion.Layer.Options.Dialogs
+{
+    using Helion.Render.Common.Renderers;
+    using Helion.Util.Configs.Components;
+    using Helion.Util.Configs.Options;
+    using Helion.Util.Configs.Values;
+    using System;
+    using System.Collections.Generic;
+
+    internal class TexturePickerDialog : ListDialog
+    {
+        public string SelectedTexture { get; private set; }
+
+        public TexturePickerDialog(ConfigHud config, IConfigValue configValue, OptionMenuAttribute attr) : base(config, configValue, attr)
+        {
+        }
+
+        protected override void ModifyListElements(List<string> valuesList, IHudRenderContext hud, bool sizeChanged)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override void RenderDialogHeader(IHudRenderContext hud)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override void SelectedRowChanged(string selectedRowLabel, int selectedRowIndex, bool mouseClick)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Core/Layer/Options/Dialogs/TexturePickerDialog.cs
+++ b/Core/Layer/Options/Dialogs/TexturePickerDialog.cs
@@ -4,30 +4,113 @@
     using Helion.Util.Configs.Components;
     using Helion.Util.Configs.Options;
     using Helion.Util.Configs.Values;
+    using Helion.Window;
     using System;
     using System.Collections.Generic;
+    using System.Linq;
 
     internal class TexturePickerDialog : ListDialog
     {
+        private const int BlinkIntervalMilliseconds = 500;
+
+        private bool m_isInitialized;
+        private string m_typedName;
+        private string m_header;
+        private string m_headerWithUnderscore;
         public string SelectedTexture { get; private set; }
 
-        public TexturePickerDialog(ConfigHud config, IConfigValue configValue, OptionMenuAttribute attr) : base(config, configValue, attr)
+        public TexturePickerDialog(ConfigHud config, IConfigValue configValue, OptionMenuAttribute attr)
+            : base(config, configValue, attr)
         {
+            SelectedTexture = (string)configValue.ObjectValue;
+            m_typedName = SelectedTexture;
+
+            m_header = $"Texture: {m_typedName}";
+            m_headerWithUnderscore = $"Texture: {m_typedName}_";
         }
 
-        protected override void ModifyListElements(List<string> valuesList, IHudRenderContext hud, bool sizeChanged)
+        public override void HandleInput(IConsumableInput input)
         {
-            throw new NotImplementedException();
+            bool textChanged = false;
+
+            // Backspace and typed characters will change the current path directly
+            if (input.ConsumePressOrContinuousHold(Window.Input.Key.Backspace))
+            {
+                m_typedName = m_typedName.Length > 0 ? m_typedName.Remove(m_typedName.Length - 1) : m_typedName;
+                UpdateHeader();
+                textChanged = true;
+            }
+
+            ReadOnlySpan<char> typedChars = input.ConsumeTypedCharacters();
+            if (typedChars.Length > 0)
+            {
+                m_typedName = $"{m_typedName}{typedChars}";
+                UpdateHeader();
+                textChanged = true;
+
+            }
+
+            if (textChanged)
+            {
+                (_, string selectedTexture) = SelectRowByBeginsWith(m_typedName, StringComparison.OrdinalIgnoreCase, false);
+                if (!string.IsNullOrEmpty(selectedTexture))
+                {
+                    SelectedTexture = selectedTexture;
+                    EnsureSelectedVisible = true;
+                }
+            }
+
+            base.HandleInput(input);
+        }
+
+        protected override void ModifyListElements(List<string> valuesList, IHudRenderContext hud, bool sizeChanged, out bool didChange)
+        {
+            didChange = false;
+
+            if (!m_isInitialized)
+            {
+                valuesList.Clear();
+
+                // Note:  We could also include the sprites here, but that makes this list even more ridiculously long.
+                List<string> names =
+                [
+                    .. hud.Textures.GetNames(Resources.ResourceNamespace.Textures),
+                    .. hud.Textures.GetNames(Resources.ResourceNamespace.Flats),
+                    .. hud.Textures.GetNames(Resources.ResourceNamespace.Graphics),
+                ];
+
+                valuesList.AddRange(names.Distinct().Order());
+
+                m_isInitialized = true;
+                didChange = true;
+            }
         }
 
         protected override void RenderDialogHeader(IHudRenderContext hud)
         {
-            throw new NotImplementedException();
+            if (DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond / BlinkIntervalMilliseconds % 2 == 0)
+            {
+                RenderDialogText(hud, m_header, color: Graphics.Color.Yellow);
+            }
+            else
+            {
+                RenderDialogText(hud, m_headerWithUnderscore, color: Graphics.Color.Yellow);
+            }
+
+            RenderDialogImage(hud, SelectedTexture, (100, 100));
         }
 
         protected override void SelectedRowChanged(string selectedRowLabel, int selectedRowIndex, bool mouseClick)
         {
-            throw new NotImplementedException();
+            SelectedTexture = selectedRowLabel;
+            m_typedName = selectedRowLabel;
+            UpdateHeader();
+        }
+
+        private void UpdateHeader()
+        {
+            m_header = $"Texture: {m_typedName}";
+            m_headerWithUnderscore = $"Texture: {m_typedName}_";
         }
     }
 }

--- a/Core/Layer/Options/OptionsLayer.cs
+++ b/Core/Layer/Options/OptionsLayer.cs
@@ -7,6 +7,7 @@ using Helion.Geometry;
 using Helion.Geometry.Boxes;
 using Helion.Geometry.Vectors;
 using Helion.Graphics;
+using Helion.Layer.Options.Dialogs;
 using Helion.Layer.Options.Sections;
 using Helion.Render.Common.Enums;
 using Helion.Render.Common.Renderers;

--- a/Core/Layer/Options/Sections/ListedConfigSection.cs
+++ b/Core/Layer/Options/Sections/ListedConfigSection.cs
@@ -184,6 +184,24 @@ public class ListedConfigSection : IOptionSection
                     m_dialog = new ColorDialog(m_config.Hud, configData.CfgValue, configData.Attr, color);
                     m_dialog.OnClose += Dialog_OnClose;
                 }
+                else if (configData.Attr.DialogType != DialogType.Default)
+                {
+                    switch (configData.Attr.DialogType)
+                    {
+                        case DialogType.TexturePicker:
+                            m_dialog = new TexturePickerDialog(m_config.Hud, configData.CfgValue, configData.Attr);
+                            break;
+                        case DialogType.SoundFontPicker:
+                            m_dialog = new FileListDialog(m_config.Hud, configData.CfgValue, configData.Attr, ".SF2,.SF3");
+                            break;
+                        default:
+                            throw new NotImplementedException($"Unimplemented dialog type: {configData.Attr.DialogType}");
+                    }
+
+                    lockOptions |= LockOptions.AllowMouse;
+                    m_dialog.OnClose += Dialog_OnClose;
+                }
+
 
                 if (configData.CfgValue.ObjectValue is FileInfo)
                 {
@@ -233,6 +251,11 @@ public class ListedConfigSection : IOptionSection
                     m_rowEditText.Clear();
                     m_rowEditText.Append(fileDialog.SelectedFile.ToString());
                 }
+            }
+            if (sender is TexturePickerDialog textureDialog)
+            {
+                m_rowEditText.Clear();
+                m_rowEditText.Append(textureDialog.SelectedTexture);
             }
             SubmitEditRow();
         }
@@ -534,7 +557,7 @@ public class ListedConfigSection : IOptionSection
 
         hud.Text("Press R to reset the selected setting to its default", Font, fontSize, (0, y), out textDimension,
             both: Align.TopMiddle, color: Color.Firebrick);
-        y += textDimension.Height  + m_config.Hud.GetScaled(8);
+        y += textDimension.Height + m_config.Hud.GetScaled(8);
 
         hud.Text(OptionType.ToString(), Font, m_config.Hud.GetLargeFontSize(), (0, y), out Dimension headerArea, both: Align.TopMiddle, color: Color.Red);
         y += headerArea.Height + m_config.Hud.GetScaled(8);

--- a/Core/Layer/Options/Sections/ListedConfigSection.cs
+++ b/Core/Layer/Options/Sections/ListedConfigSection.cs
@@ -3,6 +3,7 @@ using Helion.Geometry;
 using Helion.Geometry.Boxes;
 using Helion.Geometry.Vectors;
 using Helion.Graphics;
+using Helion.Layer.Options.Dialogs;
 using Helion.Render.Common.Enums;
 using Helion.Render.Common.Renderers;
 using Helion.Util;

--- a/Core/Render/Common/Textures/IRendererTextureManager.cs
+++ b/Core/Render/Common/Textures/IRendererTextureManager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Helion.Resources;
 
@@ -31,4 +32,11 @@ public interface IRendererTextureManager : IDisposable
     /// otherwise will search only in the provided one.</param>
     /// <returns>True if found, false if not.</returns>
     bool TryGet(string name, [NotNullWhen(true)] out IRenderableTextureHandle? handle, ResourceNamespace? specificNamespace = null);
+
+    /// <summary>
+    /// Get a list of texture names
+    /// </summary>
+    /// <param name="specificNamespace">Namespace to filter to</param>
+    /// <returns>A list of texture names</returns>
+    IEnumerable<string> GetNames(ResourceNamespace specificNamespace);
 }

--- a/Core/Render/OpenGL/Texture/GLTextureManager.cs
+++ b/Core/Render/OpenGL/Texture/GLTextureManager.cs
@@ -96,7 +96,7 @@ public abstract class GLTextureManager<GLTextureType> : IRendererTextureManager
 
     public IEnumerable<string> GetNames(ResourceNamespace specificNamespace)
     {
-        return ArchiveCollection.ImageRetriever.GetAllNames(specificNamespace);
+        return ArchiveCollection.ImageRetriever.GetNames(specificNamespace);
     }
 
     /// <summary>

--- a/Core/Render/OpenGL/Texture/GLTextureManager.cs
+++ b/Core/Render/OpenGL/Texture/GLTextureManager.cs
@@ -94,6 +94,11 @@ public abstract class GLTextureManager<GLTextureType> : IRendererTextureManager
         return false;
     }
 
+    public IEnumerable<string> GetNames(ResourceNamespace specificNamespace)
+    {
+        return ArchiveCollection.ImageRetriever.GetAllNames(specificNamespace);
+    }
+
     /// <summary>
     /// Checks if the texture manager contains the image.
     /// </summary>
@@ -312,14 +317,14 @@ public abstract class GLTextureManager<GLTextureType> : IRendererTextureManager
     {
         if (m_disposed)
             return;
-        
+
         NullTexture.Dispose();
         WhiteTexture.Dispose();
         NullFont.Dispose();
-        
+
         TextureTracker.GetValues().ForEach(texture => texture?.Dispose());
         TextureTrackerClamp.GetValues().ForEach(texture => texture?.Dispose());
-        
+
         foreach (var pair in m_fonts)
             pair.Value.Dispose();
 

--- a/Core/Resources/Archives/Collection/ArchiveCollectionEntries.cs
+++ b/Core/Resources/Archives/Collection/ArchiveCollectionEntries.cs
@@ -95,6 +95,11 @@ public class ArchiveCollectionEntries
         return entry;
     }
 
+    public IEnumerable<string> GetNames(ResourceNamespace specificNamespace)
+    {
+        return m_namespaceEntries.GetNames(specificNamespace);
+    }
+
     // WARNING: Should only be used sparingly on startup. Never at runtime. This list is allocated each time.
     public List<Entry> GetAllByNamespace(ResourceNamespace resourceNamespace)
     {

--- a/Core/Resources/Images/ArchiveImageRetriever.cs
+++ b/Core/Resources/Images/ArchiveImageRetriever.cs
@@ -8,7 +8,9 @@ using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.PixelFormats;
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Image = Helion.Graphics.Image;
 
 namespace Helion.Resources.Images;
@@ -63,6 +65,19 @@ public class ArchiveImageRetriever : IImageRetriever
             return ImageFromDefinition(definition);
 
         return null;
+    }
+
+    /// <summary>
+    /// Returns a list of all image names.
+    /// This creates a new list.
+    /// </summary>
+    /// <returns>All image names, optionally filtered to a specific namespace</returns>
+    public IEnumerable<string> GetAllNames(ResourceNamespace specificNamespace)
+    {
+        return m_compiledImages.GetNames(specificNamespace)
+            .Concat(m_archiveCollection.Entries.GetNames(specificNamespace))
+            .Concat(m_archiveCollection.Definitions.Textures.GetNames(specificNamespace))
+            .ToList();
     }
 
     public Image? GetOnly(string name, ResourceNamespace targetNamespace)

--- a/Core/Resources/Images/ArchiveImageRetriever.cs
+++ b/Core/Resources/Images/ArchiveImageRetriever.cs
@@ -72,7 +72,7 @@ public class ArchiveImageRetriever : IImageRetriever
     /// This creates a new list.
     /// </summary>
     /// <returns>All image names, optionally filtered to a specific namespace</returns>
-    public IEnumerable<string> GetAllNames(ResourceNamespace specificNamespace)
+    public IEnumerable<string> GetNames(ResourceNamespace specificNamespace)
     {
         return m_compiledImages.GetNames(specificNamespace)
             .Concat(m_archiveCollection.Entries.GetNames(specificNamespace))

--- a/Core/Resources/Images/IImageRetriever.cs
+++ b/Core/Resources/Images/IImageRetriever.cs
@@ -1,4 +1,5 @@
 using Helion.Graphics;
+using System.Collections.Generic;
 
 namespace Helion.Resources.Images;
 
@@ -25,4 +26,11 @@ public interface IImageRetriever
     /// <param name="targetNamespace">The namespace to check.</param>
     /// <returns>The image, or null if none can be found.</returns>
     Image? GetOnly(string name, ResourceNamespace targetNamespace);
+
+    /// <summary>
+    /// Get the names of all images in the specific namespace
+    /// </summary>
+    /// <param name="specificNamespace">The desired namespace</param>
+    /// <returns>A list of image names</returns>
+    IEnumerable<string> GetAllNames(ResourceNamespace specificNamespace);
 }

--- a/Core/Resources/Images/IImageRetriever.cs
+++ b/Core/Resources/Images/IImageRetriever.cs
@@ -32,5 +32,5 @@ public interface IImageRetriever
     /// </summary>
     /// <param name="specificNamespace">The desired namespace</param>
     /// <returns>A list of image names</returns>
-    IEnumerable<string> GetAllNames(ResourceNamespace specificNamespace);
+    IEnumerable<string> GetNames(ResourceNamespace specificNamespace);
 }

--- a/Core/Resources/ResourceTracker.cs
+++ b/Core/Resources/ResourceTracker.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Helion.Util.Container;
 
 namespace Helion.Resources;
@@ -105,6 +106,16 @@ public class ResourceTracker<T> where T : class
 
         m_tableByName.TryGetValue(name, out var value);
         return value;
+    }
+
+    /// <summary>
+    /// Gets a list of resources in the specified namespace.
+    /// This creates a new list.
+    /// </summary>
+    /// <returns>A list of resource names</returns>
+    public IEnumerable<string> GetNames(ResourceNamespace resourceNamespace)
+    {
+        return m_table.GetSecondKeys(resourceNamespace);
     }
 
     /// <summary>

--- a/Core/Util/Configs/Components/ConfigAudio.cs
+++ b/Core/Util/Configs/Components/ConfigAudio.cs
@@ -39,6 +39,6 @@ public class ConfigAudio
     public readonly ConfigValue<string> Device = new(IAudioSystem.DefaultAudioDevice);
 
     [ConfigInfo("SoundFont file to use for MIDI/MUS music playback.")]
-    [OptionMenu(OptionSectionType.Audio, "SoundFont File")]
-    public readonly ConfigValue<FileInfo> SoundFontFile = new(new($"SoundFonts{Path.DirectorySeparatorChar}Default.sf2"));
+    [OptionMenu(OptionSectionType.Audio, "SoundFont File", dialogType: DialogType.SoundFontPicker)]
+    public readonly ConfigValue<string> SoundFontFile = new($"SoundFonts{Path.DirectorySeparatorChar}Default.sf2");
 }

--- a/Core/Util/Configs/Components/ConfigHud.cs
+++ b/Core/Util/Configs/Components/ConfigHud.cs
@@ -147,7 +147,7 @@ public class ConfigHud
     public readonly ConfigValue<StatusBarSizeType> StatusBarSize = new(StatusBarSizeType.Minimal, OnlyValidEnums<StatusBarSizeType>());
 
     [ConfigInfo("Background texture for status bar when it doesn't fill the screen.")]
-    [OptionMenu(OptionSectionType.Hud, "Status Bar Texture")]
+    [OptionMenu(OptionSectionType.Hud, "Status Bar Texture", dialogType: DialogType.TexturePicker)]
     public readonly ConfigValue<string> BackgroundTexture = new("W94_1");
 
     [ConfigInfo("Render average frames per second in corner of display.")]

--- a/Core/Util/Configs/Options/DialogType.cs
+++ b/Core/Util/Configs/Options/DialogType.cs
@@ -1,0 +1,20 @@
+﻿namespace Helion.Util.Configs.Options
+{
+    public enum DialogType
+    {
+        /// <summary>
+        /// Use the default dialog for this data type (usually none, but colors automatically get a color picker)
+        /// </summary>
+        Default,
+
+        /// <summary>
+        /// Use the SoundFont file picker
+        /// </summary>
+        SoundFontPicker,
+
+        /// <summary>
+        /// Use the texture lump picker
+        /// </summary>
+        TexturePicker,
+    }
+}

--- a/Core/Util/Configs/Options/OptionMenuAttribute.cs
+++ b/Core/Util/Configs/Options/OptionMenuAttribute.cs
@@ -5,13 +5,14 @@ namespace Helion.Util.Configs.Options;
 [AttributeUsage(AttributeTargets.Field)]
 public class OptionMenuAttribute : Attribute
 {
-    public OptionMenuAttribute(OptionSectionType section, string name, bool disabled = false, bool spacer = false, bool allowReset = true)
+    public OptionMenuAttribute(OptionSectionType section, string name, bool disabled = false, bool spacer = false, bool allowReset = true, DialogType dialogType = Options.DialogType.Default)
     {
         Section = section;
         Name = name;
         Disabled = disabled;
         Spacer = spacer;
         AllowBulkReset = allowReset;
+        DialogType = dialogType;
     }
 
     public readonly OptionSectionType Section;
@@ -19,4 +20,5 @@ public class OptionMenuAttribute : Attribute
     public readonly bool Disabled;
     public readonly bool Spacer;
     public readonly bool AllowBulkReset;
+    public readonly DialogType? DialogType;
 }

--- a/Core/Util/Container/HashTable.cs
+++ b/Core/Util/Container/HashTable.cs
@@ -83,6 +83,13 @@ public class HashTable<K1, K2, V> where V : class
     public IEnumerable<K1> GetFirstKeys() => m_table.Keys.ToList();
 
     /// <summary>
+    /// Gets a list of the second-level keys, for a given value of a first key.
+    /// This will return a new list.
+    /// </summary>
+    /// <returns>A new list of all second-level keys for a given first key value</returns>
+    public IEnumerable<K2> GetSecondKeys(K1 firstKey) => m_table.TryGetValue(firstKey, out var contents) ? contents.Keys.ToList() : [];
+
+    /// <summary>
     /// Gets the value in the map.
     /// </summary>
     /// <param name="firstKey">The first key.</param>


### PR DESCRIPTION
This adds a "texture picker" dialog derived from the "list" dialog I added for the SoundFonts.  It allows the user to pick a texture by scrolling through the list and selecting something (using either the keyboard or mouse), or by typing in a texture name.  If the user types a _partial_ texture name, we try to find the first texture that starts with the same string.

The header section of the dialog displays a 100x100 scaled preview of the texture.