### PR TITLE
Add controller preset system 

### DIFF
--- a/Client/Client.Commands.Bind.cs
+++ b/Client/Client.Commands.Bind.cs
@@ -47,6 +47,11 @@ public partial class Client
         if (removeExisting)
             m_config.Keys.Remove(inputKey.Value);
         m_config.Keys.Add(inputKey.Value, command);
+
+        if (m_config.Keys.IsControllerInput(inputKey.Value))
+        {
+            m_config.Controller.ControllerPreset.Set(Util.Configs.Impl.ControllerPresetType.Custom);
+        }
     }
 
     [ConsoleCommand("unbind", "Unbinds a key with an optional specific command")]
@@ -75,8 +80,14 @@ public partial class Client
         }
 
         string command = args.Args[1];
-        if (!m_config.Keys.Remove(inputKey.Value, command))
+        bool removed = m_config.Keys.Remove(inputKey.Value, command);
+        if (!removed)
             HelionLog.Error($"{inputKey} does not have ${command}");
+
+        if (removed && m_config.Keys.IsControllerInput(inputKey.Value))
+        {
+            m_config.Controller.ControllerPreset.Set(Util.Configs.Impl.ControllerPresetType.Custom);
+        }
     }
 
     [ConsoleCommand("inputkeys", "List all input keys")]

--- a/Client/Client.Config.cs
+++ b/Client/Client.Config.cs
@@ -14,9 +14,10 @@ public partial class Client
         m_config.Audio.MusicVolume.OnChanged += MusicVolume_OnChanged;
         m_config.Audio.SoundVolume.OnChanged += SoundVolume_OnChanged;
         m_config.Audio.SoundFontFile.OnChanged += SoundFont_OnChanged;
-        m_config.Audio.Synthesizer.OnChanged += this.UseOPLEmulation_OnChanged;
+        m_config.Audio.Synthesizer.OnChanged += UseOPLEmulation_OnChanged;
 
         m_config.Mouse.Look.OnChanged += Look_OnChanged;
+        m_config.Controller.ControllerPreset.OnChanged += ControllerPreset_OnChanged;
 
         m_config.Window.State.OnChanged += WindowState_OnChanged;
         m_config.Window.Dimension.OnChanged += WindowDimension_OnChanged;
@@ -27,7 +28,7 @@ public partial class Client
 
         m_config.Hud.AutoScale.OnChanged += AutoScale_OnChanged;
 
-        m_config.Compatibility.SessionCompatLevel.OnChanged += this.SessionCompatLevel_OnChanged;
+        m_config.Compatibility.SessionCompatLevel.OnChanged += SessionCompatLevel_OnChanged;
 
         CalculateHudScale();
     }
@@ -114,5 +115,10 @@ public partial class Client
     {
         m_archiveCollection.Definitions.CompLevelDefinition.CompLevel = e;
         m_archiveCollection.Definitions.CompLevelDefinition.Apply(m_config, true);
+    }
+
+    private void ControllerPreset_OnChanged(object? sender, Util.Configs.Impl.ControllerPresetType e)
+    {
+        m_config.Keys.LoadControllerPreset(e);
     }
 }

--- a/Core/Layer/Options/Sections/KeyBindingSection.cs
+++ b/Core/Layer/Options/Sections/KeyBindingSection.cs
@@ -215,6 +215,9 @@ public class KeyBindingSection : IOptionSection
                     m_configUpdated = true;
                     m_config.Keys.Add(key, commandKeys.Command);
                     commandKeys.Keys.Add(key);
+                    if (m_config.Keys.IsControllerInput(key))
+                        m_config.Controller.ControllerPreset.Set(ControllerPresetType.Custom);
+
                     m_soundManager.PlayStaticSound(MenuSounds.Choose);
                 }
 
