### PR TITLE
don't save to config when loading demo/save compatibility values

### DIFF
--- a/Client/Client.Demo.cs
+++ b/Client/Client.Demo.cs
@@ -113,7 +113,7 @@ public partial class Client
 
     private void Player_PlaybackEnded(object? sender, EventArgs e)
     {
-        m_config.ApplyConfiguration(m_userConfigValues);
+        m_config.ApplyConfiguration(m_userConfigValues, writeToConfig: false);
         m_userConfigValues.Clear();
     }
 
@@ -148,7 +148,7 @@ public partial class Client
             m_userConfigValues.Add(new ConfigValueModel(component.Path, component.Value.ObjectValue));
         }
 
-        m_config.ApplyConfiguration(m_demoModel.ConfigValues);
+        m_config.ApplyConfiguration(m_demoModel.ConfigValues, writeToConfig: false);
     }
 
     private void SetDefaultDemoValues(Dictionary<string, ConfigComponent> components)

--- a/Core/Layer/Worlds/WorldLayer.cs
+++ b/Core/Layer/Worlds/WorldLayer.cs
@@ -225,7 +225,7 @@ public partial class WorldLayer : IGameLayerParent
         if (worldModel == null)
             return;
 
-        config.ApplyConfiguration(worldModel.ConfigValues);
+        config.ApplyConfiguration(worldModel.ConfigValues, writeToConfig: false);
     }
     
     public static SinglePlayerWorld? CreateWorldGeometry(GlobalData globalData, IConfig config, IAudioSystem audioSystem,

--- a/Core/Layer/Worlds/WorldLayer.cs
+++ b/Core/Layer/Worlds/WorldLayer.cs
@@ -180,23 +180,23 @@ public partial class WorldLayer : IGameLayerParent
         compat.ResetToUserValues();
 
         if (mapInfoDef.HasOption(MapOptions.CompatMissileClip))
-            compat.MissileClip.SetWithNoWriteConfig(true);
+            compat.MissileClip.Set(true, writeToConfig: false);
         if (mapInfoDef.HasOption(MapOptions.CompatShortestTexture))
-            compat.VanillaShortestTexture.SetWithNoWriteConfig(true);
+            compat.VanillaShortestTexture.Set(true, writeToConfig: false);
         if (mapInfoDef.HasOption(MapOptions.CompatFloorMove))
-            compat.VanillaSectorPhysics.SetWithNoWriteConfig(true);
+            compat.VanillaSectorPhysics.Set(true, writeToConfig: false);
         if (mapInfoDef.HasOption(MapOptions.CompatNoCrossOver))
-            compat.InfinitelyTallThings.SetWithNoWriteConfig(true);
+            compat.InfinitelyTallThings.Set(true, writeToConfig: false);
         if (mapInfoDef.HasOption(MapOptions.CompatLimitPain))
-            compat.PainElementalLostSoulLimit.SetWithNoWriteConfig(true);
+            compat.PainElementalLostSoulLimit.Set(true, writeToConfig: false);
         if (mapInfoDef.HasOption(MapOptions.CompatNoTossDrops))
-            compat.NoTossDrops.SetWithNoWriteConfig(true);
+            compat.NoTossDrops.Set(true, writeToConfig: false);
         if (mapInfoDef.HasOption(MapOptions.CompatStairs))
-            compat.Stairs.SetWithNoWriteConfig(true);
+            compat.Stairs.Set(true, writeToConfig: false);
         if (mapInfoDef.HasOption(MapOptions.CompatExplosion1) || mapInfoDef.HasOption(MapOptions.CompatExplosion2)) // These aren't separated like ZDoom, but are unlikely to be toggled independently
-            compat.OriginalExplosion.SetWithNoWriteConfig(true);
+            compat.OriginalExplosion.Set(true, writeToConfig: false);
         if (mapInfoDef.HasOption(MapOptions.VileGhosts))
-            compat.VileGhosts.SetWithNoWriteConfig(true);
+            compat.VileGhosts.Set(true, writeToConfig: false);
 
         foreach (var mapCompat in MapCompat)
         {
@@ -212,10 +212,9 @@ public partial class WorldLayer : IGameLayerParent
     {
         foreach (var (field, set) in props)
         {
-            var configValue = field.GetValue(config.Compatibility) as ConfigValue<bool>;
-            if (configValue == null)
+            if (field.GetValue(config.Compatibility) is not ConfigValue<bool> configValue)
                 continue;
-            configValue.SetWithNoWriteConfig(set);
+            configValue.Set(set, writeToConfig: false);
         }
     }
 

--- a/Core/Resources/Definitions/CompLevelDefinition.cs
+++ b/Core/Resources/Definitions/CompLevelDefinition.cs
@@ -48,30 +48,30 @@ public class CompLevelDefinition
         switch (CompLevel)
         {
             case CompLevel.Vanilla:
-                compat.InfinitelyTallThings.SetWithNoWriteConfig(true);
-                compat.OriginalExplosion.SetWithNoWriteConfig(true);
-                compat.VanillaMovementPhysics.SetWithNoWriteConfig(true);
-                compat.VanillaSectorPhysics.SetWithNoWriteConfig(true);
-                compat.VanillaSectorSound.SetWithNoWriteConfig(true);
-                compat.MissileClip.SetWithNoWriteConfig(true);
-                compat.Stairs.SetWithNoWriteConfig(true);
-                compat.PainElementalLostSoulLimit.SetWithNoWriteConfig(true);
-                compat.Doom2ProjectileWalkTriggers.SetWithNoWriteConfig(true);
-                compat.AllowItemDropoff.SetWithNoWriteConfig(false);
-                compat.Mbf21.SetWithNoWriteConfig(false);
+                compat.InfinitelyTallThings.Set(true, writeToConfig: false);
+                compat.OriginalExplosion.Set(true, writeToConfig: false);
+                compat.VanillaMovementPhysics.Set(true, writeToConfig: false);
+                compat.VanillaSectorPhysics.Set(true, writeToConfig: false);
+                compat.VanillaSectorSound.Set(true, writeToConfig: false);
+                compat.MissileClip.Set(true, writeToConfig: false);
+                compat.Stairs.Set(true, writeToConfig: false);
+                compat.PainElementalLostSoulLimit.Set(true, writeToConfig: false);
+                compat.Doom2ProjectileWalkTriggers.Set(true, writeToConfig: false);
+                compat.AllowItemDropoff.Set(false, writeToConfig: false);
+                compat.Mbf21.Set(false, writeToConfig: false);
                 break;
             case CompLevel.Boom:
             case CompLevel.Mbf:
-                compat.AllowItemDropoff.SetWithNoWriteConfig(true);
-                compat.VanillaSectorPhysics.SetWithNoWriteConfig(false);
-                compat.Stairs.SetWithNoWriteConfig(false);
-                compat.Mbf21.SetWithNoWriteConfig(false);
+                compat.AllowItemDropoff.Set(true, writeToConfig: false);
+                compat.VanillaSectorPhysics.Set(false, writeToConfig: false);
+                compat.Stairs.Set(false, writeToConfig: false);
+                compat.Mbf21.Set(false, writeToConfig: false);
                 break;
             case CompLevel.Mbf21:
-                compat.AllowItemDropoff.SetWithNoWriteConfig(true);
-                compat.Mbf21.SetWithNoWriteConfig(true);
-                compat.VanillaSectorPhysics.SetWithNoWriteConfig(false);
-                compat.Stairs.SetWithNoWriteConfig(false);
+                compat.AllowItemDropoff.Set(true, writeToConfig: false);
+                compat.Mbf21.Set(true, writeToConfig: false);
+                compat.VanillaSectorPhysics.Set(false, writeToConfig: false);
+                compat.Stairs.Set(false, writeToConfig: false);
                 break;
         }
 

--- a/Core/Util/Configs/IConfig.cs
+++ b/Core/Util/Configs/IConfig.cs
@@ -46,7 +46,7 @@ public interface IConfig
     void ApplyQueuedChanges(ConfigSetFlags setFlags);
 
     Dictionary<string, ConfigComponent> GetComponents();
-    void ApplyConfiguration(IList<ConfigValueModel> configValues);
+    void ApplyConfiguration(IList<ConfigValueModel> configValues, bool writeToConfig = true);
 
     List<(IConfigValue, OptionMenuAttribute, ConfigInfoAttribute)> GetAllConfigFields();
 }

--- a/Core/Util/Configs/Impl/Config.cs
+++ b/Core/Util/Configs/Impl/Config.cs
@@ -145,7 +145,7 @@ public class Config : IConfig
 
     public Dictionary<string, ConfigComponent> GetComponents() => Components;
 
-    public void ApplyConfiguration(IList<ConfigValueModel> configValues)
+    public void ApplyConfiguration(IList<ConfigValueModel> configValues, bool writeToConfig = true)
     {
         foreach (var configModel in configValues)
         {
@@ -155,7 +155,7 @@ public class Config : IConfig
                 continue;
             }
 
-            if (component.Value.Set(configModel.Value) == ConfigSetResult.NotSetByBadConversion)
+            if (component.Value.Set(configModel.Value, writeToConfig) == ConfigSetResult.NotSetByBadConversion)
                 Log.Error($"Bad configuration value '{configModel.Value}' for '{configModel.Key}'.");
         }
     }

