### PR TITLE
 fix input key consume

### DIFF
--- a/Core/Layer/GameLayerManager.cs
+++ b/Core/Layer/GameLayerManager.cs
@@ -74,7 +74,7 @@ public class GameLayerManager : IGameLayerManager
     private readonly HudRenderContext m_hudContext = new(default);
     private readonly OptionsLayer m_optionsLayer;
     private readonly ConsoleLayer m_consoleLayer;
-    private readonly Action<IConsumableInput, KeyCommandItem> m_checkScreenShotCommand;
+    private readonly Func<IConsumableInput, KeyCommandItem, bool> m_checkScreenShotCommand;
     private Renderer m_renderer;
     private IRenderableSurfaceContext m_ctx;
     private IHudRenderContext m_hudRenderCtx;
@@ -400,15 +400,16 @@ public class GameLayerManager : IGameLayerManager
         }
 
         WorldLayer?.HandleInput(input);
-        input.IterateCommands(m_config.Keys.GetKeyMapping(), m_checkScreenShotCommand, false);
+        input.IterateCommands(m_config.Keys.GetKeyMapping(), m_checkScreenShotCommand);
     }
 
-    private void CheckScreenShotCommand(IConsumableInput input, KeyCommandItem cmd)
+    private bool CheckScreenShotCommand(IConsumableInput input, KeyCommandItem cmd)
     {
         if (cmd.Command != Constants.Input.Screenshot || !input.ConsumeKeyPressed(cmd.Key))
-            return;
+            return false;
 
         m_console.SubmitInputText(Constants.Input.Screenshot);
+        return true;
     }
 
     private void CheckMenuShortcuts(IConsumableInput input)

--- a/Core/Layer/Worlds/WorldLayer.Input.cs
+++ b/Core/Layer/Worlds/WorldLayer.Input.cs
@@ -101,25 +101,26 @@ public partial class WorldLayer
         }
 
         if (m_parent.LoadingLayer == null)
-            input.IterateCommands(World.Config.Keys.GetKeyMapping(), m_checkCommandAction, true);
+            input.IterateCommands(World.Config.Keys.GetKeyMapping(), m_checkCommandAction);
     }
 
-    private void CheckCommand(IConsumableInput input, KeyCommandItem cmd)
+    private bool CheckCommand(IConsumableInput input, KeyCommandItem cmd)
     {
         // Handling this at the GameLayerManager level so screenshots can work on title/options etc.
         if (cmd.Command == Input.Screenshot)
-            return;
+            return false;
 
         if ((m_parent.LoadingLayer != null || World.Paused) && InGameCommands.Contains(cmd.Command))
-            return;
+            return false;
 
         // This layer should eat all regular base commands whenever it's on top, to prevent things like "move automap"
         // commands from getting passed down to the console when the automap isn't raised (it'll always be on top and
         // thus will have had a chance to consume its inputs first).
         if (BaseCommands.Contains(cmd.Command))
-            return;
+            return false;
 
         m_parent.SubmitConsoleText(cmd.Command);
+        return true;
     }
 
     private void HandlePausePress()

--- a/Core/Layer/Worlds/WorldLayer.cs
+++ b/Core/Layer/Worlds/WorldLayer.cs
@@ -70,7 +70,7 @@ public partial class WorldLayer : IGameLayerParent
     private readonly Action<IHudRenderContext> m_virtualDrawFullStatusBarAction;
     private readonly Action<HudStatusBarbackground> m_virtualStatusBarBackgroundAction;
     private readonly Action<IHudRenderContext> m_virtualDrawPauseAction;
-    private readonly Action<IConsumableInput, KeyCommandItem> m_checkCommandAction;
+    private readonly Func<IConsumableInput, KeyCommandItem, bool> m_checkCommandAction;
     private StatusBarSizeType m_statusBarSizeType = StatusBarSizeType.Minimal;
     private TickerInfo m_lastTickInfo = new(0, 0);
     private Vec2I m_autoMapOffset = (0, 0);

--- a/Core/Window/IConsumableInput.cs
+++ b/Core/Window/IConsumableInput.cs
@@ -26,5 +26,5 @@ public interface IConsumableInput
     Vec2I ConsumeMouseMove();
     Vec2I GetMouseMove();
     int ConsumeScroll();
-    void IterateCommands(IList<KeyCommandItem> commands, Action<IConsumableInput, KeyCommandItem> onCommand, bool consumeKeyPressed);
+    void IterateCommands(IList<KeyCommandItem> commands, Func<IConsumableInput, KeyCommandItem, bool> onCommand);
 }

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -11,6 +11,7 @@
   - Fixed visual scroll offsets not being restored from a save for walls and flats
   - Fixed instant sector floors not raising when two monsters are overlapping
   - Fixed A_BfgSpray to be created after damage so they are rendered at corpse height if a monster is killed.
+  - Fixed issue with screenshot command not being processed.
 
 ## Features:
   - Initial id24 specification support


### PR DESCRIPTION
fix ConsumeKeyDown to only consume if it was pressed, update iterate commands callback to return if it should be consumed (fixes issues with printscreen)

fixes #639 