### PR TITLE
fix automap not consuming key presses

### DIFF
--- a/Core/Layer/Worlds/WorldLayer.Input.cs
+++ b/Core/Layer/Worlds/WorldLayer.Input.cs
@@ -157,23 +157,23 @@ public partial class WorldLayer
     private void HandleAutoMapInput(IConsumableInput input)
     {
         int scrollAmount = 0;
-        if (IsCommandContinuousHold(Constants.Input.AutoMapDecrease, input, out scrollAmount))
+        if (IsCommandContinuousHold(Input.AutoMapDecrease, input, out scrollAmount))
             ChangeAutoMapSize(GetChangeAmount(input, -1, scrollAmount));
-        else if (IsCommandContinuousHold(Constants.Input.AutoMapIncrease, input, out scrollAmount))
+        else if (IsCommandContinuousHold(Input.AutoMapIncrease, input, out scrollAmount))
             ChangeAutoMapSize(GetChangeAmount(input, 1, scrollAmount));
-        else if (IsCommandContinuousHold(Constants.Input.AutoMapUp, input))
+        else if (IsCommandContinuousHold(Input.AutoMapUp, input))
             ChangeAutoMapOffsetY(true);
-        else if (IsCommandContinuousHold(Constants.Input.AutoMapDown, input))
+        else if (IsCommandContinuousHold(Input.AutoMapDown, input))
             ChangeAutoMapOffsetY(false);
-        else if (IsCommandContinuousHold(Constants.Input.AutoMapRight, input))
+        else if (IsCommandContinuousHold(Input.AutoMapRight, input))
             ChangeAutoMapOffsetX(true);
-        else if (IsCommandContinuousHold(Constants.Input.AutoMapLeft, input))
+        else if (IsCommandContinuousHold(Input.AutoMapLeft, input))
             ChangeAutoMapOffsetX(false);
-        else if (IsCommandPressed(Constants.Input.AutoMapAddMarker, input))
+        else if (IsCommandPressed(Input.AutoMapAddMarker, input))
             m_console.SubmitInputText("mark.add");
-        else if (IsCommandPressed(Constants.Input.AutoMapRemoveNearbyMarkers, input))
+        else if (IsCommandPressed(Input.AutoMapRemoveNearbyMarkers, input))
             m_console.SubmitInputText("mark.remove");
-        else if (IsCommandPressed(Constants.Input.AutoMapClearAllMarkers, input))
+        else if (IsCommandPressed(Input.AutoMapClearAllMarkers, input))
             m_console.SubmitInputText("mark.clear");
     }
 

--- a/Core/Util/Configs/Impl/ConfigKeyMapping.cs
+++ b/Core/Util/Configs/Impl/ConfigKeyMapping.cs
@@ -220,7 +220,7 @@ public class ConfigKeyMapping : IConfigKeyMapping
             if (!cmd.Command.Equals(command, StringComparison.OrdinalIgnoreCase))
                 continue;
 
-            if (input.ConsumeKeyPressed(cmd.Key) || input.Manager.IsKeyContinuousHold(cmd.Key))
+            if (input.ConsumePressOrContinuousHold(cmd.Key))
                 return true;
 
             if (ConsumeMouseWheel(cmd.Key, input, out scrollAmount))

--- a/Core/Window/Input/ConsumableInput.cs
+++ b/Core/Window/Input/ConsumableInput.cs
@@ -67,10 +67,16 @@ public class ConsumableInput : IConsumableInput
 
     public bool ConsumePressOrContinuousHold(Key key)
     {
-        if (Manager.IsKeyDown(key) && Manager.IsKeyContinuousHold(key))
-            return true;
+        if (Manager.IsKeyDown(key))
+        {
+            bool hold = Manager.IsKeyContinuousHold(key);
+            bool consumed = ConsumeKeyPressed(key);
+            if (!consumed)
+                m_inputDownConsumed.Add(key);
+            return consumed || hold;
+        }
 
-        return ConsumeKeyPressed(key);
+        return false;
     }
 
     public ReadOnlySpan<char> ConsumeTypedCharacters()


### PR DESCRIPTION
use input.ConsumePressOrContinuousHold
fix ConsumePressOrContinuousHold to always consume the key even if the hold doesn't fire a press event

fixes #810 