### PR TITLE
Add slider controls for numeric config values when using gamepad

### DIFF
--- a/Core/Layer/Options/Dialogs/SingleSliderDialog.cs
+++ b/Core/Layer/Options/Dialogs/SingleSliderDialog.cs
@@ -1,0 +1,69 @@
+﻿using Helion.Geometry.Vectors;
+using Helion.Graphics;
+using Helion.Layer.Options.Sections;
+using Helion.Render.Common.Enums;
+using Helion.Render.Common.Renderers;
+using Helion.Util.Configs.Components;
+using Helion.Util.Configs.Options;
+using Helion.Util.Configs.Values;
+using Helion.Window;
+using System;
+
+namespace Helion.Layer.Options.Dialogs;
+
+internal class SingleSliderDialog : DialogBase
+{
+    private readonly IConfigValue m_configValue;
+    private readonly OptionMenuAttribute m_attr;
+    private readonly Slider m_slider;
+    private readonly BoxList m_cursorPosList = new();
+    private int m_valueStartX;
+
+    public decimal SliderValue => m_slider.Value;
+    public IConfigValue ConfigValue => m_configValue;
+
+    public SingleSliderDialog(ConfigWindow config, IConfigValue configValue, OptionMenuAttribute attr, decimal optionValue)
+        : base(config, "OK", "Cancel")
+    {
+        m_configValue = configValue;
+        m_attr = attr;
+
+        m_slider = CreateSlider(optionValue, (decimal)attr.SliderMin, (decimal)attr.SliderMax, (decimal)attr.SliderStep);
+    }
+
+    private static Slider CreateSlider(decimal value, decimal min, decimal max, decimal step)
+    {
+        var slider = new Slider(value, step, min, max);
+        slider.MaxOffset = 0;
+        return slider;
+    }
+
+    public override void HandleInput(IConsumableInput input)
+    {
+        base.HandleInput(input);
+        m_slider.HandleInput(input);
+    }
+
+    protected override void RenderDialogContents(IRenderableSurfaceContext ctx, IHudRenderContext hud, bool widthChanged)
+    {
+        RenderDialogText(hud, m_attr.Name, windowAlign: Align.TopMiddle, anchorAlign: Align.TopMiddle);
+        hud.AddOffset((m_dialogOffset.X + m_padding, 0));
+        m_valueStartX = hud.MeasureText("Green", Font, m_fontSize).Width + m_padding * 4;
+        RenderSlider(ctx, hud, "Value", m_slider, 0);
+    }
+
+    private void RenderSlider(IRenderableSurfaceContext ctx, IHudRenderContext hud, string text, Slider slider, int row)
+    {
+        text = ListedConfigSection.GetEllipsesText(hud, text, Font, m_fontSize, m_box.Width);
+        hud.Text(text, Font, m_fontSize, (m_selectorSize.Width + m_padding, 0), color: Color.Red);
+        int numWidth = hud.MeasureText("999", Font, m_fontSize).Width;
+        hud.AddOffset((m_valueStartX, 0), () =>
+        {
+            slider.Width = new(Math.Clamp(m_box.Width - m_valueStartX - numWidth - m_padding, 0, 320), SizeMetric.Pixel);
+            slider.Render(m_config, ctx, hud);
+        });
+
+        m_cursorPosList.Add(new(hud.GetOffset(), hud.GetOffset() + (m_valueStartX, m_rowHeight)), row);
+        hud.AddOffset((0, m_rowHeight + m_padding));
+    }
+}

--- a/Core/Layer/Options/Dialogs/Slider.cs
+++ b/Core/Layer/Options/Dialogs/Slider.cs
@@ -10,17 +10,17 @@ using System;
 
 namespace Helion.Layer.Options.Dialogs;
 
