### PR TITLE
fix map marker clearing, add messages

### DIFF
--- a/Client/Client.Commands.cs
+++ b/Client/Client.Commands.cs
@@ -164,6 +164,7 @@ public partial class Client
 
         var world = m_layerManager.WorldLayer.World;
         world.EntityManager.Create("MapMarker", m_layerManager.WorldLayer.World.Player.Position + RenderInfo.LastAutomapOffset.Double.To3D(0));
+        HelionLog.Info($"Added a map marker.");
     }
 
     [ConsoleCommand("mark.remove", "Removes map markers within a 128 radius.")]
@@ -172,6 +173,7 @@ public partial class Client
         if (m_layerManager.WorldLayer == null)
             return;
 
+        int removedCount = 0;
         var world = m_layerManager.WorldLayer.World;
         var box = new Box2D(world.Player.Position.XY + RenderInfo.LastAutomapOffset.Double, 128);
         var entity = world.EntityManager.Head;
@@ -179,9 +181,17 @@ public partial class Client
         {
             var nextEntity = entity.Next;
             if (entity.Definition.EditorId == (int)EditorId.MapMarker && entity.Overlaps2D(box))
+            {
                 world.EntityManager.Destroy(entity);
+                removedCount++;
+            }
             entity = nextEntity;
         }
+        if (removedCount > 0)
+            HelionLog.Info($"Removed {removedCount} nearby map marker{(removedCount > 1 ? "s" : "")}.");
+        else
+            HelionLog.Info($"No nearby map markers to remove.");
+
     }
 
     [ConsoleCommand("mark.clear", "Removes all map markers.")]
@@ -190,15 +200,23 @@ public partial class Client
         if (m_layerManager.WorldLayer == null)
             return;
 
+        int removedCount = 0;
         var world = m_layerManager.WorldLayer.World;
         var entity = world.EntityManager.Head;
         while (entity != null)
         {
             var nextEntity = entity.Next;
             if (entity.Definition.EditorId == (int)EditorId.MapMarker)
+            {
                 world.EntityManager.Destroy(entity);
+                removedCount++;
+            }
             entity = nextEntity;
         }
+        if (removedCount > 0)
+            HelionLog.Info($"Removed all {removedCount} map markers.");
+        else
+            HelionLog.Info($"No map markers to remove.");
     }
 
     [ConsoleCommand("findkeys", "Finds the next key in the map.")]

--- a/Client/Client.Commands.cs
+++ b/Client/Client.Commands.cs
@@ -174,10 +174,13 @@ public partial class Client
 
         var world = m_layerManager.WorldLayer.World;
         var box = new Box2D(world.Player.Position.XY + RenderInfo.LastAutomapOffset.Double, 128);
-        for (var entity = world.EntityManager.Head; entity != null; entity = entity.Next)
+        var entity = world.EntityManager.Head;
+        while (entity != null)
         {
+            var nextEntity = entity.Next;
             if (entity.Definition.EditorId == (int)EditorId.MapMarker && entity.Overlaps2D(box))
                 world.EntityManager.Destroy(entity);
+            entity = nextEntity;
         }
     }
 
@@ -188,10 +191,13 @@ public partial class Client
             return;
 
         var world = m_layerManager.WorldLayer.World;
-        for (var entity = world.EntityManager.Head; entity != null; entity = entity.Next)
+        var entity = world.EntityManager.Head;
+        while (entity != null)
         {
+            var nextEntity = entity.Next;
             if (entity.Definition.EditorId == (int)EditorId.MapMarker)
                 world.EntityManager.Destroy(entity);
+            entity = nextEntity;
         }
     }
 


### PR DESCRIPTION
Fixes #658
`mark.clear` and `mark.remove` would only remove one map marker because the entity linked list would be modified upon removal of a marker. This fixes that and adds some messages as well:

![marker](https://github.com/user-attachments/assets/2620ff05-bdac-4a61-935d-4d380bb3a556)
