### PR TITLE
add melt/no transitions; use main framebuffer for render/screenshots; tweak loading screen

### DIFF
--- a/Client/Client.Commands.cs
+++ b/Client/Client.Commands.cs
@@ -1,5 +1,6 @@
 using Helion.Geometry.Boxes;
 using Helion.Layer.EndGame;
+using Helion.Layer.Transition;
 using Helion.Layer.Worlds;
 using Helion.Maps;
 using Helion.Maps.Bsp.Zdbsp;
@@ -676,7 +677,7 @@ public partial class Client
         var loadingLayer = m_layerManager.LoadingLayer;
         if (loadingLayer == null)
         {
-            loadingLayer = new(m_archiveCollection, m_config, string.Empty);
+            loadingLayer = new(m_archiveCollection, m_config, string.Empty, showLoadingImage: showLoadingTitlepic);
             m_layerManager.Add(loadingLayer);
         }
 
@@ -685,7 +686,9 @@ public partial class Client
 
         UnRegisterWorldEvents();
 
-        m_layerManager.ClearAllExcept(loadingLayer);
+        // keep any intermission/endgame layers so we can draw loading text over them,
+        // and once the loading has completed, copy the framebuffer for the transition
+        m_layerManager.ClearAllExcept(m_layerManager.IntermissionLayer, m_layerManager.EndGameLayer, loadingLayer);
         m_archiveCollection.DataCache.FlushReferences();
 
         await Task.Run(() => LoadMap(mapInfoDef, worldModel, previousWorld, eventContext));
@@ -754,7 +757,9 @@ public partial class Client
         RegisterWorldEvents(newLayer);
 
         m_layerManager.Add(newLayer);
-        m_layerManager.ClearAllExcept(newLayer, m_layerManager.LoadingLayer);
+        // keep any intermission/endgame layers so we can draw loading text over them,
+        // and once the loading has completed, copy the framebuffer for the transition
+        m_layerManager.ClearAllExcept(newLayer, m_layerManager.IntermissionLayer, m_layerManager.EndGameLayer, m_layerManager.LoadingLayer);
 
         if (players.Count > 0 && m_config.Game.AutoSave)
         {
@@ -929,6 +934,12 @@ public partial class Client
         m_layerManager.Remove(m_layerManager.IntermissionLayer);
     }
 
+    private void PlayTransition()
+    {
+        if (m_layerManager.TransitionLayer == null)
+            m_layerManager.Add(new TransitionLayer(m_config));
+    }
+
     private async Task EndGame(IWorld world, Func<FindMapResult> getNextMapInfo)
     {
         try
@@ -953,6 +964,7 @@ public partial class Client
             if (isChangingClusters || world.MapInfo.EndGame != null || nextMapResult.Options.HasFlag(FindMapResultOptions.EndGame))
             {
                 HandleZDoomTransition(world, cluster, nextCluster, nextMapInfo);
+                PlayTransition();
             }
             else if (nextMapInfo != null)
             {

--- a/Client/Client.Initialize.cs
+++ b/Client/Client.Initialize.cs
@@ -39,7 +39,7 @@ public partial class Client
             }
 
             bool success = await Task.Run(() => LoadFiles(iwad));
-            m_layerManager.RemoveWithoutAnimation(m_layerManager.LoadingLayer);
+            m_layerManager.Remove(m_layerManager.LoadingLayer);
             if (!success)
             {
                 ShowConsole();

--- a/Core/Layer/GameLayerManager.cs
+++ b/Core/Layer/GameLayerManager.cs
@@ -10,6 +10,7 @@ using Helion.Layer.Images;
 using Helion.Layer.IwadSelection;
 using Helion.Layer.Menus;
 using Helion.Layer.Options;
+using Helion.Layer.Transition;
 using Helion.Layer.Worlds;
 using Helion.Menus.Impl;
 using Helion.Render;
@@ -26,12 +27,10 @@ using Helion.Util.Profiling;
 using Helion.Util.Timing;
 using Helion.Window;
 using Helion.World.Save;
-using static Helion.Util.Assertion.Assert;
 using Helion.Geometry.Boxes;
-using Helion.Util.Configs.Components;
 using Helion.Render.OpenGL.Renderers.Legacy.World.Shader;
-using Helion.Window.Input;
-using Helion.Util.Container;
+using static Helion.Util.Assertion.Assert;
+using Helion.Util.Configs.Components;
 using Helion.Util.Configs.Impl;
 
 namespace Helion.Layer;
@@ -57,6 +56,7 @@ public class GameLayerManager : IGameLayerManager
     public IntermissionLayer? IntermissionLayer { get; private set; }
     public IwadSelectionLayer? IwadSelectionLayer {  get; private set; }
     public LoadingLayer? LoadingLayer { get; private set; }
+    public TransitionLayer? TransitionLayer { get; private set; }
     public WorldLayer? WorldLayer { get; private set; }
     public long OptionsLastClosedNanos => m_optionsLayer.LastClosedNanos;
     public SaveGameEvent? LastSave;
@@ -82,7 +82,7 @@ public class GameLayerManager : IGameLayerManager
 
     private IEnumerable<IGameLayer> Layers => new List<IGameLayer?>
     {
-        ConsoleLayer, OptionsLayer, MenuLayer, ReadThisLayer, TitlepicLayer, EndGameLayer, IntermissionLayer, WorldLayer
+        ConsoleLayer, OptionsLayer, MenuLayer, ReadThisLayer, TitlepicLayer, EndGameLayer, IntermissionLayer, TransitionLayer, WorldLayer
     }.WhereNotNull();
 
     public GameLayerManager(IConfig config, IWindow window, HelionConsole console, ConsoleCommands consoleCommands,
@@ -204,6 +204,10 @@ public class GameLayerManager : IGameLayerManager
                 Remove(LoadingLayer);
                 LoadingLayer = layer;
                 break;
+            case TransitionLayer layer:
+                Remove(TransitionLayer);
+                TransitionLayer = layer;
+                break;
             case null:
                 break;
             default:
@@ -302,6 +306,11 @@ public class GameLayerManager : IGameLayerManager
             IwadSelectionLayer?.Dispose();
             IwadSelectionLayer = null;
         }
+        else if (ReferenceEquals(layer, LoadingLayer))
+        {
+            LoadingLayer?.Dispose();
+            LoadingLayer = null;
+        }
     }
 
     private void RemoveAnimatedLayer(object layer)
@@ -326,10 +335,10 @@ public class GameLayerManager : IGameLayerManager
             MenuLayer?.Dispose();
             MenuLayer = null;
         }
