### PR TITLE
Add analog input for controllers

### DIFF
--- a/Client/Input/Joystick/JoystickAdapter.cs
+++ b/Client/Input/Joystick/JoystickAdapter.cs
@@ -7,7 +7,7 @@
     using System.Timers;
     using OpenTKJoystick = OpenTK.Windowing.GraphicsLibraryFramework.JoystickState;
 
-    public class JoystickAdapter
+    public class JoystickAdapter : IAnalogAdapter
     {
         private const int RezeroDelay = 1000;
 
@@ -72,6 +72,7 @@
         {
             m_windowJoystickStates = joystickInputs;
             m_inputManager = inputManager;
+            m_inputManager.AnalogAdapter = this;
             AxisStates = [];
             m_joystickState = new JoystickState[2];
             m_deadZone = axisDeadzone;

--- a/Client/Input/Joystick/JoystickStatic.cs
+++ b/Client/Input/Joystick/JoystickStatic.cs
@@ -1,6 +1,7 @@
 ﻿namespace Helion.Client.Input.Joystick
 {
     using Helion.Window.Input;
+    using System.Collections.Generic;
 
     public static class JoystickStatic
     {
@@ -77,5 +78,29 @@
             Key.Axis10Plus,
             Key.Axis10Minus,
         ];
+
+        public static readonly Dictionary<Key, (int axisId, bool isPositive)> KeysToAxis = new()
+        {
+            { Key.Axis1Plus, (0, true) },
+            { Key.Axis1Minus, (0, false) },
+            { Key.Axis2Plus, (1, true) },
+            { Key.Axis2Minus, (1, false) },
+            { Key.Axis3Plus, (2, true) },
+            { Key.Axis3Minus, (2, false) },
+            { Key.Axis4Plus, (3, true) },
+            { Key.Axis4Minus, (3, false) },
+            { Key.Axis5Plus, (4, true) },
+            { Key.Axis5Minus, (4, false) },
+            { Key.Axis6Plus, (5, true) },
+            { Key.Axis6Minus, (5, false) },
+            { Key.Axis7Plus, (6, true) },
+            { Key.Axis7Minus, (6, false) },
+            { Key.Axis8Plus, (7, true) },
+            { Key.Axis8Minus, (7, false) },
+            { Key.Axis9Plus, (8, true) },
+            { Key.Axis9Minus, (8, false) },
+            { Key.Axis10Plus, (9, true) },
+            { Key.Axis10Minus, (9, false) },
+        };
     }
 }

--- a/Client/Window.cs
+++ b/Client/Window.cs
@@ -63,13 +63,18 @@ public class Window : GameWindow, IWindow
         MouseWheel += Window_MouseWheel;
         TextInput += Window_TextInput;
 
-        m_joystickAdapter = new JoystickAdapter(JoystickStates, (float)m_config.Game.GameControllerDeadZone.Value, m_inputManager);
+        m_joystickAdapter = new JoystickAdapter(
+            JoystickStates,
+            (float)m_config.Game.GameControllerDeadZone.Value,
+            (float)m_config.Game.GameControllerSaturation.Value,
+            m_inputManager);
         SetGameControllerPolling(m_config.Game.EnableGameController);
 
         m_config.Render.MaxFPS.OnChanged += OnMaxFpsChanged;
         m_config.Render.VSync.OnChanged += OnVSyncChanged;
         m_config.Game.EnableGameController.OnChanged += EnableGameController_OnChanged;
         m_config.Game.GameControllerDeadZone.OnChanged += GameControllerDeadZone_OnChanged;
+        m_config.Game.GameControllerSaturation.OnChanged += GameControllerSaturation_OnChanged;
     }
 
     public void SetMousePosition(Vec2I pos)
@@ -296,6 +301,11 @@ public class Window : GameWindow, IWindow
         m_joystickAdapter.DeadZone = (float)e;
     }
 
