### PR TITLE
transitions rework

### DIFF
--- a/Client/Client.Commands.cs
+++ b/Client/Client.Commands.cs
@@ -343,8 +343,7 @@ public partial class Client
         m_layerManager.LastSave = new(saveGame, worldModel, string.Empty, true);
         PrepLoadMap();
         await LoadMapAsync(GetMapInfo(worldModel.MapName), worldModel, null,
-        // TODO: need to allow transition layer to grab framebuffer before world is disposed
-            showLoadingTitlepic: true);//world == null || !world.MapInfo.MapName.EqualsIgnoreCase(worldModel.MapName));
+            showLoadingTitlepic: world == null || !world.MapInfo.MapName.EqualsIgnoreCase(worldModel.MapName));
     }
 
     [ConsoleCommand("map", "Starts a new world with the map provided")]
@@ -709,11 +708,11 @@ public partial class Client
         loadingLayer.LoadingText = $"Loading {mapInfoDef.GetDisplayNameWithPrefix(m_archiveCollection)}...";
         loadingLayer.LoadingImage = m_archiveCollection.GameInfo.TitlePage;
 
+        PrepareTransition();
+
         UnRegisterWorldEvents();
 
-        // keep any intermission/endgame layers so we can draw loading text over them,
-        // and once the loading has completed, copy the framebuffer for the transition
-        m_layerManager.ClearAllExcept(m_layerManager.IntermissionLayer, m_layerManager.EndGameLayer, loadingLayer);
+        m_layerManager.ClearAllExcept(loadingLayer, m_layerManager.TransitionLayer);
         m_archiveCollection.DataCache.FlushReferences();
 
         await Task.Run(() => LoadMap(mapInfoDef, worldModel, previousWorld, eventContext));
@@ -782,9 +781,7 @@ public partial class Client
         RegisterWorldEvents(newLayer);
 
         m_layerManager.Add(newLayer);
-        // keep any intermission/endgame layers so we can draw loading text over them,
-        // and once the loading has completed, copy the framebuffer for the transition
-        m_layerManager.ClearAllExcept(newLayer, m_layerManager.IntermissionLayer, m_layerManager.EndGameLayer, m_layerManager.LoadingLayer);
+        m_layerManager.ClearAllExcept(newLayer, m_layerManager.LoadingLayer, m_layerManager.TransitionLayer);
 
         if (players.Count > 0 && m_config.Game.AutoSave)
         {
@@ -886,14 +883,12 @@ public partial class Client
 
                 case LevelChangeType.Reset:
                     PrepLoadMap();
-                    // TODO: we need to grab the framebuffer for the transition before the world is disposed
-                    await LoadMapAsync(world.MapInfo, null, null, e, showLoadingTitlepic: true);//false);
+                    await LoadMapAsync(world.MapInfo, null, null, e, showLoadingTitlepic: false);
                     break;
 
                 case LevelChangeType.ResetOrLoadLast:
                     PrepLoadMap();
-                    // TODO: we need to grab the framebuffer for the transition before the world is disposed
-                    await LoadMapAsync(world.MapInfo, m_lastWorldModel, null, e, showLoadingTitlepic: true);//false);
+                    await LoadMapAsync(world.MapInfo, m_lastWorldModel, null, e, showLoadingTitlepic: false);
                     break;
             }
         }
@@ -961,10 +956,15 @@ public partial class Client
         m_layerManager.Remove(m_layerManager.IntermissionLayer);
     }
 
-    private void PlayTransition()
+    private void PrepareTransition()
     {
         if (m_layerManager.TransitionLayer == null)
             m_layerManager.Add(new TransitionLayer(m_config));
+    }
+
+    private void PlayTransition()
+    {
+        m_layerManager.TransitionLayer?.Start();
     }
 
     private async Task EndGame(IWorld world, Func<FindMapResult> getNextMapInfo)
@@ -991,6 +991,7 @@ public partial class Client
             if (isChangingClusters || world.MapInfo.EndGame != null || nextMapResult.Options.HasFlag(FindMapResultOptions.EndGame))
             {
                 HandleZDoomTransition(world, cluster, nextCluster, nextMapInfo);
+                PrepareTransition();
                 PlayTransition();
             }
             else if (nextMapInfo != null)

