### PR TITLE
Use Ubuntu 22.04 for build workflows

### DIFF
--- a/.github/workflows/Nightly.yml
+++ b/.github/workflows/Nightly.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   buildRelease:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   buildRelease:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This mostly shouldn't matter for regular .NET builds, but it is better to be safe.  This will probably matter if we use the Linux build environment to generate AOT builds in the future.