### PR TITLE
Vanilla render fixes

### DIFF
--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
@@ -20,7 +20,6 @@ using System.Collections.Generic;
 using OpenTK.Graphics.OpenGL;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using Helion.Render.OpenGL.Renderers.Legacy.World.Shader;
 
 namespace Helion.Render.OpenGL.Renderers.Legacy.World.Geometry.Static;
 
@@ -107,7 +106,7 @@ public class StaticCacheGeometryRenderer : IDisposable
             m_coverWallGeometryOneSided = AllocateGeometryData(GeometryType.Wall, textureIndex,
                 repeat: true, addToGeometry: false, world.Lines.Count * WallVertices, overrideTexture: texture);
             m_coverFlatGeometry = AllocateGeometryData(GeometryType.Flat, textureIndex,
-                repeat: true, addToGeometry: true, overrideTexture: texture);
+                repeat: true, addToGeometry: false, overrideTexture: texture);
         }
 
         for (int i = 0; i < world.Sectors.Count; i++)

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -297,6 +297,7 @@ public class LegacyWorldRenderer : WorldRenderer
         SetStaticUniforms(renderInfo);
         m_geometryRenderer.RenderStaticGeometryWalls();
         m_geometryRenderer.RenderStaticGeometryFlats();
+        RenderTwoSidedMiddleWalls(renderInfo);
 
         GL.Clear(ClearBufferMask.DepthBufferBit);
         GL.ColorMask(false, false, false, false);
@@ -312,17 +313,11 @@ public class LegacyWorldRenderer : WorldRenderer
         m_staticProgram.Bind();
         GL.ActiveTexture(TextureUnit.Texture0);
         m_geometryRenderer.RenderStaticOneSidedCoverWalls();
+        RenderTwoSidedMiddleWalls(renderInfo);
         GL.ColorMask(true, true, true, true);
 
         m_entityRenderer.RenderNonAlpha(renderInfo);
         m_entityRenderer.RenderAlpha(renderInfo);
-
-        // Draw flats to depth buffer so two-sided middle walls won't bleed through flats
-        GL.ColorMask(false, false, false, false);
-        RenderFlats(renderInfo);
-        GL.ColorMask(true, true, true, true);
-
-        RenderTwoSidedMiddleWalls(renderInfo);
 
         m_interpolationProgram.Bind();
         GL.ActiveTexture(TextureUnit.Texture0);

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -61,3 +61,5 @@
   - Fix MAPINFO/ZMAPINFO defaultmap clearing properties (fixes Eviternity MAP30 endgame sequence)
   - Fix clicking/popping noises in WAV audio files (credit: sinshu)
   - Fix A_KeenDie to call A_Fall (fixes blocking alien eggs in Tricking & Tearing at Warpspeed MAP05)
+  - Fix transfer heights flats not rendering with emulate vanilla rendering
+  - Fix transparent sprites discarding two-sided middle walls with emulate vanilla rendering


### PR DESCRIPTION
fix ordering so that two-sided middle walls are not discarded
do not add cover flat geometry to the main list

fixes #812 