--- a/Client/Client.Commands.cs
+++ b/Client/Client.Commands.cs
@@ -958,8 +958,8 @@ public partial class Client
 
     private void PrepareTransition()
     {
-        if (m_layerManager.TransitionLayer == null)
-            m_layerManager.Add(new TransitionLayer(m_config));
+        m_layerManager.RemoveWithoutAnimation(m_layerManager.TransitionLayer);
+        m_layerManager.Add(new TransitionLayer(m_config));
     }
 
     private void PlayTransition()

--- a/Core/Layer/GameLayerManager.cs
+++ b/Core/Layer/GameLayerManager.cs
@@ -659,7 +659,6 @@ public class GameLayerManager : IGameLayerManager
 
         m_profiler.Render.MiscLayers.Start();
         ctx.Hud(m_hudContext, m_renderHudAction);
-        TransitionLayer?.Render(m_ctx);
         m_profiler.Render.MiscLayers.Stop();
     }
 
@@ -697,6 +696,10 @@ public class GameLayerManager : IGameLayerManager
 
         ReadThisLayer?.Render(hudCtx);
         IwadSelectionLayer?.Render(m_ctx, hudCtx);
+        // flush queue with HUD etc to screen, so we can refill the queue with
+        // loading screen elements to draw over the transition layer
+        m_hudRenderCtx.DrawQueuedHudImages();
+        TransitionLayer?.Render(m_ctx);
         LoadingLayer?.Render(m_ctx, m_hudRenderCtx);
 
         RenderConsole(hudCtx);
@@ -715,7 +718,7 @@ public class GameLayerManager : IGameLayerManager
         if (m_config.Hud.AutoMap.Overlay)
         {
             worldLayer.RenderHud(m_ctx, RenderHudOptions.Weapon | RenderHudOptions.Crosshair | RenderHudOptions.BackDrop);
-            m_hudRenderCtx.DrawHud();
+            m_hudRenderCtx.DrawQueuedHudImages();
             worldLayer.RenderAutomap(m_ctx);
             worldLayer.RenderHud(m_ctx, RenderHudOptions.Hud);
         }

