### PR TITLE
Fixed-width number formatting for stats display

### DIFF
--- a/Assets/Assets/Fonts.txt
+++ b/Assets/Assets/Fonts.txt
@@ -200,6 +200,109 @@ font SmallFontGrayscale
     }
 }
 
+font SmallFontGrayscaleFixedWidthNumbers
+{
+    space = 4;
+    fixedWidthNumber = "0";
+    grayscale = true;
+    grayscaleNormalization = true;
+    align = top;
+    useOffset = true;
+    characters
+    {
+        "!" STCFN033;
+        "\"" STCFN034;
+        "#" STCFN035;
+        "$" STCFN036;
+        "%" STCFN037;
+        "&" STCFN038;
+        "'" STCFN039;
+        "(" STCFN040;
+        ")" STCFN041;
+        "*" STCFN042;
+        "+" STCFN043;
+        "," STCFN044;
+        "-" STCFN045;
+        "." STCFN046;
+        "/" STCFN047;
+        "0" STCFN048;
+        "1" STCFN049;
+        "2" STCFN050;
+        "3" STCFN051;
+        "4" STCFN052;
+        "5" STCFN053;
+        "6" STCFN054;
+        "7" STCFN055;
+        "8" STCFN056;
+        "9" STCFN057;
+        ":" STCFN058;
+        ";" STCFN059;
+        "<" STCFN060;
+        "=" STCFN061;
+        ">" STCFN062;
+        "?" STCFN063 default;
+        "@" STCFN064;
+        "A" STCFN065;
+        "B" STCFN066;
+        "C" STCFN067;
+        "D" STCFN068;
+        "E" STCFN069;
+        "F" STCFN070;
+        "G" STCFN071;
+        "H" STCFN072;
+        "I" STCFN073;
+        "J" STCFN074;
+        "K" STCFN075;
+        "L" STCFN076;
+        "M" STCFN077;
+        "N" STCFN078;
+        "O" STCFN079;
+        "P" STCFN080;
+        "Q" STCFN081;
+        "R" STCFN082;
+        "S" STCFN083;
+        "T" STCFN084;
+        "U" STCFN085;
+        "V" STCFN086;
+        "W" STCFN087;
+        "X" STCFN088;
+        "Y" STCFN089;
+        "Z" STCFN090;
+        "[" STCFN091;
+        "\\" STCFN092;
+        "]" STCFN093;
+        "^" STCFN094;
+        "_" STCFN095;
+        "a" STCFN065;
+        "b" STCFN066;
+        "c" STCFN067;
+        "d" STCFN068;
+        "e" STCFN069;
+        "f" STCFN070;
+        "g" STCFN071;
+        "h" STCFN072;
+        "i" STCFN073;
+        "j" STCFN074;
+        "k" STCFN075;
+        "l" STCFN076;
+        "m" STCFN077;
+        "n" STCFN078;
+        "o" STCFN079;
+        "p" STCFN080;
+        "q" STCFN081;
+        "r" STCFN082;
+        "s" STCFN083;
+        "t" STCFN084;
+        "u" STCFN085;
+        "v" STCFN086;
+        "w" STCFN087;
+        "x" STCFN088;
+        "y" STCFN089;
+        "z" STCFN090;
+        "|" STCFN121;
+    }
+}
+
 font LargeHudFont
 {
     space = 14;

--- a/Core/Graphics/Fonts/Font.cs
+++ b/Core/Graphics/Fonts/Font.cs
@@ -18,13 +18,14 @@ public class Font : IEnumerable<(char, Glyph)>
     public readonly int? FixedWidth;
     public readonly int? FixedHeight;
     public readonly Glyph? FixedWidthChar;
+    public readonly Glyph? FixedWidthNumber;
     public readonly Image Image;
     public readonly bool IsTrueTypeFont;
     private readonly Dictionary<char, Glyph> m_glyphs;
     private readonly Glyph m_defaultGlyph;
 
     public Font(string name, Dictionary<char, Glyph> glyphs, Image image, char defaultChar = DefaultChar,
-        bool isTrueTypeFont = false, int? fixedWidth = null, int? fixedHeight = null, char? fixedWidthChar = null)
+        bool isTrueTypeFont = false, int? fixedWidth = null, int? fixedHeight = null, char? fixedWidthChar = null, char? fixedWidthNumber = null)
     {
         Name = name;
         m_glyphs = glyphs;
@@ -40,6 +41,9 @@ public class Font : IEnumerable<(char, Glyph)>
         FixedHeight = fixedHeight;
         if (fixedWidthChar.HasValue && TryGet(fixedWidthChar.Value, out var fixedChar))
             FixedWidthChar = fixedChar;
+
+        if (fixedWidthNumber.HasValue && TryGet(fixedWidthNumber.Value, out var fixedNumber))
+            FixedWidthNumber = fixedNumber;
     }
 
     public Glyph Get(char c) => TryGet(c, out Glyph result) ? result : m_defaultGlyph;

