### PR TITLE
Implement xBRZ text upscaling

### DIFF
--- a/Client/Client.Commands.cs
+++ b/Client/Client.Commands.cs
@@ -939,7 +939,7 @@ public partial class Client
             PrepareTransition();
             PlayTransition();
             IntermissionLayer intermissionLayer = new(m_layerManager, world, m_config.Keys, m_soundManager,
-                m_audioSystem.Music, world.MapInfo, getNextMapInfo);
+                m_audioSystem.Music, world.MapInfo, getNextMapInfo, m_config.Hud.FontUpscalingFactor);
             intermissionLayer.Exited += IntermissionLayer_Exited;
             m_layerManager.Add(intermissionLayer);
         }

--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="OpenTK.Windowing.Common" Version="4.7.4" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.4" />
     <PackageReference Include="TextCopy" Version="6.2.1" />
+    <PackageReference Include="xBRZNet" Version="1.2.0" />
     <PackageReference Include="zdbspSharp" Version="1.0.3" />
   </ItemGroup>
 </Project>

--- a/Core/Graphics/Fonts/Font.cs
+++ b/Core/Graphics/Fonts/Font.cs
@@ -1,8 +1,7 @@
+using Helion.Util.Extensions;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using Helion.Util.Extensions;
-using static Helion.Util.Assertion.Assert;
 
 namespace Helion.Graphics.Fonts;
 
@@ -17,6 +16,7 @@ public class Font : IEnumerable<(char, Glyph)>
     public readonly int MaxHeight;
     public readonly int? FixedWidth;
     public readonly int? FixedHeight;
+    public readonly int UpscalingFactor;
     public readonly Glyph? FixedWidthChar;
     public readonly Glyph? FixedWidthNumber;
     public readonly Image Image;
@@ -25,7 +25,7 @@ public class Font : IEnumerable<(char, Glyph)>
     private readonly Glyph m_defaultGlyph;
 
     public Font(string name, Dictionary<char, Glyph> glyphs, Image image, char defaultChar = DefaultChar,
-        bool isTrueTypeFont = false, int? fixedWidth = null, int? fixedHeight = null, char? fixedWidthChar = null, char? fixedWidthNumber = null)
+        bool isTrueTypeFont = false, int? fixedWidth = null, int? fixedHeight = null, char? fixedWidthChar = null, int upscalingFactor = 1, char? fixedWidthNumber = null)
     {
         Name = name;
         m_glyphs = glyphs;
@@ -36,6 +36,8 @@ public class Font : IEnumerable<(char, Glyph)>
 
         if (!glyphs.TryGetValue(defaultChar, out m_defaultGlyph))
             m_defaultGlyph = glyphs.Values.FirstOrDefault();
+
+        UpscalingFactor = upscalingFactor;
 
         FixedWidth = fixedWidth;
         FixedHeight = fixedHeight;

--- a/Core/Layer/Intermission/IntermissionLayer.Render.cs
+++ b/Core/Layer/Intermission/IntermissionLayer.Render.cs
@@ -139,22 +139,22 @@ public partial class IntermissionLayer
 
         if (IntermissionState >= IntermissionState.NextMap && NextMapInfo != null)
         {
-            hud.Image(NowEnteringImage, (0, offsetY), out HudBox drawArea, both: Align.TopMiddle);
+            hud.Image(NowEnteringImage, (0, offsetY), out HudBox drawArea, both: Align.TopMiddle, upscalingFactor: m_textUpscalingFactor);
             offsetY += (5 * drawArea.Height) / 4;
-            DrawMapTitle(hud, NextMapInfo, ref offsetY);
+            DrawMapTitle(hud, NextMapInfo, ref offsetY, m_textUpscalingFactor);
         }
         else
         {
-            DrawMapTitle(hud, CurrentMapInfo, ref offsetY);
-            hud.Image(FinishedImage, (0, offsetY), both: Align.TopMiddle);
+            DrawMapTitle(hud, CurrentMapInfo, ref offsetY, m_textUpscalingFactor);
+            hud.Image(FinishedImage, (0, offsetY), both: Align.TopMiddle, upscalingFactor: m_textUpscalingFactor);
         }
     }
 
