### PR TITLE
Entity property refactor

### DIFF
--- a/Core/Layer/EndGame/EndGameLayer.Logic.cs
+++ b/Core/Layer/EndGame/EndGameLayer.Logic.cs
@@ -117,7 +117,7 @@ public partial class EndGameLayer
                     break;
 
                 case CastEntityState.Attack:
-                    if (m_castFrameCount == 24 || m_castEntity.FrameState.IsState(Constants.FrameStates.See))
+                    if (m_castFrameCount == 24 || m_castEntity.FrameState.IsState(m_castEntity.Definition, Constants.FrameStates.See))
                     {
                         m_castFrameCount = 0;
                         SetCastEntityState(CastEntityState.See, false);
@@ -139,7 +139,7 @@ public partial class EndGameLayer
                 return;
             }
 
-            m_castEntity.FrameState.SetFrameIndexNoAction(m_castEntity.Frame.NextFrameIndex);
+            m_castEntity.FrameState.SetFrameIndexNoAction(m_castEntity, m_castEntity.Frame.NextFrameIndex);
         }
 
         m_castEntityFrameTicks = m_castEntity.Frame.Ticks;
@@ -191,13 +191,13 @@ public partial class EndGameLayer
                 SetCastEntityAttackState();
                 break;
             case CastEntityState.Death:
-                m_castEntity.FrameState.SetFrameIndexByLabel(Constants.FrameStates.Death);
+                m_castEntity.FrameState.SetFrameIndexByLabel(m_castEntity, Constants.FrameStates.Death);
                 sound = m_castEntity.Definition.Properties.DeathSound;
                 if (m_castEntity.Definition.Name.EqualsIgnoreCase("DoomPlayer"))
                     sound = "player/male/death1";
                 break;
             default:
-                m_castEntity.FrameState.SetFrameIndexByLabel(Constants.FrameStates.See);
+                m_castEntity.FrameState.SetFrameIndexByLabel(m_castEntity, Constants.FrameStates.See);
                 sound = m_castEntity.Definition.Properties.SeeSound;
                 break;
         }
@@ -271,9 +271,9 @@ public partial class EndGameLayer
 
         EntityFrame? frame;
         if (ShouldUseMeleeState(m_castEntity, m_castIsMelee))
-            frame = m_castEntity.FrameState.GetStateFrame(Constants.FrameStates.Melee);
+            frame = m_castEntity.FrameState.GetStateFrame(m_castEntity.Definition, Constants.FrameStates.Melee);
         else
-            frame = m_castEntity.FrameState.GetStateFrame(Constants.FrameStates.Missile);
+            frame = m_castEntity.FrameState.GetStateFrame(m_castEntity.Definition, Constants.FrameStates.Missile);
 
         return frame;
     }
@@ -286,9 +286,9 @@ public partial class EndGameLayer
         m_castIsMelee = m_castMelee;
 
         if (ShouldUseMeleeState(m_castEntity, m_castIsMelee))
-            m_castEntity.FrameState.SetFrameIndexByLabel(Constants.FrameStates.Melee);
+            m_castEntity.FrameState.SetFrameIndexByLabel(m_castEntity, Constants.FrameStates.Melee);
         else
-            m_castEntity.FrameState.SetFrameIndexByLabel(Constants.FrameStates.Missile);
+            m_castEntity.FrameState.SetFrameIndexByLabel(m_castEntity, Constants.FrameStates.Missile);
 
         m_castMelee = !m_castMelee;
     }

--- a/Core/Util/Constants.cs
+++ b/Core/Util/Constants.cs
@@ -36,6 +36,8 @@ public static class Constants
 
     public const int HitscanTestDamage = int.MinValue;
 
+    public const short ClearBlock = short.MaxValue;
+
     /// <summary>
     /// The name of the decorate player class.
     /// </summary>

