### PR TITLE
Add gyro button

### DIFF
--- a/Client/Input/Controller/ControllerAdapter.cs
+++ b/Client/Input/Controller/ControllerAdapter.cs
@@ -51,7 +51,10 @@
             }
             set
             {
-                ZeroGyroAbsolute();
+                if (!m_gyroEnabled)
+                {
+                    ZeroGyroAbsolute();
+                }
                 m_gyroEnabled = value;
             }
         }
@@ -204,7 +207,7 @@
 
         public bool TryGetGyroAbsolute(Helion.Window.Input.GyroAxis axis, out double value)
         {
-            if (!m_enabled || m_activeController == null || !m_activeController.HasGyro)
+            if (!m_enabled || !m_gyroEnabled || m_activeController == null || !m_activeController.HasGyro)
             {
                 value = 0;
                 return false;

--- a/Client/Input/Controller/ControllerAdapter.cs
+++ b/Client/Input/Controller/ControllerAdapter.cs
@@ -10,18 +10,57 @@
     {
         public float AnalogDeadZone;
         private bool m_enabled;
-        private bool m_rumbleEnabled;
         private readonly InputManager m_inputManager;
         private SDLControllerWrapper m_controllerWrapper;
         private bool m_disposedValue;
+        private bool m_gyroEnabled;
 
         private Controller? m_activeController;
+        public bool Enabled
+        {
+            get
+            {
+                return m_enabled;
+            }
+            set
+            {
+                if (value)
+                {
+                    m_controllerWrapper.DetectControllers();
+                    m_activeController = m_controllerWrapper.Controllers.FirstOrDefault();
+                }
+                else
+                {
+                    // Ensure no buttons are "stuck" when we disable the controller.
+                    for (Key k = Key.LeftYPlus; k <= Key.DPadRight; k++)
+                    {
+                        m_inputManager.SetKeyUp(k);
+                    }
+                }
+                m_enabled = value;
+            }
+        }
+
+        public bool RumbleEnabled { get; set; }
+
+        public bool GyroEnabled
+        {
+            get
+            {
+                return m_gyroEnabled;
+            }
+            set
+            {
+                ZeroGyroAbsolute();
+                m_gyroEnabled = value;
+            }
+        }
 
         public ControllerAdapter(float analogDeadZone, bool enabled, bool rumbleEnabled, InputManager inputManager)
         {
             AnalogDeadZone = analogDeadZone;
             m_enabled = enabled;
-            m_rumbleEnabled = rumbleEnabled;
+            RumbleEnabled = rumbleEnabled;
             m_inputManager = inputManager;
             inputManager.AnalogAdapter = this;
 
@@ -42,29 +81,6 @@
             {
                 m_activeController = m_controllerWrapper.Controllers.First();
             }
-        }
-
-        public void SetEnabled(bool enable)
-        {
-            if (enable)
-            {
-                m_controllerWrapper.DetectControllers();
-                m_activeController = m_controllerWrapper.Controllers.FirstOrDefault();
-            }
-            else
-            {
-                // Ensure no buttons are "stuck" when we disable the controller.
-                for (Key k = Key.LeftYPlus; k <= Key.DPadRight; k++)
-                {
-                    m_inputManager.SetKeyUp(k);
-                }
-            }
-            m_enabled = enable;
-        }
-
-        public void SetRumbleEnabled(bool enable)
-        {
-            m_rumbleEnabled = enable;
         }
 
         public void Poll()
@@ -154,7 +170,7 @@
 
         public bool TryGetGyroAxis(GyroOrAccelAxis axis, out float value)
         {
-            if (!m_enabled || m_activeController == null || !m_activeController.HasGyro)
+            if (!m_enabled || !m_gyroEnabled || m_activeController == null || !m_activeController.HasGyro)
             {
                 value = 0;
                 return false;
@@ -205,7 +221,7 @@
 
         public void Rumble(ushort lowFrequency, ushort highFrequency, uint durationms)
         {
-            if (m_enabled && m_rumbleEnabled && m_activeController?.HasRumble == true)
+            if (m_enabled && RumbleEnabled && m_activeController?.HasRumble == true)
             {
                 m_activeController.Rumble(lowFrequency, highFrequency, durationms);
             }
@@ -213,7 +229,7 @@
 
         public void RumbleForSoundCreated(object? sender, SoundCreatedEventArgs evt)
         {
-            if (!m_enabled || !m_rumbleEnabled || m_activeController?.HasRumble != true)
+            if (!m_enabled || !RumbleEnabled || m_activeController?.HasRumble != true)
             {
                 return;
             }

--- a/Client/Window.cs
+++ b/Client/Window.cs
@@ -303,11 +303,11 @@ public class Window : GameWindow, IWindow
 
     private void EnableGameController_OnChanged(object? sender, bool e)
     {
-        JoystickAdapter.SetEnabled(e);
+        JoystickAdapter.Enabled = e;
     }
     private void GameControllerRumble_OnChanged(object? sender, bool e)
     {
-        JoystickAdapter.SetRumbleEnabled(e);
+        JoystickAdapter.RumbleEnabled = e;
     }
 
     private void PerformDispose()

--- a/Core/Layer/Worlds/WorldLayer.Input.cs
+++ b/Core/Layer/Worlds/WorldLayer.Input.cs
@@ -102,6 +102,12 @@ public partial class WorldLayer
         if (!input.HandleKeyInput)
             return;
 
+        if (input.Manager.AnalogAdapter != null)
+        {
+            input.Manager.AnalogAdapter.GyroEnabled = m_config.Controller.GyroAimOnByDefault
+                ^ IsCommandDown(Input.GyroButton, input, out _, out _);
+        }
+
         if (IsCommandPressed(Input.Pause, input))
             HandlePausePress();
 

--- a/Core/Util/Configs/Components/ConfigController.cs
+++ b/Core/Util/Configs/Components/ConfigController.cs
@@ -46,7 +46,7 @@ public class ConfigController : ConfigElement<ConfigController>
     // Gyro aiming
 
     [ConfigInfo("Gyro axis to use for turning left and right.")]
-    [OptionMenu(OptionSectionType.Controller, "Gyro Aim Turn Axis")]
+    [OptionMenu(OptionSectionType.Controller, "Gyro Aim Turn Axis", spacer: true)]
     public readonly ConfigValue<GyroTurnAxis> GyroAimTurnAxis = new(GyroTurnAxis.Yaw);
 
     [ConfigInfo("Vertical aiming sensitivity for gyro input.")]
@@ -57,7 +57,7 @@ public class ConfigController : ConfigElement<ConfigController>
     [OptionMenu(OptionSectionType.Controller, "Gyro Aim Turn Sensitivity", sliderMin: 0, sliderMax: 10, sliderStep: .1)]
     public readonly ConfigValue<double> GyroAimHorizontalSensitivity = new(3.0, Clamp(0, 10.0));
 
-    [ConfigInfo("Whether gyro aiming is on or off by default.  This also inverts the function of the gyro button.")]
+    [ConfigInfo("Whether gyro aiming is on or off by default.  Holding the gyro button on the controller will temporarily switch this.")]
     [OptionMenu(OptionSectionType.Controller, "Gyro On By Default")]
     public readonly ConfigValue<bool> GyroAimOnByDefault = new(true);
 }

--- a/Core/Util/Configs/Components/ConfigController.cs
+++ b/Core/Util/Configs/Components/ConfigController.cs
@@ -56,5 +56,9 @@ public class ConfigController : ConfigElement<ConfigController>
     [ConfigInfo("Horizontal aiming sensitivity for gyro input.")]
     [OptionMenu(OptionSectionType.Controller, "Gyro Aim Turn Sensitivity", sliderMin: 0, sliderMax: 10, sliderStep: .1)]
     public readonly ConfigValue<double> GyroAimHorizontalSensitivity = new(3.0, Clamp(0, 10.0));
+
+    [ConfigInfo("Whether gyro aiming is on or off by default.  This also inverts the function of the gyro button.")]
+    [OptionMenu(OptionSectionType.Controller, "Gyro On By Default")]
+    public readonly ConfigValue<bool> GyroAimOnByDefault = new(true);
 }
 

--- a/Core/Util/Configs/Impl/ConfigKeyMapping.cs
+++ b/Core/Util/Configs/Impl/ConfigKeyMapping.cs
@@ -85,6 +85,8 @@ public partial class ConfigKeyMapping : IConfigKeyMapping
         (Key.DPadUp,            Constants.Input.NextWeapon),
         (Key.DPadDown,          Constants.Input.PreviousWeapon),
         (Key.ButtonStart,       Constants.Input.Menu),
+        (Key.ButtonLeftShoulder,Constants.Input.GyroButton),
+        (Key.LeftTriggerPlus,   Constants.Input.GyroButton),
     };
 
     public void SetInitialDefaultKeyBindings()

--- a/Core/Util/Constants.cs
+++ b/Core/Util/Constants.cs
@@ -232,6 +232,7 @@ public static class Constants
         Input.OptionsMenu,
         Input.Menu,
         Input.CenterView,
+        Input.GyroButton,
     };
 
     public static readonly HashSet<string> InGameCommands = new(StringComparer.OrdinalIgnoreCase)
@@ -260,6 +261,7 @@ public static class Constants
         Input.WeaponSlot6,
         Input.WeaponSlot7,
         Input.CenterView,
+        Input.GyroButton,
     };
 
     public static class ConsoleCommands

--- a/Core/Util/Constants.cs
+++ b/Core/Util/Constants.cs
@@ -160,6 +160,7 @@ public static class Constants
         public const string OptionsMenu = "OptionsMenu";
         public const string Menu = "Menu";
         public const string GammaCorrection = "GammaCorrection";
+        public const string GyroButton = "GyroButton";
     }
 
     public static class Fonts

--- a/Core/Window/Input/IGameControlAdapter.cs
+++ b/Core/Window/Input/IGameControlAdapter.cs
@@ -74,7 +74,14 @@ public interface IGameControlAdapter
     bool TryGetGyroAbsolute(GyroAxis axis, out double absoluteValue);
 
     /// <summary>
-    /// Reset estimated absolute positions for the controller's onboard gyroscope
+    /// Reset estimated absolute orientations for the controller's onboard gyroscope
     /// </summary>
     void ZeroGyroAbsolute();
+
+    /// <summary>
+    /// Gets or sets whether the controller should _try_ to report gyro and accelerometer values (if it has a gyro)
+    /// Toggling this on and off should also re-zero any absolute orientation values reported by the gyro,
+    /// as these have likely become out-of-date.
+    /// </summary>
+    bool GyroEnabled { get; set; }
 }