+    private void GameControllerSaturation_OnChanged(object? sender, double e)
+    {
+        m_joystickAdapter.Saturation = (float)e;
+    }
+
     private void EnableGameController_OnChanged(object? sender, bool e)
     {
         SetGameControllerPolling(e);
@@ -334,6 +344,7 @@ public class Window : GameWindow, IWindow
         m_config.Render.VSync.OnChanged -= OnVSyncChanged;
         m_config.Game.EnableGameController.OnChanged -= EnableGameController_OnChanged;
         m_config.Game.GameControllerDeadZone.OnChanged -= GameControllerDeadZone_OnChanged;
+        m_config.Game.GameControllerSaturation.OnChanged -= GameControllerSaturation_OnChanged;
 
         Renderer.Dispose();
 

--- a/Client/Window.cs
+++ b/Client/Window.cs
@@ -65,16 +65,16 @@ public class Window : GameWindow, IWindow
 
         m_joystickAdapter = new JoystickAdapter(
             JoystickStates,
-            (float)m_config.Game.GameControllerDeadZone.Value,
-            (float)m_config.Game.GameControllerSaturation.Value,
+            (float)m_config.Controller.GameControllerDeadZone.Value,
+            (float)m_config.Controller.GameControllerSaturation.Value,
             m_inputManager);
-        SetGameControllerPolling(m_config.Game.EnableGameController);
+        SetGameControllerPolling(m_config.Controller.EnableGameController);
 
         m_config.Render.MaxFPS.OnChanged += OnMaxFpsChanged;
         m_config.Render.VSync.OnChanged += OnVSyncChanged;
-        m_config.Game.EnableGameController.OnChanged += EnableGameController_OnChanged;
-        m_config.Game.GameControllerDeadZone.OnChanged += GameControllerDeadZone_OnChanged;
-        m_config.Game.GameControllerSaturation.OnChanged += GameControllerSaturation_OnChanged;
+        m_config.Controller.EnableGameController.OnChanged += EnableGameController_OnChanged;
+        m_config.Controller.GameControllerDeadZone.OnChanged += GameControllerDeadZone_OnChanged;
+        m_config.Controller.GameControllerSaturation.OnChanged += GameControllerSaturation_OnChanged;
     }
 
     public void SetMousePosition(Vec2I pos)
@@ -342,9 +342,9 @@ public class Window : GameWindow, IWindow
 
         m_config.Render.MaxFPS.OnChanged -= OnMaxFpsChanged;
         m_config.Render.VSync.OnChanged -= OnVSyncChanged;
-        m_config.Game.EnableGameController.OnChanged -= EnableGameController_OnChanged;
-        m_config.Game.GameControllerDeadZone.OnChanged -= GameControllerDeadZone_OnChanged;
-        m_config.Game.GameControllerSaturation.OnChanged -= GameControllerSaturation_OnChanged;
+        m_config.Controller.EnableGameController.OnChanged -= EnableGameController_OnChanged;
+        m_config.Controller.GameControllerDeadZone.OnChanged -= GameControllerDeadZone_OnChanged;
+        m_config.Controller.GameControllerSaturation.OnChanged -= GameControllerSaturation_OnChanged;
 
         Renderer.Dispose();
 

--- a/Core/Layer/Worlds/WorldLayer.Input.cs
+++ b/Core/Layer/Worlds/WorldLayer.Input.cs
@@ -47,7 +47,7 @@ public partial class WorldLayer
     };
 
     // Convert analog inputs into movements, assumes analog values are in range [0..1]
