### PR TITLE
Bump versions of native libraries

### DIFF
--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -68,9 +68,9 @@
 
   <ItemGroup>
     <PackageReference Include="OpenTK" Version="4.7.4" />
-    <PackageReference Include="Helion.NFluidsynth" Version="1.0.0" />
-    <PackageReference Include="Helion.SDLControllerWrapper" Version="1.1.3" />
-    <PackageReference Include="Helion.ZMusic" Version="1.0.0" />
+    <PackageReference Include="Helion.NFluidsynth" Version="1.0.0.1" />
+    <PackageReference Include="Helion.SDLControllerWrapper" Version="1.2.0.1" />
+    <PackageReference Include="Helion.ZMusic" Version="1.0.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
These all have minor changes regarding loader precedence--they now favor the executable directory over whatever is in runtimes/<rid>/native.