--- a/Core/World/Impl/SinglePlayer/SinglePlayerWorld.cs
+++ b/Core/World/Impl/SinglePlayer/SinglePlayerWorld.cs
@@ -40,8 +40,6 @@ public class SinglePlayerWorld : WorldBase
     private bool m_chaseCamMode;
     private WorldType m_worldType = WorldType.SinglePlayer;
     private int m_renderDistanceOverride;
-    private double m_gyroYawAngle;
-    private double m_gyroPitchAngle;
     private bool m_firstUpdate = true;
 
     public override WorldType WorldType => m_worldType;
@@ -579,17 +577,20 @@ public class SinglePlayerWorld : WorldBase
             return;
         }
 
-        if (input.Manager.AnalogAdapter?.TryGetGyroAbsolute((GyroAxis)(int)Config.Controller.GyroAimTurnAxis.Value, out double yaw) == true)
+        if (input.Manager.AnalogAdapter != null)
         {
-            player.AddToYaw((float)((yaw - m_gyroYawAngle) * Config.Controller.GyroAimHorizontalSensitivity), true);
-            m_gyroYawAngle = yaw;
-        }
+            if (input.Manager.AnalogAdapter.TryGetGyroAbsolute((GyroAxis)(int)Config.Controller.GyroAimTurnAxis.Value, out double yaw) == true)
+            {
+                player.AddToYaw((float)(yaw * Config.Controller.GyroAimHorizontalSensitivity), true);
+            }
 