--- a/Core/Layer/GameLayerManager.cs
+++ b/Core/Layer/GameLayerManager.cs
@@ -640,6 +640,8 @@ public class GameLayerManager : IGameLayerManager
     private void RenderDefault(IRenderableSurfaceContext ctx)
     {
         m_ctx = ctx;
+        // if preparing a transition, unless we're going to show the titlepic,
+        // we'll want to grab the previous frame's framebuffer immediately
         if (LoadingLayer?.HasImage != true)
             TransitionLayer?.GrabFramebufferIfNeeded(m_ctx);
         m_hudContext.Dimension = m_renderer.RenderDimension;

--- a/Core/Layer/GameLayerManager.cs
+++ b/Core/Layer/GameLayerManager.cs
@@ -702,7 +702,7 @@ public class GameLayerManager : IGameLayerManager
         // allow the transition layer to copy it to framebuffer, and then draw
         // the progress bar over it
         LoadingLayer?.RenderImage(m_ctx, m_hudRenderCtx);
-        m_hudRenderCtx.DrawQueuedHudImages();
+        m_hudRenderCtx.DrawHud();
         if (LoadingLayer?.HasImage == true)
         {
             TransitionLayer?.GrabFramebufferIfNeeded(m_ctx);
@@ -727,7 +727,7 @@ public class GameLayerManager : IGameLayerManager
         if (m_config.Hud.AutoMap.Overlay)
         {
             worldLayer.RenderHud(m_ctx, RenderHudOptions.Weapon | RenderHudOptions.Crosshair | RenderHudOptions.BackDrop);
-            m_hudRenderCtx.DrawQueuedHudImages();
+            m_hudRenderCtx.DrawHud();
             worldLayer.RenderAutomap(m_ctx);
             worldLayer.RenderHud(m_ctx, RenderHudOptions.Hud);
         }

--- a/Core/Layer/GameLayerManager.cs
+++ b/Core/Layer/GameLayerManager.cs
@@ -698,10 +698,16 @@ public class GameLayerManager : IGameLayerManager
 
         ReadThisLayer?.Render(hudCtx);
         IwadSelectionLayer?.Render(m_ctx, hudCtx);
+        // if the loading layer has an image to render, we'll draw it to screen,
+        // allow the transition layer to copy it to framebuffer, and then draw
+        // the progress bar over it
         LoadingLayer?.RenderImage(m_ctx, m_hudRenderCtx);
         m_hudRenderCtx.DrawQueuedHudImages();
         if (LoadingLayer?.HasImage == true)
+        {
             TransitionLayer?.GrabFramebufferIfNeeded(m_ctx);
+            m_ctx.ClearDepth();
+        }
         TransitionLayer?.Render(m_ctx);
         LoadingLayer?.RenderProgress(m_ctx, m_hudRenderCtx);
 

--- a/Core/Layer/GameLayerManager.cs
+++ b/Core/Layer/GameLayerManager.cs
@@ -693,17 +693,16 @@ public class GameLayerManager : IGameLayerManager
         EndGameLayer?.Render(m_ctx, hudCtx);
         ReadThisLayer?.Render(hudCtx);
         IwadSelectionLayer?.Render(m_ctx, hudCtx);
+
         // if the loading layer has an image to render, we'll draw it to screen,
         // allow the transition layer to copy it to framebuffer, and then draw
         // the progress bar over it
         LoadingLayer?.RenderImage(m_ctx, m_hudRenderCtx);
         m_hudRenderCtx.DrawHud();
         if (LoadingLayer?.HasImage == true)
-        {
             TransitionLayer?.GrabFramebufferIfNeeded(m_ctx);
-            m_ctx.ClearDepth();
-        }
         TransitionLayer?.Render(m_ctx);
+        m_ctx.ClearDepth();
 
         if (MenuLayer != null)
             RenderWithAlpha(hudCtx, MenuLayer.Animation, RenderMenu);

--- a/Core/Layer/GameLayerManager.cs
+++ b/Core/Layer/GameLayerManager.cs
@@ -640,6 +640,8 @@ public class GameLayerManager : IGameLayerManager
     private void RenderDefault(IRenderableSurfaceContext ctx)
     {
         m_ctx = ctx;
+        if (LoadingLayer?.HasImage != true)
+            TransitionLayer?.GrabFramebufferIfNeeded(m_ctx);
         m_hudContext.Dimension = m_renderer.RenderDimension;
         m_hudContext.DrawPalette = true;
         ctx.Viewport(m_renderer.RenderDimension.Box);
@@ -696,11 +698,12 @@ public class GameLayerManager : IGameLayerManager
 
         ReadThisLayer?.Render(hudCtx);
         IwadSelectionLayer?.Render(m_ctx, hudCtx);
-        // flush queue with HUD etc to screen, so we can refill the queue with
-        // loading screen elements to draw over the transition layer
+        LoadingLayer?.RenderImage(m_ctx, m_hudRenderCtx);
         m_hudRenderCtx.DrawQueuedHudImages();
+        if (LoadingLayer?.HasImage == true)
+            TransitionLayer?.GrabFramebufferIfNeeded(m_ctx);
         TransitionLayer?.Render(m_ctx);
-        LoadingLayer?.Render(m_ctx, m_hudRenderCtx);
+        LoadingLayer?.RenderProgress(m_ctx, m_hudRenderCtx);
 
         RenderConsole(hudCtx);
 

--- a/Core/Layer/GameLayerManager.cs
+++ b/Core/Layer/GameLayerManager.cs
@@ -691,13 +691,6 @@ public class GameLayerManager : IGameLayerManager
         IntermissionLayer?.Render(m_ctx, hudCtx);
         TitlepicLayer?.Render(hudCtx);
         EndGameLayer?.Render(m_ctx, hudCtx);
-
-        if (MenuLayer != null)
-            RenderWithAlpha(hudCtx, MenuLayer.Animation, RenderMenu);
-
-        if (OptionsLayer != null)
-            RenderWithAlpha(hudCtx, OptionsLayer.Animation, RenderOptions);
-
         ReadThisLayer?.Render(hudCtx);
         IwadSelectionLayer?.Render(m_ctx, hudCtx);
         // if the loading layer has an image to render, we'll draw it to screen,
@@ -711,6 +704,13 @@ public class GameLayerManager : IGameLayerManager
             m_ctx.ClearDepth();
         }
         TransitionLayer?.Render(m_ctx);
+
+        if (MenuLayer != null)
+            RenderWithAlpha(hudCtx, MenuLayer.Animation, RenderMenu);
+
+        if (OptionsLayer != null)
+            RenderWithAlpha(hudCtx, OptionsLayer.Animation, RenderOptions);
+
         LoadingLayer?.RenderProgress(m_ctx, m_hudRenderCtx);
 
         RenderConsole(hudCtx);

--- a/Core/Layer/Loading/LoadingLayer.cs
+++ b/Core/Layer/Loading/LoadingLayer.cs
@@ -26,6 +26,7 @@ public class LoadingLayer : IGameLayer
     public string LoadingText { get; set; }
     public string LoadingImage { get; set; } = string.Empty;
     private readonly bool m_showLoadingImage;
+    public bool HasImage => m_showLoadingImage && LoadingImage.Length > 0;
     public bool ShowSpinner { get; set; } = true;
 
     public LoadingLayer(ArchiveCollection archiveCollection, IConfig config, string text, bool showLoadingImage = true)
@@ -37,14 +38,16 @@ public class LoadingLayer : IGameLayer
         m_stopwatch.Start();
     }
 
-    public void Render(IRenderableSurfaceContext ctx, IHudRenderContext hud)
+    public void RenderImage(IRenderableSurfaceContext ctx, IHudRenderContext hud)
     {
-        if (m_showLoadingImage && LoadingImage.Length > 0)
-        {
-            hud.FillBox(new(new Vec2I(0, 0), new Vec2I(hud.Dimension.Width, hud.Dimension.Height)), Color.Black);
-            hud.RenderFullscreenImage(LoadingImage);
-        }
+        if (!HasImage)
+            return;
+        hud.FillBox(new(new Vec2I(0, 0), new Vec2I(hud.Dimension.Width, hud.Dimension.Height)), Color.Black);
+        hud.RenderFullscreenImage(LoadingImage);
+    }
 
+    public void RenderProgress(IRenderableSurfaceContext ctx, IHudRenderContext hud)
+    {
         int fontSize = m_config.Hud.GetScaled(20);
         int yOffset = -m_config.Hud.GetScaled(8);
         var dim = hud.MeasureText(LoadingText, ConsoleFont, fontSize);

--- a/Core/Layer/Transition/TransitionLayer.cs
+++ b/Core/Layer/Transition/TransitionLayer.cs
@@ -14,16 +14,16 @@ public class TransitionLayer : IGameLayer, IAnimationLayer
 {
     private readonly IConfig m_config;
     private readonly TransitionType m_type;
-    private bool m_shouldDraw;
     private bool m_inited;
+    private bool m_started;
 
     public InterpolationAnimation<IAnimationLayer> Animation { get; }
 
     public TransitionLayer(IConfig config)
     {
         m_config = config;
-        m_shouldDraw = false;
         m_inited = false;
+        m_started = false;
         m_type = m_config.Game.TransitionType;
         double duration = m_type switch
         {
@@ -40,16 +40,23 @@ public class TransitionLayer : IGameLayer, IAnimationLayer
 
     public void Start()
     {
-        m_shouldDraw = true;
+        m_started = true;
         Animation.AnimateIn();
+    }
+
+    public void GrabFramebufferIfNeeded(IRenderableSurfaceContext ctx)
+    {
+        if (m_inited)
+            return;
+        ctx.DrawTransition(m_type, 0, true);
+        m_inited = true;
     }
 
     public void Render(IRenderableSurfaceContext ctx)
     {
         Animation.Tick();
-        float progress = m_shouldDraw ? (float)Animation.GetInterpolated(1) : 0;
-        ctx.DrawTransition(m_type, progress, !m_inited);
-        m_inited = true;
+        float progress = m_started ? (float)Animation.GetInterpolated(1) : 0;
+        ctx.DrawTransition(m_type, progress, false);
     }
 
     public void HandleInput(IConsumableInput input) { }

--- a/Core/Layer/Transition/TransitionLayer.cs
+++ b/Core/Layer/Transition/TransitionLayer.cs
@@ -48,7 +48,7 @@ public class TransitionLayer : IGameLayer, IAnimationLayer
     {
         if (m_inited)
             return;
-        ctx.DrawTransition(m_type, 0, true);
+        ctx.HandleTransition(m_type, null, true);
         m_inited = true;
     }
 
@@ -56,7 +56,7 @@ public class TransitionLayer : IGameLayer, IAnimationLayer
     {
         Animation.Tick();
         float progress = m_started ? (float)Animation.GetInterpolated(1) : 0;
-        ctx.DrawTransition(m_type, progress, false);
+        ctx.HandleTransition(m_type, progress, null);
     }
 
     public void HandleInput(IConsumableInput input) { }

--- a/Core/Layer/Transition/TransitionLayer.cs
+++ b/Core/Layer/Transition/TransitionLayer.cs
@@ -14,14 +14,16 @@ public class TransitionLayer : IGameLayer, IAnimationLayer
 {
     private readonly IConfig m_config;
     private readonly TransitionType m_type;
-    private bool m_started;
+    private bool m_shouldDraw;
+    private bool m_inited;
 
     public InterpolationAnimation<IAnimationLayer> Animation { get; }
 
     public TransitionLayer(IConfig config)
     {
         m_config = config;
-        m_started = false;
+        m_shouldDraw = false;
+        m_inited = false;
         m_type = m_config.Game.TransitionType;
         double duration = m_type switch
         {
@@ -36,14 +38,18 @@ public class TransitionLayer : IGameLayer, IAnimationLayer
 
     public bool ShouldRemove() => true;
 
+    public void Start()
+    {
+        m_shouldDraw = true;
+        Animation.AnimateIn();
+    }
+
     public void Render(IRenderableSurfaceContext ctx)
     {
-        if (!m_started)
-            Animation.AnimateIn();
         Animation.Tick();
-        var progress = (float)Animation.GetInterpolated(1);
-        ctx.DrawTransition(m_type, progress, !m_started);
-        m_started = true;
+        float progress = m_shouldDraw ? (float)Animation.GetInterpolated(1) : 0;
+        ctx.DrawTransition(m_type, progress, !m_inited);
+        m_inited = true;
     }
 
     public void HandleInput(IConsumableInput input) { }

--- a/Core/Render/Common/Commands/RenderCommands.cs
+++ b/Core/Render/Common/Commands/RenderCommands.cs
@@ -62,7 +62,7 @@ public class RenderCommands
     public List<ViewportCommand> ViewportCommands = new();
     public List<DrawTextCommand> TextCommands = new();
     public List<DrawShapeCommand> ShapeCommands = new();
-    public TransitionCommand? CurrentTransitionCommand = null;
+    public List<TransitionCommand> TransitionCommands = new();
 
     public Dimension RenderDimension => m_renderDimensions;
     public Dimension WindowDimension => m_windowDimensions;
@@ -96,7 +96,7 @@ public class RenderCommands
         TextCommands.Clear();
         ShapeCommands.Clear();
         AutomapCommands.Clear();
-        CurrentTransitionCommand = null;
+        TransitionCommands.Clear();
 
         ResolutionInfo = new ResolutionInfo { VirtualDimensions = RenderDimension };
         m_scale = Vec2D.One;
@@ -172,8 +172,8 @@ public class RenderCommands
 
     public void DrawTransition(TransitionType type, float progress, bool start)
     {
-        Commands.Add(new RenderCommand(RenderCommandType.Transition, 0));
-        CurrentTransitionCommand = new TransitionCommand(type, progress, start);
+        Commands.Add(new RenderCommand(RenderCommandType.Transition, TransitionCommands.Count));
+        TransitionCommands.Add(new TransitionCommand(type, progress, start));
     }
 
     /// <summary>

--- a/Core/Render/Common/Commands/RenderCommands.cs
+++ b/Core/Render/Common/Commands/RenderCommands.cs
@@ -26,7 +26,7 @@ public enum RenderCommandType
     Viewport,
     DrawVirtualFrameBuffer,
     Automap,
-    DrawQueuedHudImages,
+    Hud,
     Transition,
 }
 
@@ -154,9 +154,9 @@ public class RenderCommands
         AutomapCommands.Add(new DrawWorldCommand(world, camera, gametick, fraction, viewerEntity, drawAutomap, automapOffset, automapScale));
     }
 
-    public void DrawQueuedHudImages()
+    public void DrawHud()
     {
-        Commands.Add(new RenderCommand(RenderCommandType.DrawQueuedHudImages, 0));
+        Commands.Add(new RenderCommand(RenderCommandType.Hud, 0));
     }
 
     public void Viewport(Dimension dimension, Vec2I? offset = null)

--- a/Core/Render/Common/Commands/RenderCommands.cs
+++ b/Core/Render/Common/Commands/RenderCommands.cs
@@ -26,7 +26,7 @@ public enum RenderCommandType
     Viewport,
     DrawVirtualFrameBuffer,
     Automap,
-    Hud,
+    DrawQueuedHudImages,
     Transition,
 }
 
@@ -154,9 +154,9 @@ public class RenderCommands
         AutomapCommands.Add(new DrawWorldCommand(world, camera, gametick, fraction, viewerEntity, drawAutomap, automapOffset, automapScale));
     }
 
-    public void DrawHud()
+    public void DrawQueuedHudImages()
     {
-        Commands.Add(new RenderCommand(RenderCommandType.Hud, 0));
+        Commands.Add(new RenderCommand(RenderCommandType.DrawQueuedHudImages, 0));
     }
 
     public void Viewport(Dimension dimension, Vec2I? offset = null)
@@ -172,6 +172,7 @@ public class RenderCommands
 
     public void DrawTransition(TransitionType type, float progress, bool start)
     {
+        Commands.Add(new RenderCommand(RenderCommandType.Transition, 0));
         CurrentTransitionCommand = new TransitionCommand(type, progress, start);
     }
 

--- a/Core/Render/Common/Commands/RenderCommands.cs
+++ b/Core/Render/Common/Commands/RenderCommands.cs
@@ -170,7 +170,7 @@ public class RenderCommands
         Commands.Add(new RenderCommand(RenderCommandType.DrawVirtualFrameBuffer, 0));
     }
 
-    public void DrawTransition(TransitionType type, float progress, bool start)
+    public void HandleTransition(TransitionType type, float? progress, bool? start)
     {
         Commands.Add(new RenderCommand(RenderCommandType.Transition, TransitionCommands.Count));
         TransitionCommands.Add(new TransitionCommand(type, progress, start));

--- a/Core/Render/Common/Commands/RenderCommands.cs
+++ b/Core/Render/Common/Commands/RenderCommands.cs
@@ -170,10 +170,10 @@ public class RenderCommands
         Commands.Add(new RenderCommand(RenderCommandType.DrawVirtualFrameBuffer, 0));
     }
 
-    public void HandleTransition(TransitionType type, float? progress, bool? start)
+    public void HandleTransition(TransitionType type, float? progress, bool? init)
     {
         Commands.Add(new RenderCommand(RenderCommandType.Transition, TransitionCommands.Count));
-        TransitionCommands.Add(new TransitionCommand(type, progress, start));
+        TransitionCommands.Add(new TransitionCommand(type, progress, init));
     }
 
     /// <summary>

--- a/Core/Render/Common/Commands/Types/TransitionCommand.cs
+++ b/Core/Render/Common/Commands/Types/TransitionCommand.cs
@@ -4,9 +4,9 @@ using System.Runtime.InteropServices;
 namespace Helion.Render.OpenGL.Commands.Types;
 
 [StructLayout(LayoutKind.Sequential)]
-public readonly struct TransitionCommand(TransitionType type, float? progress, bool? start)
+public readonly struct TransitionCommand(TransitionType type, float? progress, bool? init)
 {
     public readonly TransitionType Type = type;
     public readonly float? Progress = progress;
-    public readonly bool? Start = start;
+    public readonly bool? Init = init;
 }

--- a/Core/Render/Common/Commands/Types/TransitionCommand.cs
+++ b/Core/Render/Common/Commands/Types/TransitionCommand.cs
@@ -4,9 +4,9 @@ using System.Runtime.InteropServices;
 namespace Helion.Render.OpenGL.Commands.Types;
 
 [StructLayout(LayoutKind.Sequential)]
-public readonly struct TransitionCommand(TransitionType type, float progress, bool start)
+public readonly struct TransitionCommand(TransitionType type, float? progress, bool? start)
 {
     public readonly TransitionType Type = type;
-    public readonly float Progress = progress;
-    public readonly bool Start = start;
+    public readonly float? Progress = progress;
+    public readonly bool? Start = start;
 }

--- a/Core/Render/Common/Renderers/IHudRenderContext.cs
+++ b/Core/Render/Common/Renderers/IHudRenderContext.cs
@@ -201,5 +201,5 @@ public interface IHudRenderContext : IDisposable
     /// <summary>
     /// Draws queued images, text, shapes to screen.
     /// </summary>
-    void DrawQueuedHudImages();
+    void DrawHud();
 }

--- a/Core/Render/Common/Renderers/IHudRenderContext.cs
+++ b/Core/Render/Common/Renderers/IHudRenderContext.cs
@@ -198,5 +198,8 @@ public interface IHudRenderContext : IDisposable
     // Setting to false with colormap rendering will stop boom colormaps set from transfer heights.
     void DrawColorMap(bool set);
 
-    void DrawHud();
+    /// <summary>
+    /// Draws queued images, text, shapes to screen.
+    /// </summary>
+    void DrawQueuedHudImages();
 }

--- a/Core/Render/Common/Renderers/IRenderableSurfaceContext.cs
+++ b/Core/Render/Common/Renderers/IRenderableSurfaceContext.cs
@@ -82,5 +82,5 @@ public interface IRenderableSurfaceContext
 
     void DrawVirtualFrameBuffer();
 
-    void HandleTransition(TransitionType type, float? progress, bool? start);
+    void HandleTransition(TransitionType type, float? progress, bool? init);
 }

