### PR TITLE
Allow release builds to run if no audio devices are present

### DIFF
--- a/Client/Client.cs
+++ b/Client/Client.cs
@@ -588,7 +588,7 @@ public partial class Client : IDisposable, IInputManagement
             using IMusicPlayer musicPlayer = commandLineArgs.NoMusic ?
                 new MockMusicPlayer() :
                 new MusicPlayer(config.Audio, archiveCollection);
-            using IAudioSystem audioPlayer = new OpenALAudioSystem(config, archiveCollection, musicPlayer);
+            using IAudioSystem audioPlayer = new OpenALAudioSystem(config, archiveCollection, musicPlayer, Log);
 
             using Client client = new(commandLineArgs, config, console, audioPlayer, archiveCollection);
             client.Run();

--- a/Client/Music/FluidSynthMusicPlayer.cs
+++ b/Client/Music/FluidSynthMusicPlayer.cs
@@ -106,7 +106,7 @@ public class FluidSynthMusicPlayer : IMusicPlayer
         catch (Exception ex)
         {
             Log.Warn("Error starting FluidSynth music playback.");
-            Log.Info(ex.ToString());
+            Log.Info(ex);
         }
 
         return false;

--- a/Client/Music/MusicPlayer.cs
+++ b/Client/Music/MusicPlayer.cs
@@ -138,7 +138,15 @@ public class MusicPlayer : IMusicPlayer
         while (!m_disposed)
         {
             if (m_playQueue.TryDequeue(out var playParams))
-                CreateAndPlayMusic(playParams);
+                try
+                {
+                    CreateAndPlayMusic(playParams);
+                }
+                catch(Exception ex)
+                {
+                    Log.Warn($"Could not start music playback.");
+                    Log.Info(ex);
+                }
 
             if (m_cancelPlayQueue.IsCancellationRequested)
                 break;


### PR DESCRIPTION
This is a fairly normal situation to get into with Windows if using analog outputs only--no output devices appear until headphones or whatever are connected.  I figured it's best to leave the asserts in for debug builds, but I think it's reasonable to allow the application to start and let the user fix their audio once it's running.