### PR TITLE
Add test to protect against config event handlers leaking

### DIFF
--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -26,11 +26,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Resources\" />
-    <Folder Include="Unit\MapGeometry\" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Update ="Resources\*" CopyToOutputDirectory="PreserveNewest"/>
   </ItemGroup>
 

--- a/Tests/Unit/Util/Configs/Impl/ConfigEventLeakageTest.cs
+++ b/Tests/Unit/Util/Configs/Impl/ConfigEventLeakageTest.cs
@@ -1,0 +1,90 @@
+﻿namespace Helion.Tests.Unit.Util.Configs.Impl
+{
+    using FluentAssertions;
+    using Helion.Resources.IWad;
+    using Helion.Tests.Unit.GameAction;
+    using Helion.Util.Configs.Impl;
+    using System;
+    using System.Linq;
+    using System.Reflection;
+    using Xunit;
+
+    public class ConfigEventLeakageTest
+    {
+        [Fact(DisplayName = "Creating and destroying a game world cannot leak event handlers attached to the default Config")]
+        public void CannotLeakConfigEventHandlers()
+        {
+            Config config = new Config();
+
+            // Gather up all of the (prop, field, event) tuples defined in the Config type, 
+            // e.g. Audio Volume OnChanged
+            var eventDefinitionsByPropAndField = typeof(Config)
+                .GetProperties()
+                .SelectMany(prop => prop.PropertyType
+                    .GetFields()
+                    .SelectMany(field => field.FieldType
+                        .GetFields(BindingFlags.Instance | BindingFlags.NonPublic)
+                        .Where(evt => evt.FieldType.Name.StartsWith("EventHandler"))
+                        .Select(evt => (prop, field, evt))))
+                .ToArray();
+
+            // First do some sanity checks to ensure that we have correctly enumerated our event handlers and can actually
+            // detect changes.
+
+            // Sanity check #1:  We should have discovered at least _some_ event handlers (230 at the time this test was written)
+            eventDefinitionsByPropAndField.Length.Should().BeGreaterThan(0, "Config classes should have events defined upon them");
+
+            // Sanity check #2:  Register a trivial hanlder on Audio device OnChanged, make sure we can _find_ it.
+            config.Audio.Device.OnChanged += Device_OnChanged;
+            var handlerCounts = GetEventHandlerCounts(eventDefinitionsByPropAndField, config);
+            int audioDeviceChangedHandlerCount = handlerCounts.First(hc => hc.PropertyName == "Audio" && hc.FieldName == "Device" && hc.EventName == "OnChanged").EventCount;
+            audioDeviceChangedHandlerCount.Should().BeGreaterThan(0, "Found registered event on Audio Device Changed");
+
+            // Sanity check #3:  Make sure we can detect when we've unregistered this handler
+            config.Audio.Device.OnChanged -= Device_OnChanged;
+            handlerCounts = GetEventHandlerCounts(eventDefinitionsByPropAndField, config);
+            int audioDeviceChangedHandlerCountAfter = handlerCounts.First(hc => hc.PropertyName == "Audio" && hc.FieldName == "Device" && hc.EventName == "OnChanged").EventCount;
+            (audioDeviceChangedHandlerCount - audioDeviceChangedHandlerCountAfter).Should().Be(1);
+
+            // Now for the main event
+            // Create a game world and simulate a second of gameplay, then tear down the game world.
+
+            var world = WorldAllocator.LoadMap("Resources/boomactions.zip", "boomactions.WAD", "MAP01", GetType().Name, (world) => { }, IWadType.Doom2);
+            GameActions.TickWorld(world, 35);
+            world.Dispose();
+
+            var handlerCountsAfterWorldTeardown = GetEventHandlerCounts(eventDefinitionsByPropAndField, config);
+            for (int i = 0; i < handlerCountsAfterWorldTeardown.Length; i++)
+            {
+                var (propertyName, fieldName, eventName, beforeEventCount) = handlerCounts[i];
+                var (_, _, _, afterEventCount) = handlerCountsAfterWorldTeardown[i];
+
+                afterEventCount.Should().Be(beforeEventCount, $"{propertyName}.{fieldName}.{eventName} should have the same number of event handlers");
+            }
+        }
+
+        private static (string PropertyName, string FieldName, string EventName, int EventCount)[] GetEventHandlerCounts((PropertyInfo prop, FieldInfo field, FieldInfo evt)[] eventDefinitionsByPropAndField, Config config)
+        {
+            var registeredEventHandlerCounts = eventDefinitionsByPropAndField
+                .Select(evtDef => (
+                    PropertyName: evtDef.prop.Name,
+                    FieldName: evtDef.field.Name,
+                    EventName: evtDef.evt.Name,
+                    EventCount:
+                        (evtDef.evt.GetValue(evtDef.field.GetValue(evtDef.prop.GetValue(config))) as MulticastDelegate)?
+                            .GetInvocationList().Length ?? 0)
+                    )
+                .OrderBy(evt => evt.PropertyName)
+                .ThenBy(evt => evt.FieldName)
+                .ThenBy(evt => evt.EventName)
+                .ToArray();
+
+            return registeredEventHandlerCounts;
+        }
+
+        private static void Device_OnChanged(object? sender, string e)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Tests/Unit/Util/Configs/Impl/ConfigEventLeakageTest.cs
+++ b/Tests/Unit/Util/Configs/Impl/ConfigEventLeakageTest.cs
@@ -9,7 +9,9 @@
     using System.Reflection;
     using Xunit;
 
-    [Collection("Config events")]
+    // This needs to run in the same collection as other things that exercise game code,
+    // because it is unsafe to execute concurrently.
+    [Collection("GameActions")]
     public class ConfigEventLeakageTest
     {
         [Fact(DisplayName = "Creating and destroying a game world cannot leak event handlers attached to the default Config")]

--- a/Tests/Unit/Util/Configs/Impl/ConfigTest.cs
+++ b/Tests/Unit/Util/Configs/Impl/ConfigTest.cs
@@ -1,10 +1,14 @@
-using System.Collections.Generic;
-using System.Linq;
 using FluentAssertions;
 using Helion.Maps.Shared;
+using Helion.Resources.IWad;
+using Helion.Tests.Unit.GameAction;
 using Helion.Util.Configs.Components;
 using Helion.Util.Configs.Impl;
 using Helion.Util.Configs.Values;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using Xunit;
 
 namespace Helion.Tests.Unit.Util.Configs.Impl;
@@ -138,10 +142,84 @@ public class ConfigTest
     {
         Config config = new();
         List<(IConfigValue, Helion.Util.Configs.Options.OptionMenuAttribute, ConfigInfoAttribute)> allConfigFields = config.GetAllConfigFields();
-        foreach((IConfigValue cfgValue, _, _) in allConfigFields)
+        foreach ((IConfigValue cfgValue, _, _) in allConfigFields)
         {
             ConfigSetResult result = cfgValue.Set(cfgValue.ObjectDefaultValue);
             result.Should().NotBe(ConfigSetResult.NotSetByBadConversion);
         }
+    }
+
+    [Fact(DisplayName = "Creating and destroying a game world cannot leak event handlers attached to the default Config")]
+    public void CannotLeakConfigEventHandlers()
+    {
+        // Gather up all of the (prop, field, event) tuples defined in the Config type, 
+        // e.g. Audio Volume OnChanged
+        var eventDefinitionsByPropAndField = typeof(Config)
+            .GetProperties()
+            .SelectMany(prop => prop.PropertyType
+                .GetFields()
+                .SelectMany(field => field.FieldType
+                    .GetFields(BindingFlags.Instance | BindingFlags.NonPublic)
+                    .Where(evt => evt.FieldType.Name.StartsWith("EventHandler"))
+                    .Select(evt => (prop, field, evt))))
+            .ToArray();
+
+        // First do some sanity checks to ensure that we have correctly enumerated our event handlers and can actually
+        // detect changes.
+
+        // Sanity check #1:  We should have discovered at least _some_ event handlers (230 at the time this test was written)
+        eventDefinitionsByPropAndField.Length.Should().BeGreaterThan(0, "Config classes should have events defined upon them");
+
+        // Sanity check #2:  Register a trivial hanlder on Audio device OnChanged, make sure we can _find_ it.
+        m_config.Audio.Device.OnChanged += Device_OnChanged;
+        var handlerCounts = GetEventHandlerCounts(eventDefinitionsByPropAndField, m_config);
+        int audioDeviceChangedHandlerCount = handlerCounts.First(hc => hc.PropertyName == "Audio" && hc.FieldName == "Device" && hc.EventName == "OnChanged").EventCount;
+        audioDeviceChangedHandlerCount.Should().BeGreaterThan(0, "Found registered event on Audio Device Changed");
+
+        // Sanity check #3:  Make sure we can detect when we've unregistered this handler
+        m_config.Audio.Device.OnChanged -= Device_OnChanged;
+        handlerCounts = GetEventHandlerCounts(eventDefinitionsByPropAndField, m_config);
+        int audioDeviceChangedHandlerCountAfter = handlerCounts.First(hc => hc.PropertyName == "Audio" && hc.FieldName == "Device" && hc.EventName == "OnChanged").EventCount;
+        (audioDeviceChangedHandlerCount - audioDeviceChangedHandlerCountAfter).Should().Be(1);
+
+        // Now for the main event
+        // Create a game world and simulate a second of gameplay, then tear down the game world.
+
+        var world = WorldAllocator.LoadMap("Resources/boomactions.zip", "boomactions.WAD", "MAP01", GetType().Name, (world) => { }, IWadType.Doom2);
+        GameActions.TickWorld(world, 35);
+        world.Dispose();
+
+        var handlerCountsAfterWorldTeardown = GetEventHandlerCounts(eventDefinitionsByPropAndField, m_config);
+        for (int i = 0; i < handlerCountsAfterWorldTeardown.Length; i++)
+        {
+            var (propertyName, fieldName, eventName, beforeEventCount) = handlerCounts[i];
+            var (_, _, _, afterEventCount) = handlerCountsAfterWorldTeardown[i];
+
+            afterEventCount.Should().Be(beforeEventCount, $"{propertyName}.{fieldName}.{eventName} should have the same number of event handlers");
+        }
+    }
+
+    private static (string PropertyName, string FieldName, string EventName, int EventCount)[] GetEventHandlerCounts((PropertyInfo prop, FieldInfo field, FieldInfo evt)[] eventDefinitionsByPropAndField, Config config)
+    {
+        var registeredEventHandlerCounts = eventDefinitionsByPropAndField
+            .Select(evtDef => (
+                PropertyName: evtDef.prop.Name,
+                FieldName: evtDef.field.Name,
+                EventName: evtDef.evt.Name,
+                EventCount:
+                    (evtDef.evt.GetValue(evtDef.field.GetValue(evtDef.prop.GetValue(config))) as MulticastDelegate)?
+                        .GetInvocationList().Length ?? 0)
+                )
+            .OrderBy(evt => evt.PropertyName)
+            .ThenBy(evt => evt.FieldName)
+            .ThenBy(evt => evt.EventName)
+            .ToArray();
+
+        return registeredEventHandlerCounts;
+    }
+
+    private static void Device_OnChanged(object? sender, string e)
+    {
+        throw new NotImplementedException();
     }
 }

--- a/Tests/Unit/Util/Configs/Impl/ConfigTest.cs
+++ b/Tests/Unit/Util/Configs/Impl/ConfigTest.cs
@@ -1,14 +1,10 @@
+using System.Collections.Generic;
+using System.Linq;
 using FluentAssertions;
 using Helion.Maps.Shared;
-using Helion.Resources.IWad;
-using Helion.Tests.Unit.GameAction;
 using Helion.Util.Configs.Components;
 using Helion.Util.Configs.Impl;
 using Helion.Util.Configs.Values;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 using Xunit;
 
 namespace Helion.Tests.Unit.Util.Configs.Impl;
@@ -142,84 +138,10 @@ public class ConfigTest
     {
         Config config = new();
         List<(IConfigValue, Helion.Util.Configs.Options.OptionMenuAttribute, ConfigInfoAttribute)> allConfigFields = config.GetAllConfigFields();
-        foreach ((IConfigValue cfgValue, _, _) in allConfigFields)
+        foreach((IConfigValue cfgValue, _, _) in allConfigFields)
         {
             ConfigSetResult result = cfgValue.Set(cfgValue.ObjectDefaultValue);
             result.Should().NotBe(ConfigSetResult.NotSetByBadConversion);
         }
-    }
-
-    [Fact(DisplayName = "Creating and destroying a game world cannot leak event handlers attached to the default Config")]
-    public void CannotLeakConfigEventHandlers()
-    {
-        // Gather up all of the (prop, field, event) tuples defined in the Config type, 
-        // e.g. Audio Volume OnChanged
-        var eventDefinitionsByPropAndField = typeof(Config)
-            .GetProperties()
-            .SelectMany(prop => prop.PropertyType
-                .GetFields()
-                .SelectMany(field => field.FieldType
-                    .GetFields(BindingFlags.Instance | BindingFlags.NonPublic)
-                    .Where(evt => evt.FieldType.Name.StartsWith("EventHandler"))
-                    .Select(evt => (prop, field, evt))))
-            .ToArray();
-
-        // First do some sanity checks to ensure that we have correctly enumerated our event handlers and can actually
-        // detect changes.
-
-        // Sanity check #1:  We should have discovered at least _some_ event handlers (230 at the time this test was written)
-        eventDefinitionsByPropAndField.Length.Should().BeGreaterThan(0, "Config classes should have events defined upon them");
-
-        // Sanity check #2:  Register a trivial hanlder on Audio device OnChanged, make sure we can _find_ it.
-        m_config.Audio.Device.OnChanged += Device_OnChanged;
-        var handlerCounts = GetEventHandlerCounts(eventDefinitionsByPropAndField, m_config);
-        int audioDeviceChangedHandlerCount = handlerCounts.First(hc => hc.PropertyName == "Audio" && hc.FieldName == "Device" && hc.EventName == "OnChanged").EventCount;
-        audioDeviceChangedHandlerCount.Should().BeGreaterThan(0, "Found registered event on Audio Device Changed");
-
-        // Sanity check #3:  Make sure we can detect when we've unregistered this handler
-        m_config.Audio.Device.OnChanged -= Device_OnChanged;
-        handlerCounts = GetEventHandlerCounts(eventDefinitionsByPropAndField, m_config);
-        int audioDeviceChangedHandlerCountAfter = handlerCounts.First(hc => hc.PropertyName == "Audio" && hc.FieldName == "Device" && hc.EventName == "OnChanged").EventCount;
-        (audioDeviceChangedHandlerCount - audioDeviceChangedHandlerCountAfter).Should().Be(1);
-
-        // Now for the main event
-        // Create a game world and simulate a second of gameplay, then tear down the game world.
-
-        var world = WorldAllocator.LoadMap("Resources/boomactions.zip", "boomactions.WAD", "MAP01", GetType().Name, (world) => { }, IWadType.Doom2);
-        GameActions.TickWorld(world, 35);
-        world.Dispose();
-
-        var handlerCountsAfterWorldTeardown = GetEventHandlerCounts(eventDefinitionsByPropAndField, m_config);
-        for (int i = 0; i < handlerCountsAfterWorldTeardown.Length; i++)
-        {
-            var (propertyName, fieldName, eventName, beforeEventCount) = handlerCounts[i];
-            var (_, _, _, afterEventCount) = handlerCountsAfterWorldTeardown[i];
-
-            afterEventCount.Should().Be(beforeEventCount, $"{propertyName}.{fieldName}.{eventName} should have the same number of event handlers");
-        }
-    }
-
-    private static (string PropertyName, string FieldName, string EventName, int EventCount)[] GetEventHandlerCounts((PropertyInfo prop, FieldInfo field, FieldInfo evt)[] eventDefinitionsByPropAndField, Config config)
-    {
-        var registeredEventHandlerCounts = eventDefinitionsByPropAndField
-            .Select(evtDef => (
-                PropertyName: evtDef.prop.Name,
-                FieldName: evtDef.field.Name,
-                EventName: evtDef.evt.Name,
-                EventCount:
-                    (evtDef.evt.GetValue(evtDef.field.GetValue(evtDef.prop.GetValue(config))) as MulticastDelegate)?
-                        .GetInvocationList().Length ?? 0)
-                )
-            .OrderBy(evt => evt.PropertyName)
-            .ThenBy(evt => evt.FieldName)
-            .ThenBy(evt => evt.EventName)
-            .ToArray();
-
-        return registeredEventHandlerCounts;
-    }
-
-    private static void Device_OnChanged(object? sender, string e)
-    {
-        throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
This test detects when the "World" object life cycle leaks one or more event handlers for configuration changes.  This is important because if the World doesn't un-register its event handlers at level exit, then the configuration will still have a delegate pointed at the old World.  After multiple level changes, this can result in increased memory usage.  See https://github.com/Helion-Engine/Helion/commit/92572f2beb12e9fc3016b91c00fb4ee9bd755a35 for an example of this defect.