-    private static void DrawMapTitle(IHudRenderContext hud, MapInfoDef mapInfo, ref int offsetY)
+    private static void DrawMapTitle(IHudRenderContext hud, MapInfoDef mapInfo, ref int offsetY, int textUpscalingFactor)
     {
         if (!string.IsNullOrEmpty(mapInfo.TitlePatch))
         {
-            hud.Image(mapInfo.TitlePatch, (0, offsetY), out HudBox drawArea, both: Align.TopMiddle);
+            hud.Image(mapInfo.TitlePatch, (0, offsetY), out HudBox drawArea, both: Align.TopMiddle, upscalingFactor: textUpscalingFactor);
             offsetY += (5 * drawArea.Height) / 4;
             return;
         }
@@ -184,14 +184,14 @@ public partial class IntermissionLayer
         if (fontObject == null)
             return;
 
-        int RowOffsetY = 3 * fontObject.Get('0').Area.Height / 2;
+        int RowOffsetY = 3 * fontObject.Get('0').Area.Height / fontObject.UpscalingFactor / 2;
 
         if (IntermissionState >= IntermissionState.NextMap)
             return;
 
-        hud.Image("WIOSTK", (LeftOffsetX, OffsetY));
-        hud.Image("WIOSTI", (LeftOffsetX, OffsetY + RowOffsetY));
-        hud.Image("WISCRT2", (LeftOffsetX, OffsetY + (2 * RowOffsetY)));
+        hud.Image("WIOSTK", (LeftOffsetX, OffsetY), upscalingFactor: m_textUpscalingFactor);
+        hud.Image("WIOSTI", (LeftOffsetX, OffsetY + RowOffsetY), upscalingFactor: m_textUpscalingFactor);
+        hud.Image("WISCRT2", (LeftOffsetX, OffsetY + (2 * RowOffsetY)), upscalingFactor: m_textUpscalingFactor);
 
         if (IntermissionState >= IntermissionState.TallyingKills)
             DrawNumber(KillPercent, OffsetY);
@@ -220,18 +220,18 @@ public partial class IntermissionLayer
         if (IntermissionState >= IntermissionState.NextMap || IntermissionState < IntermissionState.TallyingTime)
             return;
 
-        hud.Image("WITIME", (LeftOffsetTimeX, -OffsetY), Align.BottomLeft);
+        hud.Image("WITIME", (LeftOffsetTimeX, -OffsetY), Align.BottomLeft, upscalingFactor: m_textUpscalingFactor);
         RenderTime(LevelTimeSeconds, RightOffsetLevelTimeX, -OffsetY);
 
         if (ParTimeSeconds != 0)
         {
-            hud.Image("WIPAR", (LeftOffsetParX, -OffsetY), Align.BottomLeft);
+            hud.Image("WIPAR", (LeftOffsetParX, -OffsetY), Align.BottomLeft, upscalingFactor: m_textUpscalingFactor);
             RenderTime(ParTimeSeconds, 320 - LeftOffsetTimeX, -OffsetY);
         }
 
         if (IntermissionState >= IntermissionState.ShowAllStats)
         {
-            hud.Image("WIMSTT", (LeftOffsetTimeX, -TotalOffsetY), Align.BottomLeft);
+            hud.Image("WIMSTT", (LeftOffsetTimeX, -TotalOffsetY), Align.BottomLeft, upscalingFactor: m_textUpscalingFactor);
 
             int seconds = World.GlobalData.TotalTime / (int)Constants.TicksPerSecond;
             RenderTime(seconds, RightOffsetLevelTimeX, -TotalOffsetY);

--- a/Core/Layer/Intermission/IntermissionLayer.cs
+++ b/Core/Layer/Intermission/IntermissionLayer.cs
@@ -43,6 +43,7 @@ public partial class IntermissionLayer : IGameLayer
     private int m_tics;
     private int m_delayStateTics;
     private readonly IConfigKeyMapping m_keys;
+    private int m_textUpscalingFactor;
 
     public event EventHandler? Exited;
 
@@ -52,7 +53,7 @@ public partial class IntermissionLayer : IGameLayer
     private bool IsNextMap => IntermissionState == IntermissionState.NextMap;
 
     public IntermissionLayer(GameLayerManager parent, IWorld world, IConfigKeyMapping keys, SoundManager soundManager,
-        IMusicPlayer musicPlayer, MapInfoDef currentMapInfo, Func<FindMapResult> getNextMapInfo)
+        IMusicPlayer musicPlayer, MapInfoDef currentMapInfo, Func<FindMapResult> getNextMapInfo, int textUpscalingFactor)
     {
         m_gameLayerManager = parent;
         World = world;
@@ -65,6 +66,7 @@ public partial class IntermissionLayer : IGameLayer
         m_totalLevelTime = World.LevelTime / (int)Constants.TicksPerSecond;
         m_renderVirtualIntermissionAction = new(RenderVirtualIntermission);
         m_keys = keys;
+        m_textUpscalingFactor = textUpscalingFactor;
 
         IntermissionPic = string.IsNullOrEmpty(currentMapInfo.ExitPic) ? "INTERPIC" : currentMapInfo.ExitPic;
         CalculatePercentages();

--- a/Core/Layer/Menus/MenuLayer.Render.cs
+++ b/Core/Layer/Menus/MenuLayer.Render.cs
@@ -42,7 +42,7 @@ public partial class MenuLayer
             switch (component)
             {
                 case MenuImageComponent imageComponent:
-                    DrawImage(hud, imageComponent, isSelected, ref offsetY);
+                    DrawImage(hud, imageComponent, isSelected, ref offsetY, m_config.Hud.FontUpscalingFactor);
                     break;
                 case MenuPaddingComponent paddingComponent:
                     offsetY += paddingComponent.PixelAmount;
@@ -68,18 +68,18 @@ public partial class MenuLayer
         offsetY += area.Height;
     }
 
-    private void DrawImage(IHudRenderContext hud, MenuImageComponent image, bool isSelected, ref int offsetY)
+    private void DrawImage(IHudRenderContext hud, MenuImageComponent image, bool isSelected, ref int offsetY, int upscalingFactor)
     {
         int drawY = image.PaddingTopY + offsetY;
         if (image.AddToOffsetY)
             offsetY += image.PaddingTopY;
 
-        if (hud.Textures.TryGet(image.ImageName, out var handle))
+        if (hud.Textures.TryGet(image.ImageName, out var handle, upscalingFactor: upscalingFactor))
         {
             Vec2I offset = TranslateDoomOffset(handle.Offset);
             int offsetX = offset.X + image.OffsetX;
 
-            hud.Image(image.ImageName, (offsetX, drawY + offset.Y), out HudBox area, both: image.ImageAlign);
+            hud.Image(image.ImageName, (offsetX, drawY + offset.Y), out HudBox area, both: image.ImageAlign, upscalingFactor: upscalingFactor);
 
             if (isSelected)
                 DrawSelectedImage(hud, image, drawY, offsetX);

--- a/Core/Layer/Menus/MenuLayer.Render.cs
+++ b/Core/Layer/Menus/MenuLayer.Render.cs
@@ -42,7 +42,7 @@ public partial class MenuLayer
             switch (component)
             {
                 case MenuImageComponent imageComponent:
-                    DrawImage(hud, imageComponent, isSelected, ref offsetY, m_config.Hud.FontUpscalingFactor);
+                    DrawImage(hud, imageComponent, isSelected, ref offsetY, imageComponent.UpscaleWithText ? m_config.Hud.FontUpscalingFactor : 1);
                     break;
                 case MenuPaddingComponent paddingComponent:
                     offsetY += paddingComponent.PixelAmount;

--- a/Core/Layer/Worlds/WorldLayer.Render.Hud.cs
+++ b/Core/Layer/Worlds/WorldLayer.Render.Hud.cs
@@ -872,7 +872,7 @@ public partial class WorldLayer
     {
         if (!font.FixedWidthChar.HasValue)
             return offsetX - 1;
-        return offsetX + font.FixedWidthChar.Value.Area.Width - 1;
+        return offsetX + font.FixedWidthChar.Value.Area.Width / font.UpscalingFactor - 1;
     }
 
     private void DrawFullHudWeaponSlots(IHudRenderContext hud)

--- a/Core/Menus/Base/MenuImageComponent.cs
+++ b/Core/Menus/Base/MenuImageComponent.cs
@@ -15,12 +15,14 @@ public class MenuImageComponent : IMenuComponent
     public readonly Align ImageAlign;
     public readonly bool AddToOffsetY;
     public readonly int? OverrideY;
+    public readonly bool UpscaleWithText;
 
     public Func<Menu?>? Action { get; }
 
     public MenuImageComponent(string imageName, int offsetX = 0, int paddingTopY = 0,
         string? activeImage = null, string? inactiveImage = null, Func<Menu?>? action = null,
-        Align imageAlign = Align.TopMiddle, int paddingBottomY = 0, bool addToOffsetY = true, int? overrideY = null, string title = "")
+        Align imageAlign = Align.TopMiddle, int paddingBottomY = 0, bool addToOffsetY = true, 
+        int? overrideY = null, string title = "", bool upscaleWithText = false)
     {
         ImageName = imageName;
         Title = title;
@@ -33,5 +35,6 @@ public class MenuImageComponent : IMenuComponent
         ImageAlign = imageAlign;
         AddToOffsetY = addToOffsetY;
         OverrideY = overrideY;
+        UpscaleWithText = upscaleWithText;
     }
 }

--- a/Core/Menus/Impl/MainMenu.cs
+++ b/Core/Menus/Impl/MainMenu.cs
@@ -58,7 +58,7 @@ public class MainMenu : Menu
         static IMenuComponent CreateMenuOption(string image, int offsetX, int paddingY, Func<Menu?> action)
         {
             const int MenuItemHeight = 16;
-            return new MenuImageComponent(image, offsetX, paddingY, "M_SKULL1", "M_SKULL2", action, imageAlign: Align.TopLeft, overrideY: MenuItemHeight);
+            return new MenuImageComponent(image, offsetX, paddingY, "M_SKULL1", "M_SKULL2", action, imageAlign: Align.TopLeft, overrideY: MenuItemHeight, upscaleWithText: true);
         }
     }
 

--- a/Core/Menus/Impl/NewGameEpisodeMenu.cs
+++ b/Core/Menus/Impl/NewGameEpisodeMenu.cs
@@ -39,7 +39,7 @@ public class NewGameEpisodeMenu : Menu
             return;
         }
 
-        Components = Components.Add(new MenuImageComponent("M_EPISOD", 54, 6, imageAlign: Align.TopLeft, overrideY: 24));
+        Components = Components.Add(new MenuImageComponent("M_EPISOD", 54, 6, imageAlign: Align.TopLeft, overrideY: 24, upscaleWithText: true));
 
         foreach (EpisodeDef episode in episodes)
         {
@@ -60,12 +60,12 @@ public class NewGameEpisodeMenu : Menu
                 string[] lines = archiveCollection.Definitions.Language.GetMessages("$SWSTRING");
                 return new MenuImageComponent(episode.PicName, OffsetX, 0, "M_SKULL1", "M_SKULL2",
                     () => new MessageMenu(config, Console, soundManager, ArchiveCollection, lines),
-                    imageAlign: Align.TopLeft);
+                    imageAlign: Align.TopLeft, upscaleWithText: true);
             }
 
             return new MenuImageComponent(episode.PicName, OffsetX, 0, "M_SKULL1", "M_SKULL2",
                     () => new NewGameSkillMenu(config, console, soundManager, archiveCollection, episode.StartMap),
-                    imageAlign: Align.TopLeft, title: ArchiveCollection.Language.GetMessage(episode.Name), overrideY: EpisodeHeight);
+                    imageAlign: Align.TopLeft, title: ArchiveCollection.Language.GetMessage(episode.Name), overrideY: EpisodeHeight, upscaleWithText: true);
         }
     }
 }

