### PR TITLE
Create shared implementation of "make image from ImageSharp source"

### DIFF
--- a/Core/Graphics/Fonts/TrueTypeFont.cs
+++ b/Core/Graphics/Fonts/TrueTypeFont.cs
@@ -69,11 +69,7 @@ public static class TrueTypeFont
                             ctx.DrawText(richTextOptions, charString, Color.White.ToImageSharp);
                         });
 
-                        charImages[c] = Image.FromArgbBytes(
-                            (charImage.Width, charImage.Height),
-                            ExtractBytesFromRgbaImage(charImage),
-                            Vec2I.Zero,
-                            ResourceNamespace.Fonts)!;
+                        charImages[c] = Image.FromImageSharp(charImage, ns: ResourceNamespace.Fonts)!;
                     }
                 }
 
@@ -92,30 +88,6 @@ public static class TrueTypeFont
     {
         var chars = Enumerable.Range(StartCharacter, CharCount).Select(char.ConvertFromUtf32);
         return string.Join("", chars);
-    }
-
-    private static byte[] ExtractBytesFromRgbaImage(Image<Rgba32> rgbaImage)
-    {
-        byte[] bytes = new byte[rgbaImage.Width * rgbaImage.Height * 4];
-        int bytesOffset = 0;
-
-        for (int y = 0; y < rgbaImage.Height; y++)
-        {
-            Span<Rgba32> pixelRow = rgbaImage.DangerousGetPixelRowMemory(y).Span;
-            for (int x = 0; x < rgbaImage.Width; x++)
-            {
-                Rgba32 rgba = pixelRow[x];
-
-                bytes[bytesOffset] = rgba.A;
-                bytes[bytesOffset + 1] = rgba.R;
-                bytes[bytesOffset + 2] = rgba.G;
-                bytes[bytesOffset + 3] = rgba.B;
-
-                bytesOffset += 4;
-            }
-        }
-
-        return bytes;
     }
 
     private static (Dictionary<char, Glyph>, Image) ComposeFontGlyphs(Dictionary<char, Image> charImages)

--- a/Core/Layer/Endoom/TextScreen.cs
+++ b/Core/Layer/Endoom/TextScreen.cs
@@ -123,22 +123,7 @@
                     }
                 });
 
-                byte[] argbData = new byte[bitmap.Height * bitmap.Width * 4];
-                int offset = 0;
-                for (int y = 0; y < bitmap.Height; y++)
-                {
-                    Span<Argb32> pixelRow = bitmap.DangerousGetPixelRowMemory(y).Span;
-                    foreach (ref Argb32 pixel in pixelRow)
-                    {
-                        argbData[offset] = pixel.A;
-                        argbData[offset + 1] = pixel.R;
-                        argbData[offset + 2] = pixel.G;
-                        argbData[offset + 3] = pixel.B;
-                        offset += 4;
-                    }
-                }
-
-                return Graphics.Image.FromArgbBytes((bitmap.Width, bitmap.Height), argbData)!;
+                return Graphics.Image.FromImageSharp(bitmap)!;
             }
         }
     }

--- a/Core/Resources/Images/ArchiveImageRetriever.cs
+++ b/Core/Resources/Images/ArchiveImageRetriever.cs
@@ -173,23 +173,7 @@ public class ArchiveImageRetriever : IImageRetriever
             {
                 using MemoryStream inputStream = new MemoryStream(data);
                 using Image<Rgba32> img = SixLabors.ImageSharp.Image.Load<Rgba32>(inputStream);
-
-                byte[] argbData = new byte[img.Height * img.Width * 4];
-                int offset = 0;
-                for (int y = 0; y < img.Height; y++)
-                {
-                    Span<Rgba32> pixelRow = img.DangerousGetPixelRowMemory(y).Span;
-                    foreach (ref Rgba32 pixel in pixelRow)
-                    {
-                        argbData[offset] = pixel.A;
-                        argbData[offset + 1] = pixel.R;
-                        argbData[offset + 2] = pixel.G;
-                        argbData[offset + 3] = pixel.B;                        
-                        offset += 4;
-                    }
-                }
-
-                image = Image.FromArgbBytes((img.Width, img.Height), argbData, (0, 0), entry.Namespace);
+                image = Image.FromImageSharp(img, (0, 0), entry.Namespace);
             }
             catch
             {


### PR DESCRIPTION
We use basically the same code, in a handful of places, to convert images from the SixLabors.ImageSharp object representation, to the Helion.Graphics representation that is used as a basis for textures:

1.  Font generation
2.  Reading image resources from inside WAD files and such
3.  Generating textures for ENDOOM text screens

If we add UI to display saved game thumbnails, we're going to have _yet another_ place that needs this logic, so it makes sense to consolidate it all into a single implementation.