### PR TITLE
Add Woof!-like weapon groups

### DIFF
--- a/Core/Demo/CommandExtensions.cs
+++ b/Core/Demo/CommandExtensions.cs
@@ -22,6 +22,10 @@ public static class CommandExtensions
             TickCommands.WeaponSlot5 => DemoTickCommands.WeaponSlot5,
             TickCommands.WeaponSlot6 => DemoTickCommands.WeaponSlot6,
             TickCommands.WeaponSlot7 => DemoTickCommands.WeaponSlot7,
+            TickCommands.WeaponGroup1 => DemoTickCommands.WeaponGroup1,
+            TickCommands.WeaponGroup2 => DemoTickCommands.WeaponGroup2,
+            TickCommands.WeaponGroup3 => DemoTickCommands.WeaponGroup3,
+            TickCommands.WeaponGroup4 => DemoTickCommands.WeaponGroup4,
             TickCommands.CenterView => DemoTickCommands.CenterView,
             _ => DemoTickCommands.None,
         };
@@ -45,6 +49,10 @@ public static class CommandExtensions
             DemoTickCommands.WeaponSlot5 => TickCommands.WeaponSlot5,
             DemoTickCommands.WeaponSlot6 => TickCommands.WeaponSlot6,
             DemoTickCommands.WeaponSlot7 => TickCommands.WeaponSlot7,
+            DemoTickCommands.WeaponGroup1 => TickCommands.WeaponGroup1,
+            DemoTickCommands.WeaponGroup2 => TickCommands.WeaponGroup2,
+            DemoTickCommands.WeaponGroup3 => TickCommands.WeaponGroup3,
+            DemoTickCommands.WeaponGroup4 => TickCommands.WeaponGroup4,
             DemoTickCommands.CenterView => TickCommands.CenterView,
             _ => TickCommands.None,
         };

--- a/Core/Demo/DemoTickCommand.cs
+++ b/Core/Demo/DemoTickCommand.cs
@@ -19,4 +19,8 @@ public enum DemoTickCommands
     WeaponSlot6,
     WeaponSlot7,
     CenterView,
+    WeaponGroup1,
+    WeaponGroup2,
+    WeaponGroup3,
+    WeaponGroup4,
 }

--- a/Core/Layer/Worlds/WorldLayer.Input.cs
+++ b/Core/Layer/Worlds/WorldLayer.Input.cs
@@ -45,6 +45,10 @@ public partial class WorldLayer
         (Input.WeaponSlot5,    TickCommands.WeaponSlot5),
         (Input.WeaponSlot6,    TickCommands.WeaponSlot6),
         (Input.WeaponSlot7,    TickCommands.WeaponSlot7),
+        (Input.WeaponGroup1,   TickCommands.WeaponGroup1),
+        (Input.WeaponGroup2,   TickCommands.WeaponGroup2),
+        (Input.WeaponGroup3,   TickCommands.WeaponGroup3),
+        (Input.WeaponGroup4,   TickCommands.WeaponGroup4),
     };
 
     // Convert analog inputs into movements, assumes analog values are in range [0..1]

--- a/Core/Util/Configs/Components/ConfigPlayer.cs
+++ b/Core/Util/Configs/Components/ConfigPlayer.cs
@@ -1,3 +1,4 @@
+using Helion.Util.Config.Components;
 using Helion.Util.Configs.Impl;
 using Helion.Util.Configs.Options;
 using Helion.Util.Configs.Values;
@@ -15,4 +16,44 @@ public class ConfigPlayer: ConfigElement<ConfigPlayer>
     [ConfigInfo("Gender of the player.")]
     [OptionMenu(OptionSectionType.General, "Player Gender")]
     public readonly ConfigValue<PlayerGender> Gender = new(default, OnlyValidEnums<PlayerGender>());