-    private static readonly Dictionary<TickCommands, Action<TickCommand, float, ConfigGame>> MovementCommmands = new()
+    private static readonly Dictionary<TickCommands, Action<TickCommand, float, ConfigController>> MovementCommmands = new()
     {
         { TickCommands.TurnLeft, (cmd, value, cfg) => cmd.AngleTurn = value * Player.FastTurnSpeed * cfg.GameControllerTurnScale },
         { TickCommands.TurnRight, (cmd,value, cfg) => cmd.AngleTurn = -value * Player.FastTurnSpeed * cfg.GameControllerTurnScale },
@@ -218,14 +218,14 @@ public partial class WorldLayer
                     weaponScroll += GetWeaponScroll(scrollAmount, key, tickCommand);
 
                 bool cancelKey = false;
-                if (m_config.Game.EnableGameController)
+                if (m_config.Controller.EnableGameController)
                 {
                     // If there is an analog input that corresponds to this key, directly enter the analog data into
                     // the current tick command's movement parameters rather than setting a key.
                     if (MovementCommmands.TryGetValue(tickCommand, out var setAction)
-                        && input.Manager.AnalogAdapter.TryGetAnalogValueForAxis(key, out float analogValue))
+                        && input.Manager.AnalogAdapter?.TryGetAnalogValueForAxis(key, out float analogValue) == true)
                     {
-                        setAction(cmd, analogValue, m_config.Game);
+                        setAction(cmd, analogValue, m_config.Controller);
                         cancelKey = true;
                     }
                 }

--- a/Core/Util/Configs/Components/ConfigController.cs
+++ b/Core/Util/Configs/Components/ConfigController.cs
@@ -1,0 +1,31 @@
+﻿namespace Helion.Util.Configs.Components;
+
+using Helion.Util.Configs.Options;
+using Helion.Util.Configs.Values;
+using static Helion.Util.Configs.Values.ConfigFilters;
+
+public class ConfigController
+{
+    // Controller
+
+    [ConfigInfo("Enable game controller support.")]
+    [OptionMenu(OptionSectionType.Controller, "Enable Game Controller", spacer: true)]
+    public readonly ConfigValue<bool> EnableGameController = new(true);
+
+    [ConfigInfo("Dead zone for analog inputs.")]
+    [OptionMenu(OptionSectionType.Controller, "Game Controller Dead Zone")]
+    public readonly ConfigValue<double> GameControllerDeadZone = new(0.2, Clamp(0.1, 0.9));
+
+    [ConfigInfo("Saturation zone for analog inputs.")]
+    [OptionMenu(OptionSectionType.Controller, "Game Controller Saturation")]
+    public readonly ConfigValue<double> GameControllerSaturation = new(0, Clamp(0, 0.3));
+
+    [ConfigInfo("Turn speed scaling factor for analog inputs.")]
+    [OptionMenu(OptionSectionType.Controller, "Game Controller Turn Scale")]
+    public readonly ConfigValue<double> GameControllerTurnScale = new(1.2, Clamp(0.1, 3.0));
+
+    [ConfigInfo("Pitch speed scaling factor for analog inputs.")]
+    [OptionMenu(OptionSectionType.Controller, "Game Controller Pitch Scale")]
+    public readonly ConfigValue<double> GameControllerPitchScale = new(0.5, Clamp(0.1, 3.0));
+}
+

--- a/Core/Util/Configs/Components/ConfigGame.cs
+++ b/Core/Util/Configs/Components/ConfigGame.cs
@@ -26,28 +26,6 @@ public class ConfigGame
     [OptionMenu(OptionSectionType.General, "Bump Use")]
     public readonly ConfigValue<bool> BumpUse = new(false);
 