--- a/Core/Render/Common/Renderers/IRenderableSurfaceContext.cs
+++ b/Core/Render/Common/Renderers/IRenderableSurfaceContext.cs
@@ -82,5 +82,5 @@ public interface IRenderableSurfaceContext
 
     void DrawVirtualFrameBuffer();
 
-    void DrawTransition(TransitionType type, float progress, bool start);
+    void HandleTransition(TransitionType type, float? progress, bool? start);
 }

--- a/Core/Render/OpenGL/GLHudRenderContext.cs
+++ b/Core/Render/OpenGL/GLHudRenderContext.cs
@@ -339,8 +339,8 @@ public class GLHudRenderContext : IHudRenderContext
         // Nothing to do
     }
 
-    public void DrawQueuedHudImages()
+    public void DrawHud()
     {
-        m_commands.DrawQueuedHudImages();
+        m_commands.DrawHud();
     }
 }

--- a/Core/Render/OpenGL/GLHudRenderContext.cs
+++ b/Core/Render/OpenGL/GLHudRenderContext.cs
@@ -339,8 +339,8 @@ public class GLHudRenderContext : IHudRenderContext
         // Nothing to do
     }
 
-    public void DrawHud()
+    public void DrawQueuedHudImages()
     {
-        m_commands.DrawHud();
+        m_commands.DrawQueuedHudImages();
     }
 }