@@ -279,6 +282,9 @@ public class KeyBindingSection : IOptionSection
     {
         m_configUpdated = true;
         var commandKeys = m_commandToKeys[m_currentRow];
+        if (commandKeys.Keys.Any(m_config.Keys.IsControllerInput))
+            m_config.Controller.ControllerPreset.Set(ControllerPresetType.Custom);
+
         foreach (Key key in commandKeys.Keys)
             m_config.Keys.Remove(key, commandKeys.Command);
 
@@ -494,6 +500,7 @@ public class KeyBindingSection : IOptionSection
     private void ResetAllKeyBindings()
     {
         m_config.Keys.SetInitialDefaultKeyBindings();
+        m_config.Keys.LoadControllerPreset(m_config.Controller.ControllerPreset);
         m_configUpdated = true;
         WriteConfigFile();
     }

--- a/Core/Util/Configs/Components/ConfigController.cs
+++ b/Core/Util/Configs/Components/ConfigController.cs
@@ -13,6 +13,10 @@ public class ConfigController: ConfigElement<ConfigController>
     [OptionMenu(OptionSectionType.Controller, "Enable Game Controller", spacer: true)]
     public readonly ConfigValue<bool> EnableGameController = new(true);
 
+    [ConfigInfo("Preset axis and button mappings for controller.")]
+    [OptionMenu(OptionSectionType.Controller, "Controller Type Preset")]
+    public readonly ConfigValue<ControllerPresetType> ControllerPreset = new(ControllerPresetType.None);
+
     [ConfigInfo("Dead zone for analog inputs.")]
     [OptionMenu(OptionSectionType.Controller, "Dead Zone", sliderMin: 0.1, sliderMax: 0.9, sliderStep: .05)]
     public readonly ConfigValue<double> GameControllerDeadZone = new(0.2, Clamp(0.1, 0.9));

--- a/Core/Util/Configs/Components/ConfigController.cs
+++ b/Core/Util/Configs/Components/ConfigController.cs
@@ -13,8 +13,8 @@ public class ConfigController: ConfigElement<ConfigController>
     [OptionMenu(OptionSectionType.Controller, "Enable Game Controller", spacer: true)]
     public readonly ConfigValue<bool> EnableGameController = new(true);
 
-    [ConfigInfo("Preset axis and button mappings for controller.")]
-    [OptionMenu(OptionSectionType.Controller, "Controller Type Preset")]
+    [ConfigInfo("Load preset axis and button mappings for controller.")]
+    [OptionMenu(OptionSectionType.Controller, "Controller Preset")]
     public readonly ConfigValue<ControllerPresetType> ControllerPreset = new(ControllerPresetType.None);
 
     [ConfigInfo("Dead zone for analog inputs.")]

--- a/Core/Util/Configs/ConfigEnums.cs
+++ b/Core/Util/Configs/ConfigEnums.cs
@@ -2,6 +2,7 @@
 using Helion.Render.Common.Textures;
 using Helion.Resources.Definitions;
 using Helion.Util.Configs.Components;
+using Helion.Util.Configs.Impl;
 using Helion.World;
 using Helion.World.Entities.Players;
 using Helion.World.StatusBar;
@@ -38,7 +39,8 @@ namespace Helion.Util.Configs
             { typeof(RenderWindowState), Enum.GetValues<RenderWindowState>() },
             { typeof(WindowBorder), Enum.GetValues<WindowBorder>() },
             { typeof(RenderColorMode), Enum.GetValues<RenderColorMode>() },
-            { typeof(BlitFilter), Enum.GetValues<BlitFilter>() }
+            { typeof(BlitFilter), Enum.GetValues<BlitFilter>() },
+            { typeof(ControllerPresetType), Enum.GetValues<ControllerPresetType>() }
         };
 
         public static Dictionary<Type, Dictionary<Enum, string>> KnownEnumLabels { get; } = new Dictionary<Type, Dictionary<Enum, string>>()
@@ -58,7 +60,8 @@ namespace Helion.Util.Configs
             { typeof(RenderWindowState), GetDescriptions<RenderWindowState>() },
             { typeof(WindowBorder), GetDescriptions<WindowBorder>() },
             { typeof(RenderColorMode), GetDescriptions<RenderColorMode>() },
-            { typeof(BlitFilter), GetDescriptions<BlitFilter>() }
+            { typeof(BlitFilter), GetDescriptions<BlitFilter>() },
+            { typeof(ControllerPresetType), GetDescriptions<ControllerPresetType>() }
         };
 
         private static Dictionary<Enum, string> GetDescriptions<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] T>() where T : struct, Enum

--- a/Core/Util/Configs/IConfigKeyMapping.cs
+++ b/Core/Util/Configs/IConfigKeyMapping.cs
@@ -97,4 +97,18 @@ public interface IConfigKeyMapping
     /// Ensures that the user has some way to get back to the menus even if they have unbound all keys.
     /// </summary>
     void EnsureMenuKey();
+
+    /// <summary>
+    /// Loads button mapping presets for the specified controller type.
+    /// If changed to "custom", this will do nothing.
+    /// </summary>
+    /// <param name="presetType">Controller type</param>
+    void LoadControllerPreset(ControllerPresetType presetType);
+
+    /// <summary>
+    /// Determines whether a given input belongs to a game controller.
+    /// </summary>
+    /// <param name="key">Input key</param>
+    /// <returns>True if input belongs to a game controller, false otherwise.</returns>
+    bool IsControllerInput(Key key);
 }

