### PR TITLE
persist deserialized music through serialization

### DIFF
--- a/Core/World/WorldBase.Serialize.cs
+++ b/Core/World/WorldBase.Serialize.cs
@@ -72,7 +72,7 @@ public partial class WorldBase
         s_worldModel.KillCount = LevelStats.KillCount;
         s_worldModel.ItemCount = LevelStats.ItemCount;
         s_worldModel.SecretCount = LevelStats.SecretCount;
-        s_worldModel.MusicName = m_lastMusicChange == null ? MapInfo.Music : m_lastMusicChange.Name;
+        s_worldModel.MusicName = m_lastMusicChange?.Name ?? s_worldModel.MusicName ?? MapInfo.Music;
         return s_worldModel;
     }
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -66,3 +66,4 @@
   - Fix map options not being set from default map (nojump nofreelook etc)
   - Fix issue where moving sectors may not render when inside a misclassified voodoo doll closet
   - Fix dehacked weapon ammo use amount
+  - Fix music changes not persisting through successive save games


### PR DESCRIPTION
When a save game is deserialized, the music in that model is played, but is not repersisted when saving again - no music change has occurred, so the starting track is used. This now prioritizes a loaded save's music over the starting music.

Fixes #983