### PR TITLE
Remove depth blit from oit render pass

### DIFF
--- a/Core/Render/OpenGL/Framebuffer/GLFramebuffer.cs
+++ b/Core/Render/OpenGL/Framebuffer/GLFramebuffer.cs
@@ -24,6 +24,7 @@ public class GLFramebuffer : IDisposable
 
     public IReadOnlyList<GLTexture2D> Textures => m_textures;
 
+    public GLTexture2D ColorAttachment0 = null!;
     public GLTexture2D? DepthTexture;
 
     public GLFramebuffer(string label, Dimension dimension, int numColorAttachments, GLFrameBufferOptions options = GLFrameBufferOptions.None)
@@ -69,6 +70,9 @@ public class GLFramebuffer : IDisposable
 
             m_textures.Add(colorAttachmentTexture);
         }
+
+        if (numColorAttachments > 0)
+            ColorAttachment0 = m_textures[0];
     }
 
     private void CreateDepthStencilAttachment(Dimension dimension, string label)

--- a/Core/Render/OpenGL/Framebuffer/GLFramebuffer.cs
+++ b/Core/Render/OpenGL/Framebuffer/GLFramebuffer.cs
@@ -24,6 +24,8 @@ public class GLFramebuffer : IDisposable
 
     public IReadOnlyList<GLTexture2D> Textures => m_textures;
 
+    public GLTexture2D? DepthTexture;
+
     public GLFramebuffer(string label, Dimension dimension, int numColorAttachments, GLFrameBufferOptions options = GLFrameBufferOptions.None)
     {
         Debug.Assert(numColorAttachments >= 0, $"Cannot have a negative amount of color attachments for framebuffer {label}");
@@ -71,13 +73,13 @@ public class GLFramebuffer : IDisposable
 
     private void CreateDepthStencilAttachment(Dimension dimension, string label)
     {
-        GLTexture2D depthTexture = new($"(Framebuffer {label}) Depth Stencil Attachment", dimension);
-        depthTexture.Bind();
+        DepthTexture = new($"(Framebuffer {label}) Depth Stencil Attachment", dimension);
+        DepthTexture.Bind();
         GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Depth32fStencil8, dimension.Width, Dimension.Height, 0, PixelFormat.DepthStencil, PixelType.Float32UnsignedInt248Rev, IntPtr.Zero);
-        GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.DepthStencilAttachment, TextureTarget.Texture2D, depthTexture.Name, 0);
-        depthTexture.Unbind();
+        GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.DepthStencilAttachment, TextureTarget.Texture2D, DepthTexture.Name, 0);
+        DepthTexture.Unbind();
 
-        m_textures.Add(depthTexture);
+        m_textures.Add(DepthTexture);
     }
 
     ~GLFramebuffer()

--- a/Core/Render/OpenGL/Framebuffer/OitFrameBuffer.cs
+++ b/Core/Render/OpenGL/Framebuffer/OitFrameBuffer.cs
@@ -1,4 +1,5 @@
 ﻿using Helion.Geometry;
+using Helion.Render.OpenGL.Textures;
 using Helion.Render.OpenGL.Util;
 using OpenTK.Graphics.OpenGL;
 using System;
@@ -10,11 +11,10 @@ public class OitFrameBuffer
     private uint m_oitFramebuffer;
     private uint m_accumTexture;
     private uint m_accumCountTexture;
-    private uint m_oitDepthTexture;
     private uint m_fuzzTexture;
     private Dimension m_oitDimension;
 
-    public void CreateOrUpdate(Dimension dimension)
+    public void CreateOrUpdate(Dimension dimension, GLTexture2D opaqueDepthTexture)
     {
         if (m_oitFramebuffer != 0 && dimension.Width == m_oitDimension.Width && dimension.Height == m_oitDimension.Height)
             return;
@@ -23,7 +23,6 @@ public class OitFrameBuffer
         {
             GL.DeleteTexture(m_accumTexture);
             GL.DeleteTexture(m_accumCountTexture);
-            GL.DeleteTexture(m_oitDepthTexture);
             GL.DeleteFramebuffer(m_oitFramebuffer);
         }
 
@@ -58,15 +57,10 @@ public class OitFrameBuffer
         GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int)TextureMagFilter.Nearest);
         GL.BindTexture(TextureTarget.Texture2D, 0);
 
