### PR TITLE
fix Intel iGPUs using OpenGL 3.3

### DIFF
--- a/Client/Client.cs
+++ b/Client/Client.cs
@@ -152,7 +152,6 @@ public partial class Client : IDisposable, IInputManagement
 
     private static void CheckOpenGLSupport()
     {
-        Log.Info("CheckOpenGLSupport {0}{1}", GlVersion.Major, GlVersion.Minor);
         GLInfo.ClipControlSupported = GlVersion.IsVersionSupported(4, 5) || GLExtensions.Supports("GL_ARB_clip_control");
         GLInfo.MapPersistentBitSupported = GlVersion.IsVersionSupported(4, 4);
     }

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -50,3 +50,4 @@
   - Fix boom generic specials to allow monsters to trigger of off model if change is 0
   - Fix various UMAPINFO issues dealing with nointermission intertext, intertextsecret, endgame, endpic, and intermusic
   - Fix berserk only restoring to initial health when modified through dehacked
+  - Fix OpenGL context using 3.3 with Intel iGPUs when a higher version is supported


### PR DESCRIPTION
create context for each requested version if forward compatible is not requested

fixes Intel iGPUs reporting the base requested version instead of highest supported