### PR TITLE
Use approximate circle-to-square mapping for move/strafe axes

### DIFF
--- a/Client/Input/Joystick/JoystickState.cs
+++ b/Client/Input/Joystick/JoystickState.cs
@@ -25,7 +25,7 @@
         {
             for (int axisId = 0; axisId < AxisValues.Length; axisId++)
             {
-                AxisValues[axisId] = (float)Math.Sin(openTKState.GetAxis(axisId) * Math.PI / 2);
+                AxisValues[axisId] = openTKState.GetAxis(axisId);
             }
             for (int buttonId = 0; buttonId < ButtonStates.Length; buttonId++)
             {

--- a/Core/Layer/Worlds/WorldLayer.Input.cs
+++ b/Core/Layer/Worlds/WorldLayer.Input.cs
@@ -246,8 +246,8 @@ public partial class WorldLayer
             // and turn as this would make freelook overly sensitive.
             CircleCoordsToSquare(analogInput.X, analogInput.Y, out analogInput.X, out analogInput.Y);
 
-            cmd.ForwardMoveSpeed = Math.Clamp(analogInput.X, -1, 1) * Player.GetForwardMovementSpeed();
-            cmd.SideMoveSpeed = Math.Clamp(analogInput.Y, -1, 1) * Player.GetSideMovementSpeed();
+            cmd.ForwardMoveSpeed = Math.Clamp(analogInput.X * m_config.Controller.GameControllerRunScale, -1, 1) * Player.GetForwardMovementSpeed();
+            cmd.SideMoveSpeed = Math.Clamp(analogInput.Y * m_config.Controller.GameControllerStrafeScale, -1, 1) * Player.GetSideMovementSpeed();
             cmd.AngleTurn = analogInput.Z * Player.FastTurnSpeed * m_config.Controller.GameControllerTurnScale;
             cmd.PitchTurn = analogInput.W * Player.FastTurnSpeed * m_config.Controller.GameControllerPitchScale;
         }

--- a/Core/Util/Configs/Components/ConfigController.cs
+++ b/Core/Util/Configs/Components/ConfigController.cs
@@ -13,15 +13,23 @@ public class ConfigController
     public readonly ConfigValue<bool> EnableGameController = new(true);
 
     [ConfigInfo("Dead zone for analog inputs.")]
-    [OptionMenu(OptionSectionType.Controller, "Game Controller Dead Zone")]
+    [OptionMenu(OptionSectionType.Controller, "Dead Zone")]
     public readonly ConfigValue<double> GameControllerDeadZone = new(0.2, Clamp(0.1, 0.9));
 
     [ConfigInfo("Turn speed scaling factor for analog inputs.")]
-    [OptionMenu(OptionSectionType.Controller, "Game Controller Turn Scale")]
+    [OptionMenu(OptionSectionType.Controller, "Turn Sensitivity")]
     public readonly ConfigValue<double> GameControllerTurnScale = new(1.0, Clamp(0.1, 3.0));
 
     [ConfigInfo("Pitch speed scaling factor for analog inputs.")]
-    [OptionMenu(OptionSectionType.Controller, "Game Controller Pitch Scale")]
+    [OptionMenu(OptionSectionType.Controller, "Pitch Sensitivity")]
     public readonly ConfigValue<double> GameControllerPitchScale = new(0.5, Clamp(0.1, 3.0));
+
+    [ConfigInfo("Run input scaling factor for analog inputs.")]
+    [OptionMenu(OptionSectionType.Controller, "Run Sensitivity")]
+    public readonly ConfigValue<double> GameControllerRunScale = new(1.0, Clamp(0.1, 3.0));
+
+    [ConfigInfo("Strafe input scaling factor for analog inputs.")]
+    [OptionMenu(OptionSectionType.Controller, "Strafe Sensitivity")]
+    public readonly ConfigValue<double> GameControllerStrafeScale = new(1.0, Clamp(0.1, 3.0));
 }
 


### PR DESCRIPTION
Assume that there is going to be crosstalk between the "strafe" and "move" axes, since most players will put them on the same control stick.  Perform a crude circle-to-square coordinate system conversion, so that the overall sensitivity is _basically_ linear if the user moves the stick in one of the cardinal directions, but scales up a bit for diagonal stick movements so it is possible to max out both velocities.