-        GL.GenTextures(1, out m_oitDepthTexture);
-        GL.BindTexture(TextureTarget.Texture2D, m_oitDepthTexture);
-        GLHelper.ObjectLabel(ObjectLabelIdentifier.Texture, (int)m_oitDepthTexture, "OIT Depth Texture");
-        GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Depth32fStencil8, width, height, 0, PixelFormat.DepthStencil, PixelType.Float32UnsignedInt248Rev, IntPtr.Zero);
-
         GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment0, TextureTarget.Texture2D, m_accumTexture, 0);
         GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment1, TextureTarget.Texture2D, m_accumCountTexture, 0);
         GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment2, TextureTarget.Texture2D, m_fuzzTexture, 0);
-        GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.DepthStencilAttachment, TextureTarget.Texture2D, m_oitDepthTexture, 0);
+        GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.DepthStencilAttachment, TextureTarget.Texture2D, opaqueDepthTexture.Name, 0);
 
         GL.DrawBuffers(3, [DrawBuffersEnum.ColorAttachment0, DrawBuffersEnum.ColorAttachment1, DrawBuffersEnum.ColorAttachment2]);
 
@@ -74,7 +68,7 @@ public class OitFrameBuffer
             throw new Exception("Failed to complete oit framebuffer");
     }
 
-    public unsafe void StartRender(GLFramebuffer opaqueBuffer)
+    public unsafe void StartRender()
     {
         var zero = stackalloc float[4] { 0f, 0f, 0f, 0f };
         BindFrameBuffer();
@@ -84,12 +78,6 @@ public class OitFrameBuffer
         GL.ClearBuffer(ClearBuffer.Color, 2, zero);
 
         SetBlendEquations();
-
-        opaqueBuffer.BindRead();
-        var width = m_oitDimension.Width;
-        var height = m_oitDimension.Height;
-        GL.BindFramebuffer(FramebufferTarget.DrawFramebuffer, m_oitFramebuffer);
-        GL.BlitFramebuffer(0, 0, width, height, 0, 0, width, height, ClearBufferMask.DepthBufferBit, BlitFramebufferFilter.Nearest);
     }
 
     public void SetBlendEquations()
@@ -101,6 +89,11 @@ public class OitFrameBuffer
     public void BindFrameBuffer()
     {
         GL.BindFramebuffer(FramebufferTarget.Framebuffer, m_oitFramebuffer);
+    }
+
+    public void UnbindFrameBuffer()
+    {
+        GL.BindFramebuffer(FramebufferTarget.Framebuffer, 0);
     }
 
     public void BindTextures(TextureUnit accumTexture, TextureUnit accumCountTexture, TextureUnit fuzzTexture, TextureUnit opaqueTexture, GLFramebuffer framebuffer)

--- a/Core/Render/OpenGL/Framebuffer/OitFrameBuffer.cs
+++ b/Core/Render/OpenGL/Framebuffer/OitFrameBuffer.cs
@@ -105,6 +105,6 @@ public class OitFrameBuffer
         GL.ActiveTexture(fuzzTexture);
         GL.BindTexture(TextureTarget.Texture2D, m_fuzzTexture);
         GL.ActiveTexture(opaqueTexture);
-        GL.BindTexture(TextureTarget.Texture2D, framebuffer.Textures[0].Name);
+        GL.BindTexture(TextureTarget.Texture2D, framebuffer.ColorAttachment0.Name);
     }
 }