-    // Controller
-
-    [ConfigInfo("Enable game controller support.")]
-    [OptionMenu(OptionSectionType.General, "Enable Game Controller", spacer: true)]
-    public readonly ConfigValue<bool> EnableGameController = new(true);
-
-    [ConfigInfo("Dead zone for game controller analog inputs.")]
-    [OptionMenu(OptionSectionType.General, "Game Controller Dead Zone")]
-    public readonly ConfigValue<double> GameControllerDeadZone = new(0.2, Clamp(0.1, 0.9));
-
-    [ConfigInfo("Saturation zone for game controller analog inputs.")]
-    [OptionMenu(OptionSectionType.General, "Game Controller Saturation")]
-    public readonly ConfigValue<double> GameControllerSaturation = new(0, Clamp(0, 0.3));
-
-    [ConfigInfo("Turn speed scaling factor for controller analog inputs.")]
-    [OptionMenu(OptionSectionType.General, "Game Controller Turn Scale")]
-    public readonly ConfigValue<double> GameControllerTurnScale = new(1.5, Clamp(0.1, 3.0));
-
-    [ConfigInfo("Pitch speed scaling factor for controller analog inputs.")]
-    [OptionMenu(OptionSectionType.General, "Game Controller Pitch Scale")]
-    public readonly ConfigValue<double> GameControllerPitchScale = new(0.5, Clamp(0.1, 3.0));
-
     // Visual effects
 
     [ConfigInfo("Scale red amount drawn to screen when the player takes damage.")]

--- a/Core/Util/Configs/Components/ConfigGame.cs
+++ b/Core/Util/Configs/Components/ConfigGame.cs
@@ -26,13 +26,19 @@ public class ConfigGame
     [OptionMenu(OptionSectionType.General, "Bump Use")]
     public readonly ConfigValue<bool> BumpUse = new(false);
 
+    // Controller
+
     [ConfigInfo("Enable game controller support.")]
-    [OptionMenu(OptionSectionType.General, "Enable Game Controller")]
+    [OptionMenu(OptionSectionType.General, "Enable Game Controller", spacer: true)]
     public readonly ConfigValue<bool> EnableGameController = new(true);
 
     [ConfigInfo("Dead zone for game controller analog inputs.")]
     [OptionMenu(OptionSectionType.General, "Game Controller Dead Zone")]
-    public readonly ConfigValue<double> GameControllerDeadZone = new(0.1, Clamp(0.1, 0.9));
+    public readonly ConfigValue<double> GameControllerDeadZone = new(0.2, Clamp(0.1, 0.9));
+
+    [ConfigInfo("Saturation zone for game controller analog inputs.")]
+    [OptionMenu(OptionSectionType.General, "Game Controller Saturation")]
+    public readonly ConfigValue<double> GameControllerSaturation = new(0, Clamp(0, 0.3));
 
     // Visual effects
 
@@ -78,7 +84,7 @@ public class ConfigGame
     [OptionMenu(OptionSectionType.General, "Mark Secrets")]
     public readonly ConfigValue<bool> MarkSecrets = new(false);
 
-    
+
     // Difficulty modifiers
 
     [ConfigInfo("Remove all monsters from the game.", save: false, serialize: true)]

--- a/Core/Util/Configs/Components/ConfigGame.cs
+++ b/Core/Util/Configs/Components/ConfigGame.cs
@@ -40,6 +40,14 @@ public class ConfigGame
     [OptionMenu(OptionSectionType.General, "Game Controller Saturation")]
     public readonly ConfigValue<double> GameControllerSaturation = new(0, Clamp(0, 0.3));
 
+    [ConfigInfo("Turn speed scaling factor for controller analog inputs.")]
+    [OptionMenu(OptionSectionType.General, "Game Controller Turn Scale")]
+    public readonly ConfigValue<double> GameControllerTurnScale = new(1.5, Clamp(0.1, 3.0));
+
+    [ConfigInfo("Pitch speed scaling factor for controller analog inputs.")]
+    [OptionMenu(OptionSectionType.General, "Game Controller Pitch Scale")]
+    public readonly ConfigValue<double> GameControllerPitchScale = new(0.5, Clamp(0.1, 3.0));
+
     // Visual effects
 
     [ConfigInfo("Scale red amount drawn to screen when the player takes damage.")]

--- a/Core/Util/Configs/IConfig.cs
+++ b/Core/Util/Configs/IConfig.cs
@@ -15,6 +15,7 @@ public interface IConfig
     ConfigAudio Audio { get; }
     ConfigCompat Compatibility { get; }
     ConfigConsole Console { get; }