+
+    [ConfigInfo("")]
+    [OptionMenu(OptionSectionType.General, "Group 1 1st")]
+    public readonly ConfigValue<ConfigWeaponSlots> Group1Weapon1 = new(ConfigWeaponSlots.ShotgunOrSuperShotgun, OnlyValidEnums<ConfigWeaponSlots>());
+    [ConfigInfo("")]
+    [OptionMenu(OptionSectionType.General, "        2nd")]
+    public readonly ConfigValue<ConfigWeaponSlots> Group1Weapon2 = new(ConfigWeaponSlots.ShotgunOrSuperShotgun, OnlyValidEnums<ConfigWeaponSlots>());
+    [ConfigInfo("")]
+    [OptionMenu(OptionSectionType.General, "        3rd")]
+    public readonly ConfigValue<ConfigWeaponSlots> Group1Weapon3 = new(ConfigWeaponSlots.None, OnlyValidEnums<ConfigWeaponSlots>());
+
+    [ConfigInfo("")]
+    [OptionMenu(OptionSectionType.General, "Group 2 1st")]
+    public readonly ConfigValue<ConfigWeaponSlots> Group2Weapon1 = new(ConfigWeaponSlots.RocketLauncher, OnlyValidEnums<ConfigWeaponSlots>());
+    [ConfigInfo("")]
+    [OptionMenu(OptionSectionType.General, "        2nd")]
+    public readonly ConfigValue<ConfigWeaponSlots> Group2Weapon2 = new(ConfigWeaponSlots.Melee, OnlyValidEnums<ConfigWeaponSlots>());
+    [ConfigInfo("")]
+    [OptionMenu(OptionSectionType.General, "        3rd")]
+    public readonly ConfigValue<ConfigWeaponSlots> Group2Weapon3 = new(ConfigWeaponSlots.Melee, OnlyValidEnums<ConfigWeaponSlots>());
+
+    [ConfigInfo("")]
+    [OptionMenu(OptionSectionType.General, "Group 3 1st")]
+    public readonly ConfigValue<ConfigWeaponSlots> Group3Weapon1 = new(ConfigWeaponSlots.PlasmaRifle, OnlyValidEnums<ConfigWeaponSlots>());
+    [ConfigInfo("")]
+    [OptionMenu(OptionSectionType.General, "        2nd")]
+    public readonly ConfigValue<ConfigWeaponSlots> Group3Weapon2 = new(ConfigWeaponSlots.BFG9000, OnlyValidEnums<ConfigWeaponSlots>());
+    [ConfigInfo("")]
+    [OptionMenu(OptionSectionType.General, "        3rd")]
+    public readonly ConfigValue<ConfigWeaponSlots> Group3Weapon3 = new(ConfigWeaponSlots.None, OnlyValidEnums<ConfigWeaponSlots>());
+
+    [ConfigInfo("")]
+    [OptionMenu(OptionSectionType.General, "Group 4 1st")]
+    public readonly ConfigValue<ConfigWeaponSlots> Group4Weapon1 = new(ConfigWeaponSlots.Chaingun, OnlyValidEnums<ConfigWeaponSlots>());
+    [ConfigInfo("")]
+    [OptionMenu(OptionSectionType.General, "        2nd")]
+    public readonly ConfigValue<ConfigWeaponSlots> Group4Weapon2 = new(ConfigWeaponSlots.Pistol, OnlyValidEnums<ConfigWeaponSlots>());
+    [ConfigInfo("")]
+    [OptionMenu(OptionSectionType.General, "        3rd")]
+    public readonly ConfigValue<ConfigWeaponSlots> Group4Weapon3 = new(ConfigWeaponSlots.None, OnlyValidEnums<ConfigWeaponSlots>());
 }

