### PR TITLE
Allow user to edit saved game names

### DIFF
--- a/Core/Layer/GameLayerManager.cs
+++ b/Core/Layer/GameLayerManager.cs
@@ -54,7 +54,7 @@ public class GameLayerManager : IGameLayerManager
     public TitlepicLayer? TitlepicLayer { get; private set; }
     public EndGameLayer? EndGameLayer { get; private set; }
     public IntermissionLayer? IntermissionLayer { get; private set; }
-    public IwadSelectionLayer? IwadSelectionLayer {  get; private set; }
+    public IwadSelectionLayer? IwadSelectionLayer { get; private set; }
     public LoadingLayer? LoadingLayer { get; private set; }
     public TransitionLayer? TransitionLayer { get; private set; }
     public WorldLayer? WorldLayer { get; private set; }
@@ -159,7 +159,7 @@ public class GameLayerManager : IGameLayerManager
         if (gameLayer is IAnimationLayer animationLayer)
         {
             animationLayer.Animation.OnStart += Animation_OnStart;
-            animationLayer.Animation.OnComplete += Animation_OnComplete; 
+            animationLayer.Animation.OnComplete += Animation_OnComplete;
         }
 
         switch (gameLayer)
@@ -382,7 +382,7 @@ public class GameLayerManager : IGameLayerManager
                 input.ConsumeAll();
                 return;
             }
-            
+
             if (ShouldCreateMenu(input))
             {
                 if (ReadThisLayer != null)
@@ -460,7 +460,7 @@ public class GameLayerManager : IGameLayerManager
             input.ConsumeAll();
             return true;
         }
-        
+
         return ConsumeCommandPressed(Constants.Input.Menu, input);
     }
 
@@ -495,7 +495,7 @@ public class GameLayerManager : IGameLayerManager
 
     public void ExpireAnimations()
     {
-        foreach(var layer in Layers)
+        foreach (var layer in Layers)
         {
             if (layer is IAnimationLayer animationLayer)
                 animationLayer.Animation.StopAndFireComplete();
@@ -520,7 +520,7 @@ public class GameLayerManager : IGameLayerManager
             animation.AnimateOut();
             return;
         }
-        
+
         animation.AnimateIn();
     }
 
@@ -570,7 +570,7 @@ public class GameLayerManager : IGameLayerManager
         if (!CanSave)
             return;
 
