### PR TITLE
Route FluidSynth output through OpenAL

### DIFF
--- a/Client/Music/MusicPlayer.cs
+++ b/Client/Music/MusicPlayer.cs
@@ -39,15 +39,17 @@ public class MusicPlayer : IMusicPlayer
                 TaskCreationOptions.LongRunning, TaskScheduler.Default);
 
         AudioStreamFactory streamFactory = new AudioStreamFactory();
-        float volume = (float)(configAudio.MusicVolume.Value * .5);
 
         m_zMusicPlayer = new ZMusicWrapper.ZMusicPlayer(
             streamFactory,
             configAudio.Synthesizer == Synth.OPL3 ? ZMusicWrapper.MidiDevice.OPL3 : ZMusicWrapper.MidiDevice.FluidSynth,
             configAudio.SoundFontFile,
             null,
-            volume);
-        m_fluidSynthPlayer = new FluidSynthMusicPlayer(configAudio.SoundFontFile.Value, streamFactory, volume);
+            (float)(configAudio.MusicVolume.Value * .5));
+        m_fluidSynthPlayer = new FluidSynthMusicPlayer(
+            configAudio.SoundFontFile.Value,
+            streamFactory,
+            (float)m_configAudio.MusicVolume);
         SetSynthesizer();
     }
 
@@ -222,7 +224,7 @@ public class MusicPlayer : IMusicPlayer
     public void SetVolume(float volume)
     {
         m_zMusicPlayer.Volume = (float)(volume * .5);
-        m_fluidSynthPlayer.SetVolume((float)(volume * .5));
+        m_fluidSynthPlayer.SetVolume(volume);
     }
 
     public void Stop()

--- a/Client/Music/MusicPlayer.cs
+++ b/Client/Music/MusicPlayer.cs
@@ -37,24 +37,30 @@ public class MusicPlayer : IMusicPlayer
         m_archiveCollection = archiveCollection;
         m_playQueueTask = Task.Factory.StartNew(PlayQueueTask, m_cancelPlayQueue.Token,
                 TaskCreationOptions.LongRunning, TaskScheduler.Default);
+
+        AudioStreamFactory streamFactory = new AudioStreamFactory();
+        float volume = (float)(configAudio.MusicVolume.Value * .5);
+
         m_zMusicPlayer = new ZMusicWrapper.ZMusicPlayer(
-            new AudioStreamFactory(),
+            streamFactory,
             configAudio.Synthesizer == Synth.OPL3 ? ZMusicWrapper.MidiDevice.OPL3 : ZMusicWrapper.MidiDevice.FluidSynth,
             configAudio.SoundFontFile,
             null,
-            (float)(configAudio.MusicVolume.Value * .5));
-        m_fluidSynthPlayer = new FluidSynthMusicPlayer(configAudio.SoundFontFile.Value);
+            volume);
+        m_fluidSynthPlayer = new FluidSynthMusicPlayer(configAudio.SoundFontFile.Value, streamFactory, volume);
         SetSynthesizer();
     }
 
     public void OutputChanging()
     {
         m_zMusicPlayer.Pause();
+        m_fluidSynthPlayer.OutputChanging();
     }
 
     public void OutputChanged()
     {
         m_zMusicPlayer.Resume();
+        m_fluidSynthPlayer.OutputChanged();
     }
 
     private readonly struct PlayParams(byte[] data, MusicPlayerOptions options)
@@ -216,7 +222,7 @@ public class MusicPlayer : IMusicPlayer
     public void SetVolume(float volume)
     {
         m_zMusicPlayer.Volume = (float)(volume * .5);
-        m_fluidSynthPlayer.SetVolume(volume);
+        m_fluidSynthPlayer.SetVolume((float)(volume * .5));
     }
 
     public void Stop()


### PR DESCRIPTION
One of the annoyances with our current use of FluidSynth is that we're using its built-in AudioDriver class, which finds its own way to an output device.  This can have interesting consequences, such as:

1. FluidSynth may not react in the same way, or at the same time, as the rest of the application when an output device changes
2. FluidSynth may choose a completely different API to reach the output, which can produce some weird cases where sound works but music does not (I noticed this on a WSL Ubuntu environment)
3. Sometimes, the underlying output device is shut down _after_ the rest of the application, which produces a weird race condition when the application is re-launched and sometimes results in crashes down in the native parts of FluidSynth

In this change, I am adapting FluidSynth to use the same approach to output that we use for ZMusic--an "output stream" class that marshals buffers back and forth between a source (FluidSynth or ZMusic) and an output (OpenAL).  This should hopefully avoid all of the concerns raised above.

I'm choosing to do this rather than using ZMusic's built-in FluidSynth because I want to be able to do things like change SoundFonts without restarting the current track, and change tracks without reloading the SoundFont (which can take several seconds with large, Vorbis-compressed .SF3s).