--- a/Core/Render/OpenGL/Renderers/BasicFramebufferRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/BasicFramebufferRenderer.cs
@@ -55,7 +55,7 @@ public class BasicFramebufferRenderer : IDisposable
         m_program.Bind();
 
         GL.ActiveTexture(TextureUnit.Texture0);
-        buffer.Textures[0].Bind();
+        buffer.ColorAttachment0.Bind();
         m_program.BoundTexture(TextureUnit.Texture0);
         m_program.Mvp(mat4.Identity);
 

--- a/Core/Render/OpenGL/Renderers/FramebufferRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/FramebufferRenderer.cs
@@ -139,7 +139,7 @@ public class FramebufferRenderer : IDisposable
         // dimension's resolution. Also don't let it be larger than the NDC box.
         // Since our vertices are in NDC coordinates, 1.0 is the max we can go.
         Dimension windowDim = m_window.Dimension;
-        Dimension textureDim = Framebuffer.Textures[0].Dimension;
+        Dimension textureDim = Framebuffer.ColorAttachment0.Dimension;
         float scaleX = Math.Min(textureDim.AspectRatio / windowDim.AspectRatio, 1.0f);
         
         return mat4.Scale(scaleX, 1.0f, 1.0f);
@@ -157,7 +157,7 @@ public class FramebufferRenderer : IDisposable
         m_program.Bind();
 
         GL.ActiveTexture(TextureUnit.Texture0);
