### PR TITLE
Various improvements to keybinding logic

### DIFF
--- a/Core/Layer/Options/OptionsLayer.cs
+++ b/Core/Layer/Options/OptionsLayer.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Reflection;
-using System.Text;
-using Helion.Audio.Sounds;
+﻿using Helion.Audio.Sounds;
 using Helion.Geometry;
 using Helion.Geometry.Boxes;
 using Helion.Geometry.Vectors;
@@ -15,11 +11,15 @@ using Helion.Resources;
 using Helion.Util.Configs;
 using Helion.Util.Configs.Components;
 using Helion.Util.Configs.Extensions;
+using Helion.Util.Configs.Impl;
 using Helion.Util.Configs.Options;
 using Helion.Util.Configs.Values;
 using Helion.Util.Timing;
 using Helion.Window;
 using Helion.Window.Input;
+using System;
+using System.Collections.Generic;
+using System.Text;
 using static Helion.Util.Constants;
 
 namespace Helion.Layer.Options;
@@ -246,6 +246,13 @@ public class OptionsLayer : IGameLayer, IAnimationLayer
 
         if (input.ConsumeKeyPressed(Key.Escape))
         {
+            // Ensure that the user isn't closing out of the menus without some kind of binding to get back into the menus.
+            m_config.Keys.EnsureMenuKey();
+            if (m_config.Keys.Changed && m_config is FileConfig fileConfig)
+            {
+                fileConfig.Write();
+            }
+
             m_soundManager.PlayStaticSound(MenuSounds.Choose);
             Animation.AnimateOut();
 
@@ -456,7 +463,7 @@ public class OptionsLayer : IGameLayer, IAnimationLayer
 
     private void GenerateFooterLines(string inputText, string font, int fontSize, IHudRenderContext hud, List<string> lines, StringBuilder builder,
         out int requiredHeight)
-    {   
+    {
         // Setting descriptions may be verbose, and may need multiple lines to render.  This method precomputes 
         // the dimensions we'll need for a footer, so we can reserve room when doing rendering and scroll offset
         // calculations.  It also returns the split text, since we need to figure that out anyway and are going to

--- a/Core/Layer/Options/Sections/KeyBindingSection.cs
+++ b/Core/Layer/Options/Sections/KeyBindingSection.cs
@@ -393,7 +393,7 @@ public class KeyBindingSection : IOptionSection
 
         hud.Text("Press R to reset bindings", Font, fontSize, (0, y), out Dimension clearArea,
             both: Align.TopMiddle, color: Color.Firebrick);
-         y += clearArea.Height + smallPad;
+        y += clearArea.Height + smallPad;
 
         hud.Text("Press enter to start binding and press a key", Font, fontSize, (0, y), out Dimension enterArea,
             both: Align.TopMiddle, color: Color.Firebrick);
@@ -485,7 +485,7 @@ public class KeyBindingSection : IOptionSection
 
     private void ResetAllKeyBindings()
     {
-        m_config.Keys.ReloadAllDefaults();
+        m_config.Keys.SetInitialDefaultKeyBindings();
         m_configUpdated = true;
         WriteConfigFile();
     }

--- a/Core/Util/Configs/IConfigKeyMapping.cs
+++ b/Core/Util/Configs/IConfigKeyMapping.cs
@@ -21,10 +21,9 @@ public interface IConfigKeyMapping
     /// </summary>
     /// <param name="key">The key to add.</param>
     /// <param name="command">The command for the key.</param>
-    void Add(Key key, string command);
+    bool Add(Key key, string command);
     bool Remove(Key key);
     bool Remove(Key key, string command);
-    void AddEmpty(Key key);
 
     /// <summary>
     /// Consumes the key for the mapped command if it is currently pressed.
@@ -81,7 +80,12 @@ public interface IConfigKeyMapping
     void ReloadDefaults(string command);
 
     /// <summary>
-    /// Restore all default bindings
+    /// Reloads all default key bindings
     /// </summary>
-    void ReloadAllDefaults();
+    void SetInitialDefaultKeyBindings();
+
+    /// <summary>
+    /// Ensures that the user has some way to get back to the menus even if they have unbound all keys.
+    /// </summary>
+    void EnsureMenuKey();
 }

--- a/Core/Util/Configs/Impl/ConfigKeyMapping.cs
+++ b/Core/Util/Configs/Impl/ConfigKeyMapping.cs
@@ -19,7 +19,7 @@ public class ConfigKeyMapping : IConfigKeyMapping
     public bool Changed { get; private set; }
     private readonly List<KeyCommandItem> m_commands = new();
 
-    private static readonly (Key key, string command)[] DefaultBindings = new[]
+    private static readonly (Key key, string command)[] DefaultBindingsByKey = new[]
     {
         (Key.W,             Constants.Input.Forward),
         (Key.A,             Constants.Input.Left),
@@ -70,18 +70,29 @@ public class ConfigKeyMapping : IConfigKeyMapping
         (Key.MouseWheelDown, Constants.Input.AutoMapDecrease),
     };
 
-    public void AddDefaultsIfMissing()
+    public void SetInitialDefaultKeyBindings()
     {
-        Log.Trace("Adding default key commands to config keys");
+        Log.Trace("Resetting key bindings to defaults");
 
-        var defaultBindingsByKey = DefaultBindings
-            .GroupBy(binding => binding.key)
-            .Select(grp => (grp.Key, grp.Select(binding => binding.command).ToArray()))
-            .ToArray();
+        m_commands.Clear();
 
-        foreach((Key key, string[] actions) in defaultBindingsByKey)
+        foreach ((Key key, string action) in DefaultBindingsByKey)
         {
-            AddIfMissing(key, actions);
+            m_commands.Add(new(key, action));
+        }
+
+        Changed = true;
+    }
+
+    public void EnsureMenuKey()
+    {
+        if (!m_commands.Any(binding => binding.Command == Constants.Input.Menu))
+        {
+            (Key menuKey, _) = DefaultBindingsByKey
+                .First(binding => binding.command == Constants.Input.Menu);
+
+            m_commands.Add(new(menuKey, Constants.Input.Menu));
+            Changed = true;
         }
     }
 
@@ -90,40 +101,21 @@ public class ConfigKeyMapping : IConfigKeyMapping
         Changed = false;
     }
 
-    private bool HasKey(Key key)
+    public bool Add(Key key, string command)
     {
-        for (int i = 0; i < m_commands.Count; i++)
-        {
-            if (m_commands[i].Key == key)
-                return true;
-        }
-
-        return false;
-    }
-
-    private void AddIfMissing(Key key, params string[] commands)
-    {
-        if (HasKey(key))
-            return;
-
-        foreach (var command in commands)
-            Add(key, command);
-    }
-
-    public void Add(Key key, string command)
-    {
-        if (key == Key.Unknown || command == "")
-            return;
+        if (key == Key.Unknown || string.IsNullOrEmpty(command))
+            return false;
 
         for (int i = 0; i < m_commands.Count; i++)
         {
             var cmd = m_commands[i];
             if (cmd.Key == key && command.Equals(cmd.Command, StringComparison.OrdinalIgnoreCase))
-                return;
+                return false;
         }
 
         Changed = true;
         m_commands.Add(new(key, command));
+        return true;
     }
 
     public bool Remove(Key key)
@@ -147,16 +139,7 @@ public class ConfigKeyMapping : IConfigKeyMapping
             break;
         }
 