--- a/Core/Util/Configs/Components/ConfigPlayer.cs
+++ b/Core/Util/Configs/Components/ConfigPlayer.cs
@@ -10,50 +10,50 @@ namespace Helion.Util.Configs.Components;
 public class ConfigPlayer: ConfigElement<ConfigPlayer>
 {
     [ConfigInfo("Name of the player.")]
-    [OptionMenu(OptionSectionType.General, "Player Name", spacer: true)]
+    [OptionMenu(OptionSectionType.Player, "Player Name", spacer: true)]
     public readonly ConfigValue<string> Name = new("Player", IfEmptyDefaultTo("Player"));
 
     [ConfigInfo("Gender of the player.")]
-    [OptionMenu(OptionSectionType.General, "Player Gender")]
+    [OptionMenu(OptionSectionType.Player, "Player Gender")]
     public readonly ConfigValue<PlayerGender> Gender = new(default, OnlyValidEnums<PlayerGender>());
 
     [ConfigInfo("")]
-    [OptionMenu(OptionSectionType.General, "Group 1 1st")]
+    [OptionMenu(OptionSectionType.Player, "Group 1 1st", spacer: true)]
     public readonly ConfigValue<ConfigWeaponSlots> Group1Weapon1 = new(ConfigWeaponSlots.ShotgunOrSuperShotgun, OnlyValidEnums<ConfigWeaponSlots>());
     [ConfigInfo("")]
-    [OptionMenu(OptionSectionType.General, "        2nd")]
+    [OptionMenu(OptionSectionType.Player, "        2nd")]
     public readonly ConfigValue<ConfigWeaponSlots> Group1Weapon2 = new(ConfigWeaponSlots.ShotgunOrSuperShotgun, OnlyValidEnums<ConfigWeaponSlots>());
     [ConfigInfo("")]
-    [OptionMenu(OptionSectionType.General, "        3rd")]
+    [OptionMenu(OptionSectionType.Player, "        3rd")]
     public readonly ConfigValue<ConfigWeaponSlots> Group1Weapon3 = new(ConfigWeaponSlots.None, OnlyValidEnums<ConfigWeaponSlots>());
 
     [ConfigInfo("")]
-    [OptionMenu(OptionSectionType.General, "Group 2 1st")]
+    [OptionMenu(OptionSectionType.Player, "Group 2 1st", spacer: true)]
     public readonly ConfigValue<ConfigWeaponSlots> Group2Weapon1 = new(ConfigWeaponSlots.RocketLauncher, OnlyValidEnums<ConfigWeaponSlots>());
     [ConfigInfo("")]
-    [OptionMenu(OptionSectionType.General, "        2nd")]
+    [OptionMenu(OptionSectionType.Player, "        2nd")]
     public readonly ConfigValue<ConfigWeaponSlots> Group2Weapon2 = new(ConfigWeaponSlots.Melee, OnlyValidEnums<ConfigWeaponSlots>());
     [ConfigInfo("")]
-    [OptionMenu(OptionSectionType.General, "        3rd")]
+    [OptionMenu(OptionSectionType.Player, "        3rd")]
     public readonly ConfigValue<ConfigWeaponSlots> Group2Weapon3 = new(ConfigWeaponSlots.Melee, OnlyValidEnums<ConfigWeaponSlots>());
 
     [ConfigInfo("")]
-    [OptionMenu(OptionSectionType.General, "Group 3 1st")]
+    [OptionMenu(OptionSectionType.Player, "Group 3 1st", spacer: true)]
     public readonly ConfigValue<ConfigWeaponSlots> Group3Weapon1 = new(ConfigWeaponSlots.PlasmaRifle, OnlyValidEnums<ConfigWeaponSlots>());
     [ConfigInfo("")]
-    [OptionMenu(OptionSectionType.General, "        2nd")]
+    [OptionMenu(OptionSectionType.Player, "        2nd")]
     public readonly ConfigValue<ConfigWeaponSlots> Group3Weapon2 = new(ConfigWeaponSlots.BFG9000, OnlyValidEnums<ConfigWeaponSlots>());
     [ConfigInfo("")]
-    [OptionMenu(OptionSectionType.General, "        3rd")]
+    [OptionMenu(OptionSectionType.Player, "        3rd")]
     public readonly ConfigValue<ConfigWeaponSlots> Group3Weapon3 = new(ConfigWeaponSlots.None, OnlyValidEnums<ConfigWeaponSlots>());
 
     [ConfigInfo("")]
-    [OptionMenu(OptionSectionType.General, "Group 4 1st")]
+    [OptionMenu(OptionSectionType.Player, "Group 4 1st", spacer: true)]
     public readonly ConfigValue<ConfigWeaponSlots> Group4Weapon1 = new(ConfigWeaponSlots.Chaingun, OnlyValidEnums<ConfigWeaponSlots>());
     [ConfigInfo("")]
-    [OptionMenu(OptionSectionType.General, "        2nd")]
+    [OptionMenu(OptionSectionType.Player, "        2nd")]
     public readonly ConfigValue<ConfigWeaponSlots> Group4Weapon2 = new(ConfigWeaponSlots.Pistol, OnlyValidEnums<ConfigWeaponSlots>());
     [ConfigInfo("")]
-    [OptionMenu(OptionSectionType.General, "        3rd")]
+    [OptionMenu(OptionSectionType.Player, "        3rd")]
     public readonly ConfigValue<ConfigWeaponSlots> Group4Weapon3 = new(ConfigWeaponSlots.None, OnlyValidEnums<ConfigWeaponSlots>());
 }

