### PR TITLE
Separate HUD scaling from menu text scaling

### DIFF
--- a/Core/Layer/IwadSelection/IwadSelectionLayer.cs
+++ b/Core/Layer/IwadSelection/IwadSelectionLayer.cs
@@ -62,8 +62,8 @@ public class IwadSelectionLayer : IGameLayer
 
     public void Render(IRenderableSurfaceContext ctx, IHudRenderContext hud)
     {
-        int fontSize = m_config.Hud.GetLargeFontSize();
-        int spacer = m_config.Hud.GetScaled(8);
+        int fontSize = m_config.Hud.GetHudLargeFontSize();
+        int spacer = m_config.Hud.GetHudScaled(8);
 
         hud.RenderFullscreenImage("background");
         hud.FillBox(new(new Vec2I(0, 0), new Vec2I(hud.Dimension.Width, hud.Dimension.Height)), Color.Black, alpha: 0.8f);

--- a/Core/Layer/Loading/LoadingLayer.cs
+++ b/Core/Layer/Loading/LoadingLayer.cs
@@ -48,8 +48,8 @@ public class LoadingLayer : IGameLayer
 
     public void RenderProgress(IRenderableSurfaceContext ctx, IHudRenderContext hud)
     {
-        int fontSize = m_config.Hud.GetScaled(20);
-        int yOffset = -m_config.Hud.GetScaled(8);
+        int fontSize = m_config.Hud.GetHudScaled(20);
+        int yOffset = -m_config.Hud.GetHudScaled(8);
         var dim = hud.MeasureText(LoadingText, ConsoleFont, fontSize);
         if (dim.Width == 0 && dim.Height == 0)
             return;
@@ -64,7 +64,7 @@ public class LoadingLayer : IGameLayer
         }
 
         if (ShowSpinner)
-            hud.Text(Spinner[m_spinner], ConsoleFont, fontSize, (-dim.Width / 2 - m_config.Hud.GetScaled(16), yOffset), both: Align.BottomMiddle);
+            hud.Text(Spinner[m_spinner], ConsoleFont, fontSize, (-dim.Width / 2 - m_config.Hud.GetHudScaled(16), yOffset), both: Align.BottomMiddle);
     }
 
     public void HandleInput(IConsumableInput input)

--- a/Core/Layer/Options/Dialogs/ColorDialog.cs
+++ b/Core/Layer/Options/Dialogs/ColorDialog.cs
@@ -29,7 +29,7 @@ internal class ColorDialog : DialogBase
     public Vec3I SelectedColor => m_color;
     public IConfigValue ConfigValue => m_configValue;
 
