### PR TITLE
Set render frequency based on refresh rate if vsync on and no limiter set

### DIFF
--- a/Core/Util/Configs/Components/ConfigRender.cs
+++ b/Core/Util/Configs/Components/ConfigRender.cs
@@ -46,9 +46,9 @@ public class ConfigRender
     [OptionMenu(OptionSectionType.Render, "VSync")]
     public readonly ConfigValue<RenderVsyncMode> VSync = new(RenderVsyncMode.On);
 
-    [ConfigInfo("Maximum frames per second. Zero is equivalent to no cap.")]
+    [ConfigInfo("Maximum frames per second. Zero is equivalent to no cap if vsync is off (or monitor refresh rate if vsync is on/adaptive).")]
     [OptionMenu(OptionSectionType.Render, "Max FPS")]
-    public readonly ConfigValue<int> MaxFPS = new(250, fps =>
+    public readonly ConfigValue<int> MaxFPS = new(0, fps =>
     {
         return fps switch
         {

--- a/Core/Window/MonitorData.cs
+++ b/Core/Window/MonitorData.cs
@@ -1,3 +1,3 @@
 ﻿namespace Helion.Window;
 
-public record MonitorData(int Index, int HorizontalResolution, int VerticalResolution, object Handle);
+public record MonitorData(int Index, int HorizontalResolution, int VerticalResolution, int RefreshRate, object Handle);


### PR DESCRIPTION
This improves the "out-of-box" experience, because the current defaults of "vsync on, limiter 250" doesn't look smooth at all on 60 and 144hz monitors.