-        if (WorldLayer == null  || !LastSave.HasValue)
+        if (WorldLayer == null || !LastSave.HasValue || LastSave?.SaveGame.IsAutoSave == true)
         {
             GoToSaveOrLoadMenu(true);
             return;
@@ -579,7 +579,7 @@ public class GameLayerManager : IGameLayerManager
         if (m_config.Game.QuickSaveConfirm)
         {
             MessageMenu confirm = new(m_config, m_console, m_soundManager, m_archiveCollection,
-                new[] { "Are you sure you want to overwrite:", LastSave.Value.SaveGame.Model != null ? LastSave.Value.SaveGame.Model.Text : "Save", "Press Y to confirm." },
+                new[] { "Are you sure you want to overwrite:", LastSave?.SaveGame.Model != null ? LastSave.Value.SaveGame.Model.Text : "Save", "Press Y to confirm." },
                 isYesNoConfirm: true, clearMenus: true);
             confirm.Cleared += Confirm_Cleared;
 
@@ -726,7 +726,7 @@ public class GameLayerManager : IGameLayerManager
     {
         if (!worldLayer.DrawAutomap)
         {
-            worldLayer.RenderHud(m_ctx, RenderHudOptions.Hud | RenderHudOptions.Crosshair| RenderHudOptions.Weapon);
+            worldLayer.RenderHud(m_ctx, RenderHudOptions.Hud | RenderHudOptions.Crosshair | RenderHudOptions.Weapon);
             return;
         }
 

--- a/Core/Layer/GameLayerManager.cs
+++ b/Core/Layer/GameLayerManager.cs
@@ -606,7 +606,12 @@ public class GameLayerManager : IGameLayerManager
 
         var world = WorldLayer!.World;
         var save = LastSave.Value;
-        m_saveGameManager.WriteSaveGame(world, world.MapInfo.GetMapNameWithPrefix(world.ArchiveCollection), save.SaveGame);
+        // If the saved game name has been customized, preserve that customization
+        bool isCustomizedName = save.SaveGame.Model?.MapName != save.SaveGame.Model?.Text;
+        string name = isCustomizedName
+            ? save.SaveGame.Model?.Text ?? "Unnamed"
+            : world.MapInfo.GetMapNameWithPrefix(world.ArchiveCollection);
+        m_saveGameManager.WriteSaveGame(world, name, save.SaveGame);
         world.DisplayMessage(world.Player, null, SaveMenu.SaveMessage);
     }
 

--- a/Core/Menus/Base/MenuSaveRowComponent.cs
+++ b/Core/Menus/Base/MenuSaveRowComponent.cs
@@ -5,15 +5,18 @@ namespace Helion.Menus.Base;
 
 public class MenuSaveRowComponent : IMenuComponent
 {
-    public string Text { get; }
-    public Func<Menu?>? Action { get; }
+    public string Text { get; set; }
+    public string MapName { get; set; }
+
+    public Func<Menu?>? Action { get; set; }
     public Func<Menu?>? DeleteAction { get; }
     public SaveGame? SaveGame { get; }
 
-    public MenuSaveRowComponent(string text, Func<Menu?>? action = null,
+    public MenuSaveRowComponent(string text, string mapName, Func<Menu?>? action = null,
         Func<Menu?>? deleteAction = null, SaveGame? saveGame = null)
     {
         Text = text;
+        MapName = mapName;
         Action = action;
         DeleteAction = deleteAction;
         SaveGame = saveGame;

--- a/Core/Menus/Base/MenuSaveRowComponent.cs
+++ b/Core/Menus/Base/MenuSaveRowComponent.cs
@@ -7,12 +7,12 @@ public class MenuSaveRowComponent : IMenuComponent
 {
     public string Text { get; set; }
     public string MapName { get; set; }
-
     public Func<Menu?>? Action { get; set; }
     public Func<Menu?>? DeleteAction { get; }
     public SaveGame? SaveGame { get; }
+    public bool IsAutoSave { get; }
 
-    public MenuSaveRowComponent(string text, string mapName, Func<Menu?>? action = null,
+    public MenuSaveRowComponent(string text, string mapName, bool isAutoSave, Func<Menu?>? action = null,
         Func<Menu?>? deleteAction = null, SaveGame? saveGame = null)
     {
         Text = text;
@@ -20,5 +20,6 @@ public class MenuSaveRowComponent : IMenuComponent
         Action = action;
         DeleteAction = deleteAction;
         SaveGame = saveGame;
+        IsAutoSave = isAutoSave;
     }
 }

--- a/Core/Menus/Impl/SaveMenu.cs
+++ b/Core/Menus/Impl/SaveMenu.cs
@@ -127,31 +127,39 @@ public class SaveMenu : Menu
                 {
                     if (m_hasRowLock)
                     {
+                        // We're already in "name edit mode"
                         EditRow(savedGameRow, input);
                     }
-                    else if (input.ConsumeKeyPressed(Key.Enter) && !savedGameRow.IsAutoSave)
+                    else if (input.ConsumeKeyPressed(Key.Enter))
                     {
-                        m_customNameBuilder.Clear();
-                        m_previousDisplayName = savedGameRow.Text;
-
-                        m_defaultSavedGameName = (GetWorld(out IWorld? world) && world != null)
-                            ? world.MapInfo.GetMapNameWithPrefix(world.ArchiveCollection)
-                            : UnknownSavedGameName;
-
-                        if (savedGameRow.Text == EmptySlot || savedGameRow.Text == savedGameRow.MapName)
+                        if (savedGameRow.IsAutoSave)
                         {
-                            // New saved game, or saved game with default (map) name; update to current map name
-                            m_customNameBuilder.Append(m_defaultSavedGameName);
-                            savedGameRow.Text = m_defaultSavedGameName;
+                            SoundManager.PlayStaticSound(Constants.MenuSounds.Invalid);
                         }
                         else
                         {
-                            // saved game with non-default name; preserve name
-                            m_customNameBuilder.Append(savedGameRow.Text);
-                        }
+                            m_customNameBuilder.Clear();
+                            m_previousDisplayName = savedGameRow.Text;
 
-                        m_hasRowLock = true;
-                        SoundManager.PlayStaticSound(Constants.MenuSounds.Choose);
+                            m_defaultSavedGameName = (GetWorld(out IWorld? world) && world != null)
+                                ? world.MapInfo.GetMapNameWithPrefix(world.ArchiveCollection)
+                                : UnknownSavedGameName;
+
+                            if (savedGameRow.Text == EmptySlot || savedGameRow.Text == savedGameRow.MapName)
+                            {
+                                // New saved game, or saved game with default (map) name; update to current map name
+                                m_customNameBuilder.Append(m_defaultSavedGameName);
+                                savedGameRow.Text = m_defaultSavedGameName;
+                            }
+                            else
+                            {
+                                // saved game with non-default name; preserve name
+                                m_customNameBuilder.Append(savedGameRow.Text);
+                            }
+
+                            m_hasRowLock = true;
+                            SoundManager.PlayStaticSound(Constants.MenuSounds.Choose);
+                        }
                     }
                 }
                 else if (!m_isSave && input.ConsumeKeyPressed(Key.Enter)) // Load

--- a/Core/Menus/Impl/SaveMenu.cs
+++ b/Core/Menus/Impl/SaveMenu.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using Helion.Audio.Sounds;
 using Helion.Layer.Menus;
 using Helion.Menus.Base;
@@ -21,11 +22,13 @@ namespace Helion.Menus.Impl;
 
 public class SaveMenu : Menu
 {
+    public const string SaveMessage = "Game saved.";
     private static readonly Logger Log = LogManager.GetCurrentClassLogger();
     private const int MaxRows = 9;
     private const string SaveHeaderImage = "M_SGTTL";
     private const string LoadHeaderImage = "M_LGTTL";
-    public const string SaveMessage = "Game saved.";
+    private const string UnknownSavedGameName = "Unknown";
+    private const string EmptySlot = "Empty slot";
 
     public bool IsTypingName { get; private set; }
 
@@ -33,6 +36,11 @@ public class SaveMenu : Menu
     private readonly SaveGameManager m_saveGameManager;
     private readonly bool m_isSave;
     private readonly bool m_canSave;
+
+    private bool m_hasRowLock;
+    private string m_previousDisplayName;
+    private string m_defaultSavedGameName;
+    private StringBuilder m_customNameBuilder = new StringBuilder();
 
     private SaveGame? m_deleteSave;
 
@@ -94,7 +102,8 @@ public class SaveMenu : Menu
 
         if (savedGames.Count < MaxRows)
         {
-            MenuSaveRowComponent saveRowComponent = new("Empty slot", CreateNewSaveGame());
+            MenuSaveRowComponent saveRowComponent = new(EmptySlot, string.Empty);
+            saveRowComponent.Action = CreateNewSaveGame(() => saveRowComponent.Text);
             Components = Components.Add(saveRowComponent);
         }
     }
@@ -109,8 +118,102 @@ public class SaveMenu : Menu
             return;
         }
 
-        if (input.ConsumeKeyPressed(Key.Enter) && ComponentIndex.HasValue)
-            Components[ComponentIndex.Value].Action?.Invoke();
+        if (ComponentIndex.HasValue)
+        {
+            MenuSaveRowComponent? savedGameRow = Components[ComponentIndex.Value] as MenuSaveRowComponent;
+            if (savedGameRow != null)
+            {
+                if (m_isSave)
+                {
+                    if (m_hasRowLock)
+                    {
+                        EditRow(savedGameRow, input);
+                    }
+                    else if (input.ConsumeKeyPressed(Key.Enter))
+                    {
+                        m_customNameBuilder.Clear();
+                        m_previousDisplayName = savedGameRow.Text;
+
+                        m_defaultSavedGameName = (GetWorld(out IWorld? world) && world != null)
+                            ? world.MapInfo.GetMapNameWithPrefix(world.ArchiveCollection)
+                            : UnknownSavedGameName;
+
+                        if (savedGameRow.Text == EmptySlot || savedGameRow.Text == savedGameRow.MapName)
+                        {
+                            // New saved game, or saved game with default (map) name; update to current map name
+                            m_customNameBuilder.Append(m_defaultSavedGameName);
+                            savedGameRow.Text = m_defaultSavedGameName;
+                        }
+                        else
+                        {
+                            // saved game with non-default name; preserve name
+                            m_customNameBuilder.Append(savedGameRow.Text);
+                        }
+
+                        m_hasRowLock = true;
+                    }
+                }
+                else if (!m_isSave && input.ConsumeKeyPressed(Key.Enter)) // Load
+                {
+                    savedGameRow.Action?.Invoke();
+                }
+            }
+        }
+    }
+
+    public void EditRow(MenuSaveRowComponent savedGameRow, IConsumableInput input)
+    {
+        if (input.ConsumeKeyPressed(Key.Escape))
+        {
+            // The user has decided not to save.
+            // Undo any customizations they've made to the display name of the saved game, and leave edit mode.
+            savedGameRow.Text = m_previousDisplayName;
+            m_hasRowLock = false;
+        }
+        else if (input.ConsumeKeyPressed(Key.Enter))
+        {
+            // If there's any text in the field, use that as the name, else force the defualt.
+            savedGameRow.Text = m_customNameBuilder.Length > 0
+                ? m_customNameBuilder.ToString()
+                : m_defaultSavedGameName;
+
+            savedGameRow.Action?.Invoke();
+            m_hasRowLock = false;
+        }
+        else
+        {
+            // Handle all other typed input.
+            if (input.ConsumeKeyPressed(Key.Backspace))
+            {
+                if (m_customNameBuilder.ToString() == m_defaultSavedGameName)
+                {
+                    m_customNameBuilder.Clear();
+                }
+
+                if (m_customNameBuilder.Length > 0)
+                {
+                    m_customNameBuilder.Remove(m_customNameBuilder.Length - 1, 1);
+                }
+            }
+
+            var chars = input.ConsumeTypedCharacters();
+            m_customNameBuilder.Append(chars);
+
+            savedGameRow.Text = m_customNameBuilder.ToString() + Blink();
+        }
+
+        // Ensure we have no remaining input whatsoever.
+        input.ConsumeAll();
+    }
+
+    private static string Blink()
+    {
+        const string editStr = "_";
+        if (DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond / 500 % 2 == 0)
+        {
+            return editStr;
+        }
+        return string.Empty;
     }
 
     private IEnumerable<IMenuComponent> CreateSaveRowComponents(IEnumerable<SaveGame> savedGames)
@@ -118,12 +221,14 @@ public class SaveMenu : Menu
         return savedGames.Take(MaxRows)
             .Select(save =>
             {
-                string displayName = save.Model?.Text ?? "Unknown";
-                return new MenuSaveRowComponent(displayName, UpdateSaveGame(save), CreateDeleteCommand(save));
+                string displayName = save.Model?.Text ?? UnknownSavedGameName;
+                MenuSaveRowComponent saveRow = new(displayName, save.Model?.MapName ?? UnknownSavedGameName, null, CreateDeleteCommand(save));
+                saveRow.Action = new Func<Menu?>(UpdateSaveGame(save, new(() => saveRow.Text)));
+                return saveRow;
             });
     }
 
-    private Func<Menu?> UpdateSaveGame(SaveGame save)
+    private Func<Menu?> UpdateSaveGame(SaveGame save, Func<string> getName)
     {
         return () =>
         {
@@ -135,7 +240,7 @@ public class SaveMenu : Menu
 
             if (GetWorld(out IWorld? world) && world != null)
             {
-                SaveGameEvent saveGameEvent = m_saveGameManager.WriteSaveGame(world, world.MapInfo.GetMapNameWithPrefix(world.ArchiveCollection), save);
+                SaveGameEvent saveGameEvent = m_saveGameManager.WriteSaveGame(world, getName(), save);
                 m_parent.Close();
 
                 HandleSaveEvent(world, saveGameEvent);
@@ -149,13 +254,13 @@ public class SaveMenu : Menu
         };
     }
 
-    private Func<Menu?> CreateNewSaveGame()
+    private Func<Menu?> CreateNewSaveGame(Func<string> getName)
     {
         return () =>
         {
             if (GetWorld(out IWorld? world) && world != null)
             {
-                SaveGameEvent saveGameEvent = m_saveGameManager.WriteNewSaveGame(world, world.MapInfo.GetMapNameWithPrefix(world.ArchiveCollection));
+                SaveGameEvent saveGameEvent = m_saveGameManager.WriteNewSaveGame(world, getName());
                 m_parent.Manager.Remove(m_parent);
 
                 HandleSaveEvent(world, saveGameEvent);
@@ -204,9 +309,9 @@ public class SaveMenu : Menu
         return savedGames.Take(MaxRows)
             .Select(save =>
             {
-                string displayName = save.Model?.Text ?? "Unknown";
+                string displayName = save.Model?.Text ?? UnknownSavedGameName;
                 string fileName = System.IO.Path.GetFileName(save.FileName);
-                return new MenuSaveRowComponent(displayName, CreateConsoleCommand($"load {fileName}"),
+                return new MenuSaveRowComponent(displayName, string.Empty, CreateConsoleCommand($"load {fileName}"),
                     CreateDeleteCommand(save), save);
             });
     }

--- a/Core/World/Save/SaveGame.cs
+++ b/Core/World/Save/SaveGame.cs
@@ -31,6 +31,8 @@ public class SaveGame
 
     public string FilePath => Path.Combine(SaveDir, FileName);
 
+    public bool IsAutoSave => Path.GetFileName(FileName).StartsWith("autosave");
+
     public SaveGame(string saveDir, string filename, SaveGameModel model)
     {
         SaveDir = saveDir;


### PR DESCRIPTION
When the user attempts to save a game, we now provide them an opportunity to edit its name.
1.  If it is a NEW saved game, or an existing saved game where the name has NOT been customized (that is, the name is the same as the previous map name), create a new default name based on the current map name.
2. If the user is attempting to overwrite an existing saved game with a customized name, preserve its name and let them edit it from there.
3. Do not allow the user to overwrite autosaves, either through Quick Save or through the menu.  This is just asking for trouble if we ever implement an autosave rotation/limit.