-        else if (ReferenceEquals(layer, LoadingLayer))
+        else if (ReferenceEquals(layer, TransitionLayer))
         {
-            LoadingLayer?.Dispose();
-            LoadingLayer = null;
+            TransitionLayer?.Dispose();
+            TransitionLayer = null;
         }
     }
 
@@ -626,7 +635,7 @@ public class GameLayerManager : IGameLayerManager
 
     private void RenderDefault(IRenderableSurfaceContext ctx)
     {
-        m_ctx = ctx;        
+        m_ctx = ctx;
         m_hudContext.Dimension = m_renderer.RenderDimension;
         m_hudContext.DrawPalette = true;
         ctx.Viewport(m_renderer.RenderDimension.Box);
@@ -646,6 +655,7 @@ public class GameLayerManager : IGameLayerManager
 
         m_profiler.Render.MiscLayers.Start();
         ctx.Hud(m_hudContext, m_renderHudAction);
+        TransitionLayer?.Render(m_ctx);
         m_profiler.Render.MiscLayers.Stop();
     }
 
@@ -683,9 +693,7 @@ public class GameLayerManager : IGameLayerManager
 
         ReadThisLayer?.Render(hudCtx);
         IwadSelectionLayer?.Render(m_ctx, hudCtx);
-
-        if (LoadingLayer != null)
-            RenderWithAlpha(hudCtx, LoadingLayer.Animation, RenderLoadingLayer);
+        LoadingLayer?.Render(m_ctx, m_hudRenderCtx);
 
         RenderConsole(hudCtx);
 
@@ -729,11 +737,6 @@ public class GameLayerManager : IGameLayerManager
         m_hudRenderCtx.DrawPalette(true);
         m_hudContext.DrawColorMap = ShaderVars.PaletteColorMode;
         m_hudRenderCtx.DrawColorMap(ShaderVars.PaletteColorMode);
-    }
-
-    private void RenderLoadingLayer()
-    {
-        LoadingLayer?.Render(m_ctx, m_hudRenderCtx);
     }
 
     private void RenderMenu()
@@ -786,6 +789,7 @@ public class GameLayerManager : IGameLayerManager
         Remove(OptionsLayer);
         Remove(ConsoleLayer);
         Remove(LoadingLayer);
+        Remove(TransitionLayer);
 
         m_disposed = true;
     }

--- a/Core/Layer/Loading/LoadingLayer.cs
+++ b/Core/Layer/Loading/LoadingLayer.cs
@@ -14,7 +14,7 @@ using System.Diagnostics;
 
 namespace Helion.Layer.IwadSelection;
 
