### PR TITLE
ENDOOM improvements

### DIFF
--- a/Core/Layer/Endoom/EndoomLayer.cs
+++ b/Core/Layer/Endoom/EndoomLayer.cs
@@ -8,14 +8,7 @@
     using Helion.Util.Extensions;
     using Helion.Util.Timing;
     using Helion.Window;
-    using SixLabors.Fonts;
-    using SixLabors.ImageSharp;
-    using SixLabors.ImageSharp.Advanced;
-    using SixLabors.ImageSharp.Drawing.Processing;
-    using SixLabors.ImageSharp.PixelFormats;
-    using SixLabors.ImageSharp.Processing;
     using System;
-    using System.IO;
 
     public class EndoomLayer : IGameLayer
     {
@@ -35,24 +28,30 @@
         private readonly Action m_closeAction;
         private readonly ArchiveCollection m_archiveCollection;
 
-        private Graphics.Image? m_endoomImage1;
-        private Graphics.Image? m_endoomImage2;
+
         private IRenderableTextureHandle? m_texture1;
         private IRenderableTextureHandle? m_texture2;
         private Action? m_texture1Remove;
         private Action? m_texture2Remove;
 
+        private int m_pixelHeight;
         private bool m_disposed;
+
+        private TextScreen? m_endoomScreen;
+        private byte[]? m_fontBytes;
 
         public EndoomLayer(Action closeAction, ArchiveCollection archiveCollection, int height)
         {
             m_closeAction = closeAction;
             m_archiveCollection = archiveCollection;
+            m_pixelHeight = height;
 
-            ComputeImages(
-                m_archiveCollection.FindEntry(LUMPNAME)?.ReadData() ?? [],
-                m_archiveCollection.FindEntry(FONTNAME)?.ReadData() ?? [],
-                height);
+            byte[]? endoomData = m_archiveCollection.FindEntry(LUMPNAME)?.ReadData();
+            if (endoomData != null)
+            {
+                m_endoomScreen = new TextScreen(endoomData, ENDOOMROWS, ENDOOMCOLUMNS);
+                m_fontBytes = m_archiveCollection.FindEntry(FONTNAME)?.ReadData();
+            }
         }
 
         public void HandleInput(IConsumableInput input)
@@ -73,122 +72,32 @@
         {
             hud.Clear(Graphics.Color.Black);
 
-            if (m_endoomImage1 == null || m_endoomImage2 == null)
+            if (m_endoomScreen == null || m_fontBytes == null)
             {
+                // If we don't have anything to render, just bail out
                 m_closeAction();
-                return; // This may never actually get reached
-            }
-
-            if (m_texture1 == null)
-            {
-                m_texture1 = hud.CreateImage(m_endoomImage1, IMAGENAME1, Resources.ResourceNamespace.Textures, out m_texture1Remove);
-                m_texture2 = hud.CreateImage(m_endoomImage2, IMAGENAME2, Resources.ResourceNamespace.Textures, out m_texture2Remove);
-            }
-
-            _ = ((DateTime.Now.Millisecond / 500) == 0) // cycle 2x/second
-                ? hud.RenderFullscreenImage(IMAGENAME1, aspectRatioDivisor: 1f)
-                : hud.RenderFullscreenImage(IMAGENAME2, aspectRatioDivisor: 1f);
-        }
-
-        private void ComputeImages(byte[] endoomBytes, byte[] fontBytes, int height)
-        {
-            // In what might be one of the silliest performance regressions possible, we're emulating the ENDOOM screen,
-            // which was originally a sequence of bytes that could be copied directly to video memory, by rendering it
-            // into a bitmap.
-            if (endoomBytes.Length != ENDOOMBYTES)
-            {
-                // Not valid ENDOOM lump
                 return;
             }
 
-            byte[] textBytes = new byte[ENDOOMBYTES / 2];
-            byte[] colorBytes = new byte[ENDOOMBYTES / 2];
+            bool blinkPhase = ((DateTime.Now.Millisecond / 500) == 0) && m_endoomScreen.HasBlink; // cycle 2x/second IF there is something to blink
 
-            for (int i = 0; i < endoomBytes.Length; i += 2)
+            string textureName = blinkPhase ? IMAGENAME2 : IMAGENAME1;
+            ref IRenderableTextureHandle? handle = ref (blinkPhase ? ref m_texture2 : ref m_texture1);
+            ref Action? removeAction = ref (blinkPhase ? ref m_texture2Remove : ref m_texture2Remove);
+
+            EnsureTexture(hud, textureName, blinkPhase, ref handle, ref removeAction);
+            hud.RenderFullscreenImage(textureName, aspectRatioDivisor: 1f);
+        }
+
+        public void EnsureTexture(IHudRenderContext hud, string textureName, bool blink, ref IRenderableTextureHandle? handle, ref Action? removeAction)
+        {
+            if (handle != null)
             {
-                textBytes[i / 2] = endoomBytes[i];
-                colorBytes[i / 2] = endoomBytes[i + 1];
+                return;
             }
 
-            using (MemoryStream fontDataStream = new MemoryStream(fontBytes))
-            {
-                FontCollection fontCollection = new();
-                FontFamily consoleFontFamily = fontCollection.Add(fontDataStream);
-                Font consoleFont = consoleFontFamily.CreateFont(height / 25); // Use whatever pixel value gets us 25 lines
-                RichTextOptions textOptions = new(consoleFont);
-                // Assume we are using a monospace font, so all upper-case chars have the same effective dimensions.  
-                // We're intentionally going to pack characters just a little too close together, so that any "block" characters don't end up with 
-                // fine lines in between.
-                FontRectangle dimensions = TextMeasurer.MeasureAdvance("A", textOptions);
-                float charHeight = dimensions.Height - 1;
-                float charWidth = dimensions.Width - 1;
-
-                for (int imageCount = 0; imageCount < 2; imageCount++)
-                {
-                    float xOffset = 0, yOffset = 0;
-                    using (Image<Rgba32> endoomBitmap = new Image<Rgba32>((int)charWidth * ENDOOMCOLUMNS, height))
-                    {
-                        endoomBitmap.Mutate(ctx =>
-                        {
-                            for (int row = 0; row < ENDOOMROWS; row++)
-                            {
-                                xOffset = 0;
-                                for (int column = 0; column < ENDOOMCOLUMNS; column++)
-                                {
-                                    byte colorByte = colorBytes[(row * ENDOOMCOLUMNS) + column];
-                                    byte blink = (byte)(colorByte >> 7);
-                                    Color backColor = Conversions.TextColors[(byte)((byte)(colorByte << 1) >> 5)]; // Bits 4-6 (discard 7)
-                                    Color foreColor = blink == 0 || imageCount == 0
-                                        ? Conversions.TextColors[(byte)((byte)(colorByte << 4) >> 4)] // Bits 0-3
-                                        : backColor;
-
-                                    ctx.FillPolygon(
-                                        backColor,
-                                        new PointF(xOffset, yOffset),
-                                        new PointF(xOffset + charWidth, yOffset),
-                                        new PointF(xOffset + charWidth, yOffset + charHeight),
-                                        new PointF(xOffset, yOffset + charHeight));
-
-                                    ctx.DrawText(
-                                        $"{Convert.ToChar(Conversions.UnicodeByteMappings[textBytes[(row * ENDOOMCOLUMNS) + column]])}",
-                                        consoleFont,
-                                        foreColor,
-                                        new PointF() { X = xOffset, Y = yOffset });
-                                    xOffset += charWidth;
-                                }
-                                yOffset += charHeight;
-                            }
-                        });
-
-
-                        byte[] argbData = new byte[endoomBitmap.Height * endoomBitmap.Width * 4];
-                        int offset = 0;
-                        for (int y = 0; y < endoomBitmap.Height; y++)
-                        {
-                            Span<Rgba32> pixelRow = endoomBitmap.DangerousGetPixelRowMemory(y).Span;
-                            foreach (ref Rgba32 pixel in pixelRow)
-                            {
-                                argbData[offset] = pixel.A;
-                                argbData[offset + 1] = pixel.R;
-                                argbData[offset + 2] = pixel.G;
-                                argbData[offset + 3] = pixel.B;
-                                offset += 4;
-                            }
-                        }
-
-                        Graphics.Image? convertedImage = Graphics.Image.FromArgbBytes((endoomBitmap.Width, endoomBitmap.Height), argbData);
-
-                        if (imageCount == 0)
-                        {
-                            m_endoomImage1 = convertedImage;
-                        }
-                        else
-                        {
-                            m_endoomImage2 = convertedImage;
-                        }
-                    }
-                }
-            }
+            Graphics.Image image = m_endoomScreen!.GenerateImage(m_fontBytes!, m_pixelHeight, blink);
+            handle = hud.CreateImage(image, textureName, Resources.ResourceNamespace.Textures, out m_texture1Remove);
         }
 
         protected virtual void Dispose(bool disposing)
@@ -197,8 +106,6 @@
             {
                 if (disposing)
                 {
-                    m_endoomImage1 = null;
-                    m_endoomImage2 = null;
                     m_texture1Remove?.Invoke();
                     m_texture2Remove?.Invoke();
                     (m_texture1 as GLTexture)?.Dispose();

--- a/Core/Layer/Endoom/EndoomLayer.cs
+++ b/Core/Layer/Endoom/EndoomLayer.cs
@@ -44,7 +44,13 @@
         {
             m_closeAction = closeAction;
             m_archiveCollection = archiveCollection;
-            m_pixelHeight = height;
+
+            // Find an integer scale for pixel height that keeps the render at or under 1080 px tall.  Rendering text to image is VERY slow.
+            for (int scaleFactor = 1; m_pixelHeight == 0; scaleFactor++)
+            {
+                int scaled = height / scaleFactor;
+                m_pixelHeight = scaled <= 1080 ? scaled : 0;
+            }
 
             byte[]? endoomData = m_archiveCollection.FindEntry(LUMPNAME)?.ReadData();
             if (endoomData != null)

--- a/Core/Layer/Endoom/TextScreen.cs
+++ b/Core/Layer/Endoom/TextScreen.cs
@@ -22,30 +22,36 @@
         // This value indicates whether there are any blinking characters in this text screen
         public readonly bool HasBlink;
 
-        public TextScreen(byte[] screenData, int height, int width)
+        /// <summary>
+        /// Represents a screen full of double-byte (color plus character) characters, similar to an 80x25 console text buffer
+        /// </summary>
+        /// <param name="screenData">Raw byte data for the screen</param>
+        /// <param name="rows">Number of rows in the screen</param>
+        /// <param name="columns">Number of columns in the screen</param>
+        /// <exception cref="Exception">Thrown if the number of bytes does not match 2 * rows * columns</exception>
+        public TextScreen(byte[] screenData, int rows, int columns)
         {
-            if (!(screenData.Length >= height * width * 2))
+            if (!(screenData.Length >= rows * columns * 2))
             {
                 throw new Exception("Text screen data must contain at least (height * width * 2) bytes");
             }
 
-            m_height = height;
-            m_width = width;
+            m_height = rows;
+            m_width = columns;
 
-            m_backgroundColors = new Color[height * width];
-            m_foregroundColors = new Color[height * width];
-            m_characters = new char[height * width];
-            m_blink = new bool[height * width];
+            m_backgroundColors = new Color[rows * columns];
+            m_foregroundColors = new Color[rows * columns];
+            m_characters = new char[rows * columns];
+            m_blink = new bool[rows * columns];
 
-
-            for (int index = 0; index < height * width; index++)
+            for (int index = 0; index < rows * columns; index++)
             {
                 byte textByte = screenData[index * 2];
                 byte colorByte = screenData[index * 2 + 1];
 
                 byte blink = (byte)(colorByte >> 7);
                 Color backColor = Conversions.TextColors[(byte)((byte)(colorByte << 1) >> 5)]; // Bits 4-6 (discard 7)
-                Color foreColor = Conversions.TextColors[(byte)((byte)(colorByte << 4) >> 4)]; // Bits 0-3                    
+                Color foreColor = Conversions.TextColors[(byte)((byte)(colorByte << 4) >> 4)]; // Bits 0-3              
 
                 m_characters[index] = Convert.ToChar(Conversions.UnicodeByteMappings[textByte]);
                 m_foregroundColors[index] = foreColor;
@@ -56,73 +62,83 @@
             }
         }
 
-        public Graphics.Image GenerateImage(byte[] fontData, int pixelHeight, bool blink)
+        /// <summary>
+        /// Generate an ARGB(8,8,8,8) image from this text buffer
+        /// </summary>
+        /// <param name="fontData">Byte data for a TrueType font to render the text with.  Monospace strongly recommended.</param>
+        /// <param name="pixelHeight">Desired height for the output</param>
+        /// <param name="blinkOn">If True, then characters marked with "blink" will show background color only in this image</param>
+        /// <returns>A rendering of this text buffer</returns>
+        public Graphics.Image GenerateImage(byte[] fontData, int pixelHeight, bool blinkOn)
         {
+            Font? consoleFont = null;
+
             using (MemoryStream fontDataStream = new MemoryStream(fontData))
             {
                 FontCollection fontCollection = new();
                 FontFamily consoleFontFamily = fontCollection.Add(fontDataStream);
-                Font consoleFont = consoleFontFamily.CreateFont(pixelHeight / m_height); // Use whatever pixel value fits all the lines
-                RichTextOptions textOptions = new(consoleFont);
-                // Assume we are using a monospace font, so all upper-case chars have the same effective dimensions.  
-                // We're intentionally going to pack characters just a little too close together, so that any "block" characters don't end up with 
-                // fine lines in between.
-                FontRectangle dimensions = TextMeasurer.MeasureAdvance("A", textOptions);
-                float charHeight = dimensions.Height - 1;
-                float charWidth = dimensions.Width - 1;
+                consoleFont = consoleFontFamily.CreateFont(pixelHeight / m_height); // Use whatever pixel value fits all the lines
+            }
 
-                float xOffset = 0, yOffset = 0;
-                using (Image<Argb32> bitmap = new Image<Argb32>((int)charWidth * m_width, pixelHeight))
+            RichTextOptions textOptions = new(consoleFont);
+            // Assume we are using a monospace font, so all upper-case chars have the same effective dimensions.  
+            // We're intentionally going to pack characters just a little too close together, so that any "block" characters don't end up with 
+            // fine lines in between.
+            FontRectangle dimensions = TextMeasurer.MeasureAdvance("A", textOptions);
+            float charHeight = dimensions.Height - 1;
+            float charWidth = dimensions.Width - 1;
+
+            float xOffset = 0, yOffset = 0;
+            using (Image<Argb32> bitmap = new Image<Argb32>((int)charWidth * m_width, pixelHeight))
+            {
+                bitmap.Mutate(ctx =>
                 {
-                    bitmap.Mutate(ctx =>
+                    int index = 0;
+                    for (int row = 0; row < m_height; row++)
                     {
-                        int index = 0;
-                        for (int row = 0; row < m_height; row++)
+                        xOffset = 0;
+                        for (int column = 0; column < m_width; column++)
                         {
-                            xOffset = 0;
-                            for (int column = 0; column < m_width; column++)
+                            Color foregroundColor = m_foregroundColors[index];
+                            Color backgroundColor = m_backgroundColors[index];
+                            char textCharacter = m_characters[index];
+                            bool characterBlinking = m_blink[index];
+
+                            ctx.FillPolygon(
+                                backgroundColor,
+                                new PointF(xOffset, yOffset),
+                                new PointF(xOffset + charWidth, yOffset),
+                                new PointF(xOffset + charWidth, yOffset + charHeight),
+                                new PointF(xOffset, yOffset + charHeight));
+
+                            if (!(characterBlinking && blinkOn))
                             {
-                                Color foregroundColor = m_foregroundColors[index];
-                                Color backgroundColor = m_backgroundColors[index];
-                                char textCharacter = m_characters[index];
-                                bool characterBlinking = m_blink[index];
-
-                                ctx.FillPolygon(
-                                    backgroundColor,
-                                    new PointF(xOffset, yOffset),
-                                    new PointF(xOffset + charWidth, yOffset),
-                                    new PointF(xOffset + charWidth, yOffset + charHeight),
-                                    new PointF(xOffset, yOffset + charHeight));
-
-                                if (!(characterBlinking && blink))
-                                {
-                                    ctx.DrawText($"{textCharacter}", consoleFont, foregroundColor, new PointF() { X = xOffset, Y = yOffset });
-                                }
-                                xOffset += charWidth;
-
-                                index++;
+                                ctx.DrawText($"{textCharacter}", consoleFont, foregroundColor, new PointF() { X = xOffset, Y = yOffset });
                             }
-                            yOffset += charHeight;
-                        }
-                    });
+                            xOffset += charWidth;
 
-                    byte[] argbData = new byte[bitmap.Height * bitmap.Width * 4];
-                    int offset = 0;
-                    for (int y = 0; y < bitmap.Height; y++)
-                    {
-                        Span<Argb32> pixelRow = bitmap.DangerousGetPixelRowMemory(y).Span;
-                        foreach (ref Argb32 pixel in pixelRow)
-                        {
-                            argbData[offset] = pixel.A;
-                            argbData[offset + 1] = pixel.R;
-                            argbData[offset + 2] = pixel.G;
-                            argbData[offset + 3] = pixel.B;
-                            offset += 4;
+                            index++;
                         }
+                        yOffset += charHeight;
                     }
+                });
 
-                    return Graphics.Image.FromArgbBytes((bitmap.Width, bitmap.Height), argbData)!;
+                byte[] argbData = new byte[bitmap.Height * bitmap.Width * 4];
+                int offset = 0;
+                for (int y = 0; y < bitmap.Height; y++)
+                {
+                    Span<Argb32> pixelRow = bitmap.DangerousGetPixelRowMemory(y).Span;
+                    foreach (ref Argb32 pixel in pixelRow)
+                    {
+                        argbData[offset] = pixel.A;
+                        argbData[offset + 1] = pixel.R;
+                        argbData[offset + 2] = pixel.G;
+                        argbData[offset + 3] = pixel.B;
+                        offset += 4;
+                    }
                 }
+
+                return Graphics.Image.FromArgbBytes((bitmap.Width, bitmap.Height), argbData)!;
             }
         }
     }

--- a/Core/Layer/Endoom/TextScreen.cs
+++ b/Core/Layer/Endoom/TextScreen.cs
@@ -1,0 +1,129 @@
+﻿namespace Helion.Layer.Endoom
+{
+    using SixLabors.Fonts;
+    using SixLabors.ImageSharp;
+    using SixLabors.ImageSharp.Advanced;
+    using SixLabors.ImageSharp.Drawing.Processing;
+    using SixLabors.ImageSharp.PixelFormats;
+    using SixLabors.ImageSharp.Processing;
+    using System;
+    using System.IO;
+
+    public class TextScreen
+    {
+        private int m_height;
+        private int m_width;
+
+        private Color[] m_backgroundColors;
+        private Color[] m_foregroundColors;
+        private char[] m_characters;
+        private bool[] m_blink;
+
+        // This value indicates whether there are any blinking characters in this text screen
+        public readonly bool HasBlink;
+
+        public TextScreen(byte[] screenData, int height, int width)
+        {
+            if (!(screenData.Length >= height * width * 2))
+            {
+                throw new Exception("Text screen data must contain at least (height * width * 2) bytes");
+            }
+
+            m_height = height;
+            m_width = width;
+
+            m_backgroundColors = new Color[height * width];
+            m_foregroundColors = new Color[height * width];
+            m_characters = new char[height * width];
+            m_blink = new bool[height * width];
+
+
+            for (int index = 0; index < height * width; index++)
+            {
+                byte textByte = screenData[index * 2];
+                byte colorByte = screenData[index * 2 + 1];
+
+                byte blink = (byte)(colorByte >> 7);
+                Color backColor = Conversions.TextColors[(byte)((byte)(colorByte << 1) >> 5)]; // Bits 4-6 (discard 7)
+                Color foreColor = Conversions.TextColors[(byte)((byte)(colorByte << 4) >> 4)]; // Bits 0-3                    
+
+                m_characters[index] = Convert.ToChar(Conversions.UnicodeByteMappings[textByte]);
+                m_foregroundColors[index] = foreColor;
+                m_backgroundColors[index] = backColor;
+                m_blink[index] = blink != 0;
+
+                HasBlink |= (blink != 0);
+            }
+        }
+
+        public Graphics.Image GenerateImage(byte[] fontData, int pixelHeight, bool blink)
+        {
+            using (MemoryStream fontDataStream = new MemoryStream(fontData))
+            {
+                FontCollection fontCollection = new();
+                FontFamily consoleFontFamily = fontCollection.Add(fontDataStream);
+                Font consoleFont = consoleFontFamily.CreateFont(pixelHeight / m_height); // Use whatever pixel value fits all the lines
+                RichTextOptions textOptions = new(consoleFont);
+                // Assume we are using a monospace font, so all upper-case chars have the same effective dimensions.  
+                // We're intentionally going to pack characters just a little too close together, so that any "block" characters don't end up with 
+                // fine lines in between.
+                FontRectangle dimensions = TextMeasurer.MeasureAdvance("A", textOptions);
+                float charHeight = dimensions.Height - 1;
+                float charWidth = dimensions.Width - 1;
+
+                float xOffset = 0, yOffset = 0;
+                using (Image<Argb32> bitmap = new Image<Argb32>((int)charWidth * m_width, pixelHeight))
+                {
+                    bitmap.Mutate(ctx =>
+                    {
+                        int index = 0;
+                        for (int row = 0; row < m_height; row++)
+                        {
+                            xOffset = 0;
+                            for (int column = 0; column < m_width; column++)
+                            {
+                                Color foregroundColor = m_foregroundColors[index];
+                                Color backgroundColor = m_backgroundColors[index];
+                                char textCharacter = m_characters[index];
+                                bool characterBlinking = m_blink[index];
+
+                                ctx.FillPolygon(
+                                    backgroundColor,
+                                    new PointF(xOffset, yOffset),
+                                    new PointF(xOffset + charWidth, yOffset),
+                                    new PointF(xOffset + charWidth, yOffset + charHeight),
+                                    new PointF(xOffset, yOffset + charHeight));
+
+                                if (!(characterBlinking && blink))
+                                {
+                                    ctx.DrawText($"{textCharacter}", consoleFont, foregroundColor, new PointF() { X = xOffset, Y = yOffset });
+                                }
+                                xOffset += charWidth;
+
+                                index++;
+                            }
+                            yOffset += charHeight;
+                        }
+                    });
+
+                    byte[] argbData = new byte[bitmap.Height * bitmap.Width * 4];
+                    int offset = 0;
+                    for (int y = 0; y < bitmap.Height; y++)
+                    {
+                        Span<Argb32> pixelRow = bitmap.DangerousGetPixelRowMemory(y).Span;
+                        foreach (ref Argb32 pixel in pixelRow)
+                        {
+                            argbData[offset] = pixel.A;
+                            argbData[offset + 1] = pixel.R;
+                            argbData[offset + 2] = pixel.G;
+                            argbData[offset + 3] = pixel.B;
+                            offset += 4;
+                        }
+                    }
+
+                    return Graphics.Image.FromArgbBytes((bitmap.Width, bitmap.Height), argbData)!;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
1. Add integer scaling to ensure that rendered ENDOOM output is no more than 1080px high
2. Render ENDOOM one frame at a time, rather than pre-rendering both frames
3. Only treat ENDOOM as having two frames if the "blink" feature is used for any of the chars

These changes are designed to slightly reduce the perceived lag in rendering the ENDOOM screen on quit.  Unfortunately, it is always going to be kind of slow, because we are using some pretty heavyweight image manipulation methods to render what SHOULD be a text screen.

I would have preferred to implement ENDOOM as a text screen, but Windows doesn't really give us a good way to create a console/terminal in a windowed, graphical application.  There are ways to do it, but we'd need different entire P/Invoke-based code paths for Windows and Linux.