--- a/Core/World/Entities/Definition/States/EntityActionFunctions.cs
+++ b/Core/World/Entities/Definition/States/EntityActionFunctions.cs
@@ -468,7 +468,7 @@ public static class EntityActionFunctions
 
     private static void A_BFGSpray(Entity entity)
     {
-        var owner = entity.Owner.Get();
+        var owner = entity.Owner();
         if (owner == null)
             return;
 
@@ -596,7 +596,7 @@ public static class EntityActionFunctions
 
     private static void A_SpawnFly(Entity entity)
     {
-        var target = entity.Target.Get();
+        var target = entity.Target();
         if (target == null)
         {
             WorldStatic.EntityManager.Destroy(entity);
@@ -650,7 +650,7 @@ public static class EntityActionFunctions
 
     private static void A_BruisAttack(Entity entity)
     {
-        var target = entity.Target.Get();
+        var target = entity.Target();
         if (target == null)
             return;
 
@@ -668,7 +668,7 @@ public static class EntityActionFunctions
 
     private static void A_BspiAttack(Entity entity)
     {
-        var target = entity.Target.Get();
+        var target = entity.Target();
         if (target == null)
             return;
 
@@ -689,7 +689,7 @@ public static class EntityActionFunctions
 
     private static void A_CPosAttack(Entity entity)
     {
-        var target = entity.Target.Get();
+        var target = entity.Target();
         if (target == null)
             return;
 
@@ -737,7 +737,7 @@ public static class EntityActionFunctions
         if (entity.ReactionTime > 0)
             entity.ReactionTime -= entity.SlowTickMultiplier;
 
-        var target = entity.Target.Get();
+        var target = entity.Target();
         if (entity.Threshold > 0)
         {
             if (target == null || target.IsDead)
@@ -978,7 +978,7 @@ public static class EntityActionFunctions
 
     private static void A_CyberAttack(Entity entity)
     {
-        var target = entity.Target.Get();
+        var target = entity.Target();
         if (target == null)
             return;
 
@@ -1040,7 +1040,7 @@ public static class EntityActionFunctions
     {
         // Pass through owner if set (usually a projectile)
         // Barrels pass through who shot them (Target)
-        Entity? attackSource = entity.Owner.Get() ?? entity.Target.Get();
+        Entity? attackSource = entity.Owner() ?? entity.Target();
         WorldStatic.World.RadiusExplosion(entity, attackSource ?? entity, 128, 128);
     }
 
@@ -1066,7 +1066,7 @@ public static class EntityActionFunctions
 
     public static void A_FaceTarget(Entity entity)
     {
-        var target = entity.Target.Get();
+        var target = entity.Target();
         if (target == null)
             return;
 
@@ -1122,7 +1122,7 @@ public static class EntityActionFunctions
 
     private static void FatAttack(Entity entity, double fireSpread1, double fireSpread2)
     {
-        var target = entity.Target.Get();
+        var target = entity.Target();
         if (target == null || WorldStatic.FatShot == null)
             return;
 
@@ -1140,7 +1140,7 @@ public static class EntityActionFunctions
 
     private static void A_FatRaise(Entity entity)
     {
-        var target = entity.Target.Get();
+        var target = entity.Target();
         if (target == null)
             return;
 
@@ -1150,8 +1150,8 @@ public static class EntityActionFunctions
 
     private static void A_Fire(Entity entity)
     {
-        var target = entity.Target.Get();
-        var tracer = entity.Tracer.Get();
+        var target = entity.Target();
+        var tracer = entity.Tracer();
         if (target == null || tracer == null)
             return;
 
@@ -1369,7 +1369,7 @@ public static class EntityActionFunctions
 
     private static void A_HeadAttack(Entity entity)
     {
-        var target = entity.Target.Get();
+        var target = entity.Target();
         if (target == null)
             return;
 
@@ -1676,7 +1676,7 @@ public static class EntityActionFunctions
 
     private static void A_PainAttack(Entity entity)
     {
-        if (entity.Target.Get() == null)
+        if (entity.Target() == null)
             return;
 
         A_FaceTarget(entity);
@@ -1731,7 +1731,7 @@ public static class EntityActionFunctions
         }
 
         entity.Flags.NoClip = wasNoClip;
-        skull.SetTarget(entity.Target.Get());
+        skull.SetTarget(entity.Target());
         A_SkullAttack(skull);
     }
 
@@ -1752,7 +1752,7 @@ public static class EntityActionFunctions
 
     private static void A_PosAttack(Entity entity)
     {
-        if (entity.Target.Get() == null)
+        if (entity.Target() == null)
             return;
 
         entity.PlayAttackSound();
@@ -1994,7 +1994,7 @@ public static class EntityActionFunctions
 
     private static void A_SPosAttack(Entity entity)
     {
-        if (entity.Target.Get() == null)
+        if (entity.Target() == null)
             return;
 
         WorldStatic.SoundManager.CreateSoundOn(entity, "shotguy/attack", new SoundParams(entity));
@@ -2011,7 +2011,7 @@ public static class EntityActionFunctions
 
     public static void A_SargAttack(Entity entity)
     {
-        var target = entity.Target.Get();
+        var target = entity.Target();
         if (target == null)
             return;
 
@@ -2367,7 +2367,7 @@ public static class EntityActionFunctions
 
     private static void A_SkelFist(Entity entity)
     {
-        var target = entity.Target.Get();
+        var target = entity.Target();
         if (target == null)
             return;
 
@@ -2383,7 +2383,7 @@ public static class EntityActionFunctions
 
     public static void A_SkelMissile(Entity entity)
     {
-        var target = entity.Target.Get();
+        var target = entity.Target();
         if (target == null || WorldStatic.RevenantTracer == null)
             return;
 
@@ -2394,7 +2394,7 @@ public static class EntityActionFunctions
 
     private static void A_SkelWhoosh(Entity entity)
     {
-        if (entity.Target.Get() == null)
+        if (entity.Target() == null)
             return;
 
         A_FaceTarget(entity);
@@ -2403,7 +2403,7 @@ public static class EntityActionFunctions
 
     private static void A_SkullAttack(Entity entity)
     {
-        var target = entity.Target.Get();
+        var target = entity.Target();
         if (target == null)
             return;
 
@@ -2468,7 +2468,7 @@ public static class EntityActionFunctions
 
     private static void Refire(Entity entity, int randomChance)
     {
-        var target = entity.Target.Get();
+        var target = entity.Target();
         A_FaceTarget(entity);
 
         if (WorldStatic.Random.NextByte() < randomChance)
@@ -2483,7 +2483,7 @@ public static class EntityActionFunctions
 
     private static void A_SPosAttackUseAtkSound(Entity entity)
     {
-        var target = entity.Target.Get();
+        var target = entity.Target();
         if (target == null)
             return;
 
@@ -2611,7 +2611,7 @@ public static class EntityActionFunctions
 
     private static void A_TroopAttack(Entity entity)
     {
-        var target = entity.Target.Get();
+        var target = entity.Target();
         if (target == null)
             return;
 
@@ -2676,7 +2676,7 @@ public static class EntityActionFunctions
 
     private static void A_VileAttack(Entity entity)
     {
-        var target = entity.Target.Get();
+        var target = entity.Target();
         if (target == null)
             return;
 
@@ -2689,7 +2689,7 @@ public static class EntityActionFunctions
         WorldStatic.World.DamageEntity(target, entity, 20, DamageType.Normal, Thrust.Horizontal);
         target.Velocity.Z = 1000.0 / target.Definition.Properties.Mass;
 
-        var fire = entity.Tracer.Get();
+        var fire = entity.Tracer();
         if (fire == null)
             return;
 
@@ -2724,7 +2724,7 @@ public static class EntityActionFunctions
 
     private static void A_VileTarget(Entity entity)
     {
-        var target = entity.Target.Get();
+        var target = entity.Target();
         if (target == null)
             return;
 
@@ -2805,7 +2805,7 @@ public static class EntityActionFunctions
 
     private static void A_Detonate(Entity entity)
     {
-        WorldStatic.World.RadiusExplosion(entity, entity.Target.Get() ?? entity, entity.Properties.Damage.Value, entity.Properties.Damage.Value);
+        WorldStatic.World.RadiusExplosion(entity, entity.Target() ?? entity, entity.Properties.Damage.Value, entity.Properties.Damage.Value);
     }
 
     private static void A_Spawn(Entity entity)
@@ -2834,7 +2834,7 @@ public static class EntityActionFunctions
 
     private static void A_Scratch(Entity entity)
     {
-        var target = entity.Target.Get();
+        var target = entity.Target();
         if (target == null)
             return;
 
@@ -3102,14 +3102,14 @@ public static class EntityActionFunctions
 
         if (entity.Flags.Missile || entity.Flags.MbfBouncer)
         {
-            createdEntity.SetOwner(entity.Owner.Get());
-            createdEntity.SetTracer(entity.Tracer.Get());
+            createdEntity.SetOwner(entity.Owner());
+            createdEntity.SetTracer(entity.Tracer());
         }
         else
         {
             createdEntity.SetOwner(entity);
             createdEntity.SetTarget(entity);
-            createdEntity.SetTracer(entity.Tracer.Get());
+            createdEntity.SetTracer(entity.Tracer());
         }
     }
 
@@ -3134,7 +3134,7 @@ public static class EntityActionFunctions
 
     private static void A_MonsterProjectile(Entity entity)
     {
-        var target = entity.Target.Get();
+        var target = entity.Target();
         if (target == null || !GetDehackedActorDefinition(entity, entity.Frame.DehackedArgs1, out var projectileDef))
             return;
 
@@ -3151,7 +3151,7 @@ public static class EntityActionFunctions
 
     private static void A_MonsterBulletAttack(Entity entity)
     {
-        if (entity.Target.Get() == null)
+        if (entity.Target() == null)
             return;
 
         double spreadAngle = MathHelper.ToRadians(MathHelper.FromFixed(entity.Frame.DehackedArgs1));
@@ -3175,7 +3175,7 @@ public static class EntityActionFunctions
 
     private static void A_MonsterMeleeAttack(Entity entity)
     {
-        var target = entity.Target.Get();
+        var target = entity.Target();
         if (target == null)
             return;
 
@@ -3197,13 +3197,13 @@ public static class EntityActionFunctions
     private static void A_RadiusDamage(Entity entity)
     {
         int maxDamage = entity.Frame.DehackedArgs1;
-        Entity? attackSource = entity.Owner.Get() ?? entity.Target.Get();
+        Entity? attackSource = entity.Owner() ?? entity.Target();
         WorldStatic.World.RadiusExplosion(entity, attackSource ?? entity, entity.Frame.DehackedArgs2, maxDamage);
     }
 
     private static void A_NoiseAlert(Entity entity)
     {
-        var target = entity.Target.Get();
+        var target = entity.Target();
         if (target == null)
             return;
 
@@ -3244,7 +3244,7 @@ public static class EntityActionFunctions
 
     private static void A_FindTracer(Entity entity)
     {
-        if (entity.Tracer.Get() != null)
+        if (entity.Tracer() != null)
             return;
 
         double fov = MathHelper.ToRadians(MathHelper.FromFixed(entity.Frame.DehackedArgs1));
@@ -3269,7 +3269,7 @@ public static class EntityActionFunctions
 
     private static void A_JumpIfTargetInSight(Entity entity)
     {
-        var target = entity.Target.Get();
+        var target = entity.Target();
         if (target == null)
             return;
 
@@ -3280,7 +3280,7 @@ public static class EntityActionFunctions
 
     private static void A_JumpIfTargetCloser(Entity entity)
     {
-        var target = entity.Target.Get();
+        var target = entity.Target();
         if (target == null)
             return;
 
@@ -3295,7 +3295,7 @@ public static class EntityActionFunctions
 
     private static void A_JumpIfTracerInSight(Entity entity)
     {
-        var tracer = entity.Tracer.Get();
+        var tracer = entity.Tracer();
         if (tracer == null)
             return;
 
@@ -3306,7 +3306,7 @@ public static class EntityActionFunctions
 
     private static void A_JumpIfTracerCloser(Entity entity)
     {
-        var tracer = entity.Tracer.Get();
+        var tracer = entity.Tracer();
         if (tracer == null)
             return;
 
@@ -3365,7 +3365,7 @@ public static class EntityActionFunctions
 
     public static void A_ClosetChase(Entity entity)
     {
-        var target = entity.Target.Get();
+        var target = entity.Target();
         if (target != null && target.IsDead)
             return;
 

--- a/Core/World/Entities/Definition/States/EntityActionFunctions.cs
+++ b/Core/World/Entities/Definition/States/EntityActionFunctions.cs
@@ -7,6 +7,7 @@ using Helion.Maps.Specials;
 using Helion.Maps.Specials.Compatibility;
 using Helion.Maps.Specials.Vanilla;
 using Helion.Maps.Specials.ZDoom;
+using Helion.Resources.Archives.Entries;
 using Helion.Util;
 using Helion.Util.RandomGenerators;
 using Helion.World.Entities.Inventories;
@@ -770,7 +771,7 @@ public static class EntityActionFunctions
         if (target != null && entity.Definition.MeleeState != null && entity.InMeleeRange(target))
         {
             entity.PlayAttackSound();
-            entity.FrameState.SetFrameIndex(entity.Definition.MeleeState.Value);
+            entity.FrameState.SetFrameIndex(entity, entity.Definition.MeleeState.Value);
         }
 
         if (entity.IsDisposed)
@@ -784,7 +785,7 @@ public static class EntityActionFunctions
             entity.Definition.MissileState != null && entity.CheckMissileRange())
         {
             entity.Flags.JustAttacked = true;
-            entity.FrameState.SetFrameIndex(entity.Definition.MissileState.Value);
+            entity.FrameState.SetFrameIndex(entity, entity.Definition.MissileState.Value);
         }
         else if (WorldStatic.Random.NextByte() < 3)
         {
@@ -1362,7 +1363,7 @@ public static class EntityActionFunctions
         if (entity.PlayerObj != null)
         {
             if (entity.Definition.MissileState != null)
-                entity.FrameState.SetFrameIndex(entity.Definition.MissileState.Value);
+                entity.FrameState.SetFrameIndex(entity, entity.Definition.MissileState.Value);
             entity.PlayerObj.Weapon?.SetFlashState();
         }
     }
@@ -1828,7 +1829,7 @@ public static class EntityActionFunctions
         if (entity.PlayerObj.IsDead)
         {
             entity.PlayerObj.WeaponOffset.Y = Constants.WeaponBottom;
-            entity.PlayerObj.AnimationWeapon.FrameState.SetState("NULL");
+            entity.PlayerObj.AnimationWeapon.FrameState.SetState(entity, entity.Definition, "NULL");
             return;
         }
 
@@ -1883,7 +1884,7 @@ public static class EntityActionFunctions
         if (WorldStatic.Dehacked)
             playReadySound = player.Weapon.FrameState.Frame.VanillaIndex == (int)ThingState.SAW;
         else
-            playReadySound = player.Weapon.FrameState.IsState(Constants.FrameStates.Ready);
+            playReadySound = player.Weapon.FrameState.IsState(player.Weapon.Definition, Constants.FrameStates.Ready);
 
         if (!player.IsVooDooDoll && player.Weapon.Definition.Properties.Weapons.ReadySound.Length > 0 && playReadySound)
         {
@@ -2791,7 +2792,7 @@ public static class EntityActionFunctions
         if (WorldStatic.World.Random.NextByte() < entity.Frame.DehackedMisc2 &&
             entityFrameTable.VanillaFrameMap.TryGetValue(entity.Frame.DehackedMisc1, out EntityFrame? newFrame))
         {
-            entity.FrameState.SetState(newFrame);
+            entity.FrameState.SetState(entity, newFrame);
         }
     }
 
@@ -2985,7 +2986,7 @@ public static class EntityActionFunctions
 
         var entityFrameTable = WorldStatic.World.ArchiveCollection.Definitions.EntityFrameTable;
         if (WorldStatic.Random.NextByte() < chance && entityFrameTable.VanillaFrameMap.TryGetValue(state, out EntityFrame? newFrame))
-            entity.PlayerObj!.Weapon!.FrameState.SetState(newFrame);
+            entity.PlayerObj!.Weapon!.FrameState.SetState(entity, newFrame);
     }
 
     private static void A_ConsumeAmmo(Entity entity)
@@ -3014,7 +3015,7 @@ public static class EntityActionFunctions
         var entityFrameTable = WorldStatic.World.ArchiveCollection.Definitions.EntityFrameTable;
         if (entity.PlayerObj!.Inventory.Amount(weapon.Definition.Properties.Weapons.AmmoType) < amount &&
             entityFrameTable.VanillaFrameMap.TryGetValue(state, out EntityFrame? newFrame))
-            weapon.FrameState.SetState(newFrame);
+            weapon.FrameState.SetState(entity, newFrame);
     }
 
     public static void A_FireRailGun(Entity entity)
@@ -3047,7 +3048,7 @@ public static class EntityActionFunctions
         Weapon weapon = entity.PlayerObj!.Weapon!;
         var entityFrameTable = WorldStatic.World.ArchiveCollection.Definitions.EntityFrameTable;
         if (entityFrameTable.VanillaFrameMap.TryGetValue(state, out EntityFrame? newFrame))
-            weapon.FrameState.SetState(newFrame);
+            weapon.FrameState.SetState(entity, newFrame);
     }
 
     private static void A_GunFlashTo(Entity entity)
@@ -3060,7 +3061,7 @@ public static class EntityActionFunctions
         bool thirdPersonFrame = frame.DehackedArgs2 == 0;
 
         if (thirdPersonFrame)
-            entity.PlayerObj!.FrameState.SetState(Constants.FrameStates.Missile);
+            entity.PlayerObj!.FrameState.SetState(entity, entity.Definition, Constants.FrameStates.Missile);
 
         var entityFrameTable = WorldStatic.World.ArchiveCollection.Definitions.EntityFrameTable;
         if (entityFrameTable.VanillaFrameMap.TryGetValue(state, out EntityFrame? newFrame))
@@ -3264,7 +3265,7 @@ public static class EntityActionFunctions
 
         var entityFrameTable = WorldStatic.World.ArchiveCollection.Definitions.EntityFrameTable;
         if (entity.Health < health && entityFrameTable.VanillaFrameMap.TryGetValue(state, out EntityFrame? newFrame))
-            entity.FrameState.SetState(newFrame);
+            entity.FrameState.SetState(entity, newFrame);
     }
 
     private static void A_JumpIfTargetInSight(Entity entity)
@@ -3290,7 +3291,7 @@ public static class EntityActionFunctions
         var entityFrameTable = WorldStatic.World.ArchiveCollection.Definitions.EntityFrameTable;
         if (distance > entity.Position.ApproximateDistance2D(target.Position) &&
             entityFrameTable.VanillaFrameMap.TryGetValue(state, out EntityFrame? newFrame))
-            entity.FrameState.SetState(newFrame);
+            entity.FrameState.SetState(entity, newFrame);
     }
 
     private static void A_JumpIfTracerInSight(Entity entity)
@@ -3316,7 +3317,7 @@ public static class EntityActionFunctions
         var entityFrameTable = WorldStatic.World.ArchiveCollection.Definitions.EntityFrameTable;
         if (distance > entity.Position.ApproximateDistance2D(tracer.Position) &&
             entityFrameTable.VanillaFrameMap.TryGetValue(state, out EntityFrame? newFrame))
-            entity.FrameState.SetState(newFrame);
+            entity.FrameState.SetState(entity, newFrame);
     }
 
     private static void A_JumpIfFlagsSet(Entity entity)
@@ -3332,7 +3333,7 @@ public static class EntityActionFunctions
 
         var entityFrameTable = WorldStatic.World.ArchiveCollection.Definitions.EntityFrameTable;
         if (entityFrameTable.VanillaFrameMap.TryGetValue(state, out EntityFrame? newFrame))
-            entity.FrameState.SetState(newFrame);
+            entity.FrameState.SetState(entity, newFrame);
     }
 
     private static void A_AddFlags(Entity entity)
@@ -3384,7 +3385,7 @@ public static class EntityActionFunctions
         if (!WorldStatic.World.CheckLineOfSight(from, to))
             return;
 
-        from.FrameState.SetState(newFrame);
+        from.FrameState.SetState(from, newFrame);
     }
 
     private static bool GetDehackedActorDefinition(Entity entity, int index, [NotNullWhen(true)] out EntityDefinition? def)

--- a/Core/World/Entities/Definition/States/FrameState.cs
+++ b/Core/World/Entities/Definition/States/FrameState.cs
@@ -29,25 +29,19 @@ public struct FrameState
     private static int SlowTickOffsetTracer;
 
     public EntityFrame Frame;
-    private readonly Entity m_entity;
-    private readonly Dictionary<string, int> m_stateLabels;
     private readonly FrameStateOptions m_options;
 
     public int CurrentTick;
     public int FrameIndex;
 
-    public FrameState(Entity entity, EntityDefinition definition, FrameStateOptions options = FrameStateOptions.DestroyOnStop)
+    public FrameState(EntityDefinition definition, FrameStateOptions options = FrameStateOptions.DestroyOnStop)
     {
-        m_entity = entity;
-        m_stateLabels = definition.States.Labels;
         m_options = options;
         Frame = WorldStatic.Frames[FrameIndex];
     }
 
     public FrameState(Entity entity, EntityDefinition definition, FrameStateModel frameStateModel)
     {
-        m_entity = entity;
-        m_stateLabels = definition.States.Labels;
         FrameIndex = frameStateModel.FrameIndex;
         CurrentTick = frameStateModel.Tics;
 
@@ -58,93 +52,93 @@ public struct FrameState
 
         Frame = WorldStatic.Frames[FrameIndex];
         if (Frame.MasterFrameIndex == WorldStatic.ClosetLookFrameIndex)
-            m_entity.ClosetFlags |= ClosetFlags.ClosetLook;
+            entity.ClosetFlags |= ClosetFlags.ClosetLook;
         if (Frame.MasterFrameIndex == WorldStatic.ClosetChaseFrameIndex)
-            m_entity.ClosetFlags |= ClosetFlags.ClosetChase;
+            entity.ClosetFlags |= ClosetFlags.ClosetChase;
 
-        if ((m_entity.ClosetFlags & (ClosetFlags.ClosetLook | ClosetFlags.ClosetChase)) != 0)
-            m_entity.ClosetFlags |= ClosetFlags.MonsterCloset;
+        if ((entity.ClosetFlags & (ClosetFlags.ClosetLook | ClosetFlags.ClosetChase)) != 0)
+            entity.ClosetFlags |= ClosetFlags.MonsterCloset;
     }
 
-    public EntityFrame? GetStateFrame(string label)
+    public EntityFrame? GetStateFrame(EntityDefinition def, string label)
     {
-        if (m_stateLabels.TryGetValue(label, out int index))
+        if (def.States.Labels.TryGetValue(label, out int index))
             return WorldStatic.Frames[index];
 
         return null;
     }
 
     // Only for end game cast - really shouldn't be used.
-    public void SetFrameIndexByLabel(string label)
+    public void SetFrameIndexByLabel(Entity entity, string label)
     {
-        if (m_stateLabels.TryGetValue(label, out int index))
-            SetFrameIndexMember(index);
+        if (entity.Definition.States.Labels.TryGetValue(label, out int index))
+            SetFrameIndexMember(entity, index);
     }
 
-    public void SetFrameIndex(int index)
+    public void SetFrameIndex(Entity entity, int index)
     {
         if (index < 0 || index >= WorldStatic.Frames.Count)
             return;
 
-        SetFrameIndexMember(index);
-        SetFrameIndexInternal(index);
+        SetFrameIndexMember(entity,index);
+        SetFrameIndexInternal(entity, index);
     }
 
-    public void SetFrameIndexNoAction(int index)
+    public void SetFrameIndexNoAction(Entity entity, int index)
     {
         if (index < 0 || index >= WorldStatic.Frames.Count)
             return;
 
-        SetFrameIndexMember(index);
+        SetFrameIndexMember(entity, index);
         CurrentTick = Frame.Ticks;
     }
 
-    public bool SetState(string label, int offset = 0, bool warn = true, bool executeStateFunctions = true)
+    public bool SetState(Entity entity, EntityDefinition def, string label, int offset = 0, bool warn = true, bool executeStateFunctions = true)
     {
         if (!executeStateFunctions)
-            return SetStateNoAction(label, offset, warn);
+            return SetStateNoAction(entity, label, offset, warn);
 
-        if (m_stateLabels.TryGetValue(label, out int index))
+        if (def.States.Labels.TryGetValue(label, out int index))
         {
             if (index + offset >= 0 && index + offset < WorldStatic.Frames.Count)
-                SetFrameIndexInternal(index + offset);
+                SetFrameIndexInternal(entity, index + offset);
             else
-                SetFrameIndexInternal(index);
+                SetFrameIndexInternal(entity, index);
 
             return true;
         }
 
         if (warn)
-            Log.Warn("Unable to find state label {0} for actor {1}", label, m_entity.Definition.Name);
+            Log.Warn("Unable to find state label {0} for actor {1}", label, def.Name);
 
         return false;
     }
 
-    public bool SetStateNoAction(string label, int offset = 0, bool warn = true)
+    public bool SetStateNoAction(Entity entity, string label, int offset = 0, bool warn = true)
     {
-        if (m_stateLabels.TryGetValue(label, out int index))
+        if (entity.Definition.States.Labels.TryGetValue(label, out int index))
         {
             if (index + offset >= 0 && index + offset < WorldStatic.Frames.Count)
-                SetFrameIndexMember(index + offset);
+                SetFrameIndexMember(entity, index + offset);
             else
-                SetFrameIndexMember(FrameIndex = index);
+                SetFrameIndexMember(entity, FrameIndex = index);
 
             CurrentTick = Frame.Ticks;
             return true;
         }
 
         if (warn)
-            Log.Warn("Unable to find state label {0} for actor {1}", label, m_entity.Definition.Name);
+            Log.Warn("Unable to find state label {0} for actor {1}", label, entity.Definition.Name);
 
         return false;
     }
 
-    public void SetState(EntityFrame entityFrame) =>
-        SetFrameIndexInternal(entityFrame.MasterFrameIndex);
+    public void SetState(Entity entity, EntityFrame entityFrame) =>
+        SetFrameIndexInternal(entity, entityFrame.MasterFrameIndex);
 
-    public bool IsState(string label)
+    public bool IsState(EntityDefinition def, string label)
     {
-        if (m_stateLabels.TryGetValue(label, out int index))
+        if (def.States.Labels.TryGetValue(label, out int index))
             return FrameIndex == index;
 
         return false;
@@ -157,26 +151,26 @@ public struct FrameState
         CurrentTick = tics;
     }
 
-    private void SetFrameIndexMember(int index)
+    private void SetFrameIndexMember(Entity entity, int index)
     {
         FrameIndex = index;
         Frame = WorldStatic.Frames[FrameIndex];
 
-        if (m_entity.ClosetFlags == ClosetFlags.None)
+        if (entity.ClosetFlags == ClosetFlags.None)
             return;
 
         if (Frame.MasterFrameIndex == WorldStatic.ClosetLookFrameIndex)
-            m_entity.ClosetFlags |= ClosetFlags.ClosetLook;
+            entity.ClosetFlags |= ClosetFlags.ClosetLook;
         if (Frame.MasterFrameIndex == WorldStatic.ClosetChaseFrameIndex)
-            m_entity.ClosetFlags |= ClosetFlags.ClosetChase;
+            entity.ClosetFlags |= ClosetFlags.ClosetChase;
     }
 
-    private void SetFrameIndexInternal(int index)
+    private void SetFrameIndexInternal(Entity entity, int index)
     {
         int loopCount = 0;
         while (true)
         {
-            SetFrameIndexMember(index);
+            SetFrameIndexMember(entity, index);
             CurrentTick = Frame.Ticks;
 
             if (WorldStatic.IsFastMonsters && Frame.Properties.Fast)
@@ -185,31 +179,31 @@ public struct FrameState
             if (WorldStatic.IsSlowMonsters && Frame.Properties.Slow)
                 CurrentTick *= 2;
 
-            CheckSlowTickDistance();
+            CheckSlowTickDistance(entity);
             // Doom set the offsets only if misc1 wasn't zero. Only was applied through the player sprite code.
-            if ((m_options & FrameStateOptions.PlayerSprite) != 0 && Frame.DehackedMisc1 != 0 && m_entity.PlayerObj != null)
+            if ((m_options & FrameStateOptions.PlayerSprite) != 0 && Frame.DehackedMisc1 != 0 && entity.PlayerObj != null)
             {
-                m_entity.PlayerObj.WeaponOffset.X = Frame.DehackedMisc1;
-                m_entity.PlayerObj.WeaponOffset.Y = Frame.DehackedMisc2;
-                m_entity.PlayerObj.PrevWeaponOffset.X = Frame.DehackedMisc1;
-                m_entity.PlayerObj.PrevWeaponOffset.Y = Frame.DehackedMisc2;
+                entity.PlayerObj.WeaponOffset.X = Frame.DehackedMisc1;
+                entity.PlayerObj.WeaponOffset.Y = Frame.DehackedMisc2;
+                entity.PlayerObj.PrevWeaponOffset.X = Frame.DehackedMisc1;
+                entity.PlayerObj.PrevWeaponOffset.Y = Frame.DehackedMisc2;
             }
 
             if ((m_options & FrameStateOptions.DestroyOnStop) != 0 && Frame.IsNullFrame)
             {
-                WorldStatic.EntityManager.Destroy(m_entity);
+                WorldStatic.EntityManager.Destroy(entity);
                 return;
             }
 
             loopCount++;
             if (loopCount > InfiniteLoopLimit)
             {
-                LogStackError();
+                LogStackError(entity.Definition);
                 return;
             }
 
-            Frame.ActionFunction?.Invoke(m_entity);
-            if (m_entity == null || FrameIndex == Constants.NullFrameIndex)
+            Frame.ActionFunction?.Invoke(entity);
+            if (entity == null || FrameIndex == Constants.NullFrameIndex)
                 return;
 
             if (Frame.BranchType == ActorStateBranch.Stop && Frame.Ticks >= 0)
@@ -222,53 +216,53 @@ public struct FrameState
         }
     }
 
-    private void CheckSlowTickDistance()
+    private void CheckSlowTickDistance(Entity entity)
     {
-        m_entity.SlowTickMultiplier = 1;
+        entity.SlowTickMultiplier = 1;
         if (!WorldStatic.SlowTickEnabled || WorldStatic.SlowTickDistance <= 0)
             return;
 
-        if (m_entity.ClosetFlags != ClosetFlags.None || m_entity.IsPlayer)
+        if (entity.ClosetFlags != ClosetFlags.None || entity.IsPlayer)
             return;
 
         if (CurrentTick > 0 &&
             (Frame.IsSlowTickTracer || Frame.IsSlowTickChase || Frame.IsSlowTickLook) &&
-            (m_entity.RenderDistanceSquared > WorldStatic.SlowTickDistance * WorldStatic.SlowTickDistance ||
-            m_entity.LastRenderGametick != WorldStatic.World.Gametick))
+            (entity.RenderDistanceSquared > WorldStatic.SlowTickDistance * WorldStatic.SlowTickDistance ||
+            entity.LastRenderGametick != WorldStatic.World.Gametick))
         {
             // Stagger the frame ticks using SlowTickOffset so they don't all run on the same gametick
             // Sets to a range of -1 to +2
             int offset = 0;
             if (Frame.IsSlowTickChase && WorldStatic.SlowTickChaseMultiplier > 0)
             {
-                m_entity.SlowTickMultiplier = WorldStatic.SlowTickChaseMultiplier;
+                entity.SlowTickMultiplier = WorldStatic.SlowTickChaseMultiplier;
                 offset = (SlowTickOffsetChase++ & 3) - 1;
             }
             else if (Frame.IsSlowTickLook && WorldStatic.SlowTickLookMultiplier > 0)
             {
-                m_entity.SlowTickMultiplier = WorldStatic.SlowTickLookMultiplier;
+                entity.SlowTickMultiplier = WorldStatic.SlowTickLookMultiplier;
                 offset = (SlowTickOffsetLook++ & 3) - 1;
             }
             else if (Frame.IsSlowTickTracer && WorldStatic.SlowTickTracerMultiplier > 0)
             {
-                m_entity.SlowTickMultiplier = WorldStatic.SlowTickTracerMultiplier;
+                entity.SlowTickMultiplier = WorldStatic.SlowTickTracerMultiplier;
                 offset = (SlowTickOffsetTracer++ & 3) - 1;
             }
 
-            CurrentTick *= m_entity.SlowTickMultiplier + offset;
+            CurrentTick *= entity.SlowTickMultiplier + offset;
         }
     }
 
-    private void LogStackError()
+    private void LogStackError(EntityDefinition def)
     {
         string method = string.Empty;
         if (Frame.ActionFunction != null)
             method = $"function '{Frame.ActionFunction.Method.Name}'";
 
-        Log.Error($"Stack limit reached for '{m_entity.Definition.Name}' {method}");
+        Log.Error($"Stack limit reached for '{def.Name}' {method}");
     }
 
-    public void Tick()
+    public void Tick(Entity entity)
     {
         Precondition(FrameIndex >= 0 && FrameIndex < WorldStatic.Frames.Count, "Out of range frame index for entity");
         if (CurrentTick == -1)
@@ -279,11 +273,11 @@ public struct FrameState
         {
             if (Frame.BranchType == ActorStateBranch.Stop && (m_options & FrameStateOptions.DestroyOnStop) != 0)
             {
-                WorldStatic.EntityManager.Destroy(m_entity);
+                WorldStatic.EntityManager.Destroy(entity);
                 return;
             }
 
-            SetFrameIndexInternal(Frame.NextFrameIndex);
+            SetFrameIndexInternal(entity, Frame.NextFrameIndex);
         }
     }
 
@@ -303,7 +297,7 @@ public struct FrameState
         if (obj is not FrameState frameState)
             return false;
 
-        return frameState.m_entity.Id == m_entity.Id &&
+        return
             frameState.FrameIndex == FrameIndex &&
             frameState.CurrentTick == CurrentTick &&
             frameState.m_options == m_options;

--- a/Core/World/Entities/Enemy.cs
+++ b/Core/World/Entities/Enemy.cs
@@ -39,7 +39,7 @@ public partial class Entity
         m_direction = direction;
 
     public bool ValidEnemyTarget(Entity? entity) => entity != null &&
-        !entity.IsDead && (!IsFriend(entity) || Target.IsNull());
+        !entity.IsDead && (!IsFriend(entity) || Target() == null);
 
     public void SetMoveDirection(MoveDir dir) => m_direction = dir;
 
@@ -72,7 +72,7 @@ public partial class Entity
         {
             if (Flags.Friendly)
             {
-                var previousTarget = Target.Get();
+                var previousTarget = Target();
                 SetTarget(newTarget);
                 if (newTarget != null && newTarget.IsPlayer && newTarget != previousTarget && Definition.MissileState.HasValue)
                 {
@@ -169,7 +169,7 @@ public partial class Entity
         // Dehacked can modify things into enemies that can move but this flag doesn't exist in the original game.
         // Set this flag for anything that tries to move, otherwise they can clip ito other things and get stuck, especialliy with float.
         Flags.CanPass = true;
-        Assert.Precondition(Target.Get() != null, "Target is null");
+        Assert.Precondition(Target() != null, "Target is null");
 
         MoveDir dir0;
         MoveDir dir1;
@@ -180,7 +180,7 @@ public partial class Entity
         if (oppositeDirection != MoveDir.None)
             oppositeDirection = (MoveDir)(((int)oppositeDirection) ^ 4);
 
-        var target = Target.Get()!;
+        var target = Target()!;
         double dx = target.Position.X - Position.X;
         double dy = target.Position.Y - Position.Y;
 
@@ -408,7 +408,7 @@ public partial class Entity
         if (IsPlayer || IsDead || !Flags.Float || Flags.Skullfly || Flags.InFloat || OnGround)
             return 0.0;
 
-        var target = Target.Get();
+        var target = Target();
         if (target == null)
             return 0.0;
 
@@ -446,7 +446,7 @@ public partial class Entity
 
     public bool CheckMissileRange()
     {
-        var target = Target.Get();
+        var target = Target();
         if (target == null || IsFriend(target) || !WorldStatic.World.CheckLineOfSight(this, target))
             return false;
 

--- a/Core/World/Entities/Enemy.cs
+++ b/Core/World/Entities/Enemy.cs
@@ -101,7 +101,7 @@ public partial class Entity
 
     public void SetClosetLook()
     {
-        FrameState.SetFrameIndex(WorldStatic.World.ArchiveCollection.EntityFrameTable.ClosetLookFrameIndex);
+        FrameState.SetFrameIndex(this, WorldStatic.World.ArchiveCollection.EntityFrameTable.ClosetLookFrameIndex);
         AddFrameTicks(ClosetLookCount);
         ClosetLookCount++;
     }
@@ -114,7 +114,7 @@ public partial class Entity
     public void SetClosetChase()
     {
         ClosetFlags = ClosetFlags & ~ClosetFlags.ClosetLook;
-        FrameState.SetFrameIndex(WorldStatic.World.ArchiveCollection.EntityFrameTable.ClosetChaseFrameIndex);
+        FrameState.SetFrameIndex(this, WorldStatic.World.ArchiveCollection.EntityFrameTable.ClosetChaseFrameIndex);
         AddFrameTicks(ClosetChaseCount);
         ClosetChaseCount++;
     }

--- a/Core/World/Entities/Entity.cs
+++ b/Core/World/Entities/Entity.cs
@@ -189,7 +189,7 @@ public partial class Entity : IDisposable, ITickable, ISoundSource
         Alpha = (float)Properties.Alpha;
         MonsterMovementSpeed = Properties.MonsterMovementSpeed;
 
-        FrameState = new(this, definition);
+        FrameState = new(definition);
     }
 
     public void Set(int index, EntityModel entityModel, EntityDefinition definition, IWorld world)
@@ -430,7 +430,7 @@ public partial class Entity : IDisposable, ITickable, ISoundSource
         if (Flags.BossSpawnShot && ReactionTime > 0)
             ReactionTime--;
 
-        FrameState.Tick();
+        FrameState.Tick(this);
 
         if (IsDisposed)
             return;
@@ -482,25 +482,25 @@ public partial class Entity : IDisposable, ITickable, ISoundSource
     public void SetSpawnState()
     {
         if (Definition.SpawnState != null)
-            FrameState.SetFrameIndex(Definition.SpawnState.Value);
+            FrameState.SetFrameIndex(this, Definition.SpawnState.Value);
     }
 
     public void SetSeeState()
     {
         if (Definition.SeeState != null)
-            FrameState.SetFrameIndex(Definition.SeeState.Value);
+            FrameState.SetFrameIndex(this, Definition.SeeState.Value);
     }
 
     public void SetMissileState()
     {
         if (Definition.MissileState != null)
-            FrameState.SetFrameIndex(Definition.MissileState.Value);
+            FrameState.SetFrameIndex(this, Definition.MissileState.Value);
     }
 
     public void SetMeleeState()
     {
         if (Definition.MeleeState != null)
-            FrameState.SetFrameIndex(Definition.MeleeState.Value);
+            FrameState.SetFrameIndex(this, Definition.MeleeState.Value);
     }
 
     public void SetDeathState(Entity? source)
@@ -510,7 +510,7 @@ public partial class Entity : IDisposable, ITickable, ISoundSource
         if (!IsDisposed)
             SetDeath(source, false);
                 
-        FrameState.SetFrameIndex(deathState);
+        FrameState.SetFrameIndex(this, deathState);
 
         if (!IsDisposed)
             SetDeathRandomizeTicks();
@@ -522,7 +522,7 @@ public partial class Entity : IDisposable, ITickable, ISoundSource
             SetDeath(source, true);
 
         if (Definition.XDeathState.HasValue)
-            FrameState.SetFrameIndex(Definition.XDeathState.Value);
+            FrameState.SetFrameIndex(this, Definition.XDeathState.Value);
 
         if (!IsDisposed)
             SetDeathRandomizeTicks();
@@ -548,8 +548,8 @@ public partial class Entity : IDisposable, ITickable, ISoundSource
     public bool SetCrushState()
     {
         // Check if there is a Crush state, otherwise default to GenericCrush
-        if (FrameState.SetState(Constants.FrameStates.Crush, warn: false) ||
-            FrameState.SetState(Constants.FrameStates.GenericCrush, warn: false))
+        if (FrameState.SetState(this, Definition, Constants.FrameStates.Crush, warn: false) ||
+            FrameState.SetState(this, Definition, Constants.FrameStates.GenericCrush, warn: false))
         {
             Flags.DontGib = true;
             Flags.Solid = false;
@@ -564,7 +564,7 @@ public partial class Entity : IDisposable, ITickable, ISoundSource
     {        
         if (Definition.RaiseState != null)
         {
-            FrameState.SetFrameIndex(Definition.RaiseState.Value);
+            FrameState.SetFrameIndex(this, Definition.RaiseState.Value);
             Health = Definition.Properties.Health;
             Height = Definition.Properties.Height;
             Flags.CrushGiblets = false;
@@ -574,7 +574,7 @@ public partial class Entity : IDisposable, ITickable, ISoundSource
     }
 
     public void SetHealState() =>
-        FrameState.SetState(Constants.FrameStates.Heal);
+        FrameState.SetState(this, Definition, Constants.FrameStates.Heal);
 
     public void PlaySeeSound(SoundContext ctx = default)
     {
@@ -708,7 +708,7 @@ public partial class Entity : IDisposable, ITickable, ISoundSource
         else if (setPainState && !Flags.Skullfly && Definition.PainState != null)
         {
             Flags.JustHit = true;
-            FrameState.SetFrameIndex(Definition.PainState.Value);
+            FrameState.SetFrameIndex(this, Definition.PainState.Value);
         }
 
         // Skullfly is not turned off here as the original game did not do this
@@ -934,7 +934,7 @@ public partial class Entity : IDisposable, ITickable, ISoundSource
         UnlinkFromWorld();
         Unlink();
 
-        FrameState.SetFrameIndex(Constants.NullFrameIndex);
+        FrameState.SetFrameIndex(this, Constants.NullFrameIndex);
 
         BlocksLength = 0;
         SectorNodes.Clear();

--- a/Core/World/Entities/EntityManager.cs
+++ b/Core/World/Entities/EntityManager.cs
@@ -473,7 +473,7 @@ public class EntityManager : IDisposable
         // Vanilla did not execute action functions on creation, it just set the state
         // Action functions will not execute until Tick() is called
         if (entity.Definition.SpawnState != null)
-            entity.FrameState.SetFrameIndexNoAction(entity.Definition.SpawnState.Value);
+            entity.FrameState.SetFrameIndexNoAction(entity, entity.Definition.SpawnState.Value);
 
         if (entity.Definition.Flags.CountKill || entity.Definition.Flags.IsMonster)
             entity.Health = Math.Max((int)(entity.Health * World.SkillDefinition.MonsterHealthFactor), 1);

--- a/Core/World/Entities/Inventories/Weapon.cs
+++ b/Core/World/Entities/Inventories/Weapon.cs
@@ -36,12 +36,12 @@ public class Weapon : InventoryItem, ITickable
         Owner = owner;
 
         if (frameStateModel == null)
-            FrameState = new FrameState(owner, definition, FrameStateOptions.PlayerSprite);
+            FrameState = new FrameState(definition, FrameStateOptions.PlayerSprite);
         else
             FrameState = new FrameState(owner, definition, frameStateModel.Value);
 
         if (flashStateModel == null)
-            FlashState = new FrameState(owner, definition, FrameStateOptions.None);
+            FlashState = new FrameState(definition, FrameStateOptions.None);
         else
             FlashState = new FrameState(owner, definition, flashStateModel.Value);
 
@@ -55,7 +55,7 @@ public class Weapon : InventoryItem, ITickable
     public void SetFlashState(EntityFrame frame)
     {
         Owner.WeaponFlashState = true;
-        FlashState.SetState(frame);
+        FlashState.SetState(Owner, frame);
         Owner.WeaponFlashState = false;
     }
 
@@ -66,19 +66,19 @@ public class Weapon : InventoryItem, ITickable
 
     public void SetFireState()
     {
-        FrameState.SetState(Constants.FrameStates.Fire);
+        FrameState.SetState(Owner, Definition, Constants.FrameStates.Fire);
     }
 
     public void SetFlashState(int offset = 0)
     {
         Owner.WeaponFlashState = true;
-        FlashState.SetState(Constants.FrameStates.Flash, offset, false);
+        FlashState.SetState(Owner, Definition, Constants.FrameStates.Flash, offset, false);
         Owner.WeaponFlashState = false;
     }
 
     public void SetReadyState()
     {
-        FrameState.SetState(Constants.FrameStates.Ready);
+        FrameState.SetState(Owner, Definition, Constants.FrameStates.Ready);
     }
 
     public void Tick()
@@ -86,9 +86,9 @@ public class Weapon : InventoryItem, ITickable
         ReadyState = false;
         ReadyToFire = false;
 
-        FrameState.Tick();
+        FrameState.Tick(Owner);
         Owner.WeaponFlashState = true;
-        FlashState.Tick();
+        FlashState.Tick(Owner);
         Owner.WeaponFlashState = false;
 
         if (m_tryingToFire && ReadyToFire)
@@ -103,7 +103,7 @@ public class Weapon : InventoryItem, ITickable
 
     private void SetToFireState()
     {
-        if (!FrameState.SetState(Constants.FrameStates.Fire))
+        if (!FrameState.SetState(Owner, Definition, Constants.FrameStates.Fire))
             Log.Warn("Unable to find Fire state for weapon {0}", Definition.Name);
     }
 

--- a/Core/World/Entities/Players/Player.cs
+++ b/Core/World/Entities/Players/Player.cs
@@ -5,6 +5,7 @@ using Helion.Maps.Specials.ZDoom;
 using Helion.Models;
 using Helion.Render.Common.World;
 using Helion.Render.OpenGL.Shared;
+using Helion.Resources.Archives.Entries;
 using Helion.Resources.Definitions.MapInfo;
 using Helion.Resources.Definitions.SoundInfo;
 using Helion.Util;
@@ -756,14 +757,14 @@ public class Player : Entity
             FrameState.Frame.MasterFrameIndex == Definition.SpawnState.Value &&
             Definition.SeeState.HasValue)
         {
-            FrameState.SetFrameIndex(Definition.SeeState.Value);
+            FrameState.SetFrameIndex(this, Definition.SeeState.Value);
         }
         else if (!hasMoveSpeed && Velocity == Vec3D.Zero && Definition.SpawnState.HasValue &&
             FrameState.Frame.MasterFrameIndex != Definition.SpawnState.Value &&
             // Doom hard-coded this to check for any of the 4 running states S_PLAY_RUN1 - S_PLAY_RUN4
             FrameState.Frame.MasterFrameIndex - Definition.SeeState.Value < 4)
         {
-            FrameState.SetFrameIndex(Definition.SpawnState.Value);
+            FrameState.SetFrameIndex(this, Definition.SpawnState.Value);
         }
     }
 
@@ -1432,12 +1433,12 @@ public class Player : Entity
         if (Weapon.Definition.Flags.WeaponMeleeWeapon)
         {
             if (Definition.MissileState.HasValue)
-                FrameState.SetFrameIndex(Definition.MissileState.Value);
+                FrameState.SetFrameIndex(this, Definition.MissileState.Value);
             return;
         }
 
         if (Definition.MeleeState.HasValue)
-            FrameState.SetFrameIndex(Definition.MeleeState.Value);
+            FrameState.SetFrameIndex(this, Definition.MeleeState.Value);
     }
 
     /// <summary>
@@ -1535,7 +1536,7 @@ public class Player : Entity
 
     private void SetWeaponFrameState(Weapon weapon, string label)
     {
-        weapon.FrameState.SetState(label);
+        weapon.FrameState.SetState(this, weapon.Definition, label);
     }
 
     public void SetWeaponUp()

--- a/Core/World/Entities/Players/Player.cs
+++ b/Core/World/Entities/Players/Player.cs
@@ -1592,7 +1592,7 @@ public class Player : Entity
         bool damageApplied = base.Damage(source, damage, setPainState, damageType);
         if (damageApplied)
         {
-            SetAttacker(source?.Owner.Get() ?? source);
+            SetAttacker(source?.Owner() ?? source);
             PlayPainSound(damage);
             DamageCount += damage;
             DamageCount = Math.Min(DamageCount, Definition.Properties.Health);
@@ -1638,7 +1638,7 @@ public class Player : Entity
         m_deathTics = MathHelper.Clamp((int)(Definition.Properties.Player.ViewHeight - DeathHeight), 0, (int)Definition.Properties.Player.ViewHeight);
 
         if (source != null)
-            m_killer = new WeakEntity(source.Owner.Get() ?? source);
+            m_killer = new WeakEntity(source.Owner() ?? source);
         if (m_killer.Get() == this)
             m_killer = new WeakEntity(null);
 

--- a/Core/World/Physics/PhysicsManager.cs
+++ b/Core/World/Physics/PhysicsManager.cs
@@ -154,7 +154,7 @@ public sealed class PhysicsManager
         for (int i = 0; i < entities.Length; i++)
         {
             var entity = entities[i];
-            var onEntity = entity.OnEntity.Get();
+            var onEntity = entity.OnEntity();
             bool hasOnEntity = onEntity != null;
             if (!hasOnEntity && entity.HadOnEntity)
             {
@@ -210,7 +210,7 @@ public sealed class PhysicsManager
                 entity.OnGround && entity.HighestFloorSector == sector)
             {
                 double top = destZ;
-                var onEntity = entity.OnEntity.Get();
+                var onEntity = entity.OnEntity();
                 if (onEntity != null)
                     top = onEntity.Position.Z + onEntity.Height;
                 entity.Position.Z = top;
@@ -518,7 +518,7 @@ public sealed class PhysicsManager
         while (node != null)
         {
             var checkEntity = node.Value;
-            var overEntity = checkEntity.OverEntity.Get();
+            var overEntity = checkEntity.OverEntity();
             if (overEntity != null && ContainsEntity(crushEntities, overEntity))
                 m_stackCrush.Add(checkEntity);
             node = node.Next;
@@ -593,7 +593,7 @@ public sealed class PhysicsManager
 
         pusher.Position.Z = pusher.LowestCeilingZ - pusher.Height;
 
-        var onEntity = pusher.OnEntity.Get();
+        var onEntity = pusher.OnEntity();
         if (onEntity != null)
         {
             Entity? current = onEntity;
@@ -604,7 +604,7 @@ public sealed class PhysicsManager
 
                 current.Position.Z = pusher.Position.Z - current.Height;
                 pusher = current;
-                current = pusher.OnEntity.Get();
+                current = pusher.OnEntity();
             }
         }
     }
@@ -711,7 +711,7 @@ public sealed class PhysicsManager
             return;
 
         double prevHighestFloorZ = entity.HighestFloorZ;
-        var prevOnEntity = entity.OnEntity.Get();
+        var prevOnEntity = entity.OnEntity();
         SetEntityBoundsZ(entity, intersectSectors, clampToLinkedSectors, tryMove);
         entity.SetOnEntity(null);
 
@@ -758,7 +758,7 @@ public sealed class PhysicsManager
             SetEntityOnFloorOrEntity(entity, highestFloor, smoothZ && prevHighestFloorZ != entity.HighestFloorZ);
         }
 
-        if (prevOnEntity != null && prevOnEntity != entity.OnEntity.Get())
+        if (prevOnEntity != null && prevOnEntity != entity.OnEntity())
             prevOnEntity.SetOverEntity(null);
 
         entity.CheckOnGround();
@@ -1162,7 +1162,7 @@ doneLinkToSectors:
     {
         if (!WorldStatic.InfinitelyTallThings && (entity.Flags.Flags1 & EntityFlags.FloatFlag) == 0 && !entity.IsPlayer)
         {
-            var onEntity = entity.OnEntity.Get();
+            var onEntity = entity.OnEntity();
             if (onEntity != null && (onEntity.Flags.Flags1 & EntityFlags.ActsLikeBridgeFlag) == 0)
                 return false;
         }
@@ -1726,7 +1726,7 @@ doneLinkToSectors:
         // Adds z velocity on the first tick, then adds -2 on the second instead of -1 on the first and -1 on the second.
         bool noVelocity = entity.Velocity.Z == 0;
         bool shouldApplyGravity = entity.ShouldApplyGravity();
-        if (noVelocity && !shouldApplyGravity && (entity.Flags.Flags1 & EntityFlags.FloatFlag) == 0 && entity.OnEntity.IsNull())
+        if (noVelocity && !shouldApplyGravity && (entity.Flags.Flags1 & EntityFlags.FloatFlag) == 0 && entity.OnEntity() == null)
             return;
 
         if (entity.Flags.NoGravity && entity.ShouldApplyFriction())
@@ -1736,7 +1736,7 @@ doneLinkToSectors:
 
         double floatZ = entity.GetEnemyFloatMove();
         // Only return if OnEntity is null. Need to apply clamping to prevent issues with this entity floating when the entity beneath is no longer blocking.
-        if (noVelocity && floatZ == 0 && entity.OnEntity.IsNull())
+        if (noVelocity && floatZ == 0 && entity.OnEntity() == null)
             return;
 
         Vec3D previousVelocity = entity.Velocity;

--- a/Core/World/Sound/WorldSoundManager.cs
+++ b/Core/World/Sound/WorldSoundManager.cs
@@ -107,7 +107,7 @@ public class WorldSoundManager(IWorld world, IAudioSystem audioSystem) : SoundMa
             return 1;
 
         // Checking there is no owner, otherwise rockets set the see type and get bumped out by moving floors
-        if (soundSource is Entity entity && !entity.IsPlayer && entity.Owner.IsNull())
+        if (soundSource is Entity entity && !entity.IsPlayer && entity.Owner() == null)
         {
             switch (soundParams.SoundType)
             {

--- a/Core/World/WorldBase.cs
+++ b/Core/World/WorldBase.cs
@@ -1768,7 +1768,7 @@ public abstract partial class WorldBase : IWorld
         }
 
         m_itemPickupIndexToPlayers[item.Index] = player; 
-        item.FrameState.SetState(Constants.FrameStates.Pickup, warn: false);
+        item.FrameState.SetState(item, item.Definition, Constants.FrameStates.Pickup, warn: false);
         m_itemPickupIndexToPlayers.Remove(item.Index);
 
         if (item.Flags.CountItem)
@@ -2400,7 +2400,7 @@ public abstract partial class WorldBase : IWorld
         if (offset == 0)
             blood.SetRandomizeTicks();
         else if (blood.Definition.SpawnState != null)
-            blood.FrameState.SetFrameIndex(blood.Definition.SpawnState.Value + offset);
+            blood.FrameState.SetFrameIndex(blood, blood.Definition.SpawnState.Value + offset);
     }
 
     private static void MoveIntersectCloser(in Vec3D start, ref Vec3D intersect, double angle, double distXY)
@@ -2759,7 +2759,7 @@ public abstract partial class WorldBase : IWorld
         healChaseEntity.SetTarget(entity);
         EntityActionFunctions.A_FaceTarget(healChaseEntity);
         healChaseEntity.SetTarget(saveTarget);
-        healChaseEntity.FrameState.SetState(m_healChaseData.HealState);
+        healChaseEntity.FrameState.SetState(entity, m_healChaseData.HealState);
 
         if (m_healChaseData.HealSound.Length > 0)
             WorldStatic.SoundManager.CreateSoundOn(entity, m_healChaseData.HealSound, new SoundParams(entity));

--- a/Core/World/WorldBase.cs
+++ b/Core/World/WorldBase.cs
@@ -743,13 +743,13 @@ public abstract partial class WorldBase : IWorld
 
     public void Link(Entity entity)
     {
-        Precondition(entity.SectorNodes.Empty() && entity.BlocksLength == 0, "Forgot to unlink entity before linking");
+        Precondition(entity.SectorNodes.Empty() && entity.BlockRange.StartX == Constants.ClearBlock, "Forgot to unlink entity before linking");
         PhysicsManager.LinkToWorld(entity, null, false);
     }
 
     public void LinkClamped(Entity entity)
     {
-        Precondition(entity.SectorNodes.Empty() && entity.BlocksLength == 0, "Forgot to unlink entity before linking");
+        Precondition(entity.SectorNodes.Empty() && entity.BlockRange.StartX == Constants.ClearBlock, "Forgot to unlink entity before linking");
         PhysicsManager.LinkToWorld(entity, null, true);
     }
 

--- a/Core/World/WorldBase.cs
+++ b/Core/World/WorldBase.cs
@@ -866,7 +866,7 @@ public abstract partial class WorldBase : IWorld
                 entity.SectorDamageSpecial?.Tick(entity);
                                 
                 if (!WorldStatic.InfinitelyTallThings &&
-                    (entity.HadOnEntity || entity.OnEntity.NotNull()) &&
+                    (entity.HadOnEntity || entity.OnEntity() != null) &&
                     !entity.Flags.NoGravity && !entity.Flags.NoBlockmap &&                    
                     entity.Velocity.Z == 0 && entity.Position.Z > entity.HighestFloorSector.Floor.Z)
                 {
@@ -1579,7 +1579,7 @@ public abstract partial class WorldBase : IWorld
     public virtual bool DamageEntity(Entity target, Entity? source, int damage, DamageType damageType,
         Thrust thrust = Thrust.HorizontalAndVertical, Sector? sectorSource = null)
     {
-        if (source != null && source.Owner.Get() == target)
+        if (source != null && source.Owner() == target)
             damage = (int)(damage * source.Properties.SelfDamageFactor);
 
         if (!target.Flags.Shootable || damage == 0 || target.IsDead)
@@ -1590,7 +1590,7 @@ public abstract partial class WorldBase : IWorld
         {
             Vec3D savePos = source.Position;
             // Check if the source is owned by this target and the same position and move to get a valid thrust angle. (player shot missile against wall)
-            if (source.Owner.Get() == target && source.Position.XY == target.Position.XY)
+            if (source.Owner() == target && source.Position.XY == target.Position.XY)
             {
                 Vec3D move = (source.Position.XY + Vec2D.UnitCircle(target.AngleRadians) * 2).To3D(source.Position.Z);
                 source.Position = move;
@@ -1616,7 +1616,7 @@ public abstract partial class WorldBase : IWorld
             {
                 // Player rocket jumping check, back up the source Z to get a valid pitch
                 // Only done for players, otherwise blowing up enemies will launch them in the air
-                if (zEqual && target.IsPlayer && source.Owner.Get() == target)
+                if (zEqual && target.IsPlayer && source.Owner() == target)
                 {
                     Vec3D sourcePos = new Vec3D(source.Position.X, source.Position.Y, source.Position.Z - 1.0);
                     pitch = sourcePos.Pitch(target.Position, 0.0);
@@ -1855,7 +1855,7 @@ public abstract partial class WorldBase : IWorld
             if (!entity.OverlapsZ(intersectEntity) || entity == intersectEntity)
                 continue;
 
-            if (entity.Flags.Ripper && entity.Owner.Get() != intersectEntity)
+            if (entity.Flags.Ripper && entity.Owner() != intersectEntity)
                 RipDamage(entity, intersectEntity);
             if (intersectEntity.Flags.Touchy && ShouldDieFromTouch(entity, intersectEntity))
                 intersectEntity.Kill(null);
@@ -2100,7 +2100,7 @@ public abstract partial class WorldBase : IWorld
 
         // If the player killed themself then don't display the obituary message
         // There is probably a special string for this in multiplayer for later
-        Entity killer = deathSource.Owner.Get() ?? deathSource;
+        Entity killer = deathSource.Owner() ?? deathSource;
         if (player == killer)
             return;
 
@@ -2299,7 +2299,7 @@ public abstract partial class WorldBase : IWorld
         if (applyDamage <= 0)
             return;
 
-        Entity? originalOwner = source.Owner.Get();
+        Entity? originalOwner = source.Owner();
         source.SetOwner(attackSource);
         DamageEntity(entity, source, applyDamage, DamageType.AlwaysApply, thrust);
         source.SetOwner(originalOwner);
@@ -2755,7 +2755,7 @@ public abstract partial class WorldBase : IWorld
         entity.Flags.Solid = true;
         entity.Height = entity.Definition.Properties.Height;
 
-        var saveTarget = healChaseEntity.Target.Get();
+        var saveTarget = healChaseEntity.Target();
         healChaseEntity.SetTarget(entity);
         EntityActionFunctions.A_FaceTarget(healChaseEntity);
         healChaseEntity.SetTarget(saveTarget);
@@ -2778,7 +2778,7 @@ public abstract partial class WorldBase : IWorld
 
     public void TracerSeek(Entity entity, double threshold, double maxTurnAngle, GetTracerVelocityZ velocityZ)
     {
-        var tracer = entity.Tracer.Get();
+        var tracer = entity.Tracer();
         if (tracer == null || tracer.IsDead)
             return;
 
@@ -2794,7 +2794,7 @@ public abstract partial class WorldBase : IWorld
     public void SetNewTracerTarget(Entity entity, double fieldOfViewRadians, double radius)
     {
         m_newTracerTargetData.Entity = entity;
-        m_newTracerTargetData.Owner = entity.Owner.Get() ?? entity;
+        m_newTracerTargetData.Owner = entity.Owner() ?? entity;
         m_newTracerTargetData.FieldOfViewRadians = fieldOfViewRadians;
         BlockmapTraverser.EntityTraverse(new Box2D(entity.Position.X, entity.Position.Y, radius), m_setNewTracerTargetAction);
     }
@@ -2891,7 +2891,7 @@ public abstract partial class WorldBase : IWorld
 
     private static void SetTracerAngle(Entity entity, double threshold, double maxTurnAngle)
     {
-        var tracer = entity.Tracer.Get();
+        var tracer = entity.Tracer();
         if (tracer == null)
             return;
         // Doom's angles were always 0-360 and did not allow negatives (thank you arithmetic overflow)

--- a/Core/World/WorldStatic.cs
+++ b/Core/World/WorldStatic.cs
@@ -1,6 +1,8 @@
-﻿using Helion.Util;
+﻿using Helion.Geometry.Grids;
+using Helion.Util;
 using Helion.Util.Container;
 using Helion.Util.RandomGenerators;
+using Helion.World.Blockmap;
 using Helion.World.Entities;
 using Helion.World.Entities.Definition;
 using Helion.World.Entities.Definition.States;

--- a/Tests/Unit/GameAction/EntityRef.cs
+++ b/Tests/Unit/GameAction/EntityRef.cs
@@ -40,7 +40,7 @@ namespace Helion.Tests.Unit.GameAction
             }
 
             foreach (var entity in entities1)
-                entity.Target.Get().Should().Be(lostSoul1);
+                entity.Target().Should().Be(lostSoul1);
 
             for (int i = 0; i < 10; i++)
             {
@@ -50,25 +50,25 @@ namespace Helion.Tests.Unit.GameAction
             }
 
             foreach (var entity in entities2)
-                entity.Target.Get().Should().Be(lostSoul2);
+                entity.Target().Should().Be(lostSoul2);
 
             lostSoul1.Kill(null);
             GameActions.TickWorld(world, 200);
 
             foreach (var entity in entities1)
-                entity.Target.Get().Should().BeNull();
+                entity.Target().Should().BeNull();
 
             foreach (var entity in entities2)
             {
-                entity.Target.Get().Should().NotBeNull();
-                entity.Target.Get()!.Should().Be(lostSoul2);
+                entity.Target().Should().NotBeNull();
+                entity.Target()!.Should().Be(lostSoul2);
             }
 
             lostSoul2.Kill(null);
             GameActions.TickWorld(world, 200);
 
             foreach (var entity in entities2)
-                entity.Target.Get().Should().BeNull();
+                entity.Target().Should().BeNull();
         }
 
         [Fact(DisplayName = "Test dispose tracer")]
@@ -86,13 +86,13 @@ namespace Helion.Tests.Unit.GameAction
             }
 
             foreach (var entity in entities)
-                entity.Tracer.Get().Should().Be(lostSoul1);
+                entity.Tracer().Should().Be(lostSoul1);
 
             lostSoul1.Kill(null);
             GameActions.TickWorld(world, 200);
 
             foreach (var entity in entities)
-                entity.Tracer.Get().Should().BeNull();
+                entity.Tracer().Should().BeNull();
         }
 
         [Fact(DisplayName = "Test dispose target and tracer")]
@@ -114,8 +114,8 @@ namespace Helion.Tests.Unit.GameAction
 
             foreach (var entity in entities1)
             {
-                entity.Target.Get()!.Should().Be(lostSoul1);
-                entity.Tracer.Get()!.Should().Be(lostSoul2);
+                entity.Target()!.Should().Be(lostSoul1);
+                entity.Tracer()!.Should().Be(lostSoul2);
             }
 
             for (int i = 0; i < 10; i++)
@@ -128,8 +128,8 @@ namespace Helion.Tests.Unit.GameAction
 
             foreach (var entity in entities2)
             {
-                entity.Target.Get()!.Should().Be(lostSoul2);
-                entity.Tracer.Get()!.Should().Be(lostSoul1);
+                entity.Target()!.Should().Be(lostSoul2);
+                entity.Tracer()!.Should().Be(lostSoul1);
             }
 
             lostSoul1.Kill(null);
@@ -137,16 +137,16 @@ namespace Helion.Tests.Unit.GameAction
 
             foreach (var entity in entities1)
             {
-                entity.Target.Get().Should().BeNull();
-                entity.Tracer.Get().Should().NotBeNull();
-                entity.Tracer.Get()!.Should().Be(lostSoul2);
+                entity.Target().Should().BeNull();
+                entity.Tracer().Should().NotBeNull();
+                entity.Tracer()!.Should().Be(lostSoul2);
             }
 
             foreach (var entity in entities2)
             {
-                entity.Target.Get().Should().NotBeNull();
-                entity.Target.Get()!.Should().Be(lostSoul2);
-                entity.Tracer.Get().Should().BeNull();
+                entity.Target().Should().NotBeNull();
+                entity.Target()!.Should().Be(lostSoul2);
+                entity.Tracer().Should().BeNull();
             }
 
             lostSoul2.Kill(null);
@@ -154,8 +154,8 @@ namespace Helion.Tests.Unit.GameAction
 
             foreach (var entity in entities2)
             {
-                entity.Target.Get().Should().BeNull();
-                entity.Tracer.Get().Should().BeNull();
+                entity.Target().Should().BeNull();
+                entity.Tracer().Should().BeNull();
             }
 
             foreach (var entity in entities1.Union(entities2))
@@ -163,8 +163,8 @@ namespace Helion.Tests.Unit.GameAction
 
             foreach (var entity in entities1.Union(entities2))
             {
-                entity.Target.Get().Should().BeNull();
-                entity.Tracer.Get().Should().BeNull();
+                entity.Target().Should().BeNull();
+                entity.Tracer().Should().BeNull();
             }
         }
 
@@ -176,50 +176,50 @@ namespace Helion.Tests.Unit.GameAction
             var zombie = GameActions.CreateEntity(world, "ZombieMan", new Vec3D(-256, -64, 0));
 
             zombie.SetTarget(lostSoul);
-            zombie.Target.Get().Should().Be(lostSoul);
-            zombie.Tracer.Get().Should().BeNull();
-            zombie.OnEntity.Get().Should().BeNull();
-            zombie.OverEntity.Get().Should().BeNull();
-            zombie.Owner.Get().Should().BeNull();
+            zombie.Target().Should().Be(lostSoul);
+            zombie.Tracer().Should().BeNull();
+            zombie.OnEntity().Should().BeNull();
+            zombie.OverEntity().Should().BeNull();
+            zombie.Owner().Should().BeNull();
 
             zombie.SetTarget(null);
             zombie.SetTracer(lostSoul);
-            zombie.Target.Get().Should().BeNull();
-            zombie.Tracer.Get().Should().Be(lostSoul);
-            zombie.OnEntity.Get().Should().BeNull();
-            zombie.OverEntity.Get().Should().BeNull();
-            zombie.Owner.Get().Should().BeNull();
+            zombie.Target().Should().BeNull();
+            zombie.Tracer().Should().Be(lostSoul);
+            zombie.OnEntity().Should().BeNull();
+            zombie.OverEntity().Should().BeNull();
+            zombie.Owner().Should().BeNull();
 
             zombie.SetTracer(null);
             zombie.SetOnEntity(lostSoul);
-            zombie.Target.Get().Should().BeNull();
-            zombie.Tracer.Get().Should().BeNull();
-            zombie.OnEntity.Get().Should().Be(lostSoul);
-            zombie.OverEntity.Get().Should().BeNull();
-            zombie.Owner.Get().Should().BeNull();
+            zombie.Target().Should().BeNull();
+            zombie.Tracer().Should().BeNull();
+            zombie.OnEntity().Should().Be(lostSoul);
+            zombie.OverEntity().Should().BeNull();
+            zombie.Owner().Should().BeNull();
 
             zombie.SetOnEntity(null);
             zombie.SetOverEntity(lostSoul);
-            zombie.Target.Get().Should().BeNull();
-            zombie.Tracer.Get().Should().BeNull();
-            zombie.OnEntity.Get().Should().BeNull();
-            zombie.OverEntity.Get().Should().Be(lostSoul);
-            zombie.Owner.Get().Should().BeNull();
+            zombie.Target().Should().BeNull();
+            zombie.Tracer().Should().BeNull();
+            zombie.OnEntity().Should().BeNull();
+            zombie.OverEntity().Should().Be(lostSoul);
+            zombie.Owner().Should().BeNull();
 
             zombie.SetOverEntity(null);
             zombie.SetOwner(lostSoul);
-            zombie.Target.Get().Should().BeNull();
-            zombie.Tracer.Get().Should().BeNull();
-            zombie.OnEntity.Get().Should().BeNull();
-            zombie.OverEntity.Get().Should().BeNull();
-            zombie.Owner.Get().Should().Be(lostSoul);
+            zombie.Target().Should().BeNull();
+            zombie.Tracer().Should().BeNull();
+            zombie.OnEntity().Should().BeNull();
+            zombie.OverEntity().Should().BeNull();
+            zombie.Owner().Should().Be(lostSoul);
 
             zombie.SetOwner(null);
-            zombie.Target.Get().Should().BeNull();
-            zombie.Tracer.Get().Should().BeNull();
-            zombie.OnEntity.Get().Should().BeNull();
-            zombie.OverEntity.Get().Should().BeNull();
-            zombie.Owner.Get().Should().BeNull();
+            zombie.Target().Should().BeNull();
+            zombie.Tracer().Should().BeNull();
+            zombie.OnEntity().Should().BeNull();
+            zombie.OverEntity().Should().BeNull();
+            zombie.Owner().Should().BeNull();
         }
 
         [Fact(DisplayName = "Do not free default instance to cache")]
@@ -245,11 +245,6 @@ namespace Helion.Tests.Unit.GameAction
             GameActions.TickWorld(world, 200);
 
             lostSoul.IsDisposed.Should().BeTrue();
-            lostSoul.Target.Should().Be(WeakEntity.Default);
-            lostSoul.Tracer.Should().Be(WeakEntity.Default);
-            lostSoul.OnEntity.Should().Be(WeakEntity.Default);
-            lostSoul.OverEntity.Should().Be(WeakEntity.Default);
-            lostSoul.Owner.Should().Be(WeakEntity.Default);
         }
 
         [Fact(DisplayName = "Set clear and change references")]
@@ -262,22 +257,22 @@ namespace Helion.Tests.Unit.GameAction
             var zombie2 = GameActions.CreateEntity(world, "ZombieMan", new Vec3D(-256, -64, 0));
 
             zombie1.SetTarget(lostSoul1);
-            zombie1.Target.Get().Should().Be(lostSoul1);
+            zombie1.Target().Should().Be(lostSoul1);
             zombie2.SetTarget(lostSoul1);
             zombie1.SetTarget(null);
-            zombie1.Target.Get().Should().BeNull();
+            zombie1.Target().Should().BeNull();
             zombie1.SetTarget(lostSoul1);
             zombie1.SetTarget(null);
             zombie1.SetTarget(caco1);
 
-            zombie1.Target.Get().Should().Be(caco1);
-            zombie2.Target.Get().Should().Be(lostSoul1);
+            zombie1.Target().Should().Be(caco1);
+            zombie2.Target().Should().Be(lostSoul1);
 
             lostSoul1.Kill(null);
             GameActions.TickWorld(world, 200);
 
-            zombie1.Target.Get().Should().Be(caco1);
-            zombie2.Target.Get().Should().BeNull();
+            zombie1.Target().Should().Be(caco1);
+            zombie2.Target().Should().BeNull();
 
             var lostSoul2 = GameActions.CreateEntity(world, "LostSoul", new Vec3D(-256, -64, 0));
             zombie1.SetTarget(lostSoul2);
@@ -287,8 +282,8 @@ namespace Helion.Tests.Unit.GameAction
             lostSoul2.Kill(null);
             GameActions.TickWorld(world, 200);
 
-            zombie2.Target.Get().Should().Be(caco1);
-            zombie1.Target.Get().Should().BeNull();
+            zombie2.Target().Should().Be(caco1);
+            zombie1.Target().Should().BeNull();
         }
 
         [Fact(DisplayName = "Dispose ref")]
@@ -305,7 +300,7 @@ namespace Helion.Tests.Unit.GameAction
             lostSoul1.Kill(null);
             GameActions.TickWorld(world, 200);
 
-            caco1.Target.Get().Should().BeNull();
+            caco1.Target().Should().BeNull();
         }
 
         //[Fact(DisplayName = "Dispose ref")]

--- a/Tests/Unit/GameAction/HealChase.cs
+++ b/Tests/Unit/GameAction/HealChase.cs
@@ -49,7 +49,7 @@ public class HealChase : IDisposable
         imp.IsDead.Should().BeFalse();
         imp.Flags.Solid.Should().BeTrue();
         imp.Height.Should().Be(56);
-        archvile.Target.Get().Should().Be(World.Player);
+        archvile.Target().Should().Be(World.Player);
     }
 
     [Fact(DisplayName = "Heal chase raises monster")]
@@ -75,7 +75,7 @@ public class HealChase : IDisposable
         imp.IsDead.Should().BeFalse();
         imp.Flags.Solid.Should().BeTrue();
         imp.Height.Should().Be(56);
-        archvile.Target.Get().Should().Be(World.Player);
+        archvile.Target().Should().Be(World.Player);
     }
 
     [Fact(DisplayName = "Vile chase does not raise monster because it overlaps with another monster")]

--- a/Tests/Unit/GameAction/Icon.cs
+++ b/Tests/Unit/GameAction/Icon.cs
@@ -78,7 +78,7 @@ namespace Helion.Tests.Unit.GameAction
             GameActions.AssertSound(World, bossEye, "dsbospit");
 
             var cube = FindEntity("SpawnShot", monsters);
-            cube.Target.Get().Should().Be(target);
+            cube.Target().Should().Be(target);
             TickUntilDisposed(cube);
             var fire = FindEntity("ArchvileFire", Array.Empty<Entity>());
             var monster = FindEntity(monsterName, monsters);

--- a/Tests/Unit/GameAction/Monsters.cs
+++ b/Tests/Unit/GameAction/Monsters.cs
@@ -226,15 +226,15 @@ namespace Helion.Tests.Unit.GameAction
         {
             var barrel = GameActions.CreateEntity(World, "ExplosiveBarrel", new Vec3D(-32, -480, 0), onCreated: EntityCreated);
             var monster = GameActions.CreateEntity(World, "BaronOfHell", new Vec3D(-32, -416, 0), onCreated: EntityCreated);
-            barrel.Target.Get().Should().BeNull();
-            monster.Target.Get().Should().BeNull();
+            barrel.Target().Should().BeNull();
+            monster.Target().Should().BeNull();
             int startHealth = monster.Health;
             barrel.Damage(Player, barrel.Health, false, DamageType.AlwaysApply);
             GameActions.TickWorld(World, () => { return monster.Health == startHealth; }, () => { });
 
             monster.Health.Should().BeLessThan(startHealth);
-            barrel.Target.Get().Should().Be(Player);
-            monster.Target.Get().Should().Be(Player);
+            barrel.Target().Should().Be(Player);
+            monster.Target().Should().Be(Player);
         }
 
         [Fact(DisplayName = "Barrel monster damage source")]
@@ -243,20 +243,20 @@ namespace Helion.Tests.Unit.GameAction
             var barrel = GameActions.CreateEntity(World, "ExplosiveBarrel", new Vec3D(-32, -480, 0), onCreated: EntityCreated);
             var monster = GameActions.CreateEntity(World, "BaronOfHell", new Vec3D(-32, -416, 0), onCreated: EntityCreated);
             var monster2 = GameActions.CreateEntity(World, "BaronOfHell", new Vec3D(-96, -480, 0), onCreated: EntityCreated);
-            barrel.Target.Get().Should().BeNull();
-            monster.Target.Get().Should().BeNull();
-            monster2.Target.Get().Should().BeNull();
+            barrel.Target().Should().BeNull();
+            monster.Target().Should().BeNull();
+            monster2.Target().Should().BeNull();
             int startHealth = monster.Health;
             barrel.Damage(monster2, barrel.Health, false, DamageType.AlwaysApply);
             GameActions.TickWorld(World, () => { return monster.Health == startHealth; }, () => { });
 
             monster.Health.Should().BeLessThan(startHealth);
             monster2.Health.Should().BeLessThan(startHealth);
-            barrel.Target.Get().Should().Be(monster2);
+            barrel.Target().Should().Be(monster2);
             // A baron will target another baron through a barrel explosion and will eventually rip each other apart through melee attacks
-            monster.Target.Get().Should().Be(monster2);
+            monster.Target().Should().Be(monster2);
             // monster 2 should not target itself from explosion
-            monster2.Target.Get().Should().BeNull();
+            monster2.Target().Should().BeNull();
         }
 
         [Fact(DisplayName = "Cyberdemon no radius damage")]
@@ -304,8 +304,8 @@ namespace Helion.Tests.Unit.GameAction
             source.SetTarget(dest);
             RunMissileState(source, dest, MonsterNames.First(x => x.Name == "ShotgunGuy"), false);
 
-            dest.Target.Get().Should().NotBeNull();
-            dest.Target.Get().Should().Be(source);
+            dest.Target().Should().NotBeNull();
+            dest.Target().Should().Be(source);
             dest.FrameState.FrameIndex.Should().Be(dest.Definition.SeeState);
             dest.Definition.Properties.PainChance = savePainChance;
         }
@@ -323,8 +323,8 @@ namespace Helion.Tests.Unit.GameAction
             source.SetTarget(dest);
             RunMissileState(source, dest, MonsterNames.First(x => x.Name == "ShotgunGuy"), false);
 
-            dest.Target.Get().Should().NotBeNull();
-            dest.Target.Get().Should().Be(source);
+            dest.Target().Should().NotBeNull();
+            dest.Target().Should().Be(source);
             dest.FrameState.FrameIndex.Should().Be(dest.Definition.PainState);
             dest.Definition.Properties.PainChance = savePainChance;
         }
@@ -345,8 +345,8 @@ namespace Helion.Tests.Unit.GameAction
             firstEnemy.SetTarget(dest);
             RunMissileState(firstEnemy, dest, MonsterNames.First(x => x.Name == "ShotgunGuy"), false);
 
-            dest.Target.Get().Should().NotBeNull();
-            dest.Target.Get().Should().Be(firstEnemy);
+            dest.Target().Should().NotBeNull();
+            dest.Target().Should().Be(firstEnemy);
             dest.Threshold.Should().Be(99);
 
             firstEnemy.Kill(dest);
@@ -365,15 +365,15 @@ namespace Helion.Tests.Unit.GameAction
             RunMissileState(secondEnemy, dest, MonsterNames.First(x => x.Name == "ShotgunGuy"), false);
             
             dest.Threshold.Should().Be(99);
-            dest.Target.Get().Should().Be(secondEnemy);
+            dest.Target().Should().Be(secondEnemy);
 
             // Threshold prevents from targeting the third enemy
             RunMissileState(thirdEnemy, dest, MonsterNames.First(x => x.Name == "ZombieMan"), false, checkTarget: false);
-            dest.Target.Get().Should().Be(secondEnemy);
+            dest.Target().Should().Be(secondEnemy);
 
             GameActions.TickWorld(World, () => { return dest.Threshold != 0; }, () => { });
             RunMissileState(thirdEnemy, dest, MonsterNames.First(x => x.Name == "ZombieMan"), false, checkTarget: false);
-            dest.Target.Get().Should().Be(thirdEnemy);
+            dest.Target().Should().Be(thirdEnemy);
 
             dest.Definition.Properties.PainChance = savePainChance;
         }
@@ -386,14 +386,14 @@ namespace Helion.Tests.Unit.GameAction
             int frameIndex = source.FrameState.Frame.MasterFrameIndex;
             source.AngleRadians = GameActions.GetAngle(Bearing.South);
             source.FrozenTics = 0;
-            GameActions.TickWorld(World, () => { return source.Target.Get() == null; }, () => { });
-            source.Target.Get().Should().Be(Player);
+            GameActions.TickWorld(World, () => { return source.Target() == null; }, () => { });
+            source.Target().Should().Be(Player);
 
             Player.Health = 0;
             source.FrameState.SetFrameIndex(frameIndex);
             GameActions.AssertAnySound(World, source);
 
-            source.Target.Get().Should().Be(Player);
+            source.Target().Should().Be(Player);
             GameActions.TickWorld(World, 10);
             GameActions.AssertNoSound(World, source);
             (source.FrameState.Frame.ActionFunction == EntityActionFunctions.A_Look).Should().BeTrue();
@@ -411,14 +411,14 @@ namespace Helion.Tests.Unit.GameAction
             source.Flags.Friendly = true;
             var dest = GameActions.CreateEntity(World, "Cacodemon", new(-256, -416, 0), onCreated: EntityCreated);
             source.SetTarget(dest);
-            GameActions.TickWorld(World, () => { return source.Target.Get() == null; }, () => { });
-            source.Target.Get().Should().Be(dest);
+            GameActions.TickWorld(World, () => { return source.Target() == null; }, () => { });
+            source.Target().Should().Be(dest);
 
             GameActions.SetEntityOutOfBounds(World, dest);
             GameActions.SetEntityPosition(World, Player, new Vec2D(-256, -416));
             source.FrameState.SetFrameIndex(frameIndex);
             World.CheckLineOfSight(source, Player).Should().BeTrue();
-            source.Target.Get().Should().Be(Player);
+            source.Target().Should().Be(Player);
             GameActions.SetEntityOutOfBounds(World, Player);
         }
 
@@ -433,14 +433,14 @@ namespace Helion.Tests.Unit.GameAction
             source.Flags.Friendly = true;
             var dest = GameActions.CreateEntity(World, "Cacodemon", new(-256, -416, 0), onCreated: EntityCreated);
             source.SetTarget(dest);
-            GameActions.TickWorld(World, () => { return source.Target.Get() == null; }, () => { });
-            source.Target.Get().Should().Be(dest);
+            GameActions.TickWorld(World, () => { return source.Target() == null; }, () => { });
+            source.Target().Should().Be(dest);
 
             GameActions.SetEntityOutOfBounds(World, dest);
             source.FrameState.SetFrameIndex(frameIndex);
             GameActions.AssertAnySound(World, source);
             World.CheckLineOfSight(source, Player).Should().BeFalse();
-            source.Target.Get().Should().Be(Player);
+            source.Target().Should().Be(Player);
         }
 
         [Fact(DisplayName = "Monster infighting tests")]
@@ -543,12 +543,12 @@ namespace Helion.Tests.Unit.GameAction
             {
                 // Monsters will not retaliate from archvile attack
                 if (sourceData.Name.EqualsIgnoreCase("Archvile"))
-                    dest.Target.Get().Should().BeNull();
+                    dest.Target().Should().BeNull();
                 else
-                    dest.Target.Get().Should().Be(source);
+                    dest.Target().Should().Be(source);
 
                 DebugLog("Missile - Damaged");
-                DebugLog(string.Format("Missile - {0}", dest.Target.Get() == null ? "No Target" : "Targeted"));
+                DebugLog(string.Format("Missile - {0}", dest.Target() == null ? "No Target" : "Targeted"));
                 dest.Health.Should().NotBe(int.MaxValue);
                 return;
             }
@@ -557,8 +557,8 @@ namespace Helion.Tests.Unit.GameAction
             if (sourceData.Name.Equals("PainElemental"))
             {
                 DebugLog("Missile - Damaged and Targeted (Lost Soul)");
-                dest.Target.Get().Should().NotBeNull();
-                dest.Target.Get()!.Definition.Name.Should().Be("LostSoul");
+                dest.Target().Should().NotBeNull();
+                dest.Target()!.Definition.Name.Should().Be("LostSoul");
                 dest.Health.Should().NotBe(int.MaxValue);
 
                 // Destroy the lost soul, otherwise they will mess with the rest of the tests
@@ -568,7 +568,7 @@ namespace Helion.Tests.Unit.GameAction
 
             DebugLog("Missile - No Damage");
             dest.Health.Should().Be(int.MaxValue);
-            dest.Target.Get().Should().BeNull();
+            dest.Target().Should().BeNull();
         }
 
         private void RunMeleeState(Entity source, Entity dest, MonsterData sourceData)
@@ -587,7 +587,7 @@ namespace Helion.Tests.Unit.GameAction
 
             DebugLog("Melee - Damaged and Targeted");
             // Melee attacks always damage, even if same species. Barell explosion bug is usually the only way this can happen.
-            dest.Target.Get().Should().Be(source);
+            dest.Target().Should().Be(source);
             dest.Health.Should().NotBe(int.MaxValue);   
         }
 

--- a/Tests/Unit/GameAction/Monsters.cs
+++ b/Tests/Unit/GameAction/Monsters.cs
@@ -390,7 +390,7 @@ namespace Helion.Tests.Unit.GameAction
             source.Target().Should().Be(Player);
 
             Player.Health = 0;
-            source.FrameState.SetFrameIndex(frameIndex);
+            source.FrameState.SetFrameIndex(source,frameIndex);
             GameActions.AssertAnySound(World, source);
 
             source.Target().Should().Be(Player);
@@ -416,7 +416,7 @@ namespace Helion.Tests.Unit.GameAction
 
             GameActions.SetEntityOutOfBounds(World, dest);
             GameActions.SetEntityPosition(World, Player, new Vec2D(-256, -416));
-            source.FrameState.SetFrameIndex(frameIndex);
+            source.FrameState.SetFrameIndex(source, frameIndex);
             World.CheckLineOfSight(source, Player).Should().BeTrue();
             source.Target().Should().Be(Player);
             GameActions.SetEntityOutOfBounds(World, Player);
@@ -437,7 +437,7 @@ namespace Helion.Tests.Unit.GameAction
             source.Target().Should().Be(dest);
 
             GameActions.SetEntityOutOfBounds(World, dest);
-            source.FrameState.SetFrameIndex(frameIndex);
+            source.FrameState.SetFrameIndex(source, frameIndex);
             GameActions.AssertAnySound(World, source);
             World.CheckLineOfSight(source, Player).Should().BeFalse();
             source.Target().Should().Be(Player);

--- a/Tests/Unit/GameAction/Physics/Physics_Crush.cs
+++ b/Tests/Unit/GameAction/Physics/Physics_Crush.cs
@@ -89,9 +89,9 @@ namespace Helion.Tests.Unit.GameAction
                 bottom1.Position.Z.Should().Be(0);
                 bottom2.Position.Z.Should().Be(0);
 
-                top.OnEntity.Get().Should().NotBeNull();
-                bottom1.OverEntity.Get()!.Should().Be(top);
-                bottom2.OverEntity.Get()!.Should().Be(top);
+                top.OnEntity().Should().NotBeNull();
+                bottom1.OverEntity()!.Should().Be(top);
+                bottom2.OverEntity()!.Should().Be(top);
             });
 
             top.IsDead.Should().BeTrue();

--- a/Tests/Unit/GameAction/Physics/Physics_Entity.cs
+++ b/Tests/Unit/GameAction/Physics/Physics_Entity.cs
@@ -386,7 +386,8 @@ namespace Helion.Tests.Unit.GameAction
             def.Flags.NoBlockmap = false;
 
             var monster = GameActions.CreateEntity(World, Zombieman, LiftCenter1.To3D(0));
-            monster.BlocksLength.Should().Be(1);
+            var blocks = (monster.BlockRange.EndX - monster.BlockRange.StartX) + (monster.BlockRange.EndY - monster.BlockRange.StartY);
+            blocks.Should().Be(0);
             monster.SectorNodes.Length.Should().Be(1);
             monster.Sector.Entities.Contains(monster).Should().BeTrue();
 

--- a/Tests/Unit/GameAction/Physics/Physics_Entity.cs
+++ b/Tests/Unit/GameAction/Physics/Physics_Entity.cs
@@ -20,8 +20,8 @@ namespace Helion.Tests.Unit.GameAction
             var bottom = GameActions.CreateEntity(World, "BaronOfHell", StackPos1.To3D(0));
             var top = GameActions.CreateEntity(World, "BaronOfHell", StackPos1.To3D(64));
 
-            top.OnEntity.Get().Should().Be(bottom);
-            bottom.OverEntity.Get()!.Should().Be(top);
+            top.OnEntity().Should().Be(bottom);
+            bottom.OverEntity()!.Should().Be(top);
         }
 
         [Fact(DisplayName = "OnEntity/OverEntity two on bottom")]
@@ -31,10 +31,10 @@ namespace Helion.Tests.Unit.GameAction
             var bottom2 = GameActions.CreateEntity(World, "BaronOfHell", StackPos3.To3D(0));
             var top = GameActions.CreateEntity(World, "BaronOfHell", StackPos2.To3D(64));
 
-            top.OnEntity.Get().Should().NotBeNull();
-            (top.OnEntity.Get()!.Equals(bottom1) || top.OnEntity.Get()!.Equals(bottom2)).Should().BeTrue();
-            bottom1.OverEntity.Get()!.Should().Be(top);
-            bottom2.OverEntity.Get()!.Should().Be(top);
+            top.OnEntity().Should().NotBeNull();
+            (top.OnEntity()!.Equals(bottom1) || top.OnEntity()!.Equals(bottom2)).Should().BeTrue();
+            bottom1.OverEntity()!.Should().Be(top);
+            bottom2.OverEntity()!.Should().Be(top);
         }
 
         [Fact(DisplayName = "OnEntity/OverEntity simple stack change when entity dies")]
@@ -43,15 +43,15 @@ namespace Helion.Tests.Unit.GameAction
             var bottom = GameActions.CreateEntity(World, "BaronOfHell", StackPos1.To3D(0));
             var top = GameActions.CreateEntity(World, "BaronOfHell", StackPos1.To3D(64));
 
-            top.OnEntity.Get().Should().Be(bottom);
-            bottom.OverEntity.Get()!.Should().Be(top);
+            top.OnEntity().Should().Be(bottom);
+            bottom.OverEntity()!.Should().Be(top);
 
             bottom.Kill(null);
 
             World.Tick();
 
-            top.OnEntity.Get().Should().BeNull();
-            bottom.OverEntity.Get()!.Should().BeNull();
+            top.OnEntity().Should().BeNull();
+            bottom.OverEntity()!.Should().BeNull();
 
             World.Tick();
 
@@ -65,14 +65,14 @@ namespace Helion.Tests.Unit.GameAction
             var top1 = GameActions.CreateEntity(World, "BaronOfHell", StackPos1.To3D(64));
             var top2 = GameActions.CreateEntity(World, "BaronOfHell", StackPos1.To3D(64));
 
-            top1.OnEntity.Get().Should().Be(bottom);
-            bottom.OverEntity.Get()!.Should().Be(top2);
+            top1.OnEntity().Should().Be(bottom);
+            bottom.OverEntity()!.Should().Be(top2);
 
             bottom.Kill(null);
             World.Tick();
 
-            top1.OnEntity.Get().Should().BeNull();
-            bottom.OverEntity.Get()!.Should().BeNull();
+            top1.OnEntity().Should().BeNull();
+            bottom.OverEntity()!.Should().BeNull();
 
             World.Tick();
 
@@ -87,17 +87,17 @@ namespace Helion.Tests.Unit.GameAction
             var middle = GameActions.CreateEntity(World, "BaronOfHell", StackPos1.To3D(64));
             var top = GameActions.CreateEntity(World, "BaronOfHell", StackPos1.To3D(128));
 
-            middle.OnEntity.Get().Should().Be(bottom);
-            bottom.OverEntity.Get()!.Should().Be(middle);
+            middle.OnEntity().Should().Be(bottom);
+            bottom.OverEntity()!.Should().Be(middle);
 
-            top.OnEntity.Get().Should().Be(middle);
-            middle.OverEntity.Get()!.Should().Be(top);
+            top.OnEntity().Should().Be(middle);
+            middle.OverEntity()!.Should().Be(top);
 
             middle.Kill(null);
             World.Tick();
 
-            top.OnEntity.Get().Should().BeNull();
-            middle.OverEntity.Get()!.Should().BeNull();
+            top.OnEntity().Should().BeNull();
+            middle.OverEntity()!.Should().BeNull();
 
             World.Tick();
 
@@ -110,13 +110,13 @@ namespace Helion.Tests.Unit.GameAction
             var bottom = GameActions.CreateEntity(World, "BaronOfHell", StackPos1.To3D(0));
             var top = GameActions.CreateEntity(World, "BaronOfHell", StackPos1.To3D(64));
 
-            top.OnEntity.Get().Should().Be(bottom);
-            bottom.OverEntity.Get()!.Should().Be(top);
+            top.OnEntity().Should().Be(bottom);
+            bottom.OverEntity()!.Should().Be(top);
 
             GameActions.MoveEntity(World, bottom, new Vec2D(-928, 768));
 
-            top.OnEntity.Get().Should().BeNull();
-            bottom.OverEntity.Get()!.Should().BeNull();
+            top.OnEntity().Should().BeNull();
+            bottom.OverEntity()!.Should().BeNull();
 
             World.Tick();
 
@@ -130,17 +130,17 @@ namespace Helion.Tests.Unit.GameAction
             var top1 = GameActions.CreateEntity(World, "BaronOfHell", StackPos1.To3D(64));
             var top2 = GameActions.CreateEntity(World, "BaronOfHell", StackPos2.To3D(64));
 
-            bottom.OverEntity.Should().NotBeNull();
-            (bottom.OverEntity.Get()!.Equals(top1) || bottom.OverEntity.Get()!.Equals(top2)).Should().BeTrue();
-            top1.OnEntity.Get().Should().Be(bottom);
-            top2.OnEntity.Get().Should().Be(bottom);
+            bottom.OverEntity().Should().NotBeNull();
+            (bottom.OverEntity()!.Equals(top1) || bottom.OverEntity()!.Equals(top2)).Should().BeTrue();
+            top1.OnEntity().Should().Be(bottom);
+            top2.OnEntity().Should().Be(bottom);
 
             bottom.Kill(null);
             World.Tick();
 
-            top1.OnEntity.Get().Should().BeNull();
-            top2.OnEntity.Get().Should().BeNull();
-            bottom.OverEntity.Get()!.Should().BeNull();
+            top1.OnEntity().Should().BeNull();
+            top2.OnEntity().Should().BeNull();
+            bottom.OverEntity()!.Should().BeNull();
         }
 
         [Fact(DisplayName = "OverEntity corpse falls when OnEntity moves")]
@@ -148,13 +148,13 @@ namespace Helion.Tests.Unit.GameAction
         {
             var bottom = GameActions.CreateEntity(World, "BaronOfHell", StackPos2.To3D(0));
             var top = GameActions.CreateEntity(World, "BaronOfHell", StackPos1.To3D(64));
-            bottom.OverEntity.Should().NotBeNull();
-            top.OnEntity.Should().NotBeNull();
+            bottom.OverEntity().Should().NotBeNull();
+            top.OnEntity().Should().NotBeNull();
             top.Position.Z.Should().Be(bottom.Position.Z + bottom.Height);
 
             GameActions.MoveEntity(World, bottom, (StackPos1.X, StackPos1.Y - 64));
-            bottom.OverEntity.Get().Should().BeNull();
-            top.OnEntity.Get().Should().BeNull();
+            bottom.OverEntity().Should().BeNull();
+            top.OnEntity().Should().BeNull();
 
             GameActions.TickWorld(World, 35);
             top.Position.Z.Should().Be(bottom.Position.Z);
@@ -166,13 +166,13 @@ namespace Helion.Tests.Unit.GameAction
             var bottom = GameActions.CreateEntity(World, "BaronOfHell", StackPos2.To3D(0));
             var top = GameActions.CreateEntity(World, "BaronOfHell", StackPos1.To3D(64));
             top.Kill(null);
-            bottom.OverEntity.Should().NotBeNull();
-            top.OnEntity.Should().NotBeNull();
+            bottom.OverEntity().Should().NotBeNull();
+            top.OnEntity().Should().NotBeNull();
             top.Position.Z.Should().Be(bottom.Position.Z + bottom.Height);
 
             GameActions.MoveEntity(World, bottom, (StackPos1.X, StackPos1.Y - 64));
-            bottom.OverEntity.Get().Should().BeNull();
-            top.OnEntity.Get().Should().BeNull();
+            bottom.OverEntity().Should().BeNull();
+            top.OnEntity().Should().BeNull();
 
             GameActions.TickWorld(World, 35);
             top.Position.Z.Should().Be(bottom.Position.Z);
@@ -183,8 +183,8 @@ namespace Helion.Tests.Unit.GameAction
         {
             var bottom = GameActions.CreateEntity(World, "CacoDemon", StackPos2.To3D(64));
             var top = GameActions.CreateEntity(World, "CacoDemon", StackPos1.To3D(120));
-            bottom.OverEntity.Should().NotBeNull();
-            top.OnEntity.Should().NotBeNull();
+            bottom.OverEntity().Should().NotBeNull();
+            top.OnEntity().Should().NotBeNull();
             top.Position.Z.Should().Be(bottom.Position.Z + bottom.Height);
             top.Kill(null);
 
@@ -278,7 +278,7 @@ namespace Helion.Tests.Unit.GameAction
             Vec3D pos1 = new(1168, 1064, 24);
             Vec3D moveTo = pos1 + new Vec3D(16, 0, 0);
             var moveEntity = GameActions.CreateEntity(World, "DoomImp", pos1, frozen: false);
-            moveEntity.OnEntity.Get().Should().NotBeNull();
+            moveEntity.OnEntity().Should().NotBeNull();
             moveEntity.OnGround.Should().BeTrue();
 
             GameActions.MoveEntity(World, moveEntity, moveTo.XY);
@@ -330,8 +330,8 @@ namespace Helion.Tests.Unit.GameAction
 
             entity.Position.Z.Should().Be(-32);
             Player.Position.Z.Should().Be(16);
-            Player.OnEntity.Get().Should().Be(entity);
-            entity.OverEntity.Get().Should().Be(Player);
+            Player.OnEntity().Should().Be(entity);
+            entity.OverEntity().Should().Be(Player);
         }
 
         [Fact(DisplayName = "Not moved linked entity will not pop up if there is a blocking entity")]
@@ -352,8 +352,8 @@ namespace Helion.Tests.Unit.GameAction
 
             entity.Position.Z.Should().Be(0);
             Player.Position.Z.Should().Be(entity.Height);
-            Player.OnEntity.Get().Should().Be(entity);
-            entity.OverEntity.Get().Should().Be(Player);
+            Player.OnEntity().Should().Be(entity);
+            entity.OverEntity().Should().Be(Player);
         }
 
         [Fact(DisplayName = "Not moved linked entity will not pop up if there is a blocking entity")]
@@ -444,7 +444,7 @@ namespace Helion.Tests.Unit.GameAction
             Player.AngleRadians = GameActions.GetAngle(Bearing.East);
             GameActions.MoveEntity(World, Player, 64);
             Player.Position.ApproxEquals(new Vec3D(1120, 864, 56)).Should().BeTrue();
-            Player.OnEntity.Get()!.Id.Should().Be(71);
+            Player.OnEntity()!.Id.Should().Be(71);
         }
 
         [Fact(DisplayName = "Player entity can walk on non-bridge with top z = entity z")]
@@ -455,7 +455,7 @@ namespace Helion.Tests.Unit.GameAction
             Player.AngleRadians = GameActions.GetAngle(Bearing.East);
             GameActions.MoveEntity(World, Player, 48);
             Player.Position.ApproxEquals(new Vec3D(1104, 800, 56)).Should().BeTrue();
-            Player.OnEntity.Get()!.Id.Should().Be(72);
+            Player.OnEntity()!.Id.Should().Be(72);
         }
 
         [Fact(DisplayName = "Non-player entity can walk on bridge with top z = entity z")]
@@ -466,7 +466,7 @@ namespace Helion.Tests.Unit.GameAction
             monster.AngleRadians = GameActions.GetAngle(Bearing.East);
             GameActions.MoveEntity(World, monster, 64);
             monster.Position.ApproxEquals(new Vec3D(1120, 864, 56)).Should().BeTrue();
-            monster.OnEntity.Get()!.Id.Should().Be(71);
+            monster.OnEntity()!.Id.Should().Be(71);
         }
 
         [Fact(DisplayName = "Non-player entity can't walk on non-bridge with top z = entity z")]

--- a/Tests/Unit/GameAction/Physics/Physics_Lifts.cs
+++ b/Tests/Unit/GameAction/Physics/Physics_Lifts.cs
@@ -142,16 +142,16 @@ namespace Helion.Tests.Unit.GameAction
             var monster3 = GameActions.CreateEntity(World, Zombieman, LiftCenter1.To3D(monster1.Height * 2));
 
             monster1.Position.Z.Should().Be(0);
-            monster1.OnEntity.Get().Should().BeNull();
-            monster1.OverEntity.Get()!.Should().Be(monster2);
+            monster1.OnEntity().Should().BeNull();
+            monster1.OverEntity()!.Should().Be(monster2);
 
             monster2.Position.Z.Should().Be(monster1.Height);
-            monster2.OnEntity.Get().Should().Be(monster1);
-            monster2.OverEntity.Get()!.Should().Be(monster3);
+            monster2.OnEntity().Should().Be(monster1);
+            monster2.OverEntity()!.Should().Be(monster3);
 
             monster3.Position.Z.Should().Be(monster1.Height * 2);
-            monster3.OnEntity.Get().Should().Be(monster2);
-            monster3.OverEntity.Get()!.Should().BeNull();
+            monster3.OnEntity().Should().Be(monster2);
+            monster3.OverEntity()!.Should().BeNull();
 
             GameActions.ActivateLine(World, Player, LiftLine1, ActivationContext.UseLine).Should().BeTrue();
             sector.ActiveFloorMove.Should().NotBeNull();
@@ -174,16 +174,16 @@ namespace Helion.Tests.Unit.GameAction
             var monster3 = GameActions.CreateEntity(World, Zombieman, LiftCenter1.To3D(monster1.Height * 2));
 
             monster1.Position.Z.Should().Be(0);
-            monster1.OnEntity.Get().Should().BeNull();
-            monster1.OverEntity.Get()!.Should().Be(monster2);
+            monster1.OnEntity().Should().BeNull();
+            monster1.OverEntity()!.Should().Be(monster2);
 
             monster2.Position.Z.Should().Be(monster1.Height);
-            monster2.OnEntity.Get().Should().Be(monster1);
-            monster2.OverEntity.Get()!.Should().Be(monster3);
+            monster2.OnEntity().Should().Be(monster1);
+            monster2.OverEntity()!.Should().Be(monster3);
 
             monster3.Position.Z.Should().Be(monster1.Height * 2);
-            monster3.OnEntity.Get().Should().Be(monster2);
-            monster3.OverEntity.Get()!.Should().BeNull();
+            monster3.OnEntity().Should().Be(monster2);
+            monster3.OverEntity()!.Should().BeNull();
 
             GameActions.ActivateLine(World, Player, LiftLine1, ActivationContext.UseLine).Should().BeTrue();
             sector.ActiveFloorMove.Should().NotBeNull();

--- a/Tests/Unit/GameAction/Physics/Physics_Player.cs
+++ b/Tests/Unit/GameAction/Physics/Physics_Player.cs
@@ -77,14 +77,14 @@ namespace Helion.Tests.Unit.GameAction
         public void PlayerJumpEntity()
         {
             GameActions.SetEntityPosition(World, Player, PlayerJumpEntityPos);
-            Player.OnEntity.Get().Should().NotBeNull();
+            Player.OnEntity().Should().NotBeNull();
             Player.OnGround.Should().BeTrue();
-            Player.Position.Z.Should().Be(Player.OnEntity.Get()!.Height);
+            Player.Position.Z.Should().Be(Player.OnEntity()!.Height);
             Player.Jump();
             GameActions.RunPlayerJump(World, Player);
             Player.OnGround.Should().BeTrue();
-            Player.OnEntity.Get().Should().NotBeNull();
-            Player.Position.Z.Should().Be(Player.OnEntity.Get()!.Height);
+            Player.OnEntity().Should().NotBeNull();
+            Player.Position.Z.Should().Be(Player.OnEntity()!.Height);
         }
 
         [Fact(DisplayName = "Player step up (max stair height)")]
@@ -177,8 +177,8 @@ namespace Helion.Tests.Unit.GameAction
                 World.Tick();
                 position += step;
                 Player.Position.ApproxEquals(position.To3D(bridge.Position.Z + 8)).Should().BeTrue();
-                Player.OnEntity.Get().Should().NotBeNull();
-                Player.OnEntity.Get().Should().Be(bridge);
+                Player.OnEntity().Should().NotBeNull();
+                Player.OnEntity().Should().Be(bridge);
                 Player.Sector.Id.Should().Be(9);
                 Player.OnGround.Should().BeTrue();
             }

--- a/Tests/Unit/GameAction/SectorSound.cs
+++ b/Tests/Unit/GameAction/SectorSound.cs
@@ -74,14 +74,14 @@ namespace Helion.Tests.Unit.GameAction
             World.NoiseAlert(Player, Player);
             GameActions.TickWorld(World, 10);
 
-            imp1.Target.Get().Should().Be(Player);
-            imp2.Target.Get().Should().Be(Player);
+            imp1.Target().Should().Be(Player);
+            imp2.Target().Should().Be(Player);
 
             // Blocked by block sound line
-            imp3.Target.Get().Should().BeNull();
+            imp3.Target().Should().BeNull();
 
             // Separated
-            imp4.Target.Get().Should().BeNull();
+            imp4.Target().Should().BeNull();
         }
 
         [Fact(DisplayName = "Sound from sector 2")]

--- a/Tests/Unit/GameAction/Serialization.cs
+++ b/Tests/Unit/GameAction/Serialization.cs
@@ -122,7 +122,7 @@ public class Serialization : IDisposable
 
         GameActions.GetSector(world, 0).SoundTarget.Get().Should().Be(world.Player);
         var zombieman = Zombieman(world);
-        zombieman.Target.Get().Should().Be(world.Player);
+        zombieman.Target().Should().Be(world.Player);
         world.Player.Velocity = new Vec3D(0, 16, 2);
     }
 
@@ -130,13 +130,13 @@ public class Serialization : IDisposable
     {
         var revenant = GameActions.CreateEntity(world, "Revenant", new Vec3D(-256, -16, 0), frozen: false);
         revenant.AngleRadians = GameActions.GetAngle(Bearing.South);
-        GameActions.TickWorld(world, () => { return revenant.Target.Get() == null; }, () => { });
-        revenant.Target.Get().Should().Be(world.Player);
+        GameActions.TickWorld(world, () => { return revenant.Target() == null; }, () => { });
+        revenant.Target().Should().Be(world.Player);
 
         EntityActionFunctions.A_SkelMissile(revenant);
         var tracer = GameActions.GetEntity(world, "RevenantTracer");
         tracer.SetTracer(world.Player);
-        tracer.Tracer.Get().Should().Be(world.Player);
+        tracer.Tracer().Should().Be(world.Player);
     }
 
     private static void ChangeWorld2(SinglePlayerWorld world)
@@ -323,11 +323,11 @@ public class Serialization : IDisposable
             for (int i = 0; i < entity.IntersectSectors.Length; i++)
                 entity.IntersectSectors[i].Id.Should().Be(newEntity.IntersectSectors[i].Id);
 
-            entity.Target.Get()?.Id.Should().Be(newEntity.Target.Get()?.Id);
-            entity.Tracer.Get()?.Id.Should().Be(newEntity.Tracer.Get()?.Id);
-            entity.OnEntity.Get()?.Id.Should().Be(newEntity.OnEntity.Get()?.Id);
-            entity.OverEntity.Get()?.Id.Should().Be(newEntity.OverEntity.Get()?.Id);
-            entity.Owner.Get()?.Id.Should().Be(newEntity.Owner.Get()?.Id);
+            entity.Target()?.Id.Should().Be(newEntity.Target()?.Id);
+            entity.Tracer()?.Id.Should().Be(newEntity.Tracer()?.Id);
+            entity.OnEntity()?.Id.Should().Be(newEntity.OnEntity()?.Id);
+            entity.OverEntity()?.Id.Should().Be(newEntity.OverEntity()?.Id);
+            entity.Owner()?.Id.Should().Be(newEntity.Owner()?.Id);
 
             entity.Threshold.Should().Be(newEntity.Threshold);
             entity.ReactionTime.Should().Be(newEntity.ReactionTime);

--- a/Tests/Unit/GameAction/Vanilla/VanillaThingFlags.cs
+++ b/Tests/Unit/GameAction/Vanilla/VanillaThingFlags.cs
@@ -73,20 +73,20 @@ public class VanillaThingFlags
         var hellKnight = GameActions.GetEntity(world, HellKnight);
         var baron = GameActions.GetEntity(world, Baron);
 
-        hellKnight.Target.Get().Should().BeNull();
-        baron.Target.Get().Should().BeNull();
+        hellKnight.Target().Should().BeNull();
+        baron.Target().Should().BeNull();
 
         GameActions.SetEntityPosition(world, world.Player, (-1376, -256, 0));
         GameActions.PlayerFirePistol(world, world.Player);
 
         // The ambush baron doesn't have line of sight to the player and will not wake up
         // Hellknight without ambush will wake up
-        hellKnight.Target.Get().Should().Be(world.Player);
-        baron.Target.Get().Should().BeNull();
+        hellKnight.Target().Should().Be(world.Player);
+        baron.Target().Should().BeNull();
 
         GameActions.SetEntityPosition(world, world.Player, (-832, -320, 0));
         GameActions.TickWorld(world, 12);
         // Line of sight checks are all around and not just in FOV
-        baron.Target.Get().Should().Be(world.Player);
+        baron.Target().Should().Be(world.Player);
     }
 }


### PR DESCRIPTION
move WeakEntity properties into Entity to work around struct padding issues

remove some properties from FrameState

unlink from blockmap using existing stored block range instead of also storing a list of blocks