--- a/Core/Render/OpenGL/GLRenderableSurfaceContext.cs
+++ b/Core/Render/OpenGL/GLRenderableSurfaceContext.cs
@@ -99,5 +99,5 @@ public class GLRenderableSurfaceContext : IRenderableSurfaceContext
         action(m_worldRenderContext);
     }
 
-    public void DrawTransition(TransitionType type, float progress, bool start) => Commands.DrawTransition(type, progress, start);
+    public void HandleTransition(TransitionType type, float? progress, bool? start) => Commands.HandleTransition(type, progress, start);
 }

--- a/Core/Render/OpenGL/GLRenderableSurfaceContext.cs
+++ b/Core/Render/OpenGL/GLRenderableSurfaceContext.cs
@@ -99,5 +99,5 @@ public class GLRenderableSurfaceContext : IRenderableSurfaceContext
         action(m_worldRenderContext);
     }
 
-    public void HandleTransition(TransitionType type, float? progress, bool? start) => Commands.HandleTransition(type, progress, start);
+    public void HandleTransition(TransitionType type, float? progress, bool? init) => Commands.HandleTransition(type, progress, init);
 }

--- a/Core/Render/OpenGL/Renderers/TransitionRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/TransitionRenderer.cs
@@ -68,6 +68,7 @@ public class TransitionRenderer : IDisposable
         GL.BlitFramebuffer(0, 0, sourceBuffer.Dimension.Width, sourceBuffer.Dimension.Height,
             0, 0, m_startBuffer.Dimension.Width, m_startBuffer.Dimension.Height,
             ClearBufferMask.ColorBufferBit, BlitFramebufferFilter.Linear);