--- a/Core/Util/Configs/Components/ConfigWeaponSlot.cs
+++ b/Core/Util/Configs/Components/ConfigWeaponSlot.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel;
+
+namespace Helion.Util.Config.Components;
+
+public enum ConfigWeaponSlots {
+    [Description("--")]
+    None = -1,
+    [Description("Chainsaw/Fist")]
+    Melee = 1,
+    [Description("Pistol")]
+    Pistol = 2,
+    [Description("SSG/Shotgun")]
+    ShotgunOrSuperShotgun = 3,
+    [Description("Chaingun")]
+    Chaingun = 4,
+    [Description("Rocket")]
+    RocketLauncher = 5,
+    [Description("Plasma")]
+    PlasmaRifle = 6,
+    [Description("BFG")]
+    BFG9000 = 7
+}

--- a/Core/Util/Configs/ConfigEnums.cs
+++ b/Core/Util/Configs/ConfigEnums.cs
@@ -1,8 +1,10 @@
 ﻿using Helion.Maps.Shared;
 using Helion.Render.Common.Textures;
 using Helion.Resources.Definitions;
+using Helion.Util.Config.Components;
 using Helion.Util.Configs.Components;
 using Helion.World;
+using Helion.World.Entities.Inventories;
 using Helion.World.Entities.Players;
 using Helion.World.StatusBar;
 using OpenTK.Windowing.Common;
@@ -40,6 +42,7 @@ namespace Helion.Util.Configs
             { typeof(RenderColorMode), Enum.GetValues<RenderColorMode>() },
             { typeof(BlitFilter), Enum.GetValues<BlitFilter>() },
             { typeof(GyroTurnAxis), Enum.GetValues<GyroTurnAxis>() },
+            { typeof(ConfigWeaponSlots), Enum.GetValues<ConfigWeaponSlots>() }
         };
 
         public static Dictionary<Type, Dictionary<Enum, string>> KnownEnumLabels { get; } = new Dictionary<Type, Dictionary<Enum, string>>()
@@ -61,6 +64,7 @@ namespace Helion.Util.Configs
             { typeof(RenderColorMode), GetDescriptions<RenderColorMode>() },
             { typeof(BlitFilter), GetDescriptions<BlitFilter>() },
             { typeof(GyroTurnAxis), GetDescriptions<GyroTurnAxis>() },
+            { typeof(ConfigWeaponSlots), GetDescriptions<ConfigWeaponSlots>()}
         };
 
         private static Dictionary<Enum, string> GetDescriptions<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] T>() where T : struct, Enum

--- a/Core/Util/Configs/Options/OptionSectionType.cs
+++ b/Core/Util/Configs/Options/OptionSectionType.cs
@@ -8,6 +8,7 @@ public enum OptionSectionType
     Mouse,
     Controller,
     General,
+    Player,
     Video,
     Audio,
     Render,

--- a/Core/Util/Constants.cs
+++ b/Core/Util/Constants.cs
@@ -139,6 +139,10 @@ public static class Constants
         public const string WeaponSlot5 = "WeaponSlot5";
         public const string WeaponSlot6 = "WeaponSlot6";
         public const string WeaponSlot7 = "WeaponSlot7";
+        public const string WeaponGroup1 = "WeaponGroup1";
+        public const string WeaponGroup2 = "WeaponGroup2";
+        public const string WeaponGroup3 = "WeaponGroup3";
+        public const string WeaponGroup4 = "WeaponGroup4";
         public const string Screenshot = "Screenshot";
         public const string HudIncrease = "HudIncrease";
         public const string HudDecrease = "HudDecrease";