-public class LoadingLayer : IGameLayer, IAnimationLayer
+public class LoadingLayer : IGameLayer
 {
     private static readonly string ConsoleFont = Constants.Fonts.Console;
     private static readonly string[] Spinner = ["-", "\\", "|", "/"];
@@ -25,37 +25,21 @@ public class LoadingLayer : IGameLayer, IAnimationLayer
     private int m_spinner;
     public string LoadingText { get; set; }
     public string LoadingImage { get; set; } = string.Empty;
+    private readonly bool m_showLoadingImage;
     public bool ShowSpinner { get; set; } = true;
 
-    public InterpolationAnimation<IAnimationLayer> Animation { get; }
-
-    public LoadingLayer(ArchiveCollection archiveCollection, IConfig config, string text)
+    public LoadingLayer(ArchiveCollection archiveCollection, IConfig config, string text, bool showLoadingImage = true)
     {
         m_archiveCollection = archiveCollection;
         m_config = config;
         LoadingText = text;
+        m_showLoadingImage = showLoadingImage;
         m_stopwatch.Start();
-        Animation = new(TimeSpan.FromSeconds(1), this);
-    }
-
-    public bool ShouldRemove()
-    {
-        return true;
-    }
-
-    public void SetFadeOut(TimeSpan time)
-    {
-        Animation.Stop();
-        Animation.SetDuration(time);
-        Animation.AnimateOut();
-        LoadingText = string.Empty;
     }
 
     public void Render(IRenderableSurfaceContext ctx, IHudRenderContext hud)
     {
-        Animation.Tick();
-
-        if (LoadingImage.Length > 0)
+        if (m_showLoadingImage && LoadingImage.Length > 0)
         {
             hud.FillBox(new(new Vec2I(0, 0), new Vec2I(hud.Dimension.Width, hud.Dimension.Height)), Color.Black);
             hud.RenderFullscreenImage(LoadingImage);
@@ -67,7 +51,7 @@ public class LoadingLayer : IGameLayer, IAnimationLayer
         if (dim.Width == 0 && dim.Height == 0)
             return;
 
-        hud.FillBox(new(new Vec2I(0, hud.Dimension.Height  - dim.Height + (yOffset*2)), new Vec2I(hud.Dimension.Width, hud.Dimension.Height)), Color.Black, alpha: 0.7f);
+        hud.FillBox(new(new Vec2I(0, hud.Dimension.Height - dim.Height + (yOffset * 2)), new Vec2I(hud.Dimension.Width, hud.Dimension.Height)), Color.Black, alpha: 0.7f);
         hud.Text(LoadingText, ConsoleFont, fontSize, (0, yOffset), both: Align.BottomMiddle);
 
         if (m_stopwatch.ElapsedMilliseconds >= 80)
@@ -75,7 +59,7 @@ public class LoadingLayer : IGameLayer, IAnimationLayer
             m_spinner = ++m_spinner % Spinner.Length;
             m_stopwatch.Restart();
         }
-        
+
         if (ShowSpinner)
             hud.Text(Spinner[m_spinner], ConsoleFont, fontSize, (-dim.Width / 2 - m_config.Hud.GetScaled(16), yOffset), both: Align.BottomMiddle);
     }

--- a/Core/Layer/Transition/TransitionLayer.cs
+++ b/Core/Layer/Transition/TransitionLayer.cs
@@ -25,7 +25,7 @@ public class TransitionLayer : IGameLayer, IAnimationLayer
         m_type = m_config.Game.TransitionType;
         double duration = m_type switch
         {
-            TransitionType.Fade => 0.5,
+            TransitionType.Fade => 1,
             TransitionType.Melt => 1.2,
             // avoid single-frame flicker on very short loads;
             // extend so there's there's a (barely) perceptible load screen

--- a/Core/Layer/Transition/TransitionLayer.cs
+++ b/Core/Layer/Transition/TransitionLayer.cs
@@ -1,0 +1,57 @@
+using Helion.Render.Common.Renderers;
+using Helion.Util.Configs;
+using Helion.Util.Timing;
+using Helion.Window;
+using Helion.World;
+using System;
+
+namespace Helion.Layer.Transition;
+
+/// <summary>
+/// Layer for rendering melt/fade effect between levels and screens
+/// </summary>
+public class TransitionLayer : IGameLayer, IAnimationLayer
+{
+    private readonly IConfig m_config;
+    private readonly TransitionType m_type;
+    private bool m_started;
+
+    public InterpolationAnimation<IAnimationLayer> Animation { get; }
+
+    public TransitionLayer(IConfig config)
+    {
+        m_config = config;
+        m_started = false;
+        m_type = m_config.Game.TransitionType;
+        double duration = m_type switch
+        {
+            TransitionType.Fade => 0.5,
+            TransitionType.Melt => 1.2,
+            // avoid single-frame flicker on very short loads;
+            // extend so there's there's a (barely) perceptible load screen
+            _ => 0.05,
+        };
+        Animation = new(TimeSpan.FromSeconds(duration), this);
+    }
+
+    public bool ShouldRemove() => true;
+
+    public void Render(IRenderableSurfaceContext ctx)
+    {
+        if (!m_started)
+            Animation.AnimateIn();
+        Animation.Tick();
+        var progress = (float)Animation.GetInterpolated(1);
+        ctx.DrawTransition(m_type, progress, !m_started);
+        m_started = true;
+    }
+
+    public void HandleInput(IConsumableInput input) { }
+
+    public void RunLogic(TickerInfo tickerInfo) { }
+
+    public void Dispose()
+    {
+
+    }
+}

--- a/Core/Layer/Worlds/WorldLayer.Input.cs
+++ b/Core/Layer/Worlds/WorldLayer.Input.cs
@@ -100,7 +100,7 @@ public partial class WorldLayer
             m_autoMapScale = m_config.Hud.AutoMap.Scale;
         }
 
-        if (m_parent.LoadingLayer == null)
+        if (m_parent.LoadingLayer == null && m_parent.TransitionLayer == null)
             input.IterateCommands(World.Config.Keys.GetKeyMapping(), m_checkCommandAction);
     }
 