+        sourceBuffer.BindDraw();
     }
 
     private void UploadVertices()
@@ -90,6 +91,7 @@ public class TransitionRenderer : IDisposable
         if (m_program == null)
             return;
 
+        m_startBuffer.BindRead();
         targetBuffer.BindDraw();
         GL.Viewport(0, 0, targetBuffer.Dimension.Width, targetBuffer.Dimension.Height);
         m_program.Bind();

--- a/Core/Render/Renderer.cs
+++ b/Core/Render/Renderer.cs
@@ -396,7 +396,7 @@ public partial class Renderer : IDisposable
                 case RenderCommandType.Automap:
                     HandleRenderAutomapCommand(renderCommands.AutomapCommands[cmd.Index], m_viewport);
                     break;
-                case RenderCommandType.DrawQueuedHudImages:
+                case RenderCommandType.Hud:
                     DrawHudImagesIfAnyQueued(m_viewport, m_renderInfo.Uniforms);
                     break;
                 case RenderCommandType.Viewport:

--- a/Core/Render/Renderer.cs
+++ b/Core/Render/Renderer.cs
@@ -408,7 +408,7 @@ public partial class Renderer : IDisposable
                     break;
                 case RenderCommandType.Transition:
                     var tranCmd = renderCommands.TransitionCommands[cmd.Index];