+    ConfigController Controller { get; }
     ConfigDeveloper Developer { get; }
     ConfigFiles Files { get; }
     ConfigGame Game { get; }

--- a/Core/Util/Configs/Impl/Config.cs
+++ b/Core/Util/Configs/Impl/Config.cs
@@ -22,6 +22,7 @@ public class Config : IConfig
     public ConfigAudio Audio { get; } = new();
     public ConfigCompat Compatibility { get; } = new();
     public ConfigConsole Console { get; } = new();
+    public ConfigController Controller { get; } = new();
     public ConfigDeveloper Developer { get; } = new();
     public ConfigFiles Files { get; } = new();
     public ConfigGame Game { get; } = new();

--- a/Core/Util/Configs/Options/OptionSectionType.cs
+++ b/Core/Util/Configs/Options/OptionSectionType.cs
@@ -6,6 +6,7 @@ public enum OptionSectionType
 {
     Keys,
     Mouse,
+    Controller,
     General,
     Video,
     Audio,

--- a/Core/Window/IInputManager.cs
+++ b/Core/Window/IInputManager.cs
@@ -14,7 +14,7 @@ public interface IInputManager
     Vec2I MousePosition { get; set; }
     public int Scroll { get; }
     public ReadOnlySpan<char> TypedCharacters { get; }
-
+    public IAnalogAdapter AnalogAdapter { get; }
     bool IsKeyDown(Key key);
     bool IsKeyPrevDown(Key key);
     bool IsKeyHeldDown(Key key);

--- a/Core/Window/IInputManager.cs
+++ b/Core/Window/IInputManager.cs
@@ -14,7 +14,7 @@ public interface IInputManager
     Vec2I MousePosition { get; set; }
     public int Scroll { get; }
     public ReadOnlySpan<char> TypedCharacters { get; }
-    public IAnalogAdapter AnalogAdapter { get; }
+    public IAnalogAdapter? AnalogAdapter { get; }
     bool IsKeyDown(Key key);
     bool IsKeyPrevDown(Key key);
     bool IsKeyHeldDown(Key key);

--- a/Core/Window/Input/IAnalogAdapter.cs
+++ b/Core/Window/Input/IAnalogAdapter.cs
@@ -1,0 +1,6 @@
+﻿namespace Helion.Window.Input;
+
+public interface IAnalogAdapter
+{
+    bool TryGetAnalogValueForAxis(Key key, out float axisAnalogValue);
+}

--- a/Core/Window/Input/InputManager.cs
+++ b/Core/Window/Input/InputManager.cs
@@ -38,6 +38,8 @@ public class InputManager : IInputManager
     public DynamicArray<Key> GetPrevDownKeys() => m_prevDownKeys;
     public DynamicArray<InputKey> GetEvents() => m_events;
 
+    public IAnalogAdapter? AnalogAdapter { get; set; }
+
     public InputManager()
     {
         m_consumableInput = new ConsumableInput(this);

--- a/Core/World/Entities/Players/Player.cs
+++ b/Core/World/Entities/Players/Player.cs
@@ -42,9 +42,9 @@ public class Player : Entity
     private const double PlayerViewDivider = 8.0;
     private const double ViewHeightMin = 4.0;
     private const double DeathHeight = 8.0;
+    public const double FastTurnSpeed = 7.03125 / 180 * Math.PI;
     private const double SlowTurnSpeed = 1.7578125 / 180 * Math.PI;
     private const double NormalTurnSpeed = 3.515625 / 180 * Math.PI;
-    private const double FastTurnSpeed = 7.03125 / 180 * Math.PI;
     private const int JumpDelayTicks = 7;
     private const int SlowTurnTicks = 6;
     private const double MaxPitch = Camera.MaxPitch;


### PR DESCRIPTION
This change causes key bindings that are _actually_ analog axes to send analog values to the four player movement axes (forward movement, side movement, turn, pitch) on each tick rather than sending keys.