@@ -212,6 +216,10 @@ public static class Constants
         Input.WeaponSlot5,
         Input.WeaponSlot6,
         Input.WeaponSlot7,
+        Input.WeaponGroup1,
+        Input.WeaponGroup2,
+        Input.WeaponGroup3,
+        Input.WeaponGroup4,
         Input.Screenshot,
         Input.HudIncrease,
         Input.HudDecrease,

--- a/Core/World/Entities/Players/Player.cs
+++ b/Core/World/Entities/Players/Player.cs
@@ -937,28 +937,23 @@ public class Player : Entity
         return TickCommands.None;
     }
 
-    private ConfigWeaponSlots[,] GetWeaponGroups() => new ConfigWeaponSlots[4,3] {
-        {
-            WorldStatic.World.Config.Player.Group1Weapon1,
-            WorldStatic.World.Config.Player.Group1Weapon2,
-            WorldStatic.World.Config.Player.Group1Weapon3,
-        },
-        {
-            WorldStatic.World.Config.Player.Group2Weapon1,
-            WorldStatic.World.Config.Player.Group2Weapon2,
-            WorldStatic.World.Config.Player.Group2Weapon3,
-        },
-        {
-            WorldStatic.World.Config.Player.Group3Weapon1,
-            WorldStatic.World.Config.Player.Group3Weapon2,
-            WorldStatic.World.Config.Player.Group3Weapon3,
-        },
-        {
-            WorldStatic.World.Config.Player.Group4Weapon1,
-            WorldStatic.World.Config.Player.Group4Weapon2,
-            WorldStatic.World.Config.Player.Group4Weapon3,
-        },
-    };
+    private ConfigWeaponSlots[,] m_WeaponGroups = new ConfigWeaponSlots[4,3];
+    private ConfigWeaponSlots[,] GetWeaponGroups()
+    {
+        m_WeaponGroups[0,0] = WorldStatic.World.Config.Player.Group1Weapon1;
+        m_WeaponGroups[0,1] = WorldStatic.World.Config.Player.Group1Weapon2;
+        m_WeaponGroups[0,2] = WorldStatic.World.Config.Player.Group1Weapon3;
+        m_WeaponGroups[1,0] = WorldStatic.World.Config.Player.Group2Weapon1;
+        m_WeaponGroups[1,1] = WorldStatic.World.Config.Player.Group2Weapon2;
+        m_WeaponGroups[1,2] = WorldStatic.World.Config.Player.Group2Weapon3;
+        m_WeaponGroups[2,0] = WorldStatic.World.Config.Player.Group3Weapon1;
+        m_WeaponGroups[2,1] = WorldStatic.World.Config.Player.Group3Weapon2;
+        m_WeaponGroups[2,2] = WorldStatic.World.Config.Player.Group3Weapon3;
+        m_WeaponGroups[3,0] = WorldStatic.World.Config.Player.Group4Weapon1;
+        m_WeaponGroups[3,1] = WorldStatic.World.Config.Player.Group4Weapon2;
+        m_WeaponGroups[3,2] = WorldStatic.World.Config.Player.Group4Weapon3;
+        return m_WeaponGroups;
+    }
     private int CurrentGroup = -1;
     private int CurrentGroupIndex = -1;
 

--- a/Core/World/Entities/Players/Player.cs
+++ b/Core/World/Entities/Players/Player.cs
@@ -954,22 +954,25 @@ public class Player : Entity
         m_WeaponGroups[3,2] = WorldStatic.World.Config.Player.Group4Weapon3;
         return m_WeaponGroups;
     }