--- a/Core/Util/Configs/Impl/ConfigKeyMapping.cs
+++ b/Core/Util/Configs/Impl/ConfigKeyMapping.cs
@@ -69,19 +69,6 @@ public class ConfigKeyMapping : IConfigKeyMapping
         (Key.Minus,         Constants.Input.AutoMapDecrease),
         (Key.MouseWheelUp,  Constants.Input.AutoMapIncrease),
         (Key.MouseWheelDown, Constants.Input.AutoMapDecrease),
-        // Default controller bindings
-        (Key.Axis2Minus,    Constants.Input.Forward),
-        (Key.Axis2Plus,     Constants.Input.Backward),
-        (Key.Axis1Minus,    Constants.Input.Left),
-        (Key.Axis1Plus,     Constants.Input.Right),
-        (Key.Axis3Minus,    Constants.Input.TurnLeft),
-        (Key.Axis3Plus,     Constants.Input.TurnRight),
-        (Key.Button3,       Constants.Input.Use),
-        (Key.Button1,       Constants.Input.Attack),
-        (Key.Axis6Plus,     Constants.Input.Attack),
-        (Key.DPad1Up,       Constants.Input.NextWeapon),
-        (Key.DPad1Down,     Constants.Input.PreviousWeapon),
-        (Key.Button8,       Constants.Input.Menu),
     };
 
     public void SetInitialDefaultKeyBindings()

--- a/Core/Util/Configs/Impl/ConfigKeyMapping.cs
+++ b/Core/Util/Configs/Impl/ConfigKeyMapping.cs
@@ -12,7 +12,7 @@ public readonly record struct KeyCommandItem(Key Key, string Command);
 /// <summary>
 /// A case insensitive two-way lookup.
 /// </summary>
-public class ConfigKeyMapping : IConfigKeyMapping
+public partial class ConfigKeyMapping : IConfigKeyMapping
 {
     private static readonly Logger Log = LogManager.GetCurrentClassLogger();
 
@@ -84,6 +84,21 @@ public class ConfigKeyMapping : IConfigKeyMapping
 
         Changed = true;
     }
