### PR TITLE
Optimizations/cleanup in music playback

### DIFF
--- a/Client/Music/MusicPlayer.cs
+++ b/Client/Music/MusicPlayer.cs
@@ -55,13 +55,13 @@ public class MusicPlayer : IMusicPlayer
 
     public void OutputChanging()
     {
-        m_zMusicPlayer.Pause();
+        m_zMusicPlayer.OnDeviceChanging();
         m_fluidSynthPlayer.OutputChanging();
     }
 
     public void OutputChanged()
     {
-        m_zMusicPlayer.Resume();
+        m_zMusicPlayer.OnDeviceChanged();
         m_fluidSynthPlayer.OutputChanged();
     }
 


### PR DESCRIPTION
1. Avoid getting new output streams, buffers, or other disposable objects on track change, if the formats are compatible
2. Misc. minor code cleanup
3. Set output frequency to 49716 hz (yes, really) when playing OPL music
4. Wake up the buffer fill logic at roughly 2x the buffer drain rate, not every 1 ms.  This may need fine-tuning.