### PR TITLE
Nuget package cleanup

### DIFF
--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -10,7 +10,6 @@
     <ApplicationIcon>helion.ico</ApplicationIcon>
 
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-    <NoWarn>1701;1702;NU1701</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(SelfContainedRelease)' == 'true'">

--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -8,7 +8,7 @@
     <GenerateDocumentationFile>False</GenerateDocumentationFile>
 
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <NoWarn>1701;1702;NU1701;CS1591;CS8714;CS8500</NoWarn>
+    <NoWarn>CS1591;CS8714;CS8500</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
@@ -23,8 +23,8 @@
   <ItemGroup>
     <PackageReference Include="BmpSharp" Version="0.2.0" />
     <PackageReference Include="Crc32.NET" Version="1.2.0" />
-    <PackageReference Include="GlmSharp" Version="0.9.8" />
-    <PackageReference Include="ini-parser" Version="2.5.2" />
+    <PackageReference Include="GlmSharp-netstandard" Version="0.9.8.1" />
+    <PackageReference Include="ini-parser-new" Version="2.6.2" />
     <PackageReference Include="NAudio" Version="2.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NLog" Version="5.2.8" />

--- a/Core/Util/Configs/Impl/FileConfig.cs
+++ b/Core/Util/Configs/Impl/FileConfig.cs
@@ -137,7 +137,7 @@ public class FileConfig : Config
 
         bool AddEngineFields(IniData data)
         {
-            if (!data.Sections.AddSection(EngineSectionName))
+            if (!data.Sections.Add(EngineSectionName))
             {
                 Log.Error("Failed to add engine section header when writing config");
                 return false;
@@ -153,7 +153,7 @@ public class FileConfig : Config
 
         bool AddKeyFields(IniData data)
         {
-            if (!data.Sections.AddSection(KeysSectionName))
+            if (!data.Sections.Add(KeysSectionName))
             {
                 Log.Error("Failed to add key section header when writing config");
                 return false;


### PR DESCRIPTION
1.  Remove NU17xx suppressions
2.  Update legacy packages to their .NET Core-compliant successors