-        Framebuffer.Textures[0].Bind();
+        Framebuffer.ColorAttachment0.Bind();
         m_program.BoundTexture(TextureUnit.Texture0);
         m_program.Mvp(mvp);
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Data/RenderDataManager.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Data/RenderDataManager.cs
@@ -26,6 +26,7 @@ public class RenderDataManager<[DynamicallyAccessedMembers(DynamicallyAccessedMe
     }
 
     public bool HasFuzz() => m_fuzzData.HasDataToRender();
+    public bool HasAlpha() => m_alphaData.HasDataToRender();
 
     public void Clear()
     {

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
@@ -61,6 +61,7 @@ public class EntityRenderer : IDisposable
     }
 
     public bool HasFuzz() => m_dataManager.HasFuzz();
+    public bool HasAlpha() => m_dataManager.HasAlpha();
 
     public void UpdateTo(IWorld world)
     {

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -321,11 +321,14 @@ public class LegacyWorldRenderer : WorldRenderer
 
     private unsafe void RenderTransparent(RenderInfo renderInfo, GLFramebuffer framebuffer, bool vanillaRender)
     {
-        m_oitFrameBuffer.StartRender();
-
         bool fuzzData = m_entityRenderer.HasFuzz();
-        GL.DepthMask(false);
+        bool alphaData = m_entityRenderer.HasAlpha();
+        bool alphaWalls = m_worldDataManager.HasAlphaWalls();
+        if (!fuzzData && !alphaData && !alphaWalls)
+            return;
 
+        m_oitFrameBuffer.StartRender();
+        GL.DepthMask(false);
         m_entityRenderer.RenderOitTransparentPass(renderInfo);
 
         m_oitFrameBuffer.BindTextures(TextureUnit.Texture4, TextureUnit.Texture5, TextureUnit.Texture6, TextureUnit.Texture7, framebuffer);
@@ -346,7 +349,7 @@ public class LegacyWorldRenderer : WorldRenderer
             m_entityRenderer.RenderOitTransparentFuzzPass(renderInfo);
         }
 
-        if (vanillaRender && m_worldDataManager.HasAlphaWalls())
+        if (vanillaRender && alphaWalls)
             RenderFlatsToDepth(renderInfo);
 
         m_interpolationTransparentProgram.Bind();
@@ -359,7 +362,7 @@ public class LegacyWorldRenderer : WorldRenderer
 
         m_entityRenderer.RenderOitCompositePass(renderInfo);
 
-        if (m_worldDataManager.HasAlphaWalls())
+        if (alphaWalls)
         {
             if (vanillaRender)
                 RenderFlatsToDepth(renderInfo);

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -227,7 +227,10 @@ public class LegacyWorldRenderer : WorldRenderer
         m_spriteTransparency = m_config.Render.SpriteTransparency;
         Clear(world, renderInfo);
 
-        m_oitFrameBuffer.CreateOrUpdate((renderInfo.Viewport.Width, renderInfo.Viewport.Height));
+        if (framebuffer.DepthTexture == null)
+            throw new Exception("Framebuffer must have a depth texture.");
+
+        m_oitFrameBuffer.CreateOrUpdate((renderInfo.Viewport.Width, renderInfo.Viewport.Height), framebuffer.DepthTexture);
 
         if (m_lastTicker != world.GameTicker)
             m_entityRenderer.Start(renderInfo);
@@ -318,10 +321,11 @@ public class LegacyWorldRenderer : WorldRenderer
 
     private unsafe void RenderTransparent(RenderInfo renderInfo, GLFramebuffer framebuffer, bool vanillaRender)
     {
+        m_oitFrameBuffer.StartRender();
+
         bool fuzzData = m_entityRenderer.HasFuzz();
         GL.DepthMask(false);
 
-        m_oitFrameBuffer.StartRender(framebuffer);
         m_entityRenderer.RenderOitTransparentPass(renderInfo);
 
         m_oitFrameBuffer.BindTextures(TextureUnit.Texture4, TextureUnit.Texture5, TextureUnit.Texture6, TextureUnit.Texture7, framebuffer);
@@ -369,6 +373,7 @@ public class LegacyWorldRenderer : WorldRenderer
         if (fuzzData)
             m_entityRenderer.RenderOitFuzzRefractionPass(renderInfo, true);
 
+        m_oitFrameBuffer.UnbindFrameBuffer();
         GL.DepthMask(true);
     }
 

--- a/Core/Render/OpenGL/Renderers/TransitionRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/TransitionRenderer.cs
@@ -97,7 +97,7 @@ public class TransitionRenderer : IDisposable
         m_program.Bind();
 
         GL.ActiveTexture(TextureUnit.Texture0);
-        m_startBuffer.Textures[0].Bind();
+        m_startBuffer.ColorAttachment0.Bind();
         if (m_program is MeltTransitionProgram meltProgram)
         {
             // the melt shader uses ticks, so convert [0,1] to [0,42] ticks

--- a/Core/Render/Renderer.cs
+++ b/Core/Render/Renderer.cs
@@ -651,7 +651,7 @@ public partial class Renderer : IDisposable
     {
         // Bind main buffer for fuzz refraction sampling when player has partial invisibility
         GL.ActiveTexture(TextureUnit.Texture7);
-        GL.BindTexture(TextureTarget.Texture2D, m_mainFramebuffer.Textures[0].Name);
+        GL.BindTexture(TextureTarget.Texture2D, m_mainFramebuffer.ColorAttachment0.Name);
         m_hudRenderer.Render(viewport, m_mainFramebuffer.Dimension, uniforms);
         m_hudRenderer.Clear();
     }
@@ -677,7 +677,7 @@ public partial class Renderer : IDisposable
     private void BlitVirtualFramebufferToMain()
     {
         var mainDimension = m_mainFramebuffer.Dimension;
-        var virtualDimension = m_virtualFramebuffer.Textures[0].Dimension;
+        var virtualDimension = m_virtualFramebuffer.ColorAttachment0.Dimension;
         float scaleX = (m_config.Window.Virtual.Stretch)
             ? 1f
             : Math.Min(virtualDimension.AspectRatio / mainDimension.AspectRatio, 1.0f);


### PR DESCRIPTION
Use the depth texture from the main render buffer to remove the blit of the depth buffer. The blit is fairly slow and is especially noticeable on slower integrated cards.

Adds check to also short from the transparent pass which can happen if the user has sprite transparency disable since the OIT framebuffer rendering does have a cost to it.