### PR TITLE
support taller graphics/fonts on save menu

### DIFF
--- a/Core/Menus/Impl/SaveMenu.cs
+++ b/Core/Menus/Impl/SaveMenu.cs
@@ -90,15 +90,14 @@ public class SaveMenu : Menu
         }
     }
 
-    private readonly IMenuComponent SaveHeader = new MenuImageComponent(SaveHeaderImage);
-    private readonly IMenuComponent LoadHeader = new MenuImageComponent(LoadHeaderImage);
-    private readonly ImmutableArray<IMenuComponent> NoSavedGamesComponents = [
-        new MenuPaddingComponent(8),
-        new MenuSmallTextComponent(NoSavedGamesText)
-    ];
+    private readonly MenuImageComponent SaveHeader = new(SaveHeaderImage);
+    private readonly MenuImageComponent LoadHeader = new(LoadHeaderImage);
+    private readonly MenuPaddingComponent BigPadding = new(8);
+    private readonly MenuPaddingComponent SmallPadding = new(4);
+    private readonly MenuSmallTextComponent NoSavedGamesComponent = new(NoSavedGamesText);
 
     private List<IMenuComponent> GetPaginationFooter() => [
-        new MenuPaddingComponent(5),
+        SmallPadding,
         new MenuSmallTextComponent($"<- Page {m_currentPage}/{GetPageCount()} ->")
     ];
 
@@ -128,17 +127,16 @@ public class SaveMenu : Menu
 
     private List<IMenuComponent> GenerateSaveMenuComponents()
     {
-        List<IMenuComponent> newComponents = [SaveHeader];
+        List<IMenuComponent> newComponents = [SaveHeader, BigPadding];
 
         if (m_isSave && !m_canSave)
         {
-            newComponents.Add(new MenuPaddingComponent(8));
             string[] text = ArchiveCollection.Definitions.Language.GetMessages("$SAVEDEAD");
             for (int i = 0; i < text.Length; i++)
             {
                 newComponents.Add(new MenuSmallTextComponent(text[i]));
                 if (i != text.Length - 1)
-                    newComponents.Add(new MenuPaddingComponent(8));
+                    newComponents.Add(SmallPadding);
             }
         }
         else
@@ -169,10 +167,10 @@ public class SaveMenu : Menu
 
     private List<IMenuComponent> GenerateLoadMenuComponents()
     {
-        List<IMenuComponent> newComponents = [LoadHeader];
+        List<IMenuComponent> newComponents = [LoadHeader, BigPadding];
 
         if (m_saveGames.Empty())
-            newComponents.AddRange(NoSavedGamesComponents);
+            newComponents.Add(NoSavedGamesComponent);
         else
         {
             var saveRowComponents = GetCurrentPageSaveGames().Select(save =>


### PR DESCRIPTION
For taller graphics, space is taken away from the gap, which is normally 4px. Fonts are now also drawn at their original size.

This also moves the selection image slightly to closer match other ports.

![aa-before](https://github.com/user-attachments/assets/24c98dae-c959-4670-be4e-a99634281bd3)
![aa-after](https://github.com/user-attachments/assets/e790a7c7-3a87-4655-8a94-f2859f05931e)
![bt-before](https://github.com/user-attachments/assets/f2d1935c-d66d-4f84-9884-bb7a48b94292)
![bt-after](https://github.com/user-attachments/assets/bc3dd532-1ce3-4a59-82dd-6e043ef8ce7d)
![d2-before](https://github.com/user-attachments/assets/b0f6f9db-a026-4659-90bd-9a45642172b3)
![d2-after](https://github.com/user-attachments/assets/155a4b48-4424-4159-ae6e-31cbadd55a63)
