### PR TITLE
Reuse FluidSynth synthesizer

### DIFF
--- a/Client/Music/FluidSynthMusicPlayer.cs
+++ b/Client/Music/FluidSynthMusicPlayer.cs
@@ -4,6 +4,7 @@ using NFluidsynth;
 using NLog;
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using static Helion.Util.Assertion.Assert;
 
 namespace Helion.Client.Music;
@@ -26,6 +27,12 @@ public class FluidSynthMusicPlayer : IMusicPlayer
     {
         m_settings = new Settings();
         m_settings[ConfigurationKeys.SynthAudioChannels].IntValue = 2;
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            m_settings[ConfigurationKeys.AudioDriver].StringValue = "sdl2";
+        }
+
         m_synth = new(m_settings);
         m_audioDriver = new(m_synth.Settings, m_synth);
         EnsureSoundFont(soundFontFile);

--- a/Client/Music/FluidSynthMusicPlayer.cs
+++ b/Client/Music/FluidSynthMusicPlayer.cs
@@ -65,8 +65,6 @@ public class FluidSynthMusicPlayer : IMusicPlayer
             if (options.HasFlag(MusicPlayerOptions.Loop))
                 m_player.SetLoop(-1);
 
-            SetVolumeInternal();
-
             m_player.Add(m_lastFile);
             m_player.Play();
 
