### PR TITLE
Disable music playback when ENDOOM is displayed

### DIFF
--- a/Client/Client.Commands.cs
+++ b/Client/Client.Commands.cs
@@ -309,6 +309,7 @@ public partial class Client
         if (m_config.Game.DisplayEndoom)
         {
             m_audioSystem.Music.Stop();
+            m_audioSystem.Music.Enabled = false;
             m_layerManager.ShowEndoom(m_window.Close);
         }
         else

--- a/Client/Music/FluidSynthMusicPlayer.cs
+++ b/Client/Music/FluidSynthMusicPlayer.cs
@@ -30,6 +30,7 @@ public class FluidSynthMusicPlayer : IMusicPlayer
 
     private IOutputStream? m_stream;
     private Player? m_player;
+    private bool m_enabled = true;
 
     public FluidSynthMusicPlayer(string soundFontFile, IOutputStreamFactory streamFactory, float sourceVolume)
     {
@@ -53,9 +54,22 @@ public class FluidSynthMusicPlayer : IMusicPlayer
         m_stream?.SetVolume(newVolume);
     }
 
+    public bool Enabled
+    {
+        get => m_enabled;
+        set
+        {
+            m_enabled = value;
+            if (!value)
+            {
+                Stop();
+            }
+        }
+    }
+
     public unsafe bool Play(byte[] data, MusicPlayerOptions options)
     {
-        if (m_disposed)
+        if (m_disposed || !m_enabled)
             return false;
 
         try

--- a/Client/Music/MusicPlayer.cs
+++ b/Client/Music/MusicPlayer.cs
@@ -30,6 +30,7 @@ public class MusicPlayer : IMusicPlayer
     private FluidSynthMusicPlayer m_fluidSynthPlayer;
     private bool m_genMidiPatchLoaded;
     private PlayParams? m_currentTrack;
+    private bool m_enabled = true;
 
     public MusicPlayer(ConfigAudio configAudio, ArchiveCollection archiveCollection)
     {
@@ -73,7 +74,7 @@ public class MusicPlayer : IMusicPlayer
 
     public bool Play(byte[] data, MusicPlayerOptions options)
     {
-        if (m_disposed)
+        if (m_disposed || !m_enabled)
             return false;
 
         m_playQueue.Clear();
@@ -130,6 +131,9 @@ public class MusicPlayer : IMusicPlayer
 
     private void CreateAndPlayMusic(PlayParams playParams)
     {
+        if (!m_enabled)
+            return;
+
         m_currentTrack = playParams;
         var data = playParams.Data;
         var options = playParams.Options;
@@ -237,6 +241,24 @@ public class MusicPlayer : IMusicPlayer
     {
         m_zMusicPlayer.Volume = (float)(volume * .5);
         m_fluidSynthPlayer.SetVolume(volume);
+    }
+
+    public bool Enabled
+    {
+        get => m_enabled;
+        set
+        {
+            m_enabled = value;
+            if (m_fluidSynthPlayer != null)
+            {
+                m_fluidSynthPlayer.Enabled = value;
+            }
+
+            if (!value)
+            {
+                Stop();
+            }
+        }
     }
 
     public void Stop()

--- a/Core/Audio/IMusicPlayer.cs
+++ b/Core/Audio/IMusicPlayer.cs
@@ -35,6 +35,11 @@ public interface IMusicPlayer : IDisposable
     void Stop();
 
     /// <summary>
+    /// Enables or disables the music system.  If disabled, the system will ignore requests to play music.
+    /// </summary>
+    bool Enabled { get; set; }
+
+    /// <summary>
     /// Ask the music player to stop playback temporarily and discard any outputs it is currently using
     /// </summary>
     void OutputChanging();

--- a/Core/Audio/Impl/MockMusicPlayer.cs
+++ b/Core/Audio/Impl/MockMusicPlayer.cs
@@ -33,5 +33,7 @@ namespace Helion.Audio.Impl
         {
 
         }
+
+        public bool Enabled { get; set; }
     }
 }


### PR DESCRIPTION
Some layers, like the titlepic layer, have timed music-start events, so just stopping the music once may not be enough if they are somewhere in the stack.

Addresses https://github.com/Helion-Engine/Helion/issues/774