@@ -110,7 +110,7 @@ public partial class WorldLayer
         if (cmd.Command == Input.Screenshot)
             return false;
 
-        if ((m_parent.LoadingLayer != null || World.Paused) && InGameCommands.Contains(cmd.Command))
+        if ((m_parent.LoadingLayer != null || m_parent.TransitionLayer != null || World.Paused) && InGameCommands.Contains(cmd.Command))
             return false;
 
         // This layer should eat all regular base commands whenever it's on top, to prevent things like "move automap"

--- a/Core/Layer/Worlds/WorldLayer.Logic.cs
+++ b/Core/Layer/Worlds/WorldLayer.Logic.cs
@@ -20,7 +20,8 @@ public partial class WorldLayer
                                       m_parent.TitlepicLayer != null ||
                                       m_parent.IntermissionLayer != null ||
                                       m_parent.ReadThisLayer != null ||
-                                      m_parent.LoadingLayer != null;
+                                      m_parent.LoadingLayer != null ||
+                                      m_parent.TransitionLayer != null;
 
     public void Stop()
     {

--- a/Core/Render/Common/Commands/RenderCommands.cs
+++ b/Core/Render/Common/Commands/RenderCommands.cs
@@ -4,6 +4,7 @@ using Helion.Geometry;
 using Helion.Geometry.Vectors;
 using Helion.Graphics;
 using Helion.Graphics.Geometry;
+using Helion.Layer.Transition;
 using Helion.Render.Common.Enums;
 using Helion.Render.OpenGL.Commands.Types;
 using Helion.Render.OpenGL.Shared;
@@ -25,7 +26,8 @@ public enum RenderCommandType
     Viewport,
     DrawVirtualFrameBuffer,
     Automap,
-    Hud
+    Hud,
+    Transition,
 }
 
 [StructLayout(LayoutKind.Sequential)]
@@ -60,6 +62,7 @@ public class RenderCommands
     public List<ViewportCommand> ViewportCommands = new();
     public List<DrawTextCommand> TextCommands = new();
     public List<DrawShapeCommand> ShapeCommands = new();
+    public TransitionCommand? CurrentTransitionCommand = null;
 
     public Dimension RenderDimension => m_renderDimensions;
     public Dimension WindowDimension => m_windowDimensions;
@@ -93,6 +96,7 @@ public class RenderCommands
         TextCommands.Clear();
         ShapeCommands.Clear();
         AutomapCommands.Clear();
+        CurrentTransitionCommand = null;
 
         ResolutionInfo = new ResolutionInfo { VirtualDimensions = RenderDimension };
         m_scale = Vec2D.One;
@@ -164,6 +168,11 @@ public class RenderCommands
     public void DrawVirtualFrameBuffer()
     {
         Commands.Add(new RenderCommand(RenderCommandType.DrawVirtualFrameBuffer, 0));
+    }
+
+    public void DrawTransition(TransitionType type, float progress, bool start)
+    {
+        CurrentTransitionCommand = new TransitionCommand(type, progress, start);
     }
 
     /// <summary>

--- a/Core/Render/Common/Commands/Types/TransitionCommand.cs
+++ b/Core/Render/Common/Commands/Types/TransitionCommand.cs
@@ -1,0 +1,12 @@
+using Helion.World;
+using System.Runtime.InteropServices;
+
+namespace Helion.Render.OpenGL.Commands.Types;
+
+[StructLayout(LayoutKind.Sequential)]
+public readonly struct TransitionCommand(TransitionType type, float progress, bool start)
+{
+    public readonly TransitionType Type = type;
+    public readonly float Progress = progress;
+    public readonly bool Start = start;
+}

