### PR TITLE
Intermission and endgame layers should only consume USE and ATTACK

### DIFF
--- a/Client/Client.Commands.cs
+++ b/Client/Client.Commands.cs
@@ -913,8 +913,8 @@ public partial class Client
         }
         else
         {
-            IntermissionLayer intermissionLayer = new(m_layerManager, world, m_soundManager, m_audioSystem.Music,
-                world.MapInfo, getNextMapInfo);
+            IntermissionLayer intermissionLayer = new(m_layerManager, world, m_config.Keys, m_soundManager,
+                m_audioSystem.Music, world.MapInfo, getNextMapInfo);
             intermissionLayer.Exited += IntermissionLayer_Exited;
             m_layerManager.Add(intermissionLayer);
         }
@@ -978,7 +978,7 @@ public partial class Client
         if (cluster == null)
             return;
 
-        EndGameLayer endGameLayer = new(m_archiveCollection, m_audioSystem.Music, m_soundManager, world, cluster, nextCluster, nextMapInfo, m_isSecretExit);
+        EndGameLayer endGameLayer = new(world, m_config.Keys, m_soundManager, m_audioSystem.Music, m_archiveCollection, cluster, nextCluster, nextMapInfo, m_isSecretExit);
         endGameLayer.Exited += EndGameLayer_Exited;
 
         m_layerManager.Add(endGameLayer);

--- a/Core/Layer/EndGame/EndGameLayer.Input.cs
+++ b/Core/Layer/EndGame/EndGameLayer.Input.cs
@@ -1,5 +1,6 @@
-using System;
+using Helion.Util;
 using Helion.Window;
+using System;
 
 namespace Helion.Layer.EndGame;
 
@@ -9,7 +10,7 @@ public partial class EndGameLayer
 
     public void HandleInput(IConsumableInput input)
     {
-        if (input.HasAnyKeyPressed())
+        if (m_keys.ConsumeCommandKeyPress(input, Constants.Input.Use, Constants.Input.Attack))
             AdvanceState();
     }
 

--- a/Core/Layer/EndGame/EndGameLayer.cs
+++ b/Core/Layer/EndGame/EndGameLayer.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using Helion.Audio;
 using Helion.Audio.Sounds;
 using Helion.Render.Common.Renderers;
@@ -7,11 +5,14 @@ using Helion.Resources.Archives.Collection;
 using Helion.Resources.Archives.Entries;
 using Helion.Resources.Definitions.Language;
 using Helion.Resources.Definitions.MapInfo;
+using Helion.Util.Configs;
 using Helion.Util.Extensions;
 using Helion.Util.Timing;
 using Helion.World;
 using Helion.World.Entities;
 using NLog;
+using System;
+using System.Collections.Generic;
 
 namespace Helion.Layer.EndGame;
 
@@ -75,9 +76,11 @@ public partial class EndGameLayer : IGameLayer
     private CastEntityState m_castEntityState;
     private int m_castEntityFrameTicks;
     private int m_castFrameCount;
+    private IConfigKeyMapping m_keys;
 