-        if (((Config.Mouse.Look && !MapInfo.HasOption(MapOptions.NoFreelook)) || IsChaseCamMode)
-            && (input.Manager.AnalogAdapter?.TryGetGyroAbsolute(GyroAxis.Pitch, out double pitch) == true))
-        {
-            player.AddToPitch((float)((pitch - m_gyroPitchAngle) * Config.Controller.GyroAimVerticalSensitivity), true);
-            m_gyroPitchAngle = pitch;
+            if (((Config.Mouse.Look && !MapInfo.HasOption(MapOptions.NoFreelook)) || IsChaseCamMode)
+                && (input.Manager.AnalogAdapter.TryGetGyroAbsolute(GyroAxis.Pitch, out double pitch) == true))
+            {
+                player.AddToPitch((float)(pitch * Config.Controller.GyroAimVerticalSensitivity), true);
+            }
+
+            input.Manager.AnalogAdapter.ZeroGyroAbsolute();
         }
     }
 }

--- a/Tests/Unit/GameLayer/GameLayerInput.cs
+++ b/Tests/Unit/GameLayer/GameLayerInput.cs
@@ -42,6 +42,8 @@ public class GameLayerInput
 
         public void Poll() { }
 
+        public bool GyroEnabled { get; set; }
+
         public bool KeyIsAnalogAxis(Key key)
         {
             return key.ToString().StartsWith("Axis");


### PR DESCRIPTION
Add a button that, when held, temporarily switches gyro input on or off.

If the player has gyro input disabled by default, this will temporarily enable it so they can use it to aim a specific shot.  If the player has gyro input enabled by default, this will temporarily disable it, so they can reposition their controller without changing their aim.