### PR TITLE
Fix volume behaviors

### DIFF
--- a/Client/Client.Config.cs
+++ b/Client/Client.Config.cs
@@ -100,8 +100,10 @@ public partial class Client
         var musicVolume = (float)(m_config.Audio.MusicVolume * m_config.Audio.Volume);
         var soundVolume = m_config.Audio.SoundVolume * m_config.Audio.Volume;
 
-        m_audioSystem.Music.SetVolume(musicVolume);
+        musicVolume = soundVolume == 0 ? musicVolume : (float)(musicVolume / soundVolume);
+
         m_audioSystem.SetVolume(soundVolume);
+        m_audioSystem.Music.SetVolume(musicVolume);
     }
 
     private void SoundFont_OnChanged(object? sender, string _)

--- a/Client/Client.Config.cs
+++ b/Client/Client.Config.cs
@@ -97,13 +97,9 @@ public partial class Client
 
     private void UpdateVolume()
     {
-        var musicVolume = (float)(m_config.Audio.MusicVolume * m_config.Audio.Volume);
         var soundVolume = m_config.Audio.SoundVolume * m_config.Audio.Volume;
-
-        musicVolume = soundVolume == 0 ? musicVolume : (float)(musicVolume / soundVolume);
-
         m_audioSystem.SetVolume(soundVolume);
-        m_audioSystem.Music.SetVolume(musicVolume);
+        m_audioSystem.Music.SetVolume((float)m_config.Audio.MusicVolumeNormalized);
     }
 
     private void SoundFont_OnChanged(object? sender, string _)

--- a/Client/Music/AudioStream.cs
+++ b/Client/Music/AudioStream.cs
@@ -121,6 +121,7 @@ public sealed class AudioStream : IOutputStream
 
     public void SetVolume(float volume)
     {
+        AL.Source(m_alSource, ALSourcef.MaxGain, volume);
         AL.Source(m_alSource, ALSourcef.Gain, volume);
     }
 

--- a/Client/Music/MusicPlayer.cs
+++ b/Client/Music/MusicPlayer.cs
@@ -143,7 +143,7 @@ public class MusicPlayer : IMusicPlayer
         m_lastDataHash = hash;
 
         Stop();
-        SetVolume((float)m_configAudio.MusicVolume.Value);
+        SetVolume((float)m_configAudio.MusicVolumeNormalized);
         bool isMidi = m_zMusicPlayer.IsMIDI(data, out string? error);
 
         if (!string.IsNullOrEmpty(error))

--- a/Core/Audio/Impl/OpenALAudioSystem.cs
+++ b/Core/Audio/Impl/OpenALAudioSystem.cs
@@ -88,11 +88,13 @@ public class OpenALAudioSystem : IAudioSystem
 
         if (volume == 0)
         {
+            // Shut off all the sources but set the main gain to 1 so the music can still come through
             SetSourceManagerGains(0);
             AL.Listener(ALListenerf.Gain, 1);
         }
         else
         {
+            // Set listener gain based on sound effects volume; music is scaled as a multiple of effects volume
             SetSourceManagerGains(1);
             AL.Listener(ALListenerf.Gain, (float)volume);
         }

--- a/Core/Audio/Impl/OpenALAudioSystem.cs
+++ b/Core/Audio/Impl/OpenALAudioSystem.cs
@@ -86,9 +86,23 @@ public class OpenALAudioSystem : IAudioSystem
     {
         Gain = volume;
 
-        foreach(var sourceManager in m_sourceManagers)
+        if (volume == 0)
         {
-            sourceManager.SetGain(Gain);
+            SetSourceManagerGains(0);
+            AL.Listener(ALListenerf.Gain, 1);
+        }
+        else
+        {
+            SetSourceManagerGains(1);
+            AL.Listener(ALListenerf.Gain, (float)volume);
+        }
+    }
+
+    private void SetSourceManagerGains(float gain)
+    {
+        foreach (var sourceManager in m_sourceManagers)
+        {
+            sourceManager.SetGain(gain);
         }
     }
 

--- a/Core/Util/Configs/Components/ConfigAudio.cs
+++ b/Core/Util/Configs/Components/ConfigAudio.cs
@@ -45,4 +45,6 @@ public class ConfigAudio
     [ConfigInfo("SoundFont file to use for MIDI/MUS music playback.")]
     [OptionMenu(OptionSectionType.Audio, "SoundFont File", dialogType: DialogType.SoundFontPicker)]
     public readonly ConfigValue<string> SoundFontFile = new($"SoundFonts{Path.DirectorySeparatorChar}Default.sf2");
+
+    public double MusicVolumeNormalized => (SoundVolume == 0 ? MusicVolume : (MusicVolume / SoundVolume)) * Volume;
 }

--- a/Core/Util/DataCache.cs
+++ b/Core/Util/DataCache.cs
@@ -205,6 +205,10 @@ public class DataCache
         if (audioSource is not OpenALAudioSource)
             return;
 
+        // Clear any positional audio effects
+        audioSource.SetVelocity(0, 0, 0);
+        audioSource.SetPosition(0, 0, 0);
+
         audioSource.AudioData.SoundSource.ClearSound(audioSource, audioSource.AudioData.SoundChannelType);
         audioSource.CacheFree();
         m_audioSources.Add(audioSource);


### PR DESCRIPTION
1.  Revert to the previous model of setting volume "globally" through the OpenAL Listener, to address some weird rolloff/attenuation issues with positional and moving sources.

2.  Compensate the music volume by setting its source gain as (musicVolume / soundEffectsVolume)