### PR TITLE
Tie controller vertical aiming together with mlook enabled/disabled

### DIFF
--- a/Core/Layer/Worlds/WorldLayer.Input.cs
+++ b/Core/Layer/Worlds/WorldLayer.Input.cs
@@ -248,7 +248,9 @@ public partial class WorldLayer
             cmd.ForwardMoveSpeed = Math.Clamp(analogInput.X * m_config.Controller.GameControllerRunScale, -1, 1) * Player.GetForwardMovementSpeed();
             cmd.SideMoveSpeed = Math.Clamp(analogInput.Y * m_config.Controller.GameControllerStrafeScale, -1, 1) * Player.GetSideMovementSpeed();
             cmd.AngleTurn = analogInput.Z * Player.FastTurnSpeed * m_config.Controller.GameControllerTurnScale;
-            cmd.PitchTurn = analogInput.W * Player.FastTurnSpeed * m_config.Controller.GameControllerPitchScale;
+            cmd.PitchTurn = m_config.Mouse.Look
+                ? analogInput.W * Player.FastTurnSpeed * m_config.Controller.GameControllerPitchScale
+                : 0;
         }
 
         cmd.WeaponScroll = weaponScroll;

--- a/Core/World/Impl/SinglePlayer/SinglePlayerWorld.cs
+++ b/Core/World/Impl/SinglePlayer/SinglePlayerWorld.cs
@@ -1,31 +1,31 @@
-using System;
-using System.Linq;
 using Helion.Audio;
+using Helion.Geometry.Vectors;
 using Helion.Maps;
+using Helion.Models;
 using Helion.Resources.Archives.Collection;
 using Helion.Resources.Archives.Entries;
 using Helion.Resources.Definitions.MapInfo;
-using Helion.Models;
+using Helion.Resources.Definitions.SoundInfo;
 using Helion.Util;
 using Helion.Util.Configs;
-using Helion.World.Cheats;
-using Helion.World.Entities;
-using Helion.World.Entities.Players;
-using Helion.World.Geometry;
-using Helion.World.Physics;
-using NLog;
-using System.Collections.Generic;
-using Helion.Geometry.Vectors;
 using Helion.Util.Profiling;
+using Helion.Util.RandomGenerators;
 using Helion.Window;
 using Helion.Window.Input;
-using static Helion.Util.Assertion.Assert;
-using static Helion.World.Entities.EntityManager;
-using Helion.Util.RandomGenerators;
+using Helion.World.Cheats;
+using Helion.World.Entities;
+using Helion.World.Entities.Inventories.Powerups;
+using Helion.World.Entities.Players;
+using Helion.World.Geometry;
 using Helion.World.Geometry.Islands;
 using Helion.World.Geometry.Lines;
-using Helion.World.Entities.Inventories.Powerups;
-using Helion.Resources.Definitions.SoundInfo;
+using Helion.World.Physics;
+using NLog;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using static Helion.Util.Assertion.Assert;
+using static Helion.World.Entities.EntityManager;
 
 namespace Helion.World.Impl.SinglePlayer;
 
@@ -585,7 +585,7 @@ public class SinglePlayerWorld : WorldBase
             m_gyroYawAngle = yaw;
         }
 
-        if ((!MapInfo.HasOption(MapOptions.NoFreelook) || IsChaseCamMode)
+        if (((Config.Mouse.Look && !MapInfo.HasOption(MapOptions.NoFreelook)) || IsChaseCamMode)
             && (input.Manager.AnalogAdapter?.TryGetGyroAbsolute(GyroAxis.Pitch, out double pitch) == true))
         {
             player.AddToPitch((float)((pitch - m_gyroPitchAngle) * Config.Controller.GyroAimVerticalSensitivity), true);


### PR DESCRIPTION
Both gyroscopic and analog stick "vertical aim" inputs will be ignored if mouselook is disabled.

Resolves #885