--- a/Core/Util/Configs/Values/ConfigValue.cs
+++ b/Core/Util/Configs/Values/ConfigValue.cs
@@ -85,23 +85,23 @@ public class ConfigValue<T> : IConfigValue where T : notnull
 
     public static implicit operator T(ConfigValue<T> val) => val.Value;
 
-    public ConfigSetResult Set(object newValue)
+    public ConfigSetResult Set(object newValue, bool writeToConfig = true)
     {
         try
         {
             if (typeof(T) == newValue.GetType())
             {
-                return Set((T)newValue);
+                return Set((T)newValue, writeToConfig);
             }
 
             if (typeof(T) == typeof(bool) && newValue is string str && str.Length == 1 && str[0] == '*')
             {
                 bool value = Convert.ToBoolean(Value);
-                return Set(!value);
+                return Set(!value, writeToConfig);
             }
 
             T converted = ObjectToTypeConverterOrThrow(newValue);
-            return Set(converted);
+            return Set(converted, writeToConfig);
         }
         catch
         {
@@ -109,18 +109,13 @@ public class ConfigValue<T> : IConfigValue where T : notnull
         }
     }
 
-    public ConfigSetResult Set(T newValue)
+    public ConfigSetResult Set(T newValue, bool writeToConfig = true)
     {
-        WriteToConfig = true;
+        WriteToConfig = writeToConfig;
         var result = SetValue(newValue, false);
-        UserValue = Value;
+        if (WriteToConfig)
+            UserValue = Value;
         return result;
-    }
-
-    public ConfigSetResult SetWithNoWriteConfig(T newValue)
-    {
-        WriteToConfig = false;
-        return SetValue(newValue, false);
     }
 
     public void ResetToUserValue()

--- a/Core/Util/Configs/Values/IConfigValue.cs
+++ b/Core/Util/Configs/Values/IConfigValue.cs
@@ -45,7 +45,7 @@ public interface IConfigValue
     /// </remarks>
     /// <param name="newValue">The new value.</param>
     /// <returns>The set result.</returns>
-    ConfigSetResult Set(object newValue);
+    ConfigSetResult Set(object newValue, bool writeToConfig = true);
 
     /// <summary>
     /// Applies the queued changes, if any.


### PR DESCRIPTION
Fixes #703

I need to test some more, but I think it's OK.

I didn't think `ApplyConfiguration()` should implicitly not save, so I gave it the parameter. And then in that method, since we're working with `IConfigValue`s, I added the parameter to `Set()` as well since `SetWithNoWriteConfig()` is not in the interface.