--- a/Core/Menus/Impl/NewGameSkillMenu.cs
+++ b/Core/Menus/Impl/NewGameSkillMenu.cs
@@ -75,7 +75,7 @@ public class NewGameSkillMenu : Menu
         {
             return new MenuImageComponent(image, offsetX, paddingY, "M_SKULL1", "M_SKULL2", action,
                 imageAlign: Align.TopLeft, paddingBottomY: paddingBottomY, overrideY: overrideY, addToOffsetY: addToOffsetY, 
-                title: title);
+                title: title, upscaleWithText: true);
         }
 
         Func<Menu?> Confirm(SkillDef skillDef)

--- a/Core/Menus/Impl/SaveMenu.cs
+++ b/Core/Menus/Impl/SaveMenu.cs
@@ -90,8 +90,8 @@ public class SaveMenu : Menu
         }
     }
 
-    private readonly MenuImageComponent SaveHeader = new(SaveHeaderImage);
-    private readonly MenuImageComponent LoadHeader = new(LoadHeaderImage);
+    private readonly MenuImageComponent SaveHeader = new(SaveHeaderImage,  upscaleWithText: true);
+    private readonly MenuImageComponent LoadHeader = new(LoadHeaderImage, upscaleWithText: true);
     private readonly MenuPaddingComponent BigPadding = new(8);
     private readonly MenuPaddingComponent SmallPadding = new(4);
     private readonly MenuSmallTextComponent NoSavedGamesComponent = new(NoSavedGamesText);