+
+    public void LoadControllerPreset(ControllerPresetType presetType)
+    {
+        if (presetType == ControllerPresetType.Custom)
+            return;
+
+        m_commands.RemoveAll(keyCommand => keyCommand.Key >= Key.Axis1Plus && keyCommand.Key <= Key.Button30);
+
+        foreach (var keyMapping in ControllerPresetMappings[presetType])
+        {
+            m_commands.Add(new KeyCommandItem(keyMapping.key, keyMapping.command));
+        }
+    }
+
+    public bool IsControllerInput(Key key) => key >= Key.Axis1Plus && key <= Key.Button30;
 
     public void EnsureMenuKey()
     {

--- a/Core/Util/Configs/Impl/ControllerPresets.cs
+++ b/Core/Util/Configs/Impl/ControllerPresets.cs
@@ -1,0 +1,57 @@
+﻿namespace Helion.Util.Configs.Impl
+{
+    using Helion.Window.Input;
+    using System.Collections.Generic;
+    using System.ComponentModel;
+
+    public enum ControllerPresetType
+    {
+        None,
+        Custom,
+        [Description("XBOX One (Windows)")]
+        XBoxOneWindows,
+        [Description("PS4 (Windows)")]
+        PS4Windows
+    }
+
+    public partial class ConfigKeyMapping
+    {
+        // These are intended as default mappings for custom controller types.
+
+        public static readonly Dictionary<ControllerPresetType, (Key key, string command)[]> ControllerPresetMappings = new()
+        {
+            { ControllerPresetType.None, [] },
+            { ControllerPresetType.XBoxOneWindows,
+                [
+                    (Key.Axis2Minus,    Constants.Input.Forward),
+                    (Key.Axis2Plus,     Constants.Input.Backward),
+                    (Key.Axis1Minus,    Constants.Input.Left),
+                    (Key.Axis1Plus,     Constants.Input.Right),
+                    (Key.Axis3Minus,    Constants.Input.TurnLeft),
+                    (Key.Axis3Plus,     Constants.Input.TurnRight),
+                    (Key.Button3,       Constants.Input.Use),
+                    (Key.Button1,       Constants.Input.Attack),
+                    (Key.Axis6Plus,     Constants.Input.Attack),
+                    (Key.DPad1Up,       Constants.Input.NextWeapon),
+                    (Key.DPad1Down,     Constants.Input.PreviousWeapon),
+                    (Key.Button8,       Constants.Input.Menu),
+                ]},
+            { ControllerPresetType.PS4Windows,
+                [
+                    (Key.Axis2Minus,    Constants.Input.Forward),
+                    (Key.Axis2Plus,     Constants.Input.Backward),
+                    (Key.Axis1Minus,    Constants.Input.Left),
+                    (Key.Axis1Plus,     Constants.Input.Right),
+                    (Key.Axis3Minus,    Constants.Input.TurnLeft),
+                    (Key.Axis3Plus,     Constants.Input.TurnRight),
+                    (Key.Button2,       Constants.Input.Use),
+                    (Key.Button1,       Constants.Input.Attack),
+                    (Key.Axis5Plus,     Constants.Input.Attack),
+                    (Key.DPad1Up,       Constants.Input.NextWeapon),
+                    (Key.DPad1Down,     Constants.Input.PreviousWeapon),
+                    (Key.Button13,      Constants.Input.Menu),
+                    (Key.Button14,      Constants.Input.Menu),
+                ]}
+        };
+    }
+}

--- a/Core/Util/Configs/Impl/ControllerPresets.cs
+++ b/Core/Util/Configs/Impl/ControllerPresets.cs
@@ -17,7 +17,7 @@
 
     public partial class ConfigKeyMapping
     {
-        // These are intended as default mappings for custom controller types.
+        // These are intended as default mappings for common controller types.
 
         public static readonly Dictionary<ControllerPresetType, (Key key, string command)[]> ControllerPresetMappings =
             RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?

--- a/Core/Util/Configs/Impl/ControllerPresets.cs
+++ b/Core/Util/Configs/Impl/ControllerPresets.cs
@@ -3,55 +3,98 @@
     using Helion.Window.Input;
     using System.Collections.Generic;
     using System.ComponentModel;
+    using System.Runtime.InteropServices;
 
     public enum ControllerPresetType
     {
         None,
         Custom,
-        [Description("XBOX One (Windows)")]
-        XBoxOneWindows,
-        [Description("PS4 (Windows)")]
-        PS4Windows
+        [Description("XBOX One")]
+        XBoxOne,
+        [Description("DualShock 4")]
+        PS4
     }
 
     public partial class ConfigKeyMapping
     {
         // These are intended as default mappings for custom controller types.
 
-        public static readonly Dictionary<ControllerPresetType, (Key key, string command)[]> ControllerPresetMappings = new()
-        {
-            { ControllerPresetType.None, [] },
-            { ControllerPresetType.XBoxOneWindows,
-                [
-                    (Key.Axis2Minus,    Constants.Input.Forward),
-                    (Key.Axis2Plus,     Constants.Input.Backward),
-                    (Key.Axis1Minus,    Constants.Input.Left),
-                    (Key.Axis1Plus,     Constants.Input.Right),
-                    (Key.Axis3Minus,    Constants.Input.TurnLeft),
-                    (Key.Axis3Plus,     Constants.Input.TurnRight),
-                    (Key.Button3,       Constants.Input.Use),
-                    (Key.Button1,       Constants.Input.Attack),
-                    (Key.Axis6Plus,     Constants.Input.Attack),
-                    (Key.DPad1Up,       Constants.Input.NextWeapon),
-                    (Key.DPad1Down,     Constants.Input.PreviousWeapon),
-                    (Key.Button8,       Constants.Input.Menu),
-                ]},
-            { ControllerPresetType.PS4Windows,
-                [
-                    (Key.Axis2Minus,    Constants.Input.Forward),
-                    (Key.Axis2Plus,     Constants.Input.Backward),
-                    (Key.Axis1Minus,    Constants.Input.Left),
-                    (Key.Axis1Plus,     Constants.Input.Right),
-                    (Key.Axis3Minus,    Constants.Input.TurnLeft),
-                    (Key.Axis3Plus,     Constants.Input.TurnRight),
-                    (Key.Button2,       Constants.Input.Use),
-                    (Key.Button1,       Constants.Input.Attack),
-                    (Key.Axis5Plus,     Constants.Input.Attack),
-                    (Key.DPad1Up,       Constants.Input.NextWeapon),
-                    (Key.DPad1Down,     Constants.Input.PreviousWeapon),
-                    (Key.Button13,      Constants.Input.Menu),
-                    (Key.Button14,      Constants.Input.Menu),
-                ]}
-        };
+        public static readonly Dictionary<ControllerPresetType, (Key key, string command)[]> ControllerPresetMappings =
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
+            // Windows controller mappings           
+            new()
+            {
+                { ControllerPresetType.None, [] },
+                { ControllerPresetType.XBoxOne,
+                    [
+                        (Key.Axis2Minus,    Constants.Input.Forward),
+                        (Key.Axis2Plus,     Constants.Input.Backward),
+                        (Key.Axis1Minus,    Constants.Input.Left),
+                        (Key.Axis1Plus,     Constants.Input.Right),
+                        (Key.Axis3Minus,    Constants.Input.TurnLeft),
+                        (Key.Axis3Plus,     Constants.Input.TurnRight),
+                        (Key.Button2,       Constants.Input.Use),
+                        (Key.Button3,       Constants.Input.Use),
+                        (Key.Button1,       Constants.Input.Attack),
+                        (Key.Axis6Plus,     Constants.Input.Attack),
+                        (Key.DPad1Up,       Constants.Input.NextWeapon),
+                        (Key.DPad1Down,     Constants.Input.PreviousWeapon),
+                        (Key.Button8,       Constants.Input.Menu),
+                    ]},
+                { ControllerPresetType.PS4,
+                    [
+                        (Key.Axis2Minus,    Constants.Input.Forward),
+                        (Key.Axis2Plus,     Constants.Input.Backward),
+                        (Key.Axis1Minus,    Constants.Input.Left),
+                        (Key.Axis1Plus,     Constants.Input.Right),
+                        (Key.Axis3Minus,    Constants.Input.TurnLeft),
+                        (Key.Axis3Plus,     Constants.Input.TurnRight),
+                        (Key.Button1,       Constants.Input.Use),
+                        (Key.Button3,       Constants.Input.Use),
+                        (Key.Button2,       Constants.Input.Attack),
+                        (Key.Axis5Plus,     Constants.Input.Attack),
+                        (Key.DPad1Up,       Constants.Input.NextWeapon),
+                        (Key.DPad1Down,     Constants.Input.PreviousWeapon),
+                        (Key.Button13,      Constants.Input.Menu),
+                        (Key.Button14,      Constants.Input.Menu),
+                    ]}
+            } :
+            // Linux controller mappings
+            new()
+            {
+                { ControllerPresetType.None, [] },
+                { ControllerPresetType.XBoxOne,
+                    [
+                        (Key.Axis2Minus,    Constants.Input.Forward),
+                        (Key.Axis2Plus,     Constants.Input.Backward),
+                        (Key.Axis1Minus,    Constants.Input.Left),
+                        (Key.Axis1Plus,     Constants.Input.Right),
+                        (Key.Axis4Minus,    Constants.Input.TurnLeft),
+                        (Key.Axis4Plus,     Constants.Input.TurnRight),
+                        (Key.Button2,       Constants.Input.Use),
+                        (Key.Button3,       Constants.Input.Use),
+                        (Key.Button1,       Constants.Input.Attack),
+                        (Key.Axis6Plus,     Constants.Input.Attack),
+                        (Key.DPad1Up,       Constants.Input.NextWeapon),
+                        (Key.DPad1Down,     Constants.Input.PreviousWeapon),
+                        (Key.Button8,       Constants.Input.Menu),
+                    ]},
+                { ControllerPresetType.PS4,
+                    [
+                        (Key.Axis2Minus,    Constants.Input.Forward),
+                        (Key.Axis2Plus,     Constants.Input.Backward),
+                        (Key.Axis1Minus,    Constants.Input.Left),
+                        (Key.Axis1Plus,     Constants.Input.Right),
+                        (Key.Axis4Minus,    Constants.Input.TurnLeft),
+                        (Key.Axis4Plus,     Constants.Input.TurnRight),
+                        (Key.Button2,       Constants.Input.Use),
+                        (Key.Button4,       Constants.Input.Use),
+                        (Key.Button1,       Constants.Input.Attack),
+                        (Key.Axis6Plus,     Constants.Input.Attack),
+                        (Key.DPad1Up,       Constants.Input.NextWeapon),
+                        (Key.DPad1Down,     Constants.Input.PreviousWeapon),
+                        (Key.Button11,      Constants.Input.Menu),
+                    ]}
+            };
     }
 }


### PR DESCRIPTION
The default button mappings we initially used only work with the XBox One controller, and only on Windows.  Using a PS4 DualShock controller, or even using the same controller on Linux, results in some different IDs reported for the same buttons and axes.

In this change, I'm allowing the user to select a specific controller type after enabling controller support; this will load a hopefully-reasonable set of presets for their controller.  If we obtain other controllers to try, we can add presets for those.