### PR TITLE
fix loaded musicchangers

### DIFF
--- a/Core/World/Entities/EntityManager.cs
+++ b/Core/World/Entities/EntityManager.cs
@@ -345,6 +345,9 @@ public class EntityManager : IDisposable
         FinalizeEntity(entity, false);
         if (setOnGround != null)
             entity.OnGround = setOnGround.Value;
+
+        if (entity.Definition.Name.EqualsIgnoreCase(Constants.MusicChanger))
+            MusicChangers.Add(entity);
     }
 
     public Player? GetRealPlayer(int playerNumber)


### PR DESCRIPTION
I notice that while MusicChangers are getting serialized into save games, they aren't getting processed into the world, so they break when loading a save game.

Is this the right place?