--- a/Core/Render/Common/Renderers/IHudRenderContext.cs
+++ b/Core/Render/Common/Renderers/IHudRenderContext.cs
@@ -57,25 +57,25 @@ public interface IHudRenderContext : IDisposable
 
     void Image(string texture, Vec2I origin, Align window = Align.TopLeft, Align anchor = Align.TopLeft,
         Align? both = null, ResourceNamespace resourceNamespace = ResourceNamespace.Undefined, Color? color = null,
-        float scale = 1.0f, float alpha = 1.0f, int colorMapIndex = 0)
+        float scale = 1.0f, float alpha = 1.0f, int colorMapIndex = 0, int upscalingFactor = 1)
     {
-        Image(texture, origin, out _, window, anchor, both, resourceNamespace, color, scale, alpha, colorMapIndex);
+        Image(texture, origin, out _, window, anchor, both, resourceNamespace, color, scale, alpha, colorMapIndex, upscalingFactor);
     }
 
     void Image(string texture, HudBox area, Align window = Align.TopLeft, Align anchor = Align.TopLeft,
         Align? both = null, ResourceNamespace resourceNamespace = ResourceNamespace.Undefined, Color? color = null,
-        float scale = 1.0f, float alpha = 1.0f, int colorMapIndex = 0)
+        float scale = 1.0f, float alpha = 1.0f, int colorMapIndex = 0, int upscalingFactor = 1)
     {
-        Image(texture, area, out _, window, anchor, both, resourceNamespace, color, scale, alpha, colorMapIndex);
+        Image(texture, area, out _, window, anchor, both, resourceNamespace, color, scale, alpha, colorMapIndex, upscalingFactor);
     }
 
     void Image(string texture, HudBox area, out HudBox drawArea, Align window = Align.TopLeft,
         Align anchor = Align.TopLeft, Align? both = null, ResourceNamespace resourceNamespace = ResourceNamespace.Undefined,
-        Color? color = null, float scale = 1.0f, float alpha = 1.0f, int colorMapIndex = 0);
+        Color? color = null, float scale = 1.0f, float alpha = 1.0f, int colorMapIndex = 0, int upscalingFactor = 1);
 
     void Image(string texture, Vec2I origin, out HudBox drawArea, Align window = Align.TopLeft,
         Align anchor = Align.TopLeft, Align? both = null, ResourceNamespace resourceNamespace = ResourceNamespace.Undefined,
-        Color? color = null, float scale = 1.0f, float alpha = 1.0f, int colorMapIndex = 0);
+        Color? color = null, float scale = 1.0f, float alpha = 1.0f, int colorMapIndex = 0, int upscalingFactor = 1);
 
     void Text(RenderableString str, Vec2I origin, Align window = Align.TopLeft, Align anchor = Align.TopLeft,
         Align? both = null, float alpha = 1);