-    private int CurrentGroup = -1;
-    private int CurrentGroupIndex = -1;
+    private int m_CurrentGroup = -1;
+    private int m_CurrentGroupIndex = -1;
 
     private void ExecuteWeaponGroup(TickCommand tickCommand)
     {
         var groupNumber = GetWeaponGroupIndex(GetWeaponGroupCommand(tickCommand));
         var weaponGroups = GetWeaponGroups();
-        int current_index = -1;
-        if (groupNumber == CurrentGroup) {
-            current_index = CurrentGroupIndex;
+        int currentIndex = -1;
+        if (groupNumber == m_CurrentGroup) 
+        {
+            currentIndex = m_CurrentGroupIndex;
         }
-        int resulting_index = 0;
-        Weapon? selected_weapon = null;
-        for (int slotIndex = 0; slotIndex < weaponGroups.GetLength(1); slotIndex++) {
+        int resultingIndex = 0;
+        Weapon? selectedWeapon = null;
+        for (int slotIndex = 0; slotIndex < weaponGroups.GetLength(1); slotIndex++) 
+        {
             var slot = weaponGroups[groupNumber,slotIndex];
-            if (slot != ConfigWeaponSlots.None) {
+            if (slot != ConfigWeaponSlots.None) 
+            {
                 Weapon? weapon = null;
                 if (WeaponSlot == (int)slot)
                 {
@@ -982,23 +985,27 @@ public class Player : Entity
                     weapon = Inventory.Weapons.GetWeapon((int)slot, Inventory.Weapons.GetBestSubSlot((int)slot));
                 }
 
-                if (weapon != null) {
-                    if (slotIndex > current_index) {
-                        selected_weapon = weapon;
-                        resulting_index = slotIndex;
+                if (weapon != null) 
+                {
+                    if (slotIndex > currentIndex) 
+                    {
+                        selectedWeapon = weapon;
+                        resultingIndex = slotIndex;
                         break;
-                    } else if (selected_weapon == null && slotIndex != current_index) { // Only grab the first result before the current index
-                        selected_weapon = weapon;
-                        resulting_index = slotIndex;
+                    } 
+                    else if (selectedWeapon == null && slotIndex != currentIndex) // Only grab the first result before the current index
+                    {
+                        selectedWeapon = weapon;
+                        resultingIndex = slotIndex;
                     }
                 }
             }
         }
-        if (selected_weapon != null)
+        if (selectedWeapon != null)
         {
-            ChangeWeapon(selected_weapon);
-            CurrentGroup = groupNumber;
-            CurrentGroupIndex = resulting_index;
+            ChangeWeapon(selectedWeapon);
+            m_CurrentGroup = groupNumber;
+            m_CurrentGroupIndex = resultingIndex;
         }
     }
 

--- a/Core/World/Entities/Players/Player.cs
+++ b/Core/World/Entities/Players/Player.cs
@@ -8,6 +8,7 @@ using Helion.Render.OpenGL.Shared;
 using Helion.Resources.Definitions.MapInfo;
 using Helion.Resources.Definitions.SoundInfo;
 using Helion.Util;
+using Helion.Util.Config.Components;
 using Helion.World.Blockmap;
 using Helion.World.Cheats;
 using Helion.World.Entities.Definition;
@@ -936,12 +937,27 @@ public class Player : Entity
         return TickCommands.None;
     }
 
-    private static readonly int[,] GroupAssignments = new int[4,3]
-    {
-        {2, 2, -1},
-        {5, 1, 1},
-        {6, 7, -1},
-        {4, 2, -1}
+    private ConfigWeaponSlots[,] GetWeaponGroups() => new ConfigWeaponSlots[4,3] {
+        {
+            WorldStatic.World.Config.Player.Group1Weapon1,
+            WorldStatic.World.Config.Player.Group1Weapon2,
+            WorldStatic.World.Config.Player.Group1Weapon3,
+        },
+        {
+            WorldStatic.World.Config.Player.Group2Weapon1,
+            WorldStatic.World.Config.Player.Group2Weapon2,
+            WorldStatic.World.Config.Player.Group2Weapon3,
+        },
+        {
+            WorldStatic.World.Config.Player.Group3Weapon1,
+            WorldStatic.World.Config.Player.Group3Weapon2,
+            WorldStatic.World.Config.Player.Group3Weapon3,
+        },
+        {
+            WorldStatic.World.Config.Player.Group4Weapon1,
+            WorldStatic.World.Config.Player.Group4Weapon2,
+            WorldStatic.World.Config.Player.Group4Weapon3,
+        },
     };
     private int CurrentGroup = -1;
     private int CurrentGroupIndex = -1;
@@ -949,17 +965,18 @@ public class Player : Entity
     private void ExecuteWeaponGroup(TickCommand tickCommand)
     {
         var groupNumber = GetWeaponGroupIndex(GetWeaponGroupCommand(tickCommand));
+        var weaponGroups = GetWeaponGroups();
         int current_index = -1;
         if (groupNumber == CurrentGroup) {
             current_index = CurrentGroupIndex;
         }
         int resulting_index = 0;
         Weapon? selected_weapon = null;
-        for (int slotIndex = 0; slotIndex < GroupAssignments.GetLength(1); slotIndex++) {
-            var slot = GroupAssignments[groupNumber,slotIndex];
-            if (slot != -1) {
+        for (int slotIndex = 0; slotIndex < weaponGroups.GetLength(1); slotIndex++) {
+            var slot = weaponGroups[groupNumber,slotIndex];
+            if (slot != ConfigWeaponSlots.None) {
                 Weapon? weapon = null;
-                if (WeaponSlot == slot)
+                if (WeaponSlot == (int)slot)
                 {
                     var nextSlot = Inventory.Weapons.GetNextSubSlot(this);
                     if (nextSlot.Slot != -1 && nextSlot.SubSlot != WeaponSubSlot)
@@ -967,7 +984,7 @@ public class Player : Entity
                 }
                 else
                 {
-                    weapon = Inventory.Weapons.GetWeapon(slot, Inventory.Weapons.GetBestSubSlot(slot));
+                    weapon = Inventory.Weapons.GetWeapon((int)slot, Inventory.Weapons.GetBestSubSlot((int)slot));
                 }
 
                 if (weapon != null) {

--- a/Core/World/Entities/Players/TickCommand.cs
+++ b/Core/World/Entities/Players/TickCommand.cs
@@ -18,6 +18,10 @@ public class TickCommand
         TickCommands.WeaponSlot5,
         TickCommands.WeaponSlot6,
         TickCommands.WeaponSlot7,
+        TickCommands.WeaponGroup1,
+        TickCommands.WeaponGroup2,
+        TickCommands.WeaponGroup3,
+        TickCommands.WeaponGroup4,
         TickCommands.CenterView
     };
 

--- a/Core/World/Entities/Players/TickCommandType.cs
+++ b/Core/World/Entities/Players/TickCommandType.cs
@@ -27,4 +27,8 @@ public enum TickCommands
     WeaponSlot6,
     WeaponSlot7,
     CenterView,
+    WeaponGroup1,
+    WeaponGroup2,
+    WeaponGroup3,
+    WeaponGroup4,
 }

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -12,6 +12,7 @@
   - Add option for berserk intensity
   - Add option to disable crosshair shrinking on target
   - Add use command to allow for separate bindings for shotgun/super shotgun [bind x "use shotgun"] [bind y "use supershotgun"]
+  - Add custom weapon groups similar to the ones found in Woof!, with the added bonus of being assignable to any button.
 
 ## Bug fixes:
   - Fix per ammo values for box ammo and backpack amount from dehacked patch


### PR DESCRIPTION
Allows the user to define their own groups to cycle weapons with.  The first group by default behaves like slot 2, while the other groups roughly correspond to the various vanilla ammo types.

There are some things in here that I am unhappy with or concerned about and want feedback for:
- Weapon group key bindings are on the bottom of the keybinding page. I would prefer they be right next to the weapon slot config options instead of at the bottom.
- I have contributed no testing.  Some tests would be nice, given that the group selection algorithm is a little gnarly.
- I am not sure if I should put these options into their own page instead of shoving them all in Player.
- If we add networking in the future, these new commands _will_ cause a lot of desynchronization problems.  Heck, I'm worried that this might break demos due to being the first tick commands that rely on a config for deterministic operation, but apparently Helion already records configs into the demos, so hopefully demo desyncs are not an issue.  That being said, the current implementation, due to operating on slots instead of weapons, would allow for rewriting commands to these groups to deterministic weapon slot commands that would not trigger desyncs.

If testing this branch, **BACK UP YOUR CONFIG**.

Nitpicks welcomed.

Closes #886 