--- a/Core/Layer/Endoom/EndoomLayer.cs
+++ b/Core/Layer/Endoom/EndoomLayer.cs
@@ -4,6 +4,7 @@
     using Helion.Render.Common.Textures;
     using Helion.Render.OpenGL.Texture;
     using Helion.Resources.Archives.Collection;
+    using Helion.Util;
     using Helion.Util.Extensions;
     using Helion.Util.Timing;
     using Helion.Window;
@@ -26,7 +27,7 @@
         const int ENDOOMBYTES = 4000;
         const int ENDOOMCOLUMNS = 80;
         const int ENDOOMROWS = ENDOOMBYTES / ENDOOMCOLUMNS / 2;
-        const string FONTNAME = "flexi-ibm-vga-true.regular";
+        const string FONTNAME = Constants.Fonts.VGA;
         const string LUMPNAME = "ENDOOM";
         private const string IMAGENAME1 = "ENDOOM_RENDERED_1";
         private const string IMAGENAME2 = "ENDOOM_RENDERED_2";

--- a/Core/Layer/Worlds/WorldLayer.Render.Hud.cs
+++ b/Core/Layer/Worlds/WorldLayer.Render.Hud.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using Helion.Geometry;
 using Helion.Geometry.Boxes;
 using Helion.Geometry.Vectors;
@@ -31,6 +29,8 @@ using Helion.World.Entities.Inventories.Powerups;
 using Helion.World.Entities.Players;
 using Helion.World.Geometry.Sectors;
 using Helion.World.StatusBar;
+using System;
+using System.Collections.Generic;
 using static Helion.Render.Common.RenderDimensions;
 
 namespace Helion.Layer.Worlds;
@@ -316,7 +316,7 @@ public partial class WorldLayer
         str.Clear();
         str.Append(prefix);
         str.Append("FPS: ");
-        str.Append($"{(int)Math.Round(fps),5:#####}");
+        str.Append($"{Math.Min((int)Math.Round(fps), 9999),4:####}");
 
         SetRenderableString(str.AsSpan(), renderableString, FixedNumberFont, m_infoFontSize, useDoomScale: false);
         hud.Text(renderableString, (-m_padding - m_hudPaddingX, y), both: Align.TopRight, alpha: m_hudAlpha);
@@ -422,9 +422,9 @@ public partial class WorldLayer
         if (colorMixUniforms.Sector != Vec3F.One)
             colorMix = colorMixUniforms.Sector;
 