-public class Slider(double value, double step, double min, double max, RenderSize? width = null) : IRenderControl
+public class Slider(decimal value, decimal step, decimal min, decimal max, RenderSize? width = null) : IRenderControl
 {
-    public event EventHandler<double>? ValueChanged;
+    public event EventHandler<decimal>? ValueChanged;
 
-    public double MaxOffset;
-    public double Value { get; private set; } = value;
+    public decimal MaxOffset;
+    public decimal Value { get; private set; } = value;
     public RenderSize Width { get; set; } = width ?? new(300, SizeMetric.Pixel);
 
-    private readonly double m_step = step;
-    private readonly double m_min = min;
-    private readonly double m_max = max;
+    private readonly decimal m_step = step;
+    private readonly decimal m_min = min;
+    private readonly decimal m_max = max;
 
     public void HandleInput(IConsumableInput input)
     {

--- a/Core/Util/Configs/Components/ConfigAudio.cs
+++ b/Core/Util/Configs/Components/ConfigAudio.cs
@@ -10,11 +10,11 @@ namespace Helion.Util.Configs.Components;
 public class ConfigAudio: ConfigElement<ConfigAudio>
 {
     [ConfigInfo("Music volume. 0.0 is Off, 2.0 is Maximum.")]
-    [OptionMenu(OptionSectionType.Audio, "Music Volume")]
+    [OptionMenu(OptionSectionType.Audio, "Music Volume", sliderMin: 0, sliderMax: 2.0, sliderStep: .05)]
     public readonly ConfigValue<double> MusicVolume = new(1.0, Clamp(0, 2.0));
 
     [ConfigInfo("Sound effect volume. 0.0 is Off, 2.0 is Maximum.")]
-    [OptionMenu(OptionSectionType.Audio, "Sound Volume")]
+    [OptionMenu(OptionSectionType.Audio, "Sound Volume", sliderMin: 0, sliderMax: 2.0, sliderStep: .05)]
     public readonly ConfigValue<double> SoundVolume = new(1.0, Clamp(0, 2.0));
 
     [ConfigInfo("Enables sound velocity.")]
@@ -26,11 +26,11 @@ public class ConfigAudio: ConfigElement<ConfigAudio>
     public readonly ConfigValue<RandomPitch> RandomizePitch = new(RandomPitch.None);
 
     [ConfigInfo("Randomized pitch scale value.")]
-    [OptionMenu(OptionSectionType.Audio, "Random Pitch Scale")]
+    [OptionMenu(OptionSectionType.Audio, "Random Pitch Scale", sliderMin: 0.1, sliderMax: 10, sliderStep: .1)]
     public readonly ConfigValue<double> RandomPitchScale = new(1, Clamp(0.1, 10));
 
     [ConfigInfo("Scale for sound pitch.")]
-    [OptionMenu(OptionSectionType.Audio, "Pitch Scale")]
+    [OptionMenu(OptionSectionType.Audio, "Pitch Scale", sliderMin: 0.1, sliderMax: 10, sliderStep: .1)]
     public readonly ConfigValue<double> Pitch = new(1, Clamp(0.1, 10));
 
     [ConfigInfo("Log sound errors.")]

--- a/Core/Util/Configs/Components/ConfigConsole.cs
+++ b/Core/Util/Configs/Components/ConfigConsole.cs
@@ -8,14 +8,14 @@ namespace Helion.Util.Configs.Components;
 public class ConfigConsole: ConfigElement<ConfigConsole>
 {
     [ConfigInfo("Number of messages the console buffer holds before discarding old ones.")]
-    [OptionMenu(OptionSectionType.Console, "Max Messages")]
+    [OptionMenu(OptionSectionType.Console, "Max Messages", sliderMin: 0, sliderMax: 2000, sliderStep: 10)]
     public readonly ConfigValue<int> MaxMessages = new(256, Greater(0));
 
     [ConfigInfo("Font size.")]
-    [OptionMenu(OptionSectionType.Console, "Font Size")]
+    [OptionMenu(OptionSectionType.Console, "Font Size", sliderMin: 15, sliderMax: 64, sliderStep: 1)]
     public readonly ConfigValue<int> FontSize = new(32, Greater(15));
 
     [ConfigInfo("Transparency.")]
-    [OptionMenu(OptionSectionType.Console, "Transparency")]
+    [OptionMenu(OptionSectionType.Console, "Transparency", sliderMin: 0, sliderMax: 1, sliderStep: .05)]
     public readonly ConfigValue<double> Transparency = new(0.6, ClampNormalized);
 }

--- a/Core/Util/Configs/Components/ConfigController.cs
+++ b/Core/Util/Configs/Components/ConfigController.cs
@@ -14,23 +14,23 @@ public class ConfigController: ConfigElement<ConfigController>
     public readonly ConfigValue<bool> EnableGameController = new(true);
 
     [ConfigInfo("Dead zone for analog inputs.")]
-    [OptionMenu(OptionSectionType.Controller, "Dead Zone")]
+    [OptionMenu(OptionSectionType.Controller, "Dead Zone", sliderMin: 0.1, sliderMax: 0.9, sliderStep: .05)]
     public readonly ConfigValue<double> GameControllerDeadZone = new(0.2, Clamp(0.1, 0.9));
 
     [ConfigInfo("Turn speed scaling factor for analog inputs.")]
-    [OptionMenu(OptionSectionType.Controller, "Turn Sensitivity")]
+    [OptionMenu(OptionSectionType.Controller, "Turn Sensitivity", sliderMin: 0.1, sliderMax: 3.0, sliderStep: .05)]
     public readonly ConfigValue<double> GameControllerTurnScale = new(1.0, Clamp(0.1, 3.0));
 
     [ConfigInfo("Pitch speed scaling factor for analog inputs.")]
-    [OptionMenu(OptionSectionType.Controller, "Pitch Sensitivity")]
+    [OptionMenu(OptionSectionType.Controller, "Pitch Sensitivity", sliderMin: 0.1, sliderMax: 3.0, sliderStep: .05)]
     public readonly ConfigValue<double> GameControllerPitchScale = new(0.5, Clamp(0.1, 3.0));
 
     [ConfigInfo("Run input scaling factor for analog inputs.")]
-    [OptionMenu(OptionSectionType.Controller, "Run Sensitivity")]
+    [OptionMenu(OptionSectionType.Controller, "Run Sensitivity", sliderMin: 0.1, sliderMax: 3.0, sliderStep: .05)]
     public readonly ConfigValue<double> GameControllerRunScale = new(1.0, Clamp(0.1, 3.0));
 
     [ConfigInfo("Strafe input scaling factor for analog inputs.")]
-    [OptionMenu(OptionSectionType.Controller, "Strafe Sensitivity")]
+    [OptionMenu(OptionSectionType.Controller, "Strafe Sensitivity", sliderMin: 0.1, sliderMax: 3.0, sliderStep: .05)]
     public readonly ConfigValue<double> GameControllerStrafeScale = new(1.0, Clamp(0.1, 3.0));
 }
 

--- a/Core/Util/Configs/Components/ConfigDemo.cs
+++ b/Core/Util/Configs/Components/ConfigDemo.cs
@@ -7,6 +7,6 @@ namespace Helion.Util.Configs.Components;
 public class ConfigDemo: ConfigElement<ConfigDemo>
 {
     [ConfigInfo("Playback tick multiplier rounded to the nearest tick. (0.5 = half speed, 2 = double speed)", save: true)]
-    [OptionMenu(OptionSectionType.Demo, "Playback Speed")]
+    [OptionMenu(OptionSectionType.Demo, "Playback Speed", sliderMin: .1, sliderMax: 3.0, sliderStep: .05)]
     public readonly ConfigValue<double> PlaybackSpeed = new(1);
 }

--- a/Core/Util/Configs/Components/ConfigGame.cs
+++ b/Core/Util/Configs/Components/ConfigGame.cs
@@ -30,7 +30,7 @@ public class ConfigGame: ConfigElement<ConfigGame>
     // Visual effects
 
     [ConfigInfo("Scale red amount drawn to screen when the player takes damage.")]
-    [OptionMenu(OptionSectionType.General, "Pain Intensity", spacer: true)]
+    [OptionMenu(OptionSectionType.General, "Pain Intensity", spacer: true, sliderMin: 0, sliderMax: 5.0, sliderStep: .1)]
     public readonly ConfigValue<double> PainIntensity = new(1.0);
 
     [ConfigInfo("Transition effect between levels/screens.")]
@@ -52,11 +52,11 @@ public class ConfigGame: ConfigElement<ConfigGame>
     public readonly ConfigValue<bool> AutoSave = new(true);
 
     [ConfigInfo("Number of autosaves before the oldest is replaced. 0 = No limit.")]
-    [OptionMenu(OptionSectionType.General, "Rotating Autosaves")]
+    [OptionMenu(OptionSectionType.General, "Rotating Autosaves", sliderMin: 0, sliderMax: 50, sliderStep: 1)]
     public readonly ConfigValue<int> RotatingAutoSaves = new(4, GreaterOrEqual(0));
 
     [ConfigInfo("Number of quicksaves before the oldest is replaced. 0 = Use regular save slots instead.")]
-    [OptionMenu(OptionSectionType.General, "Rotating Quicksaves")]
+    [OptionMenu(OptionSectionType.General, "Rotating Quicksaves", sliderMin: 0, sliderMax: 50, sliderStep: 1)]
     public readonly ConfigValue<int> RotatingQuickSaves = new(4, GreaterOrEqual(0));
 
     [ConfigInfo("Confirm overwrite when quicksaving to regular save slots.")]

--- a/Core/Util/Configs/Components/ConfigHud.cs
+++ b/Core/Util/Configs/Components/ConfigHud.cs
@@ -39,7 +39,7 @@ public class ConfigHudAutoMap: ConfigElement<ConfigHudAutoMap>
     public readonly ConfigValue<Vec3I> OverlayBackdropColor = new((0, 0, 0), ClampColor);
 
     [ConfigInfo("Background color transparency when using overlay.")]
-    [OptionMenu(OptionSectionType.Automap, "Backdrop Transparency")]
+    [OptionMenu(OptionSectionType.Automap, "Backdrop Transparency", sliderMin: 0, sliderMax: 1.0, sliderStep: .05)]
     public readonly ConfigValue<double> OverlayBackdropTransparency = new(0.7, ClampNormalized);
 
     [ConfigInfo("Show map title on the automap.")]
@@ -134,22 +134,22 @@ public class ConfigHud: ConfigElement<ConfigHud>
     public readonly ConfigValue<bool> CrosshairHealthIndicator = new(false);
 
     [ConfigInfo("Crosshair transparency.")]
-    [OptionMenu(OptionSectionType.Hud, "Crosshair Transparency")]
+    [OptionMenu(OptionSectionType.Hud, "Crosshair Transparency", sliderMin: 0, sliderMax: 1.0, sliderStep: .05)]
     public readonly ConfigValue<double> CrosshairTransparency = new(0.5, ClampNormalized);
 
     [ConfigInfo("Crosshair scale.")]
-    [OptionMenu(OptionSectionType.Hud, "Crosshair Scale")]
+    [OptionMenu(OptionSectionType.Hud, "Crosshair Scale", sliderMin: 0, sliderMax: 5.0, sliderStep: .1)]
     public readonly ConfigValue<double> CrosshairScale = new(1.0);
 
 
     // Bobbin'
 
     [ConfigInfo("Amount of view bobbing. 0.0 is off, 1.0 is normal.")]
-    [OptionMenu(OptionSectionType.Hud, "View Bob", spacer: true)]
+    [OptionMenu(OptionSectionType.Hud, "View Bob", spacer: true, sliderMin: 0, sliderMax: 1.0, sliderStep: .05)]
     public readonly ConfigValue<double> ViewBob = new(1.0, ClampNormalized);
 
     [ConfigInfo("Amount of weapon bobbing. 0.0 is off, 1.0 is normal.")]
-    [OptionMenu(OptionSectionType.Hud, "Weapon Bob")]
+    [OptionMenu(OptionSectionType.Hud, "Weapon Bob", sliderMin: 0, sliderMax: 1.0, sliderStep: .05)]
     public readonly ConfigValue<double> WeaponBob = new(1.0, ClampNormalized);
 
 
@@ -171,23 +171,23 @@ public class ConfigHud: ConfigElement<ConfigHud>
     public readonly ConfigValue<bool> AutoScale = new(true);
 
     [ConfigInfo("Amount to scale the HUD.")]
-    [OptionMenu(OptionSectionType.Hud, "HUD Scale")]
+    [OptionMenu(OptionSectionType.Hud, "HUD Scale", sliderMin: 0, sliderMax: 5.0, sliderStep: 1)]
     public readonly ConfigValue<double> Scale = new(2.0, Greater(0.0));
 
     [ConfigInfo("Amount of HUD transparency.")]
-    [OptionMenu(OptionSectionType.Hud, "HUD Transparency")]
+    [OptionMenu(OptionSectionType.Hud, "HUD Transparency", sliderMin: 0, sliderMax: 1.0, sliderStep: .05)]
     public readonly ConfigValue<double> Transparency = new(0.0, ClampNormalized);
 
     [ConfigInfo("Max HUD messages.")]
-    [OptionMenu(OptionSectionType.Hud, "Max HUD Messages")]
+    [OptionMenu(OptionSectionType.Hud, "Max HUD Messages", sliderMin: 0, sliderMax: 50, sliderStep: 1)]
     public readonly ConfigValue<int> MaxMessages = new(4, GreaterOrEqual(0));
 
     [ConfigInfo("Horizontal HUD margin percentage  (0.0 - 1.0).")]
-    [OptionMenu(OptionSectionType.Hud, "Horizontal Margin Percent")]
+    [OptionMenu(OptionSectionType.Hud, "Horizontal Margin Percent", sliderMin: 0, sliderMax: 1.0, sliderStep: .05)]
     public readonly ConfigValue<double> HorizontalMargin = new(0, ClampNormalized);
 
     [ConfigInfo("Font upscaling ratio (1 - 5); uses xBRZ algorithm to improve text readability", restartRequired: true)]
-    [OptionMenu(OptionSectionType.Hud, "Font Upscale Ratio")]
+    [OptionMenu(OptionSectionType.Hud, "Font Upscale Ratio", sliderMin: 1, sliderMax: 5, sliderStep: 1)]
     public readonly ConfigValue<int> FontUpscalingFactor = new(1, Clamp(1, 5));
 
     // Stats and diagnostics

--- a/Core/Util/Configs/Components/ConfigMouse.cs
+++ b/Core/Util/Configs/Components/ConfigMouse.cs
@@ -12,19 +12,19 @@ public class ConfigMouse: ConfigElement<ConfigMouse>
     public readonly ConfigValue<bool> Look = new(true);
     
     [ConfigInfo("Forward/backward movement speed when mouse look is disabled.")]
-    [OptionMenu(OptionSectionType.Mouse, "Movement Speed")]
+    [OptionMenu(OptionSectionType.Mouse, "Movement Speed", sliderMin: 0, sliderMax: 10.0, sliderStep: .1)]
     public readonly ConfigValue<double> ForwardBackwardSpeed = new(0, GreaterOrEqual(0.0));
 
     [ConfigInfo("Scale for both the pitch and yaw (affects both axes).")]
-    [OptionMenu(OptionSectionType.Mouse, "Overall Sensitivity", spacer: true)]
+    [OptionMenu(OptionSectionType.Mouse, "Overall Sensitivity", spacer: true, sliderMin: 0, sliderMax: 10.0, sliderStep: .1)]
     public readonly ConfigValue<double> Sensitivity = new(1.0);
 
     [ConfigInfo("Vertical sensitivity. This is multiplied by the overall sensitivity value.")]
-    [OptionMenu(OptionSectionType.Mouse, "Vertical Sensitivity")]
+    [OptionMenu(OptionSectionType.Mouse, "Vertical Sensitivity", sliderMin: 0, sliderMax: 10.0, sliderStep: .1)]
     public readonly ConfigValue<double> Pitch = new(1.0);
 
     [ConfigInfo("Horizontal sensitivity. This is multiplied by the overall sensitivity value.")]
-    [OptionMenu(OptionSectionType.Mouse, "Horizontal Sensitivity")]
+    [OptionMenu(OptionSectionType.Mouse, "Horizontal Sensitivity", sliderMin: 0, sliderMax: 10.0, sliderStep: .1)]
     public readonly ConfigValue<double> Yaw = new(1.0);
     
     [ConfigInfo("Invert mouse Y.")]

--- a/Core/Util/Configs/Components/ConfigRender.cs
+++ b/Core/Util/Configs/Components/ConfigRender.cs
@@ -48,7 +48,7 @@ public class ConfigRender: ConfigElement<ConfigRender>
     public readonly ConfigValue<RenderVsyncMode> VSync = new(RenderVsyncMode.On);
 
     [ConfigInfo("Maximum frames per second. Zero is equivalent to no cap if vsync is off (or monitor refresh rate if vsync is on/adaptive).")]
-    [OptionMenu(OptionSectionType.Render, "Max FPS")]
+    [OptionMenu(OptionSectionType.Render, "Max FPS", sliderMin: 0, sliderMax: 250, sliderStep: 1)]
     public readonly ConfigValue<int> MaxFPS = new(0, fps =>
     {
         return fps switch
@@ -63,7 +63,7 @@ public class ConfigRender: ConfigElement<ConfigRender>
     // Textures and filtering
 
     [ConfigInfo("Anisotropic filtering amount. A value of 1 is the same as being off. True color required.")]
-    [OptionMenu(OptionSectionType.Render, "Anisotropy", spacer: true)]
+    [OptionMenu(OptionSectionType.Render, "Anisotropy", spacer: true, sliderMin: 0, sliderMax: 16, sliderStep: 1)]
     public readonly ConfigValue<int> Anisotropy = new(8, GreaterOrEqual(1));
     
     public readonly ConfigRenderFilter Filter = new();
@@ -76,11 +76,11 @@ public class ConfigRender: ConfigElement<ConfigRender>
     // Viewport
 
     [ConfigInfo("Field of view.")]
-    [OptionMenu(OptionSectionType.Render, "Field Of View", spacer:true)]
+    [OptionMenu(OptionSectionType.Render, "Field Of View", spacer:true, sliderMin: 60.0, sliderMax: 120.0, sliderStep: .5)]
     public readonly ConfigValue<double> FieldOfView = new(90, Clamp(60.0, 120.0));
 
     [ConfigInfo("Max render distance.")]
-    [OptionMenu(OptionSectionType.Render, "Max Rendering Distance")]
+    [OptionMenu(OptionSectionType.Render, "Max Rendering Distance", sliderMin: 0.0, sliderMax: int.MaxValue, sliderStep: 100)]
     public readonly ConfigValue<int> MaxDistance = new(0);
 
 
@@ -91,7 +91,7 @@ public class ConfigRender: ConfigElement<ConfigRender>
     public readonly ConfigValue<RenderLightMode> LightMode = new(RenderLightMode.Smooth);
 
     [ConfigInfo("Added light level offset.")]
-    [OptionMenu(OptionSectionType.Render, "Extra Lighting")]
+    [OptionMenu(OptionSectionType.Render, "Extra Lighting", sliderMin: 0, sliderMax: 10.0, sliderStep: .1)]
     public readonly ConfigValue<int> ExtraLight = new(0);
 
     [ConfigInfo("Draw everything at full brightness.")]
@@ -102,7 +102,7 @@ public class ConfigRender: ConfigElement<ConfigRender>
     // Misc. Visual effects
 
     [ConfigInfo("Gamma correction level.")]
-    [OptionMenu(OptionSectionType.Render, "Gamma correction", spacer: true)]
+    [OptionMenu(OptionSectionType.Render, "Gamma correction", spacer: true, sliderMin: 1.0, sliderMax: 4.0, sliderStep: .1)]
     public readonly ConfigValue<double> GammaCorrection = new(1, Clamp(1.0, 4.0));
 
     [ConfigInfo("Emulate fake contrast like vanilla Doom.")]
@@ -114,7 +114,7 @@ public class ConfigRender: ConfigElement<ConfigRender>
     public readonly ConfigValue<bool> VanillaRender = new(false);
 
     [ConfigInfo("Fuzz amount for partial invisibility effect.")]
-    [OptionMenu(OptionSectionType.Render, "Fuzz Amount")]
+    [OptionMenu(OptionSectionType.Render, "Fuzz Amount", sliderMin: 0, sliderMax: 5.0, sliderStep: .1)]
     public readonly ConfigValue<double> FuzzAmount = new(1);
 
     [ConfigInfo("Prevent sprites from overlapping and Z-fighting.")]

--- a/Core/Util/Configs/Components/ConfigSlowTick.cs
+++ b/Core/Util/Configs/Components/ConfigSlowTick.cs
@@ -14,22 +14,22 @@ public class ConfigSlowTick: ConfigElement<ConfigSlowTick>
     public readonly ConfigValue<bool> Enabled = new(false);
 
     [ConfigInfo("Distance threshold for A_Look and A_Chase. Actors beyond this distance threshold are updated less frequently. 0 = Disabled.", demo: true)]
-    [OptionMenu(OptionSectionType.SlowTick, "Distance Threshold")]
+    [OptionMenu(OptionSectionType.SlowTick, "Distance Threshold", sliderMin: 0, sliderMax: int.MaxValue, sliderStep: 1000)]
     public readonly ConfigValue<int> Distance = new(2000, Clamp(0, int.MaxValue));
 
     [ConfigInfo("Number of times to skip setting a new chase direction when an actor fails to move due to an obstruction. 0 = Disabled.", demo: true)]
-    [OptionMenu(OptionSectionType.SlowTick, "Chase Failure Skip Count", spacer: true)]
+    [OptionMenu(OptionSectionType.SlowTick, "Chase Failure Skip Count", spacer: true, sliderMin: 0, sliderMax: SlowTickMultiplierMax, sliderStep: 1)]
     public readonly ConfigValue<int> ChaseFailureSkipCount = new(4, Clamp(0, SlowTickMultiplierMax));
 
     [ConfigInfo("Tick multiplier for chase beyond distance threshold. 0 = Disabled.", demo: true)]
-    [OptionMenu(OptionSectionType.SlowTick, "Chase Multiplier")]
+    [OptionMenu(OptionSectionType.SlowTick, "Chase Multiplier", sliderMin: 0, sliderMax: SlowTickMultiplierMax, sliderStep: 1)]
     public readonly ConfigValue<int> ChaseMultiplier = new(4, Clamp(0, SlowTickMultiplierMax));
 
     [ConfigInfo("Tick multiplier for look beyond distance threshold. 0 = Disabled.", demo: true)]
-    [OptionMenu(OptionSectionType.SlowTick, "Look Multiplier")]
+    [OptionMenu(OptionSectionType.SlowTick, "Look Multiplier", sliderMin: 0, sliderMax: SlowTickMultiplierMax, sliderStep: 1)]
     public readonly ConfigValue<int> LookMultiplier = new(2, Clamp(0, SlowTickMultiplierMax));
 
     [ConfigInfo("Tick multiplier for tracers beyond distance threshold. 0 = Disabled.", demo: true)]
-    [OptionMenu(OptionSectionType.SlowTick, "Tracer Multiplier")]
+    [OptionMenu(OptionSectionType.SlowTick, "Tracer Multiplier", sliderMin: 0, sliderMax: SlowTickMultiplierMax, sliderStep: 1)]
     public readonly ConfigValue<int> TracerMultiplier = new(4, Clamp(0, SlowTickMultiplierMax));
 }

--- a/Core/Util/Configs/Components/ConfigWindow.cs
+++ b/Core/Util/Configs/Components/ConfigWindow.cs
@@ -56,13 +56,13 @@ public class ConfigWindow: ConfigElement<ConfigWindow>
     public readonly ConfigValue<Dimension> Dimension = new((1024, 768), (_, dim) => dim.Width >= 320 && dim.Height >= 200);
 
     [ConfigInfo("Amount to scale menu text.")]
-    [OptionMenu(OptionSectionType.Video, "Menu Scale", allowReset: false)]
+    [OptionMenu(OptionSectionType.Video, "Menu Scale", allowReset: false, sliderMin: 0, sliderMax: 10, sliderStep: 1)]
     public readonly ConfigValue<double> MenuScale = new(2.0, Greater(0.0));
 
     public readonly ConfigWindowVirtual Virtual = new();
 
     [ConfigInfo("Display number for the window. Use command ListDisplays for display numbers.")]
-    [OptionMenu(OptionSectionType.Video, "Display Number", spacer: true, allowReset: false)]
+    [OptionMenu(OptionSectionType.Video, "Display Number", spacer: true, allowReset: false, sliderMin: 0, sliderMax: 10, sliderStep: 1)]
     public readonly ConfigValue<int> Display = new(0, GreaterOrEqual(0));
 
     [ConfigInfo("Color rendering mode: Palette uses Doom's colormaps and disables texture filtering, producing output that resembles software rendering. True Color interpolates color values. Application restart required.", restartRequired: true)]

--- a/Core/Util/Configs/Options/OptionMenuAttribute.cs
+++ b/Core/Util/Configs/Options/OptionMenuAttribute.cs
@@ -5,7 +5,9 @@ namespace Helion.Util.Configs.Options;
 [AttributeUsage(AttributeTargets.Field)]
 public class OptionMenuAttribute : Attribute
 {
-    public OptionMenuAttribute(OptionSectionType section, string name, bool disabled = false, bool spacer = false, bool allowReset = true, DialogType dialogType = Options.DialogType.Default)
+    public OptionMenuAttribute(OptionSectionType section, string name, bool disabled = false, bool spacer = false, bool allowReset = true,
+        DialogType dialogType = Options.DialogType.Default,
+        double sliderMin = 0, double sliderMax = 1, double sliderStep = 0)
     {
         Section = section;
         Name = name;
@@ -13,6 +15,9 @@ public class OptionMenuAttribute : Attribute
         Spacer = spacer;
         AllowBulkReset = allowReset;
         DialogType = dialogType;
+        SliderMin = sliderMin;
+        SliderMax = sliderMax;
+        SliderStep = sliderStep;
     }
 
     public readonly OptionSectionType Section;
@@ -21,4 +26,7 @@ public class OptionMenuAttribute : Attribute
     public readonly bool Spacer;
     public readonly bool AllowBulkReset;
     public readonly DialogType? DialogType;
+    public readonly double SliderMin;
+    public readonly double SliderMax;
+    public readonly double SliderStep;
 }


### PR DESCRIPTION
If the user selects a numeric config value from the menu, AND the selection was done using Gamepad Button 1, then render a slider instead of text input.

# Conflicts:
#	Core/Layer/Options/Sections/ListedConfigSection.cs