-    public ColorDialog(ConfigHud config, IConfigValue configValue, OptionMenuAttribute attr, Vec3I color)
+    public ColorDialog(ConfigWindow config, IConfigValue configValue, OptionMenuAttribute attr, Vec3I color)
         : base(config, "OK", "Cancel")
     {
         m_configValue = configValue;
@@ -76,7 +76,7 @@ internal class ColorDialog : DialogBase
         RenderDialogText(hud, m_attr.Name, windowAlign: Align.TopMiddle, anchorAlign: Align.TopMiddle);
         m_valueStartX = hud.MeasureText("Green", Font, m_fontSize).Width + m_padding * 4;
 
-        int boxSize = m_config.GetScaled(24);
+        int boxSize = m_config.GetMenuScaled(24);
         RenderColorBox(hud, 0, 0, boxSize);
         hud.AddOffset((m_dialogOffset.X + m_padding, boxSize + m_rowHeight));
 

--- a/Core/Layer/Options/Dialogs/DialogBase.cs
+++ b/Core/Layer/Options/Dialogs/DialogBase.cs
@@ -17,7 +17,7 @@ using System.Text;
 
 namespace Helion.Layer.Options.Dialogs;
 
-internal abstract class DialogBase(ConfigHud config, string? acceptButton, string? cancelButton) : IDialog
+internal abstract class DialogBase(ConfigWindow config, string? acceptButton, string? cancelButton) : IDialog
 {
     protected const string Selector = ">";
     protected const string Font = Constants.Fonts.SmallGray;
@@ -26,7 +26,7 @@ internal abstract class DialogBase(ConfigHud config, string? acceptButton, strin
 
     private readonly string? m_acceptButton = acceptButton;
     private readonly string? m_cancelButton = cancelButton;
-    protected readonly ConfigHud m_config = config;
+    protected readonly ConfigWindow m_config = config;
 
     protected Dimension m_selectorSize;
     protected int m_rowHeight;
@@ -84,11 +84,11 @@ internal abstract class DialogBase(ConfigHud config, string? acceptButton, strin
         m_buttonPosList.Clear();
 
         m_selectorSize = hud.MeasureText(Selector, Font, m_fontSize);
-        m_fontSize = m_config.GetSmallFontSize();
-        m_padding = m_config.GetScaled(8);
+        m_fontSize = m_config.GetMenuSmallFontSize();
+        m_padding = m_config.GetMenuScaled(8);
         m_rowHeight = hud.MeasureText("I", Font, m_fontSize).Height;
 
-        int border = m_config.GetScaled(1);
+        int border = m_config.GetMenuScaled(1);
         var size = new Dimension(Math.Max(hud.Width / 2, 320), Math.Max(hud.Height / 2, 200));
         hud.FillBox((0, 0, hud.Width, hud.Height), Color.Black, alpha: 0.5f);
 

--- a/Core/Layer/Options/Dialogs/FileListDialog.cs
+++ b/Core/Layer/Options/Dialogs/FileListDialog.cs
@@ -24,7 +24,7 @@ internal class FileListDialog : ListDialog
 
     public FileInfo? SelectedFile => new FileInfo(Path.Combine(m_path, m_file));
 
-    public FileListDialog(ConfigHud config, IConfigValue configValue, OptionMenuAttribute attr, string supportedFileExtensions)
+    public FileListDialog(ConfigWindow config, IConfigValue configValue, OptionMenuAttribute attr, string supportedFileExtensions)
         : base(config, configValue, attr)
     {
         m_supportedFileExtensions = new HashSet<string>(

--- a/Core/Layer/Options/Dialogs/ListDialog.cs
+++ b/Core/Layer/Options/Dialogs/ListDialog.cs
@@ -40,7 +40,7 @@ internal abstract class ListDialog : DialogBase
         set;
     }
 
-    public ListDialog(ConfigHud config, IConfigValue configValue, OptionMenuAttribute attr)
+    public ListDialog(ConfigWindow config, IConfigValue configValue, OptionMenuAttribute attr)
     : base(config, "OK", "Cancel")
     {
         m_configValue = configValue;

--- a/Core/Layer/Options/Dialogs/MessageDialog.cs
+++ b/Core/Layer/Options/Dialogs/MessageDialog.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace Helion.Layer.Options.Dialogs;
 
-internal class MessageDialog(ConfigHud config, string title, IList<string> message, string? acceptButton, string? cancelButton)
+internal class MessageDialog(ConfigWindow config, string title, IList<string> message, string? acceptButton, string? cancelButton)
     : DialogBase(config, acceptButton, cancelButton)
 {
     private readonly string m_title = title;

--- a/Core/Layer/Options/Dialogs/TexturePickerDialog.cs
+++ b/Core/Layer/Options/Dialogs/TexturePickerDialog.cs
@@ -19,7 +19,7 @@
         private string m_headerWithUnderscore;
         public string SelectedTexture { get; private set; }
 
-        public TexturePickerDialog(ConfigHud config, IConfigValue configValue, OptionMenuAttribute attr)
+        public TexturePickerDialog(ConfigWindow config, IConfigValue configValue, OptionMenuAttribute attr)
             : base(config, configValue, attr)
         {
             SelectedTexture = (string)configValue.ObjectValue;

--- a/Core/Layer/Options/IRenderControl.cs
+++ b/Core/Layer/Options/IRenderControl.cs
@@ -7,6 +7,6 @@ namespace Helion.Layer.Options;
 
 public interface IRenderControl
 {
-    public Dimension Render(ConfigHud config, IRenderableSurfaceContext ctx, IHudRenderContext hudCtx);
+    public Dimension Render(ConfigWindow config, IRenderableSurfaceContext ctx, IHudRenderContext hudCtx);
     public void HandleInput(IConsumableInput input);
 }

--- a/Core/Layer/Options/OptionsLayer.cs
+++ b/Core/Layer/Options/OptionsLayer.cs
@@ -76,7 +76,7 @@ public class OptionsLayer : IGameLayer, IAnimationLayer
         m_config.Window.State.OnChanged += WindowState_OnChanged;
         m_config.Window.Virtual.Enable.OnChanged += WindowVirtualEnable_OnChanged;
         m_config.Window.Virtual.Dimension.OnChanged += WindowVirtualDimension_OnChanged;
-        m_config.Hud.Scale.OnChanged += Scale_OnChanged;
+        m_config.Window.MenuScale.OnChanged += Scale_OnChanged;
 
         Animation = new(TimeSpan.FromMilliseconds(200), this);
         Animation.OnStart += Animation_OnStart;
@@ -122,7 +122,7 @@ public class OptionsLayer : IGameLayer, IAnimationLayer
 
     private void ResetMousePosition(IHudRenderContext hud)
     {
-        m_cursorPos = (hud.Dimension.Width / 2, m_config.Hud.GetScaled(45));
+        m_cursorPos = (hud.Dimension.Width / 2, m_config.Window.GetMenuScaled(45));
         m_window.SetMousePosition(m_cursorPos);
     }
 
@@ -142,7 +142,7 @@ public class OptionsLayer : IGameLayer, IAnimationLayer
     {
         if (configAttr.RestartRequired)
         {
-            m_dialog = new MessageDialog(m_config.Hud, "Restart required", ["Restart required for this change to take effect.", "", "Restart now?"], "Yes", "No");
+            m_dialog = new MessageDialog(m_config.Window, "Restart required", ["Restart required for this change to take effect.", "", "Restart now?"], "Yes", "No");
             m_dialog.OnClose += RestartDialog_OnClose;
             return;
         }
@@ -337,7 +337,7 @@ public class OptionsLayer : IGameLayer, IAnimationLayer
         }
     }
 
-    private int GetScrollAmount() => (int)(16 * m_config.Hud.Scale);
+    private int GetScrollAmount() => (int)(16 * m_config.Window.MenuScale);
 
     public void RunLogic(TickerInfo tickerInfo)
     {
@@ -374,11 +374,11 @@ public class OptionsLayer : IGameLayer, IAnimationLayer
 
         FillBackgroundRepeatingImages(ctx, hud);
 
-        int fontSize = m_config.Hud.GetMediumFontSize();
-        int largeFontSize = m_config.Hud.GetLargeFontSize();
-        int smallPad = m_config.Hud.GetScaled(2);
+        int fontSize = m_config.Window.GetMenuMediumFontSize();
+        int largeFontSize = m_config.Window.GetMenuLargeFontSize();
+        int smallPad = m_config.Window.GetMenuScaled(2);
 
-        m_footerScrollPadding = hud.MeasureText(" ", FooterFont, fontSize).Height * 4 + (m_config.Hud.GetScaled(8) * 2);
+        m_footerScrollPadding = hud.MeasureText(" ", FooterFont, fontSize).Height * 4 + (m_config.Window.GetMenuScaled(8) * 2);
 
         hud.Text($"{m_currentSectionIndex + 1}/{m_sections.Count}", Font, fontSize, (smallPad, smallPad),
             out _, both: Align.TopLeft, color: Color.Red);
@@ -388,9 +388,9 @@ public class OptionsLayer : IGameLayer, IAnimationLayer
         int titleY = m_scrollOffset;
         hud.Text("Options", Font, largeFontSize, (smallPad, smallPad + titleY),
                    out var titleArea, both: Align.TopMiddle, color: Color.White);
-        m_headerHeight += titleArea.Height + m_config.Hud.GetScaled(5);
+        m_headerHeight += titleArea.Height + m_config.Window.GetMenuScaled(5);
 
-        int padding = m_config.Hud.GetScaled(8);
+        int padding = m_config.Window.GetMenuScaled(8);
         if (m_sections.Count > 1)
         {
             int xOffset = (hud.Dimension.Width - titleArea.Width) / 2;
@@ -408,7 +408,7 @@ public class OptionsLayer : IGameLayer, IAnimationLayer
         hud.Text(m_sectionMessage.Length > 0 ? m_sectionMessage : "Press left or right to change pages.", Font, fontSize, (0, m_headerHeight + y),
             out Dimension pageInstrArea, both: Align.TopMiddle, color: Color.Red);
 
-        m_headerHeight += pageInstrArea.Height + m_config.Hud.GetScaled(16);
+        m_headerHeight += pageInstrArea.Height + m_config.Window.GetMenuScaled(16);
         if (m_lastSelectedRowDescription != m_selectedRowDescription)
             GenerateFooterLines(m_selectedRowDescription, FooterFont, fontSize, hud, m_footerLines, m_footerStringBuilder, out m_footerHeight);
         m_lastSelectedRowDescription = m_selectedRowDescription;
@@ -471,13 +471,13 @@ public class OptionsLayer : IGameLayer, IAnimationLayer
         LineWrap.Calculate(inputText, font, fontSize, hud.Width, hud, lines, builder, out requiredHeight);
 
         // Calculate how much room we need for the footer, with padding both above and below the text
-        int padding = m_config.Hud.GetScaled(8);
+        int padding = m_config.Window.GetMenuScaled(8);
         requiredHeight += padding * 2;
     }
 
     private void RenderFooter(List<string> lines, int startY, string font, int fontSize, IHudRenderContext hud)
     {
-        int padding = m_config.Hud.GetScaled(8);
+        int padding = m_config.Window.GetMenuScaled(8);
 
         // Make a box at the bottom of the HUD, then write the text lines over the box
         hud.FillBox(

--- a/Core/Layer/Options/Sections/KeyBindingSection.cs
+++ b/Core/Layer/Options/Sections/KeyBindingSection.cs
@@ -379,12 +379,12 @@ public class KeyBindingSection : IOptionSection
             m_updateMouse = true;
         }
 
-        int fontSize = m_config.Hud.GetSmallFontSize();
-        hud.Text("Key Bindings", Font, m_config.Hud.GetLargeFontSize(), (0, startY), out Dimension headerArea,
+        int fontSize = m_config.Window.GetMenuSmallFontSize();
+        hud.Text("Key Bindings", Font, m_config.Window.GetMenuLargeFontSize(), (0, startY), out Dimension headerArea,
             both: Align.TopMiddle, color: Color.Red);
-        int y = startY + headerArea.Height + m_config.Hud.GetScaled(8);
-        int xOffset = m_config.Hud.GetScaled(4) * 2;
-        int smallPad = m_config.Hud.GetScaled(1);
+        int y = startY + headerArea.Height + m_config.Window.GetMenuScaled(8);
+        int xOffset = m_config.Window.GetMenuScaled(4) * 2;
+        int smallPad = m_config.Window.GetMenuScaled(1);
 
         hud.Text("Scroll with the mouse wheel or hold up/down arrows", Font, fontSize, (0, y), out Dimension scrollArea,
             both: Align.TopMiddle, color: Color.Firebrick);
@@ -400,7 +400,7 @@ public class KeyBindingSection : IOptionSection
 
         hud.Text("Press enter to start binding and press a key", Font, fontSize, (0, y), out Dimension enterArea,
             both: Align.TopMiddle, color: Color.Firebrick);
-        y += enterArea.Height + m_config.Hud.GetScaled(12);
+        y += enterArea.Height + m_config.Window.GetMenuScaled(12);
 
         for (int cmdIndex = 0; cmdIndex < m_commandToKeys.Count; cmdIndex++)
         {
@@ -424,10 +424,10 @@ public class KeyBindingSection : IOptionSection
             if (cmdIndex == m_currentRow && !m_updatingKeyBinding)
             {
                 var arrowSize = hud.MeasureText("<", Font, fontSize);
-                Vec2I arrowLeft = (-xOffset - commandArea.Width - m_config.Hud.GetScaled(2), y);
+                Vec2I arrowLeft = (-xOffset - commandArea.Width - m_config.Window.GetMenuScaled(2), y);
                 hud.Text(">", Font, fontSize, arrowLeft, window: Align.TopMiddle,
                     anchor: Align.TopRight, color: Color.White);
-                Vec2I arrowRight = (-xOffset + arrowSize.Width + m_config.Hud.GetScaled(2), y);
+                Vec2I arrowRight = (-xOffset + arrowSize.Width + m_config.Window.GetMenuScaled(2), y);
                 hud.Text("<", Font, fontSize, arrowRight, window: Align.TopMiddle,
                     anchor: Align.TopRight, color: Color.White);
             }
@@ -475,7 +475,7 @@ public class KeyBindingSection : IOptionSection
             : "> Reload All Defaults <";
         hud.Text(resetText, Font, fontSize, (0, y), out Dimension area, window: Align.TopMiddle, anchor: Align.TopMiddle, color: Color.Yellow);
         m_menuPositionList.Add(new Box2I((0, y), (hud.Dimension.Width, y + area.Height)), m_commandToKeys.Count);
-        y += area.Height + m_config.Hud.GetScaled(3);
+        y += area.Height + m_config.Window.GetMenuScaled(3);
 
         // Handle case where the "Reset" row is selected; this affects auto-scrolling.
         if (m_currentRow == m_commandToKeys.Count)

--- a/Core/Layer/Options/Sections/ListedConfigSection.cs
+++ b/Core/Layer/Options/Sections/ListedConfigSection.cs
@@ -181,7 +181,7 @@ public class ListedConfigSection : IOptionSection
                 if (IsColor(configData.CfgValue, out var color))
                 {
                     lockOptions |= LockOptions.AllowMouse;
-                    m_dialog = new ColorDialog(m_config.Hud, configData.CfgValue, configData.Attr, color);
+                    m_dialog = new ColorDialog(m_config.Window, configData.CfgValue, configData.Attr, color);
                     m_dialog.OnClose += Dialog_OnClose;
                 }
                 else if (configData.Attr.DialogType != DialogType.Default)
@@ -189,10 +189,10 @@ public class ListedConfigSection : IOptionSection
                     switch (configData.Attr.DialogType)
                     {
                         case DialogType.TexturePicker:
-                            m_dialog = new TexturePickerDialog(m_config.Hud, configData.CfgValue, configData.Attr);
+                            m_dialog = new TexturePickerDialog(m_config.Window, configData.CfgValue, configData.Attr);
                             break;
                         case DialogType.SoundFontPicker:
-                            m_dialog = new FileListDialog(m_config.Hud, configData.CfgValue, configData.Attr, ".SF2,.SF3");
+                            m_dialog = new FileListDialog(m_config.Window, configData.CfgValue, configData.Attr, ".SF2,.SF3");
                             break;
                         default:
                             throw new NotImplementedException($"Unimplemented dialog type: {configData.Attr.DialogType}");
@@ -207,7 +207,7 @@ public class ListedConfigSection : IOptionSection
                 {
                     lockOptions |= LockOptions.AllowMouse;
                     // For now, the only one of these we have is for SoundFonts.  
-                    m_dialog = new FileListDialog(m_config.Hud, configData.CfgValue, configData.Attr, ".SF2,.SF3");
+                    m_dialog = new FileListDialog(m_config.Window, configData.CfgValue, configData.Attr, ".SF2,.SF3");
                     m_dialog.OnClose += Dialog_OnClose;
                 }
 
@@ -548,8 +548,8 @@ public class ListedConfigSection : IOptionSection
         }
 
         int y = startY;
-        int fontSize = m_config.Hud.GetSmallFontSize();
-        int smallPad = m_config.Hud.GetScaled(1);
+        int fontSize = m_config.Window.GetMenuSmallFontSize();
+        int smallPad = m_config.Window.GetMenuScaled(1);
 
         hud.Text("Press enter to modify the selected setting", Font, fontSize, (0, y), out Dimension textDimension,
             both: Align.TopMiddle, color: Color.Firebrick);
@@ -557,14 +557,14 @@ public class ListedConfigSection : IOptionSection
 
         hud.Text("Press R to reset the selected setting to its default", Font, fontSize, (0, y), out textDimension,
             both: Align.TopMiddle, color: Color.Firebrick);
-        y += textDimension.Height + m_config.Hud.GetScaled(8);
+        y += textDimension.Height + m_config.Window.GetMenuScaled(8);
 
-        hud.Text(OptionType.ToString(), Font, m_config.Hud.GetLargeFontSize(), (0, y), out Dimension headerArea, both: Align.TopMiddle, color: Color.Red);
-        y += headerArea.Height + m_config.Hud.GetScaled(8);
+        hud.Text(OptionType.ToString(), Font, m_config.Window.GetMenuLargeFontSize(), (0, y), out Dimension headerArea, both: Align.TopMiddle, color: Color.Red);
+        y += headerArea.Height + m_config.Window.GetMenuScaled(8);
 
-        int offsetX = m_config.Hud.GetScaled(8);
-        int spacerY = m_config.Hud.GetScaled(8);
-        int smallSpacer = m_config.Hud.GetScaled(2);
+        int offsetX = m_config.Window.GetMenuScaled(8);
+        int spacerY = m_config.Window.GetMenuScaled(8);
+        int smallSpacer = m_config.Window.GetMenuScaled(2);
         int colorBoxHeight = hud.MeasureText("I", Font, fontSize).Height;
 
         for (int i = 0; i < m_configValues.Count; i++)
@@ -622,9 +622,9 @@ public class ListedConfigSection : IOptionSection
             if (i == m_currentRowIndex && !m_rowIsSelected)
             {
                 var arrowSize = hud.MeasureText("<", Font, fontSize);
-                Vec2I arrowLeft = (-offsetX - attrArea.Width - m_config.Hud.GetScaled(2), y);
+                Vec2I arrowLeft = (-offsetX - attrArea.Width - m_config.Window.GetMenuScaled(2), y);
                 hud.Text(">", Font, fontSize, arrowLeft, window: Align.TopMiddle, anchor: Align.TopRight, color: Color.White);
-                Vec2I arrowRight = (-offsetX + arrowSize.Width + m_config.Hud.GetScaled(2), y);
+                Vec2I arrowRight = (-offsetX + arrowSize.Width + m_config.Window.GetMenuScaled(2), y);
                 hud.Text("<", Font, fontSize, arrowRight, window: Align.TopMiddle, anchor: Align.TopRight, color: Color.White);
             }
 
@@ -632,7 +632,7 @@ public class ListedConfigSection : IOptionSection
             var rowDimensions = new Box2I((0, y), (hud.Dimension.Width, y + maxHeight));
             m_menuPositionList.Add(rowDimensions, i);
 
-            y += maxHeight + m_config.Hud.GetScaled(3);
+            y += maxHeight + m_config.Window.GetMenuScaled(3);
         }
 
         string resetText = m_currentRowIndex != m_configValues.Count
@@ -640,7 +640,7 @@ public class ListedConfigSection : IOptionSection
             : "> Reload All Defaults <";
         hud.Text(resetText, Font, fontSize, (0, y), out Dimension area, window: Align.TopMiddle, anchor: Align.TopMiddle, color: Color.Yellow);
         m_menuPositionList.Add(new Box2I((0, y), (hud.Dimension.Width, y + area.Height)), m_configValues.Count);
-        y += area.Height + m_config.Hud.GetScaled(3);
+        y += area.Height + m_config.Window.GetMenuScaled(3);
 
         // Handle case where the "Reset" row is selected; this affects auto-scrolling.
         if (m_currentRowIndex == m_configValues.Count)

--- a/Core/Layer/Options/Slider.cs
+++ b/Core/Layer/Options/Slider.cs
@@ -55,20 +55,20 @@ public class Slider(double value, double step, double min, double max, RenderSiz
             ValueChanged?.Invoke(this, Value);
     }
 
-    public Dimension Render(ConfigHud config, IRenderableSurfaceContext ctx, IHudRenderContext hud)
+    public Dimension Render(ConfigWindow config, IRenderableSurfaceContext ctx, IHudRenderContext hud)
     {
-        int sliderHeight = config.GetScaled(12);
-        int sliderWidth = config.GetScaled(2);
+        int sliderHeight = config.GetMenuScaled(12);
+        int sliderWidth = config.GetMenuScaled(2);
         var width = Width.GetSize(hud.Width);
         int sliderOffsetX = (int)(Value / m_max * width);
 
-        int barHeight = config.GetScaled(2);
+        int barHeight = config.GetMenuScaled(2);
         int centerY = (sliderHeight - barHeight) / 2;
 
         hud.FillBox((0, centerY, width, centerY + barHeight), Color.Gray);
         hud.FillBox((sliderOffsetX - 1, -1, sliderOffsetX - 1 + sliderWidth + 2, sliderHeight + 1), Color.Black);
         hud.FillBox((sliderOffsetX, 0, sliderOffsetX + sliderWidth, sliderHeight), Color.Red);
-        hud.Text(Value.ToString(), Constants.Fonts.SmallGray, config.GetSmallFontSize(), (width + config.GetScaled(8), 0));
+        hud.Text(Value.ToString(), Constants.Fonts.SmallGray, config.GetMenuSmallFontSize(), (width + config.GetMenuScaled(8), 0));
         return (0, 0);
     }
 }

--- a/Core/Layer/Worlds/WorldLayer.Render.Hud.cs
+++ b/Core/Layer/Worlds/WorldLayer.Render.Hud.cs
@@ -1056,7 +1056,7 @@ public partial class WorldLayer
 
         var dim = hud.MeasureText("I", SmallHudFont, 8);
         double frac = 1.0 - (double)(MaxVisibleTimeNanos - timeSinceMessage) / MessageTransitionSpan;
-        return (int)(-(dim.Height + MessageSpacing) * frac * m_config.Hud.GetScaled(1));
+        return (int)(-(dim.Height + MessageSpacing) * frac * m_config.Hud.GetHudScaled(1));
     }
 
     private static float CalculateFade(long timeSinceMessage)

--- a/Core/Util/Configs/Components/ConfigHud.cs
+++ b/Core/Util/Configs/Components/ConfigHud.cs
@@ -162,11 +162,11 @@ public class ConfigHud
     // Formatting, scaling
 
     [ConfigInfo("Automatically scale HUD.")]
-    [OptionMenu(OptionSectionType.Hud, "Autoscale HUD", allowReset: false, spacer: true)]
+    [OptionMenu(OptionSectionType.Hud, "Autoscale HUD", spacer: true)]
     public readonly ConfigValue<bool> AutoScale = new(true);
 
     [ConfigInfo("Amount to scale the HUD.")]
-    [OptionMenu(OptionSectionType.Hud, "HUD Scale", allowReset: false)]
+    [OptionMenu(OptionSectionType.Hud, "HUD Scale")]
     public readonly ConfigValue<double> Scale = new(2.0, Greater(0.0));
 
     [ConfigInfo("Amount of HUD transparency.")]

--- a/Core/Util/Configs/Components/ConfigWindow.cs
+++ b/Core/Util/Configs/Components/ConfigWindow.cs
@@ -43,6 +43,10 @@ public class ConfigWindow
     [OptionMenu(OptionSectionType.Video, "Window Size")]
     public readonly ConfigValue<Dimension> Dimension = new((1024, 768), (_, dim) => dim.Width >= 320 && dim.Height >= 200);
 
+    [ConfigInfo("Amount to scale menu text.")]
+    [OptionMenu(OptionSectionType.Video, "Menu Scale", allowReset: false)]
+    public readonly ConfigValue<double> MenuScale = new(1.5, Greater(0.0));
+
     public readonly ConfigWindowVirtual Virtual = new();
 
     [ConfigInfo("Display number for the window. Use command ListDisplays for display numbers.")]

--- a/Core/Util/Configs/Extensions/ConfigHudExtensions.cs
+++ b/Core/Util/Configs/Extensions/ConfigHudExtensions.cs
@@ -4,15 +4,15 @@ namespace Helion.Util.Configs.Extensions;
 
 public static class ConfigHudExtensions
 {
-    public static int GetScaled(this ConfigHud config, int baseSize) =>
+    public static int GetHudScaled(this ConfigHud config, int baseSize) =>
         (int)(baseSize * config.Scale.Value);
 
-    public static int GetSmallFontSize(this ConfigHud config) =>
-        GetScaled(config, 12);
+    public static int GetHudSmallFontSize(this ConfigHud config) =>
+        GetHudScaled(config, 12);
 
-    public static int GetMediumFontSize(this ConfigHud config) =>
-        GetScaled(config, 16);
+    public static int GetHudMediumFontSize(this ConfigHud config) =>
+        GetHudScaled(config, 16);
 
-    public static int GetLargeFontSize(this ConfigHud config) =>
-        GetScaled(config, 20);
+    public static int GetHudLargeFontSize(this ConfigHud config) =>
+        GetHudScaled(config, 20);
 }

--- a/Core/Util/Configs/Extensions/ConfigMenuExtensions.cs
+++ b/Core/Util/Configs/Extensions/ConfigMenuExtensions.cs
@@ -1,0 +1,18 @@
+﻿using Helion.Util.Configs.Components;
+
+namespace Helion.Util.Configs.Extensions;
+
+public static class ConfigMenuExtensions
+{
+    public static int GetMenuScaled(this ConfigWindow config, int baseSize) =>
+        (int)(baseSize * config.MenuScale.Value);
+
+    public static int GetMenuSmallFontSize(this ConfigWindow config) =>
+        GetMenuScaled(config, 12);
+
+    public static int GetMenuMediumFontSize(this ConfigWindow config) =>
+        GetMenuScaled(config, 16);
+
+    public static int GetMenuLargeFontSize(this ConfigWindow config) =>
+        GetMenuScaled(config, 20);
+}


### PR DESCRIPTION
1.  Create a new "menu scale" option, and put it on the Video menu, right below screen resolution.  Do not tie this feature to HUD autoscaling.
2. Rename existing extension methods to make sure it's clear they're about the HUD
3. Create new extension methods to assist with scaled text values for menus
4. Adapt menu code to use the menu scale values instead of the HUD scale values