### PR TITLE
Ensure that the console always consumes all input when active

### DIFF
--- a/Core/Layer/GameLayerManager.cs
+++ b/Core/Layer/GameLayerManager.cs
@@ -368,7 +368,11 @@ public class GameLayerManager : IGameLayerManager
                 ToggleConsoleLayer(input);
 
             if (ConsoleLayer != null && ConsoleLayer.Animation.State != InterpolationAnimationState.Out)
+            {
                 ConsoleLayer.HandleInput(input);
+                input.ConsumeAll();
+                return;
+            }
             
             if (ShouldCreateMenu(input))
             {


### PR DESCRIPTION
This prevents "commands" (such as cheat modes) from getting activated if the user has alphanumeric keys bound to them.

This addresses #660 , although I want to do a larger refactor on how inputs are consumed and processed because I think the current approach feels too "patchwork."