--- a/Core/Render/Common/Renderers/IRenderableSurfaceContext.cs
+++ b/Core/Render/Common/Renderers/IRenderableSurfaceContext.cs
@@ -2,6 +2,7 @@ using System;
 using Helion.Geometry.Boxes;
 using Helion.Graphics;
 using Helion.Render.Common.Context;
+using Helion.World;
 
 namespace Helion.Render.Common.Renderers;
 
@@ -80,4 +81,6 @@ public interface IRenderableSurfaceContext
     void Automap(WorldRenderContext context, Action<IWorldRenderContext> action);
 
     void DrawVirtualFrameBuffer();
+
+    void DrawTransition(TransitionType type, float progress, bool start);
 }

--- a/Core/Render/OpenGL/Framebuffer/GLFramebuffer.cs
+++ b/Core/Render/OpenGL/Framebuffer/GLFramebuffer.cs
@@ -71,15 +71,10 @@ public class GLFramebuffer : IDisposable
         Dispose(false);
     }
 
-    public void Bind()
-    {
-        GL.BindFramebuffer(FramebufferTarget.Framebuffer, m_name);
-    }
-
-    public void Unbind()
-    {
-        GL.BindFramebuffer(FramebufferTarget.Framebuffer, 0);
-    }
+    public void Bind() => GL.BindFramebuffer(FramebufferTarget.Framebuffer, m_name);
+    public void Unbind() => GL.BindFramebuffer(FramebufferTarget.Framebuffer, 0);
+    public void BindRead() => GL.BindFramebuffer(FramebufferTarget.ReadFramebuffer, m_name);
+    public void BindDraw() => GL.BindFramebuffer(FramebufferTarget.DrawFramebuffer, m_name);
 
     protected virtual void Dispose(bool disposing)
     {

--- a/Core/Render/OpenGL/GLRenderableSurfaceContext.cs
+++ b/Core/Render/OpenGL/GLRenderableSurfaceContext.cs
@@ -5,6 +5,7 @@ using Helion.Render.Common.Context;
 using Helion.Render.Common.Renderers;
 using Helion.Render.OpenGL.Commands;
 using Helion.Window;
+using Helion.World;
 
 namespace Helion.Render.OpenGL;
 
@@ -97,4 +98,6 @@ public class GLRenderableSurfaceContext : IRenderableSurfaceContext
         m_worldRenderContext.Begin(context);
         action(m_worldRenderContext);
     }
+
+    public void DrawTransition(TransitionType type, float progress, bool start) => Commands.DrawTransition(type, progress, start);
 }

--- a/Core/Render/OpenGL/Renderers/BasicFramebufferRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/BasicFramebufferRenderer.cs
@@ -1,0 +1,86 @@
+﻿using GlmSharp;
+using Helion.Graphics;
+using Helion.Render.OpenGL.Buffer.Array.Vertex;
+using Helion.Render.OpenGL.Framebuffer;
+using Helion.Render.OpenGL.Vertex;
+using Helion.Window;
+using OpenTK.Graphics.OpenGL;
+using System;
+
+namespace Helion.Render.OpenGL.Renderers;
+
+public class BasicFramebufferRenderer : IDisposable
+{
+    private readonly IWindow m_window;
+    private readonly StaticVertexBuffer<FramebufferVertex> m_vbo = new("Framebuffer");
+    private readonly VertexArrayObject m_vao = new("Framebuffer");
+    private readonly FramebufferProgram m_program = new();
+    private bool m_disposed;
+
+    public BasicFramebufferRenderer(IWindow window)
+    {
+        m_window = window;
+
+        Attributes.BindAndApply(m_vbo, m_vao, m_program.Attributes);
+        UploadVertices();
+    }
+
+    ~BasicFramebufferRenderer()
+    {
+        Dispose(false);
+    }
+
+    private void UploadVertices()
+    {
+        FramebufferVertex topLeft = new((-1, 1), (0, 1));
+        FramebufferVertex topRight = new((1, 1), (1, 1));
+        FramebufferVertex bottomLeft = new((-1, -1), (0, 0));
+        FramebufferVertex bottomRight = new((1, -1), (1, 0));
+
+        m_vbo.Bind();
+        m_vbo.Add(topLeft, bottomLeft, topRight);
+        m_vbo.Add(topRight, bottomLeft, bottomRight);
+        m_vbo.Upload();
+        m_vbo.Unbind();
+    }
+
+    public void Render(GLFramebuffer buffer)
+    {
+        (float a, float r, float g, float b) = Color.Black.Normalized;
+
+        GL.Viewport(0, 0, m_window.Dimension.Width, m_window.Dimension.Height);
+        GL.ClearColor(r, g, b, a);
+        GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit | ClearBufferMask.StencilBufferBit);
+
+        m_program.Bind();
+
+        GL.ActiveTexture(TextureUnit.Texture0);
+        buffer.Textures[0].Bind();
+        m_program.BoundTexture(TextureUnit.Texture0);
+        m_program.Mvp(mat4.Identity);
+
+        m_vao.Bind();
+        m_vbo.DrawArrays();
+        m_vao.Unbind();
+
+        m_program.Unbind();
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (m_disposed)
+            return;
+
+        m_vbo.Dispose();
+        m_vao.Dispose();
+        m_program.Dispose();
+
+        m_disposed = true;
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+}