-        Color lightLevelColor = ShaderVars.PaletteColorMode ? Color.White :            
-            ((byte)Math.Min(lightLevel * colorMix.X, 255), 
-            (byte)Math.Min(lightLevel * colorMix.Y, 255), 
+        Color lightLevelColor = ShaderVars.PaletteColorMode ? Color.White :
+            ((byte)Math.Min(lightLevel * colorMix.X, 255),
+            (byte)Math.Min(lightLevel * colorMix.Y, 255),
             (byte)Math.Min(lightLevel * colorMix.Z, 255));
 
         string sprite = GetHudWeaponSpriteString(frameState, flash);
@@ -813,7 +813,7 @@ public partial class WorldLayer
         if (!hud.Textures.TryGet(m_config.Hud.BackgroundTexture, out var backgroundHandle))
             return;
 
-        hud.DoomVirtualResolution(m_virtualStatusBarBackgroundAction, new HudStatusBarbackground(hud, barHandle, backgroundHandle), 
+        hud.DoomVirtualResolution(m_virtualStatusBarBackgroundAction, new HudStatusBarbackground(hud, barHandle, backgroundHandle),
             ResolutionScale.None);
     }
 
@@ -877,7 +877,7 @@ public partial class WorldLayer
 
     private void DrawFullHudWeaponSlots(IHudRenderContext hud)
     {
-        if (m_statusBarSizeType ==  StatusBarSizeType.Full)
+        if (m_statusBarSizeType == StatusBarSizeType.Full)
             HudImageWithOffset(hud, "STARMS", (104, 168), both: Align.TopLeft);
 
         for (int slot = 2; slot <= 7; slot++)
@@ -1074,7 +1074,7 @@ public partial class WorldLayer
 
     private int CalculateSlide(IHudRenderContext hud, long timeSinceMessage)
     {
-        const long SlideNanoRange = MaxVisibleTimeNanos - MessageTransitionSpan;        
+        const long SlideNanoRange = MaxVisibleTimeNanos - MessageTransitionSpan;
         if (timeSinceMessage < SlideNanoRange)
             return 0;
 

--- a/Core/Layer/Worlds/WorldLayer.Render.Hud.cs
+++ b/Core/Layer/Worlds/WorldLayer.Render.Hud.cs
@@ -51,7 +51,7 @@ public partial class WorldLayer
     private static readonly Color DamageColor = (255, 0, 0);
     private const string SmallHudFont = Constants.Fonts.Small;
     private const string LargeHudFont = Constants.Fonts.LargeHud;
-    private const string ConsoleFont = Constants.Fonts.Console;
+    private const string FixedNumberFont = Constants.Fonts.SmallGrayFixedWidthNumbers;
     private int m_fontHeight = 16;
     private int m_padding = 4;
     private int m_hudPaddingX = 0;
@@ -216,14 +216,14 @@ public partial class WorldLayer
             StatValues[2] = AppendStatString(m_secretString, World.LevelStats.SecretCount, World.LevelStats.TotalSecrets);
 
             for (int i = 0; i < RenderableStatLabels.Length; i++)
-                RenderableStatLabels[i] = SetRenderableString(StatLabels[i], RenderableStatLabels[i], ConsoleFont, m_infoFontSize, 
+                RenderableStatLabels[i] = SetRenderableString(StatLabels[i], RenderableStatLabels[i], FixedNumberFont, m_infoFontSize,
                     useDoomScale: false);
 
-            RenderableStatValues[0] = SetRenderableString(m_killString.AsSpan(), m_renderKillString, ConsoleFont, m_infoFontSize,
+            RenderableStatValues[0] = SetRenderableString(m_killString.AsSpan(), m_renderKillString, FixedNumberFont, m_infoFontSize,
                 GetStatColor(World.LevelStats.KillCount, World.LevelStats.TotalMonsters), useDoomScale: false);
-            RenderableStatValues[1] = SetRenderableString(m_itemString.AsSpan(), m_renderItemString, ConsoleFont, m_infoFontSize,
+            RenderableStatValues[1] = SetRenderableString(m_itemString.AsSpan(), m_renderItemString, FixedNumberFont, m_infoFontSize,
                 GetStatColor(World.LevelStats.ItemCount, World.LevelStats.TotalItems), useDoomScale: false);
-            RenderableStatValues[2] = SetRenderableString(m_secretString.AsSpan(), m_renderSecretString, ConsoleFont, m_infoFontSize,
+            RenderableStatValues[2] = SetRenderableString(m_secretString.AsSpan(), m_renderSecretString, FixedNumberFont, m_infoFontSize,
                 GetStatColor(World.LevelStats.SecretCount, World.LevelStats.TotalSecrets), useDoomScale: false);
         }
 
@@ -261,7 +261,7 @@ public partial class WorldLayer
             m_timeString.Append(':');
             m_timeString.Append(ts.Seconds, 2);
 
-            SetRenderableString(m_timeString.AsSpan(), m_renderTimeString, ConsoleFont, m_infoFontSize, useDoomScale: false);
+            SetRenderableString(m_timeString.AsSpan(), m_renderTimeString, FixedNumberFont, m_infoFontSize, useDoomScale: false);
         }
 
         hud.Text(m_renderTimeString, labelPos, both: align, alpha: m_hudAlpha);
@@ -296,7 +296,7 @@ public partial class WorldLayer
 
     private void DrawFPS(IHudRenderContext hud, ref int topRightY)
     {
-        if (!m_config.Hud.ShowFPS && !m_config.Hud.ShowMinMaxFPS)   
+        if (!m_config.Hud.ShowFPS && !m_config.Hud.ShowMinMaxFPS)
             return;
 
         if (m_config.Hud.ShowFPS)
@@ -316,9 +316,9 @@ public partial class WorldLayer
         str.Clear();
         str.Append(prefix);
         str.Append("FPS: ");
-        str.Append((int)Math.Round(fps));
+        str.Append($"{(int)Math.Round(fps),5:#####}");
 
-        SetRenderableString(str.AsSpan(), renderableString, ConsoleFont, m_infoFontSize, useDoomScale: false);
+        SetRenderableString(str.AsSpan(), renderableString, FixedNumberFont, m_infoFontSize, useDoomScale: false);
         hud.Text(renderableString, (-m_padding - m_hudPaddingX, y), both: Align.TopRight, alpha: m_hudAlpha);
 
         y += renderableString.DrawArea.Height + FpsMessageSpacing;
@@ -339,7 +339,7 @@ public partial class WorldLayer
 
     void DrawCoordinate(IHudRenderContext hud, char axis, double position, ref int y)
     {
-        hud.Text($"{axis}: {Math.Floor(position * 10000)/10000}", ConsoleFont, m_infoFontSize,
+        hud.Text($"{axis}: {Math.Floor(position * 10000) / 10000,9:#####.000}", FixedNumberFont, m_infoFontSize,
             (-m_padding - m_hudPaddingX, y), out Dimension area, TextAlign.Right, both: Align.TopRight,
             color: Color.White, alpha: m_hudAlpha);
         y += area.Height + FpsMessageSpacing;

--- a/Core/Resources/Definitions/Fonts/Definition/FontDefinition.cs
+++ b/Core/Resources/Definitions/Fonts/Definition/FontDefinition.cs
@@ -19,6 +19,7 @@ public class FontDefinition
     public int? FixedWidth;
     public int? FixedHeight;
     public char? FixedWidthChar;
+    public char? FixedWidthNumber;
     public FontAlignment Alignment = FontAlignment.Bottom;
 
     public FontDefinition(string name)

--- a/Core/Resources/Definitions/Fonts/Definition/FontDefinitionParser.cs
+++ b/Core/Resources/Definitions/Fonts/Definition/FontDefinitionParser.cs
@@ -17,6 +17,8 @@ namespace Helion.Resources.Definitions.Fonts.Definition;
 /// ALIGNCHAR = "align" POSITION
 /// CHARDEF: STRING STRING ["default"] [ALIGNCHAR] ";"
 /// CHARACTERS: "characters" "{" CHARDEF "}"
+/// FIXEDWIDTHCHAR: "fixedwidthchar" "=" STRING ";"
+/// FIXEDWIDTHNUMBER: "fixedwidthnumber" "=" STRING ";"
 /// FONTDEF: ALIGN | SPACING | GRAYSCALE | CHARACTERS
 /// FONT: "font" IDENTIFIER "{" FONTDEF* "}"
 /// </code>
@@ -132,6 +134,13 @@ public class FontDefinitionParser : ParserBase
         Consume(';');
     }
 
+    private void ConsumeFixedWidthNumber()
+    {
+        Consume('=');
+        CurrentDefinition.FixedWidthNumber = ConsumeString()[0];
+        Consume(';');
+    }
+
     private void ConsumeFixedHeight()
     {
         Consume('=');
@@ -174,6 +183,9 @@ public class FontDefinitionParser : ParserBase
                 break;
             case "FIXEDWIDTHCHAR":
                 ConsumeFixedWidthChar();
+                break;
+            case "FIXEDWIDTHNUMBER":
+                ConsumeFixedWidthNumber();
                 break;
             case "USEOFFSET":
                 ConsumeUseOffset();

--- a/Core/Util/Constants.cs
+++ b/Core/Util/Constants.cs
@@ -168,6 +168,8 @@ public static class Constants
         public const string SmallGray = "SmallFontGrayscale";
         public const string LargeHud = "LargeHudFont";
         public const string Console = "Console";
+        public const string SmallGrayFixedWidthNumbers = "SmallFontGrayscaleFixedWidthNumbers";
+        public const string VGA = "flexi-ibm-vga-true.regular";
     };
 
     public static class LightBuffer


### PR DESCRIPTION
Create a new bitmap font where the `+- 0123456789` chars are monospace.  Use this to render the stats.