### PR TITLE
Transferheights colormap fix

### DIFF
--- a/Core/Resources/Definitions/DefinitionEntries.cs
+++ b/Core/Resources/Definitions/DefinitionEntries.cs
@@ -64,6 +64,7 @@ public class DefinitionEntries
     public readonly Id24SkyDefinition Id24SkyDefinition = new();
     public readonly Id24TranslationDefinition Id24TranslationDefinition = new();
     public readonly GameConfDefinition GameConfDefinition = new();
+    public PnamesTextureXCollection PnamesTextureXCollection => m_pnamesTextureXCollection;
 
     public DehackedDefinition? DehackedDefinition { get; set; }
 

--- a/Core/Resources/Definitions/Texture/PnamesTextureXCollection.cs
+++ b/Core/Resources/Definitions/Texture/PnamesTextureXCollection.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Helion.Resources.Archives.Entries;
+using Helion.Util.Extensions;
 using NLog;
 
 namespace Helion.Resources.Definitions.Texture;
@@ -57,5 +58,19 @@ public class PnamesTextureXCollection
             TextureX.Add(textureX);
         else
             Log.Warn("Unable to parse TextureX from {0}", entry.Path);
+    }
+
+    public bool HasPatch(string name)
+    {
+        foreach (var pnames in Pnames)
+        {
+            foreach (var patchName in pnames.Names)
+            {
+                if (patchName.EqualsIgnoreCase(name))
+                    return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/Core/Resources/TextureManager.cs
+++ b/Core/Resources/TextureManager.cs
@@ -344,6 +344,9 @@ public partial class TextureManager : ITickable
     private bool TryCreateTextureFromPatch(string name, out Texture? texture)
     {
         texture = null;
+        if (!m_archiveCollection.Definitions.PnamesTextureXCollection.HasPatch(name))
+            return false;
+
         var image = m_archiveCollection.ImageRetriever.GetOnly(name, ResourceNamespace.Global);
         if (image == null)
             return false;

--- a/Core/World/Geometry/Builder/DoomGeometryBuilder.cs
+++ b/Core/World/Geometry/Builder/DoomGeometryBuilder.cs
@@ -86,27 +86,21 @@ public static class DoomGeometryBuilder
         Side front = new(nextSideId, doomSide.Offset, upper, middle, lower, sector);
         builder.Sides.Add(front);
 
-        SetColorMaps(doomLine, textureManager, doomSide, middleTexture, upperTexture, lowerTexture, front, true);
+        SetColorMaps(doomLine, textureManager, doomSide, front, true);
 
         nextSideId++;
 
         return (front, null);
     }
 
-    private static void SetColorMaps(DoomLine doomLine, TextureManager textureManager, DoomSide doomSide, Texture middleTexture, Texture upperTexture, Texture lowerTexture, Side front, bool oneSided)
+    private static void SetColorMaps(DoomLine doomLine, TextureManager textureManager, DoomSide doomSide, Side front, bool oneSided)
     {
         // Boom only allows transfer heights colormaps for one-sided lines?
         if (oneSided && doomLine.LineType == VanillaLineSpecialType.TransferHeights)
         {
-            Colormap? upperColormap = null;
-            Colormap? middleColormap = null;
-            Colormap? lowerColormap = null;
-            if (upperTexture.Index == Constants.NoTextureIndex)
-                textureManager.TryGetColormap(doomSide.UpperTexture, out upperColormap);
-            if (middleTexture.Index == Constants.NoTextureIndex)
-                textureManager.TryGetColormap(doomSide.MiddleTexture, out middleColormap);
-            if (lowerTexture.Index == Constants.NoTextureIndex)
-                textureManager.TryGetColormap(doomSide.LowerTexture, out lowerColormap);
+            textureManager.TryGetColormap(doomSide.UpperTexture, out var upperColormap);
+            textureManager.TryGetColormap(doomSide.MiddleTexture, out var middleColormap);
+            textureManager.TryGetColormap(doomSide.LowerTexture, out var lowerColormap);
 
             if (upperColormap != null || middleColormap != null || lowerColormap != null)
                 front.Colormaps = new(upperColormap, middleColormap, lowerColormap);
@@ -152,7 +146,7 @@ public static class DoomGeometryBuilder
         Side side = new(nextSideId, facingSide.Offset, upper, middle, lower, facingSector);
         builder.Sides.Add(side);
 
-        SetColorMaps(line, textureManager, facingSide, middleTexture, upperTexture, lowerTexture, side, false);
+        SetColorMaps(line, textureManager, facingSide, side, false);
 
         nextSideId++;
         return side;

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -66,3 +66,4 @@
   - Fix transparent sprites discarding two-sided middle walls with emulate vanilla rendering
   - Fix dehacked parsing for frame args to match dehacked parsing behavior for bad integer strings
   - Fix projectile spawn not setting previous position causing the first frame to interpolate very close to the screen
+  - Fix transfer height colormaps not being applied if the colormap passes as a valid doom image (fixes twogers MAP36)


### PR DESCRIPTION
always lookup colormap for transfer heights special
ensure the entry is in the patch list before attempting to convert to an image