-                    if (tranCmd.Start == true)
+                    if (tranCmd.Init == true)
                         m_transitionRenderer.PrepareNewTransition(m_mainFramebuffer, tranCmd.Type);
                     if (tranCmd.Progress.HasValue)
                         m_transitionRenderer.Render(m_mainFramebuffer, tranCmd.Progress.Value);

--- a/Core/Render/Renderer.cs
+++ b/Core/Render/Renderer.cs
@@ -400,7 +400,7 @@ public partial class Renderer : IDisposable
                 case RenderCommandType.Automap:
                     HandleRenderAutomapCommand(renderCommands.AutomapCommands[cmd.Index], m_viewport);
                     break;
-                case RenderCommandType.Hud:
+                case RenderCommandType.DrawQueuedHudImages:
                     DrawHudImagesIfAnyQueued(m_viewport, m_renderInfo.Uniforms);
                     break;
                 case RenderCommandType.Viewport:
@@ -411,7 +411,7 @@ public partial class Renderer : IDisposable
                     BlitVirtualFramebufferToMain();
                     break;
                 case RenderCommandType.Transition:
-                    Fail("transition command shouldn't be here");
+                    m_transitionRenderer.Render(m_mainFramebuffer, renderCommands.CurrentTransitionCommand!.Value.Progress);
                     break;
                 default:
                     Fail($"Unsupported render command type: {cmd.Type}");
