### PR TITLE
Extend effective volume range

### DIFF
--- a/Client/Client.Config.cs
+++ b/Client/Client.Config.cs
@@ -13,7 +13,6 @@ public partial class Client
     {
         m_config.Audio.MusicVolume.OnChanged += MusicVolume_OnChanged;
         m_config.Audio.SoundVolume.OnChanged += SoundVolume_OnChanged;
-        m_config.Audio.Volume.OnChanged += Volume_OnChanged;
         m_config.Audio.SoundFontFile.OnChanged += SoundFont_OnChanged;
         m_config.Audio.Synthesizer.OnChanged += this.UseOPLEmulation_OnChanged;
 
@@ -97,8 +96,7 @@ public partial class Client
 
     private void UpdateVolume()
     {
-        var soundVolume = m_config.Audio.SoundVolume * m_config.Audio.Volume;
-        m_audioSystem.SetVolume(soundVolume);
+        m_audioSystem.SetVolume(m_config.Audio.SoundVolume);
         m_audioSystem.Music.SetVolume((float)m_config.Audio.MusicVolumeNormalized);
     }
 

--- a/Core/Audio/Impl/OpenALAudioSystem.cs
+++ b/Core/Audio/Impl/OpenALAudioSystem.cs
@@ -167,7 +167,7 @@ public class OpenALAudioSystem : IAudioSystem
     {
         OpenALAudioSourceManager sourceManager = new(this, m_archiveCollection, m_config);
         m_sourceManagers.Add(sourceManager);
-        SetVolume(m_config.Audio.SoundVolume * m_config.Audio.Volume);
+        SetVolume(m_config.Audio.SoundVolume);
         return sourceManager;
     }
 

--- a/Core/Util/Configs/Components/ConfigAudio.cs
+++ b/Core/Util/Configs/Components/ConfigAudio.cs
@@ -8,16 +8,13 @@ namespace Helion.Util.Configs.Components;
 
 public class ConfigAudio
 {
-    [ConfigInfo("Music volume. 0.0 is Off, 1.0 is Maximum.")]
+    [ConfigInfo("Music volume. 0.0 is Off, 2.0 is Maximum.")]
     [OptionMenu(OptionSectionType.Audio, "Music Volume")]
-    public readonly ConfigValue<double> MusicVolume = new(1.0, ClampNormalized);
+    public readonly ConfigValue<double> MusicVolume = new(1.0, Clamp(0, 2.0));
 
-    [ConfigInfo("Sound effect volume. 0.0 is Off, 1.0 is Maximum.")]
+    [ConfigInfo("Sound effect volume. 0.0 is Off, 2.0 is Maximum.")]
     [OptionMenu(OptionSectionType.Audio, "Sound Volume")]
-    public readonly ConfigValue<double> SoundVolume = new(1.0, ClampNormalized);
-
-    [ConfigInfo("Overall volume. 0.0 is Off, 1.0 is Maximum.")]
-    public readonly ConfigValue<double> Volume = new(1.0, ClampNormalized);
+    public readonly ConfigValue<double> SoundVolume = new(1.0, Clamp(0, 2.0));
 
     [ConfigInfo("Enables sound velocity.")]
     [OptionMenu(OptionSectionType.Audio, "Sound Velocity", spacer: true)]
@@ -50,5 +47,6 @@ public class ConfigAudio
     [OptionMenu(OptionSectionType.Audio, "SoundFont File", dialogType: DialogType.SoundFontPicker)]
     public readonly ConfigValue<string> SoundFontFile = new($"SoundFonts{Path.DirectorySeparatorChar}Default.sf2");
 
-    public double MusicVolumeNormalized => (SoundVolume == 0 ? MusicVolume : (MusicVolume / SoundVolume)) * Volume;
+    // Music volume is treated as a multiple of sound effects volume, because effects volume controls the master gain.
+    public double MusicVolumeNormalized => SoundVolume == 0 ? MusicVolume : (MusicVolume / SoundVolume);
 }


### PR DESCRIPTION
As things stand a gain of 1.0 is a nice, reasonable default, but from what I can tell, neither music nor sound effects get anywhere _near_ the clipping limit in Windows' audio mixer.  In this change, I'm extending the max end of both ranges to 2.0.  I _could_ just modify the scaling, but that's inconsiderate to existing users.

I'm also removing the "master" audio setting, as that hasn't been exposed on the menu for a while and I'd expect people to be generally unaware of its existence.