### PR TITLE
implement IEquatable for structs 

### DIFF
--- a/Core/Geometry/Segments/Seg2D.cs
+++ b/Core/Geometry/Segments/Seg2D.cs
@@ -12,7 +12,7 @@ using Helion.Util.Extensions;
 namespace Helion.Geometry.Segments
 {
     [StructLayout(LayoutKind.Sequential, Pack = 8)]
-    public struct Seg2D 
+    public struct Seg2D : IEquatable<Seg2D>
     {
         public Vec2D Start;
         public Vec2D End;
@@ -442,11 +442,11 @@ namespace Helion.Geometry.Segments
         {
             return ((aX - cX) * (bY - cY)) - ((aY - cY) * (bX - cX));
         }
-        public override string ToString() => $"({Start}), ({End})";
-        public override bool Equals(object? obj) => obj is Seg2D seg && Start == seg.Start && End == seg.End;
-        public override int GetHashCode() => HashCode.Combine(Start.GetHashCode(), End.GetHashCode());
+        public readonly override string ToString() => $"({Start}), ({End})";
+        public readonly override int GetHashCode() => HashCode.Combine(Start.GetHashCode(), End.GetHashCode());
+        public readonly bool Equals(Seg2D other) => Start.X == other.Start.X && Start.Y == other.Start.Y && End.X == other.End.X && End.Y == other.End.Y;
 
-        private IEnumerable<Vec2D> GetVertices()
+        private readonly IEnumerable<Vec2D> GetVertices()
         {
             yield return Start;
             yield return End;

--- a/Core/Geometry/Vectors/Vec2D.cs
+++ b/Core/Geometry/Vectors/Vec2D.cs
@@ -11,7 +11,7 @@ using Helion.Util.Extensions;
 namespace Helion.Geometry.Vectors
 {
     [StructLayout(LayoutKind.Sequential, Pack = 8)]
-    public struct Vec2D(double x, double y)
+    public struct Vec2D(double x, double y) : IEquatable<Vec2D>
     {
         public static readonly Vec2D Zero = new(0, 0);
         public static readonly Vec2D One = new(1, 1);
@@ -87,7 +87,8 @@ namespace Helion.Geometry.Vectors
         public readonly double Angle(Vector3D other) => Math.Atan2(other.Y - Y, other.X - X);
 
         public override readonly string ToString() => $"{X}, {Y}";
-        public override readonly bool Equals(object? obj) => obj is Vec2D v && X == v.X && Y == v.Y;
         public override readonly int GetHashCode() => HashCode.Combine(X, Y);
+        public readonly bool Equals(Vec2D other) => X == other.X && Y == other.Y;
+        public readonly override bool Equals(object? obj) => obj is not null && obj is Vec2D v && Equals(v);
     }
 }

--- a/Core/Geometry/Vectors/Vec3D.cs
+++ b/Core/Geometry/Vectors/Vec3D.cs
@@ -10,7 +10,7 @@ using Helion.Util.Extensions;
 namespace Helion.Geometry.Vectors
 {
     [StructLayout(LayoutKind.Sequential, Pack = 8)]
-    public struct Vec3D(double x, double y, double z)
+    public struct Vec3D(double x, double y, double z) : IEquatable<Vec3D>
     {
         public static readonly Vec3D Zero = new(0, 0, 0);
         public static readonly Vec3D One = new(1, 1, 1);
@@ -108,7 +108,8 @@ namespace Helion.Geometry.Vectors
         }
 
         public override readonly string ToString() => $"{X}, {Y}, {Z}";
-        public override readonly bool Equals(object? obj) => obj is Vec3D v && X == v.X && Y == v.Y && Z == v.Z;
         public override readonly int GetHashCode() => HashCode.Combine(X, Y, Z);
+        public readonly bool Equals(Vec3D other) => X == other.X && Y == other.Y && Z == other.Z;
+        public readonly override bool Equals(object? obj) => obj is not null && obj is Vec3D v && Equals(v);
     }
 }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/SpritePosKey.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/SpritePosKey.cs
@@ -1,32 +1,16 @@
 ﻿using Helion.Geometry.Vectors;
 using System;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Helion.Render.OpenGL.Renderers.Legacy.World.Entities;
 
-public readonly struct SpritePosKey(Vec2D pos, int sprite)
+public readonly struct SpritePosKey(Vec2D pos, int sprite) : IEquatable<SpritePosKey>
 {
     public readonly Vec2D Pos = pos;
     public readonly int Sprite = sprite;
 
-    public override int GetHashCode()
-    {
-        return HashCode.Combine(Pos.X, Pos.Y, Sprite);
-    }
-
-    public override bool Equals([NotNullWhen(true)] object? obj)
-    {
-        var key = (SpritePosKey)obj!;
-        return Sprite == key.Sprite && key.Pos.X == Pos.X && key.Pos.Y == Pos.Y;
-    }
-
-    public static bool operator ==(SpritePosKey left, SpritePosKey right)
-    {
-        return left.Equals(right);
-    }
-
-    public static bool operator !=(SpritePosKey left, SpritePosKey right)
-    {
-        return !(left == right);
-    }
+    public override int GetHashCode() => HashCode.Combine(Pos.X, Pos.Y, Sprite);
+    public readonly bool Equals(SpritePosKey other) => Sprite == other.Sprite && other.Pos.X == Pos.X && other.Pos.Y == Pos.Y;
+    public readonly override bool Equals(object? obj) => obj is not null && obj is SpritePosKey key && Equals(key);
+    public static bool operator ==(SpritePosKey left, SpritePosKey right) => left.Equals(right);
+    public static bool operator !=(SpritePosKey left, SpritePosKey right) => !(left == right);
 }


### PR DESCRIPTION
implement IEquatable for structs that may be used in dictionaries so that the object equals override isn't used creating an allocation on the heap