--- a/Core/Render/Common/Textures/IRendererTextureManager.cs
+++ b/Core/Render/Common/Textures/IRendererTextureManager.cs
@@ -30,8 +30,10 @@ public interface IRendererTextureManager : IDisposable
     /// or null if it returns false.</param>
     /// <param name="specificNamespace">If null, will search all namespaces,
     /// otherwise will search only in the provided one.</param>
+    /// <param name="upscalingFactor">Amount to upscale the texture if retrieving it 
+    /// for the first time.  If 1, no upscaling is performed.</param>
     /// <returns>True if found, false if not.</returns>
-    bool TryGet(string name, [NotNullWhen(true)] out IRenderableTextureHandle? handle, ResourceNamespace? specificNamespace = null);
+    bool TryGet(string name, [NotNullWhen(true)] out IRenderableTextureHandle? handle, ResourceNamespace? specificNamespace = null, int upscalingFactor = 1);
 
     /// <summary>
     /// Get a list of texture names

--- a/Core/Render/OpenGL/GLHudRenderContext.cs
+++ b/Core/Render/OpenGL/GLHudRenderContext.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using Helion.Geometry;
 using Helion.Geometry.Segments;
 using Helion.Geometry.Vectors;
@@ -15,6 +13,8 @@ using Helion.Render.OpenGL.Texture.Fonts;
 using Helion.Resources;
 using Helion.Resources.Archives.Collection;
 using Helion.Util.Extensions;