--- a/Core/Render/OpenGL/Renderers/TransitionPrograms.cs
+++ b/Core/Render/OpenGL/Renderers/TransitionPrograms.cs
@@ -1,0 +1,183 @@
+using GlmSharp;
+using Helion.Render.OpenGL.Shader;
+using OpenTK.Graphics.OpenGL;
+using System;
+using System.Linq;
+
+namespace Helion.Render.OpenGL.Renderers;
+
+/// <summary>
+/// Base class for level/screen transitions
+/// </summary>
+public abstract class TransitionProgram : RenderProgram
+{
+    private readonly int m_boundTextureLocation;
+    private readonly int m_mvpLocation;
+
+    public TransitionProgram() : base("Transition")
+    {
+        m_boundTextureLocation = Uniforms.GetLocation("boundTexture");
+        m_mvpLocation = Uniforms.GetLocation("mvp");
+    }
+
+    public void SetUniforms(TextureUnit unit, mat4 mvp)
+    {
+        Uniforms.Set(unit, m_boundTextureLocation);
+        Uniforms.Set(mvp, m_mvpLocation);
+    }
+
+    protected override string VertexShader() => @"
+        #version 330
+
+        layout(location = 0) in vec2 pos;
+        layout(location = 1) in vec2 uv;
+
+        out vec2 uvFrag;
+
+        uniform mat4 mvp;
+
+        void main()
+        {
+            uvFrag = uv;
+            gl_Position = mvp * vec4(pos, 0, 1);
+        }
+    ";
+}
+
+/// <summary>
+/// Transition that melts an image away, like in vanilla.
+/// </summary>
+/// <remarks>
+/// Strips can take up to 15 ticks to start moving, and 27 to fall completely:
+/// Gravity is 2px/tick² up to 8px/tick, so this takes 4 ticks to cover 16px.
+/// After that, it takes 23 ticks to cover the remaining 184px.
+/// So, this should run for 42 ticks (1.2s).
+/// </remarks>
+public class MeltTransitionProgram : TransitionProgram
+{
+    private readonly int m_ticksLocation;
+    private readonly int m_stripCountLocation;
+    private readonly float[] m_stripDelays;
+    private readonly int m_stripDelaysLocation;
+
+    public MeltTransitionProgram() : base()
+    {
+        m_ticksLocation = Uniforms.GetLocation("ticks");
+        m_stripCountLocation = Uniforms.GetLocation("stripCount");
+        m_stripDelays = GenerateStripDelays();
+        m_stripDelaysLocation = Uniforms.GetLocation("stripDelays[0]");
+    }
+
+    private static float[] GenerateStripDelays()
+    {
+        Random r = new();
+        int[] result = new int[256];
+        // In vanilla strip delays are between 0-15 ticks
+        // and each differs from the last by +-1.
+        // SubSteps can be set higher here for a smaller difference between strips.
+        const int SubSteps = 1;
+        result[0] = r.Next(16 * SubSteps);
+        for (int i = 1; i < result.Length; i++)
+        {
+            int offset = r.Next(-SubSteps, SubSteps + 1);
+            int clamped = Math.Clamp(result[i - 1] + offset, 0, 16 * SubSteps - 1);
+            result[i] = clamped;
+        }
+        return result.Select(x => x * 1f / SubSteps).ToArray();
+    }
+
+    public void SetUniforms(TextureUnit unit, mat4 mvp, float elapsedTicks, int stripCount)
+    {
+        SetUniforms(unit, mvp);
+        Uniforms.Set(elapsedTicks, m_ticksLocation);
+        Uniforms.Set(stripCount, m_stripCountLocation);
+        Uniforms.Set(m_stripDelays, m_stripDelaysLocation);
+    }
+
+    protected override string FragmentShader() => @"
+        #version 330
+
+        in vec2 uvFrag;
+
+        out vec4 fragColor;
+
+        uniform float ticks;
+        uniform int stripCount;
+        uniform float stripDelays[256];
+        uniform sampler2D boundTexture;
+
+        void main()
+        {
+            vec2 uv = uvFrag;
+            float sliceDelay = stripDelays[int(floor(uv.x * stripCount)) & 0xff];
+            float ticksFalling = max(0, ticks - sliceDelay);
+            float shift = (ticksFalling <= 4)
+                ? pow(ticksFalling, 2)
+                : 16 + 8 * (ticksFalling - 4);
+            uv.y += shift / 200;
+            fragColor = (uv.y > 1)
+                ? vec4(0,0,0,0)
+                : texture(boundTexture, uv.st);
+        }
+    ";
+}
+
+/// <summary>
+/// Transition that fades an image out.
+/// </summary>
+public class FadeTransitionProgram : TransitionProgram
+{
+    private readonly int m_progressLocation;
+
+    public FadeTransitionProgram() : base()
+    {
+        m_progressLocation = Uniforms.GetLocation("progress");
+    }
+
+    public void SetUniforms(TextureUnit unit, mat4 mvp, float progress)
+    {
+        SetUniforms(unit, mvp);
+        Uniforms.Set(progress, m_progressLocation);
+    }
+
+    protected override string FragmentShader() => @"
+        #version 330
+
+        in vec2 uvFrag;
+
+        out vec4 fragColor;
+
+        uniform float progress;
+        uniform sampler2D boundTexture;
+
+        void main()
+        {
+            fragColor = texture(boundTexture, uvFrag.st);
+            fragColor.a = 1 - progress;
+        }
+    ";
+}
+
+/// <summary>
+/// Transition that just displays the last framebuffer.
+/// </summary>
+public class NoTransitionProgram : TransitionProgram
+{
+    public NoTransitionProgram() : base() { }
+
+    protected override string FragmentShader() => @"
+        #version 330
+
+        in vec2 uvFrag;
+
+        out vec4 fragColor;
+
+        uniform float progress;
+        uniform sampler2D boundTexture;
+
+        void main()
+        {
+            fragColor = texture(boundTexture, uvFrag.st);
+        }
+    ";
+}