-    public EndGameLayer(ArchiveCollection archiveCollection, IMusicPlayer musicPlayer, SoundManager soundManager, IWorld world,
-        ClusterDef currentCluster, ClusterDef? nextCluster, MapInfoDef? nextMapInfo, bool isNextMapSecret)
+    public EndGameLayer(IWorld world, IConfigKeyMapping keys, SoundManager soundManager, IMusicPlayer musicPlayer,
+        ArchiveCollection archiveCollection, ClusterDef currentCluster, ClusterDef? nextCluster, MapInfoDef? nextMapInfo,
+        bool isNextMapSecret)
     {
         World = world;
         NextMapInfo = nextMapInfo;
@@ -105,6 +108,7 @@ public partial class EndGameLayer : IGameLayer
         m_virtualDrawCast = new(VirtualDrawCast);
         m_virtualDrawText = new(VirtualDrawText);
         m_virtualDrawBackgroundImage = new(VirtualDrawBackgroundImage);
+        m_keys = keys;
 
         m_ticker.Start();
 

--- a/Core/Layer/Intermission/IntermissionLayer.Input.cs
+++ b/Core/Layer/Intermission/IntermissionLayer.Input.cs
@@ -1,6 +1,7 @@
-using System;
+using Helion.Layer.Intermission;
 using Helion.Util;
 using Helion.Window;
+using System;
 
 namespace Helion.Layer.Worlds;
 
@@ -14,10 +15,7 @@ public partial class IntermissionLayer
         if (m_gameLayerManager.HasMenuOrConsole())
             return;
 
-        bool pressedKey = input.HasAnyKeyPressed();
-        input.ConsumeAll();
-
-        if (pressedKey)
+        if (m_keys.ConsumeCommandKeyPress(input, Constants.Input.Use, Constants.Input.Attack))
         {
             AdvanceToNextStateForcefully();
             PlayPressedKeySound();
@@ -75,22 +73,22 @@ public partial class IntermissionLayer
     {
         switch (IntermissionState)
         {
-        case IntermissionState.Started:
-            break;
-        case IntermissionState.TallyingKills:
-        case IntermissionState.TallyingItems:
-        case IntermissionState.TallyingSecrets:
-        case IntermissionState.TallyingTime:
-        case IntermissionState.ShowAllStats:
-            m_soundManager.PlayStaticSound("intermission/nextstage");
-            break;
-        case IntermissionState.NextMap:
-            m_soundManager.PlayStaticSound("intermission/paststats");
-            break;
-        case IntermissionState.Complete:
-            break;
-        default:
-            throw new HelionException($"Unknown intermission state: {IntermissionState}");
+            case IntermissionState.Started:
+                break;
+            case IntermissionState.TallyingKills:
+            case IntermissionState.TallyingItems:
+            case IntermissionState.TallyingSecrets:
+            case IntermissionState.TallyingTime:
+            case IntermissionState.ShowAllStats:
+                m_soundManager.PlayStaticSound("intermission/nextstage");
+                break;
+            case IntermissionState.NextMap:
+                m_soundManager.PlayStaticSound("intermission/paststats");
+                break;
+            case IntermissionState.Complete:
+                break;
+            default:
+                throw new HelionException($"Unknown intermission state: {IntermissionState}");
         }
     }
 }

--- a/Core/Layer/Intermission/IntermissionLayer.Logic.cs
+++ b/Core/Layer/Intermission/IntermissionLayer.Logic.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using Helion.Layer.Intermission;
 using Helion.Resources.Definitions.Intermission;
 using Helion.Resources.Definitions.MapInfo;
 using Helion.Util;

--- a/Core/Layer/Intermission/IntermissionLayer.Render.cs
+++ b/Core/Layer/Intermission/IntermissionLayer.Render.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Helion.Geometry;
 using Helion.Geometry.Vectors;
 using Helion.Graphics;
+using Helion.Layer.Intermission;
 using Helion.Render.Common;
 using Helion.Render.Common.Enums;
 using Helion.Render.Common.Renderers;

--- a/Core/Layer/Intermission/IntermissionLayer.cs
+++ b/Core/Layer/Intermission/IntermissionLayer.cs
@@ -1,17 +1,19 @@
-using System;
-using System.Text.RegularExpressions;
 using Helion.Audio;
 using Helion.Audio.Sounds;
+using Helion.Layer.Intermission;
 using Helion.Render.Common.Renderers;
 using Helion.Resources.Archives.Collection;
 using Helion.Resources.Archives.Entries;
 using Helion.Resources.Definitions.Intermission;
 using Helion.Resources.Definitions.MapInfo;
 using Helion.Util;
+using Helion.Util.Configs;
 using Helion.Util.Parser;
 using Helion.World;
 using Helion.World.Stats;
 using NLog;
+using System;
+using System.Text.RegularExpressions;
 
 namespace Helion.Layer.Worlds;
 
@@ -40,6 +42,7 @@ public partial class IntermissionLayer : IGameLayer
     private IntermissionState m_delayState;
     private int m_tics;
     private int m_delayStateTics;
+    private readonly IConfigKeyMapping m_keys;
 
     public event EventHandler? Exited;
 
@@ -48,8 +51,8 @@ public partial class IntermissionLayer : IGameLayer
     public double SecretPercent => m_levelPercents.SecretCount;
     private bool IsNextMap => IntermissionState == IntermissionState.NextMap;
 
-    public IntermissionLayer(GameLayerManager parent, IWorld world, SoundManager soundManager, IMusicPlayer musicPlayer,
-        MapInfoDef currentMapInfo, Func<FindMapResult> getNextMapInfo)
+    public IntermissionLayer(GameLayerManager parent, IWorld world, IConfigKeyMapping keys, SoundManager soundManager,
+        IMusicPlayer musicPlayer, MapInfoDef currentMapInfo, Func<FindMapResult> getNextMapInfo)
     {
         m_gameLayerManager = parent;
         World = world;
@@ -61,6 +64,7 @@ public partial class IntermissionLayer : IGameLayer
         m_musicPlayer = musicPlayer;
         m_totalLevelTime = World.LevelTime / (int)Constants.TicksPerSecond;
         m_renderVirtualIntermissionAction = new(RenderVirtualIntermission);
+        m_keys = keys;
 
         IntermissionPic = string.IsNullOrEmpty(currentMapInfo.ExitPic) ? "INTERPIC" : currentMapInfo.ExitPic;
         CalculatePercentages();

--- a/Core/Layer/Intermission/IntermissionState.cs
+++ b/Core/Layer/Intermission/IntermissionState.cs
@@ -1,4 +1,4 @@
-namespace Helion.Layer.Worlds;
+namespace Helion.Layer.Intermission;
 
 public enum IntermissionState
 {

--- a/Core/Util/Configs/IConfigKeyMapping.cs
+++ b/Core/Util/Configs/IConfigKeyMapping.cs
@@ -35,6 +35,15 @@ public interface IConfigKeyMapping
     bool ConsumeCommandKeyPress(string command, IConsumableInput input, out int scrollAmount);
 
     /// <summary>
+    /// Consumes any of the specified commands if currently pressed
+    /// This will only consume the _first_ matching command key.
+    /// </summary>
+    /// <param name="input">The consumable input</param>
+    /// <param name="commands">The commands to consume</param>
+    /// <returns>True if any of the specified commands were found and consumed</returns>
+    bool ConsumeCommandKeyPress(IConsumableInput input, params string[] commands);
+
+    /// <summary>
     /// Consumes the key for the mapped command if it is currently down.
     /// </summary>
     /// <param name="command">The command, which is not case sensitive.</param>

--- a/Core/Util/Configs/Impl/ConfigKeyMapping.cs
+++ b/Core/Util/Configs/Impl/ConfigKeyMapping.cs
@@ -161,6 +161,19 @@ public class ConfigKeyMapping : IConfigKeyMapping
         return false;
     }
 
+    public bool ConsumeCommandKeyPress(IConsumableInput input, params string[] commands)
+    {
+        foreach (string command in commands)
+        {
+            if (ConsumeCommandKeyPress(command, input, out _))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public bool ConsumeCommandKeyDown(string command, IConsumableInput input, out int scrollAmount, out Key key)
     {
         scrollAmount = 0;


### PR DESCRIPTION
This addresses part of what's going on with #652, although there are probably other input processing issues at work.

With this change, intermission, text, and endgame screens should only "advance" if the user presses whatever key is mapped to the Use or Attack actions.