+using System;
+using System.Collections.Generic;
 using Font = Helion.Graphics.Fonts.Font;
 
 namespace Helion.Render.OpenGL;
@@ -111,22 +111,22 @@ public class GLHudRenderContext : IHudRenderContext
 
     public void Image(string texture, HudBox area, out HudBox drawArea, Align window = Align.TopLeft,
         Align anchor = Align.TopLeft, Align? both = null, ResourceNamespace resourceNamespace = ResourceNamespace.Global,
-        Color? color = null, float scale = 1.0f, float alpha = 1.0f, int colorMapIndex = 0)
+         Color? color = null, float scale = 1.0f, float alpha = 1.0f, int colorMapIndex = 0, int upscalingFactor = 1)
     {
-        Image(texture, out drawArea, area, null, window, anchor, both, resourceNamespace, color, scale, alpha, false, colorMapIndex);
+        Image(texture, out drawArea, area, null, window, anchor, both, resourceNamespace, color, scale, alpha, false, colorMapIndex, upscalingFactor);
     }
 
     public void Image(string texture, Vec2I origin, out HudBox drawArea, Align window = Align.TopLeft,
         Align anchor = Align.TopLeft, Align? both = null, ResourceNamespace resourceNamespace = ResourceNamespace.Global,
-        Color? color = null, float scale = 1.0f, float alpha = 1.0f, int colorMapIndex = 0)
+        Color? color = null, float scale = 1.0f, float alpha = 1.0f, int colorMapIndex = 0, int upscalingFactor = 1)
     {
-        Image(texture, out drawArea, null, origin, window, anchor, both, resourceNamespace, color, scale, alpha, false, colorMapIndex);
+        Image(texture, out drawArea, null, origin, window, anchor, both, resourceNamespace, color, scale, alpha, false, colorMapIndex, upscalingFactor);
     }
 
     private void Image(string texture, out HudBox drawArea, HudBox? area = null, Vec2I? origin = null,
         Align window = Align.TopLeft, Align anchor = Align.TopLeft, Align? both = null,
         ResourceNamespace resourceNamespace = ResourceNamespace.Global, Color? color = null,
-        float scale = 1.0f, float alpha = 1.0f, bool drawFuzz = false, int colorMapIndex = 0)
+        float scale = 1.0f, float alpha = 1.0f, bool drawFuzz = false, int colorMapIndex = 0, int upscalingFactor = 1)
     {
         drawArea = default;
 
@@ -140,10 +140,10 @@ public class GLHudRenderContext : IHudRenderContext
         Dimension drawDim = (0, 0);
         if (area != null)
             drawDim = area.Value.Dimension;
-        else if (Textures.TryGet(texture, out var handle, resourceNamespace))
+        else if (Textures.TryGet(texture, out var handle, resourceNamespace, upscalingFactor))
             drawDim = handle.Dimension;
 
-        drawDim.Scale(scale);
+        drawDim.Scale(scale / upscalingFactor);
 
         Vec2I pos = GetDrawingCoordinateFromAlign(location.X, location.Y, drawDim.Width, drawDim.Height,
             window, anchor);
@@ -218,7 +218,11 @@ public class GLHudRenderContext : IHudRenderContext
         m_commands.DrawText(renderableString, pos.X, pos.Y, alpha, m_context.DrawPalette);
     }
 
-    public int GetFontMaxHeight(string font) => m_archiveCollection.GetFont(font)?.MaxHeight ?? 0;
+    public int GetFontMaxHeight(string font)
+    {
+        Font? fontObj = m_archiveCollection.GetFont(font);
+        return fontObj?.MaxHeight / fontObj?.UpscalingFactor ?? 0;
+    }
 
     public Dimension MeasureText(ReadOnlySpan<char> text, string font, int fontSize, int maxWidth = int.MaxValue,
         int maxHeight = int.MaxValue, float scale = 1.0f)

