### PR TITLE
don't give up focus if the loading or transition layers are active

### DIFF
--- a/Core/Layer/GameLayerManager.cs
+++ b/Core/Layer/GameLayerManager.cs
@@ -152,12 +152,11 @@ public class GameLayerManager : IGameLayerManager
         if (ConsoleLock || MenuLock)
             return false;
 
+        if (LoadingLayer != null || TransitionLayer != null)
+            return true;
+
         if (WorldLayer != null)
-        {
-            if (LoadingLayer != null)
-                return true;
             return WorldLayer.ShouldFocus;
-        }
 
         return true;
     }

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -68,3 +68,4 @@
   - Fix dehacked weapon ammo use amount
   - Fix music changes not persisting through successive save games
   - Fix scrolling floors/ceilings stopping when completes a move special
+  - Fix mouse focus issue when loading/reloading a map


### PR DESCRIPTION
fixes issues with mouse leaving when loading a map after death