@@ -95,14 +93,14 @@ public class FluidSynthMusicPlayer : IMusicPlayer
 
     public void EnsureSoundFont(FileInfo soundFontPath)
     {
-        if (!string.IsNullOrEmpty(m_soundFontLoaded))
-        {
-            m_synth.UnloadSoundFont(m_soundFontCounter, true);
-            m_soundFontLoaded = string.Empty;
-        }
-
         try
         {
+            if (!string.IsNullOrEmpty(m_soundFontLoaded))
+            {
+                m_synth.UnloadSoundFont(m_soundFontCounter, true);
+                m_soundFontLoaded = string.Empty;
+            }
+
             if (soundFontPath.FullName != m_soundFontLoaded)
             {
                 m_synth.LoadSoundFont(soundFontPath.FullName, true);
@@ -137,7 +135,7 @@ public class FluidSynthMusicPlayer : IMusicPlayer
         if (m_disposed)
             return;
 
-        Stop();
+        Stop(); // disposes m_player
         try
         {
             m_audioDriver.Dispose();

--- a/Client/Music/FluidSynthMusicPlayer.cs
+++ b/Client/Music/FluidSynthMusicPlayer.cs
@@ -4,7 +4,6 @@ using NFluidsynth;
 using NLog;
 using System;
 using System.IO;
-using System.Runtime.InteropServices;
 using static Helion.Util.Assertion.Assert;
 
 namespace Helion.Client.Music;
@@ -27,12 +26,6 @@ public class FluidSynthMusicPlayer : IMusicPlayer
     {
         m_settings = new Settings();
         m_settings[ConfigurationKeys.SynthAudioChannels].IntValue = 2;
-
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-        {
-            m_settings[ConfigurationKeys.AudioDriver].StringValue = "sdl2";
-        }
-
         m_synth = new(m_settings);
         m_audioDriver = new(m_synth.Settings, m_synth);
         EnsureSoundFont(soundFontFile);

--- a/Client/Music/FluidSynthMusicPlayer.cs
+++ b/Client/Music/FluidSynthMusicPlayer.cs
@@ -11,27 +11,24 @@ namespace Helion.Client.Music;
 public class FluidSynthMusicPlayer : IMusicPlayer
 {
     private static readonly NLog.Logger Log = LogManager.GetCurrentClassLogger();
-    private readonly Settings m_settings;
     private string m_lastFile = string.Empty;
-    private Player? m_player;
-    private Synth m_synth;
-    private bool m_soundFontLoaded;
+    private string? m_soundFontLoaded;
     private bool m_disposed;
     private float m_volume = 1;
     private uint m_soundFontCounter = 0;
+
+    private readonly Settings m_settings;
+    private Player? m_player;
+    private Synth m_synth;
+    private AudioDriver m_audioDriver;
 
     public FluidSynthMusicPlayer(FileInfo soundFontFile)
     {
         m_settings = new Settings();
         m_settings[ConfigurationKeys.SynthAudioChannels].IntValue = 2;
         m_synth = new(m_settings);
-        ChangeSoundFont(soundFontFile);
-    }
-
-    ~FluidSynthMusicPlayer()
-    {
-        FailedToDispose(this);
-        PerformDispose();
+        m_audioDriver = new(m_synth.Settings, m_synth);
+        EnsureSoundFont(soundFontFile);
     }
 
     public void SetVolume(float volume)
@@ -63,20 +60,16 @@ public class FluidSynthMusicPlayer : IMusicPlayer
             m_lastFile = TempFileManager.GetFile();
             File.WriteAllBytes(m_lastFile, data);
 
-            using (m_player = new Player(m_synth))
-            {
-                using var adriver = new AudioDriver(m_synth.Settings, m_synth);
-                if (options.HasFlag(MusicPlayerOptions.Loop))
-                    m_player.SetLoop(-1);
+            m_player = new(m_synth);
 
-                SetVolumeInternal();
+            if (options.HasFlag(MusicPlayerOptions.Loop))
+                m_player.SetLoop(-1);
 
-                m_player.Add(m_lastFile);
-                m_player.Play();
-                m_player.Join();
-            }
+            SetVolumeInternal();
 
-            m_player = null;
+            m_player.Add(m_lastFile);
+            m_player.Play();
+
             return true;
         }
         catch (Exception ex)
@@ -88,22 +81,37 @@ public class FluidSynthMusicPlayer : IMusicPlayer
         return false;
     }
 
-    public void ChangeSoundFont(FileInfo soundFontPath)
+    public void Stop()
     {
-        if (m_soundFontLoaded)
+        if (m_disposed)
+            return;
+
+        m_player?.Stop();
+        m_synth.SystemReset();
+
+        m_player?.Dispose();
+        m_player = null;
+    }
+
+    public void EnsureSoundFont(FileInfo soundFontPath)
+    {
+        if (!string.IsNullOrEmpty(m_soundFontLoaded))
         {
             m_synth.UnloadSoundFont(m_soundFontCounter, true);
-            m_soundFontLoaded = false;
+            m_soundFontLoaded = string.Empty;
         }
 
         try
         {
-            m_synth.LoadSoundFont(soundFontPath.FullName, true);
-            for (int i = 0; i < 16; i++)
-                m_synth.SoundFontSelect(i, 0);
+            if (soundFontPath.FullName != m_soundFontLoaded)
+            {
+                m_synth.LoadSoundFont(soundFontPath.FullName, true);
+                for (int i = 0; i < 16; i++)
+                    m_synth.SoundFontSelect(i, 0);
 
-            m_soundFontCounter++;
-            m_soundFontLoaded = true;
+                m_soundFontCounter++;
+                m_soundFontLoaded = soundFontPath.FullName;
+            }
         }
         catch (Exception ex)
         {
@@ -112,13 +120,10 @@ public class FluidSynthMusicPlayer : IMusicPlayer
         }
     }
 
-    public void Stop()
+    ~FluidSynthMusicPlayer()
     {
-        if (m_player == null || m_disposed)
-            return;
-
-        m_player.Stop();
-        m_player = null;
+        FailedToDispose(this);
+        PerformDispose();
     }
 
     public void Dispose()
@@ -135,8 +140,9 @@ public class FluidSynthMusicPlayer : IMusicPlayer
         Stop();
         try
         {
-            m_settings.Dispose();
+            m_audioDriver.Dispose();
             m_synth.Dispose();
+            m_settings.Dispose();
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
This is an attempt to fix some complaints related to the usage of FluidSynth in Helion:
1.  Helion sometimes crashes shortly after restarting (due to a video settings change)
2.  Helion sometimes crashes on a level transition
3.  Level transitions take a long time if the loaded SoundFont is very large, because Helion reloads the whole thing.

In this change, I am trying to reuse rather than recreate "Synth" objects.

The pattern I'm following is:
1.  Initialize a settings object, which governs how FluidSynth is supposed to operate, including things like what audio driver you want it to use.
2.  Initialize a synth object, which is the actual synthesizer
3.  Initialize an audio driver object, which is connected to the synthesizer, and is initialized per the settings (the settings govern some things like whether it uses ALSA or SDL2 on Linux, for example, so that's interesting).

The synthesizer is basically treated as a singleton and will stick around for the entire lifetime of the Helion process.  The synthesizer, and its connected settings and audio driver, are only disposed on process exit.

When Helion needs to play a music track, it will then:
1. Stop and dispose any existing Player object
2. Send a "system reset" message to the synth, which cancels all playing notes, resets panning and reverb, etc.
3. Create a new player, load the MIDI file, and tell it to play.

I suspect that the reason for the crashes was some sloppy disposal that caused the native resources to get cleaned up at inopportune times.  At the very least, my awful laptop seems to be happier with this.