--- a/Core/Render/OpenGL/Texture/GLTextureManager.cs
+++ b/Core/Render/OpenGL/Texture/GLTextureManager.cs
@@ -82,9 +82,9 @@ public abstract class GLTextureManager<GLTextureType> : IRendererTextureManager
         Dispose();
     }
 
-    public bool TryGet(string name, [NotNullWhen(true)] out IRenderableTextureHandle? handle, ResourceNamespace? specificNamespace = null)
+    public bool TryGet(string name, [NotNullWhen(true)] out IRenderableTextureHandle? handle, ResourceNamespace? specificNamespace = null, int upscalingFactor = 1)
     {
-        if (TryGet(name, specificNamespace ?? ResourceNamespace.Undefined, out GLTextureType texture))
+        if (TryGet(name, specificNamespace ?? ResourceNamespace.Undefined, out GLTextureType texture, upscalingFactor))
         {
             handle = texture;
             return true;
@@ -120,7 +120,7 @@ public abstract class GLTextureManager<GLTextureType> : IRendererTextureManager
     /// the texture you want, or it will be the null image texture.</param>
     /// <returns>True if the texture was found, false if it was not found
     /// and the out value is the null texture handle.</returns>
-    public bool TryGet(string name, ResourceNamespace priorityNamespace, out GLTextureType texture)
+    public bool TryGet(string name, ResourceNamespace priorityNamespace, out GLTextureType texture, int upscalingFactor = 1)
     {
         texture = NullTexture;
         if (name == Constants.NoTexture)
@@ -148,6 +148,11 @@ public abstract class GLTextureManager<GLTextureType> : IRendererTextureManager
 
         if (imageForNamespace != null)
         {
+            if (upscalingFactor > 1)
+            {
+                imageForNamespace = imageForNamespace.GetUpscaled(upscalingFactor);
+            }
+
             texture = CreateTexture(imageForNamespace, name, priorityNamespace);
             return true;
         }
@@ -167,6 +172,11 @@ public abstract class GLTextureManager<GLTextureType> : IRendererTextureManager
         Image? image = ArchiveCollection.ImageRetriever.Get(name, priorityNamespace);
         if (image == null)
             return false;
+
+        if (upscalingFactor > 1)
+        {
+            image = image.GetUpscaled(upscalingFactor);
+        }
 
         texture = CreateTexture(image, name, image.Namespace);
         return true;

--- a/Core/Resources/Archives/Collection/ArchiveCollection.cs
+++ b/Core/Resources/Archives/Collection/ArchiveCollection.cs
@@ -263,7 +263,7 @@ public class ArchiveCollection : IResources, IPathResolver
         FontDefinition? definition = Definitions.Fonts.Get(name);
         if (definition != null)
         {
-            Font? bitmapFont = BitmapFont.From(definition, this);
+            Font? bitmapFont = BitmapFont.From(definition, this, m_config.Hud.FontUpscalingFactor);
             m_fonts[name] = bitmapFont;
             return bitmapFont;
         }

--- a/Core/Util/Configs/Components/ConfigHud.cs
+++ b/Core/Util/Configs/Components/ConfigHud.cs
@@ -181,6 +181,9 @@ public class ConfigHud
     [OptionMenu(OptionSectionType.Hud, "Horizontal Margin Percent")]
     public readonly ConfigValue<double> HorizontalMargin = new(0, ClampNormalized);
 
+    [ConfigInfo("Font upscaling ratio (1 - 5); uses xBRZ algorithm to improve text readability", restartRequired: true)]
+    [OptionMenu(OptionSectionType.Hud, "Font Upscale Ratio")]
+    public readonly ConfigValue<int> FontUpscalingFactor = new(1, Clamp(1, 5));
 
     // Stats and diagnostics
 


### PR DESCRIPTION
This is a fixed version of my previous effort to implement xBRZ text upscaling.  My prior attempt messed around with image caching too much and seemed to produce some sort of memory leak; this implementation doesn't suffer from that problem and seems to work fine in my own playtesting.

In this change, we're _optionally_ applying xBRZ upscaling to text elements in the menus and HUD.  This can improve the readability of DOOM's bitmap fonts when they're displayed at larger scales (as they are in Helion's menus and HUD) by adding antialiased diagonal lines in place of pixel stairsteps on some characters.  Whether this effect is _desirable_ is a matter of preference, so I'm leaving it as on option that defaults to "off".

The xBRZ implementation source code is available [here](https://github.com/lemming104/xBRZ.NET).