### PR TITLE
sprite x offset fix

### DIFF
--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
@@ -167,10 +167,9 @@ public class EntityProgram : RenderProgram
 
             vec3 pos = gl_in[0].gl_Position.xyz;
             ivec2 textureDim = textureSize(boundTexture, 0);
-            float halfTexWidth = textureDim.x * 0.5;
             vec3 posMoveDir = vec3(mix(prevViewRightNormal, viewRightNormal, timeFrac), 0);
-            vec3 minPos = pos - (posMoveDir * halfTexWidth);
-            vec3 maxPos = pos + (posMoveDir * halfTexWidth) + (vec3(0, 0, 1) * textureDim.y);
+            vec3 minPos = pos;
+            vec3 maxPos = pos + (posMoveDir * textureDim.x) + (vec3(0, 0, 1) * textureDim.y);
 
             // Triangle strip ordering is: v0 v1 v2, v2 v1 v3
             // We also need to be going counter-clockwise.

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -21,3 +21,4 @@
   - Fix translation flags using incorrect colormap indices (fixes kdikdizd)
   - Fix colormaps for transfer heights not setting on two-sided lines
   - Fix cases where lines were being marked for automap when they weren't visible
+  - Fix sprite x offset rendering (fixes small red torch and burning barrel twitching)


### PR DESCRIPTION
update entity shader to render sprites from left to right instead of center to fix sprite texture offsets

fixes #875 