@@ -423,9 +423,6 @@ public partial class Renderer : IDisposable
 
         if (!virtualFrameBufferDraw)
             BlitVirtualFramebufferToMain();
-
-        if (renderCommands.CurrentTransitionCommand != null)
-            m_transitionRenderer.Render(m_mainFramebuffer, renderCommands.CurrentTransitionCommand.Value.Progress);
 
         // draw main framebuffer to default
         // BlitMainFramebufferToDefault();

--- a/Core/Render/Renderer.cs
+++ b/Core/Render/Renderer.cs
@@ -362,10 +362,6 @@ public partial class Renderer : IDisposable
 
     public void Render(RenderCommands renderCommands)
     {
-        // this needs to run first so we can snapshot the framebuffer
-        if (renderCommands.CurrentTransitionCommand?.Start == true)
-            m_transitionRenderer.PrepareNewTransition(m_mainFramebuffer, renderCommands.CurrentTransitionCommand.Value.Type);
-
         m_hudRenderer.Clear();
         UpdateFramebufferDimensionsIfNeeded();
         m_virtualFramebuffer.Bind();
@@ -411,7 +407,10 @@ public partial class Renderer : IDisposable
                     BlitVirtualFramebufferToMain();
                     break;
                 case RenderCommandType.Transition:
-                    m_transitionRenderer.Render(m_mainFramebuffer, renderCommands.CurrentTransitionCommand!.Value.Progress);
+                    var tranCmd = renderCommands.TransitionCommands[cmd.Index];
+                    if (tranCmd.Start == true)
+                        m_transitionRenderer.PrepareNewTransition(m_mainFramebuffer, tranCmd.Type);
+                    m_transitionRenderer.Render(m_mainFramebuffer, tranCmd.Progress);
                     break;
                 default:
                     Fail($"Unsupported render command type: {cmd.Type}");

--- a/Core/Render/Renderer.cs
+++ b/Core/Render/Renderer.cs
@@ -410,7 +410,8 @@ public partial class Renderer : IDisposable
                     var tranCmd = renderCommands.TransitionCommands[cmd.Index];
                     if (tranCmd.Start == true)
                         m_transitionRenderer.PrepareNewTransition(m_mainFramebuffer, tranCmd.Type);
-                    m_transitionRenderer.Render(m_mainFramebuffer, tranCmd.Progress);
+                    if (tranCmd.Progress.HasValue)
+                        m_transitionRenderer.Render(m_mainFramebuffer, tranCmd.Progress.Value);
                     break;
                 default:
                     Fail($"Unsupported render command type: {cmd.Type}");


### PR DESCRIPTION
- separates the transition command into a grab command and a draw command
- now grabs the framebuffer early so we don't have to hold on to the intermission/endgame layers during map loads, as it was before
- `showLoadingTitlepic` should now function fully as intended, so it's no longer shown during map restart
- the menu can now draw over an active transition

I've done a good amount of testing but want to test a big more before merging