--- a/Core/Render/OpenGL/Renderers/TransitionRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/TransitionRenderer.cs
@@ -1,0 +1,136 @@
+﻿using GlmSharp;
+using Helion.Render.OpenGL.Buffer.Array.Vertex;
+using Helion.Render.OpenGL.Framebuffer;
+using Helion.Render.OpenGL.Vertex;
+using Helion.Window;
+using Helion.World;
+using OpenTK.Graphics.OpenGL;
+using System;
+
+namespace Helion.Render.OpenGL.Renderers;
+
+public class TransitionRenderer : IDisposable
+{
+    private readonly IWindow m_window;
+    private readonly StaticVertexBuffer<FramebufferVertex> m_vbo = new("Transition");
+    private readonly VertexArrayObject m_vao = new("Transition");
+    private bool m_inited = false;
+    private TransitionProgram? m_program;
+    /// <summary>
+    /// The screen buffer to transition from.
+    /// </summary>
+    private GLFramebuffer m_startBuffer;
+    private bool m_disposed;
+
+    public TransitionRenderer(IWindow window)
+    {
+        m_window = window;
+        m_startBuffer = GetNewFramebuffer();
+    }
+
+    ~TransitionRenderer()
+    {
+        Dispose(false);
+    }
+
+    private GLFramebuffer GetNewFramebuffer() => new("Transition", m_window.Dimension, 1, RenderbufferStorage.Depth32fStencil8);
+
+    public void UpdateFramebufferDimensionsIfNeeded()
+    {
+        if (m_startBuffer.Dimension != m_window.Dimension && m_window.Dimension.HasPositiveArea)
+        {
+            m_startBuffer.Dispose();
+            m_startBuffer = GetNewFramebuffer();
+        }
+    }
+
+    public void PrepareNewTransition(GLFramebuffer sourceBuffer, TransitionType type)
+    {
+        m_program?.Dispose();
+        m_program = type switch
+        {
+            TransitionType.Fade => new FadeTransitionProgram(),
+            TransitionType.Melt => new MeltTransitionProgram(),
+            // show the last framebuffer for a brief moment
+            // so there's no flicker for very short loads
+            _ => new NoTransitionProgram()
+        };
+
+        Attributes.BindAndApply(m_vbo, m_vao, m_program.Attributes);
+        if (!m_inited)
+        {
+            UploadVertices();
+            m_inited = true;
+        }
+
+        sourceBuffer.BindRead();
+        m_startBuffer.BindDraw();
+        GL.BlitFramebuffer(0, 0, sourceBuffer.Dimension.Width, sourceBuffer.Dimension.Height,
+            0, 0, m_startBuffer.Dimension.Width, m_startBuffer.Dimension.Height,
+            ClearBufferMask.ColorBufferBit, BlitFramebufferFilter.Linear);
+    }
+
+    private void UploadVertices()
+    {
+        FramebufferVertex topLeft = new((-1, 1), (0, 1));
+        FramebufferVertex topRight = new((1, 1), (1, 1));
+        FramebufferVertex bottomLeft = new((-1, -1), (0, 0));
+        FramebufferVertex bottomRight = new((1, -1), (1, 0));
+
+        m_vbo.Bind();
+        m_vbo.Add(topLeft, bottomLeft, topRight);
+        m_vbo.Add(topRight, bottomLeft, bottomRight);
+        m_vbo.Upload();
+        m_vbo.Unbind();
+    }
+
+
+    public void Render(GLFramebuffer targetBuffer, float progress)
+    {
+        if (m_program == null)
+            return;
+
+        targetBuffer.BindDraw();
+        GL.Viewport(0, 0, targetBuffer.Dimension.Width, targetBuffer.Dimension.Height);
+        m_program.Bind();
+
+        GL.ActiveTexture(TextureUnit.Texture0);
+        m_startBuffer.Textures[0].Bind();
+        if (m_program is MeltTransitionProgram meltProgram)
+        {
+            // the melt shader uses ticks, so convert [0,1] to [0,42] ticks
+            float loopElapsedTicks = progress * 42;
+            // TODO: would be nice here to align strips with the virtual res
+            meltProgram.SetUniforms(TextureUnit.Texture0, mat4.Identity, loopElapsedTicks, targetBuffer.Dimension.Width / 4);
+        }
+        else if (m_program is FadeTransitionProgram fadeProgram)
+            fadeProgram.SetUniforms(TextureUnit.Texture0, mat4.Identity, progress);
+        else
+            m_program.SetUniforms(TextureUnit.Texture0, mat4.Identity);
+
+        m_vao.Bind();
+        m_vbo.DrawArrays();
+        m_vao.Unbind();
+
+        m_program.Unbind();
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (m_disposed)
+            return;
+
+        m_vbo.Dispose();
+        m_vao.Dispose();
+        m_program?.Dispose();
+        m_startBuffer.Dispose();
+
+        m_disposed = true;
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+}

--- a/Core/Render/OpenGL/Shader/ProgramUniforms.cs
+++ b/Core/Render/OpenGL/Shader/ProgramUniforms.cs
@@ -33,6 +33,8 @@ public class ProgramUniforms
     public void Set(int value, string name) => Set(value, GetLocation(name));
     public void Set(float value, int location) => GL.Uniform1(location, value);
     public void Set(float value, string name) => Set(value, GetLocation(name));
+    public void Set(float[] value, int location) => GL.Uniform1(location, value.Length, value);
+    public void Set(float[] value, string name) => Set(value, GetLocation(name));
     public void Set(Vec2F value, int location) => GL.Uniform2(location, value.X, value.Y);
     public void Set(Vec2F value, string name) => Set(value, GetLocation(name));
     public void Set(Vec3F value, int location) => GL.Uniform3(location, value.X, value.Y, value.Z);

--- a/Core/Util/Configs/Components/ConfigGame.cs
+++ b/Core/Util/Configs/Components/ConfigGame.cs
@@ -24,6 +24,10 @@ public class ConfigGame
     [OptionMenu(OptionSectionType.General, "Pain Intensity")]
     public readonly ConfigValue<double> PainIntensity = new(1.0);
 
+    [ConfigInfo("Transition effect between levels/screens.")]
+    [OptionMenu(OptionSectionType.General, "Transition Type")]
+    public readonly ConfigValue<World.TransitionType> TransitionType = new(World.TransitionType.Melt);
+
     [ConfigInfo("Player can use lines (doors, switches) by bumping into them.", demo: true)]
     [OptionMenu(OptionSectionType.General, "Bump Use", spacer: true)]
     public readonly ConfigValue<bool> BumpUse = new(false);

--- a/Core/World/TransitionType.cs
+++ b/Core/World/TransitionType.cs
@@ -1,0 +1,8 @@
+namespace Helion.World;
+
+public enum TransitionType
+{
+    None,
+    Melt,
+    Fade,
+}


### PR DESCRIPTION
This changes the rendering pipeline slightly and adds a new layer. I don't have any older hardware to test, so let's make sure I haven't affected performance here.

- A TransitionLayer was added to replace the fadeout present in LoadingLayer
- Accordingly, LoadingLayer is no longer an IAnimationLayer
- LoadingLayer now only draws the titlepic when starting a new game, otherwise it just draws the loading text bar over the intermission/text screen (to accommodate this, these layers are now not removed until the loading completes)
- The virtual framebuffer and HUD are now drawn to a main framebuffer instead of default
- TransitionLayer will issue a TransitionCommand which can copy this main framebuffer at the start of a render when a transition starts, and use that in its effects, which are drawn at the end of the pipeline just before the main framebuffer is drawn to default
- TransitionRenderer can render either fade, melt, or none (in which case the stored framebuffer is displayed for just a couple frames, to make a relatively instant load where the LoadingLayer would only appear for a frame or so less jarring)