-        AddEmpty(key);
         return removed;
-    }
-
-    public void AddEmpty(Key key)
-    {
-        if (HasKey(key))
-            return;
-
-        m_commands.Add(new(key, string.Empty));
     }
 
     public bool ConsumeCommandKeyPress(string command, IConsumableInput input, out int scrollAmount)
@@ -261,17 +244,10 @@ public class ConfigKeyMapping : IConfigKeyMapping
     public void ReloadDefaults(string command)
     {
         m_commands.RemoveAll(x => x.Command == command);
-        foreach ((Key key, _) in DefaultBindings.Where(binding => binding.command == command))
+        foreach ((Key key, _) in DefaultBindingsByKey.Where(binding => binding.command == command))
         {
             Add(key, command);
         }
-        Changed = true;
-    }
-
-    public void ReloadAllDefaults()
-    {
-        m_commands.Clear();
-        AddDefaultsIfMissing();
         Changed = true;
     }
 }

--- a/Tests/Unit/Util/Configs/Impl/ConfigKeyMappingTest.cs
+++ b/Tests/Unit/Util/Configs/Impl/ConfigKeyMappingTest.cs
@@ -73,7 +73,7 @@ public class ConfigKeyMappingTest
             GetKeyCommands(keys, key).Should().BeEmpty();
         }
 
-        keys.AddDefaultsIfMissing();
+        keys.SetInitialDefaultKeyBindings();
 
         // Now with the defaults applied, let's make sure they are in fact added.
         foreach ((Key key, string command) in ExpectedMappings)


### PR DESCRIPTION
1.  Allow the user to unbind anything they want, but ensure they always at least have a binding that lets them get back into the menus to fix the issues they've created.
2.  Do not store "empty" key bindings, do not restore default key bindings if the config file is otherwise intact and at least has the "menu" binding
3.  Ensure we write updated config file to disk when we need to do so.

This addresses https://github.com/Helion-Engine/Helion/issues/650