### PR TITLE
Update nightly and release builds to support AOT

### DIFF
--- a/.github/workflows/Nightly.yml
+++ b/.github/workflows/Nightly.yml
@@ -9,8 +9,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  buildRelease:
-
+  buildNightlyLinux:
     runs-on: ubuntu-22.04
 
     steps:
@@ -23,32 +22,55 @@ jobs:
       run: dotnet restore
     - name: Build
       run: dotnet build --no-restore
+      
     - name: Dotnet Publish Linux
-      run: dotnet publish -c Release -r linux-x64 Client/Client.csproj
-    - name: Dotnet Publish Windows
-      run: dotnet publish -c Release -r win-x64 Client/Client.csproj
-    - name: Dotnet Publish Linux Self-Contained
-      run: dotnet publish -c Release -r linux-x64 -p:SelfContainedRelease=true Client/Client.csproj
-    - name: Dotnet Publish Windows Self-Contained
-      run: dotnet publish -c Release -r win-x64 -p:SelfContainedRelease=true Client/Client.csproj
-    - name: Install zip
-      uses: montudor/action-zip@v1
-    - name: Zip Linux
-      run: zip -r ../../Helion-${{ github.ref_name }}-linux-x64.zip *
-      working-directory: Publish/linux-x64
+      run: dotnet publish -c Release -r linux-x64 Client/Client.csproj -p:SelfContainedRelease=true
+    - name: Dotnet Publish Linux AOT
+      run: dotnet publish -c Release -r linux-x64 Client/Client.csproj -p:AOT=true
+      
     - name: Zip Linux Self-Contained
       run: zip -r ../../Helion-${{ github.ref_name }}-linux-x64_SelfContained.zip *
       working-directory: Publish/linux-x64_SelfContained
-    - name: Zip Windows
-      run: zip -r ../../Helion-${{ github.ref_name }}-win-x64.zip *
-      working-directory: Publish/win-x64
-    - name: Zip Windows Self-Contained
-      run: zip -r ../../Helion-${{ github.ref_name }}-win-x64_SelfContained.zip *
-      working-directory: Publish/win-x64_SelfContained
-    - name: Update nightly release
+    - name: Zip Linux AOT
+      run: zip -r ../../Helion-${{ github.ref_name }}-linux-x64_AOT.zip *
+      working-directory: Publish/linux-x64_AOT
+
+    - name: Update nightly release (Linux)
       uses: pyTooling/Actions/releaser@r0
       with:
         tag: nightly
-        rm: true
         token: ${{ secrets.GITHUB_TOKEN }}
         files: '*.zip'
+        
+  buildNightlyWindows:
+    runs-on: windows-2022
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 9.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore
+      
+    - name: Dotnet Publish Windows
+      run: dotnet publish -c Release -r win-x64 Client/Client.csproj -p:SelfContainedRelease=true
+    - name: Dotnet Publish Windows AOT
+      run: dotnet publish -c Release -r win-x64 Client/Client.csproj -p:AOT=true
+      
+    - name: Zip Windows Self-Contained
+      run: Compress-Archive -Path .\Publish\win-x64_SelfContained\* -DestinationPath .\Helion-${{ github.ref_name }}-win-x64_SelfContained.zip
+    - name: Zip Windows AOT
+      run: Compress-Archive -Path .\Publish\win-x64_AOT\* -DestinationPath .\Helion-${{ github.ref_name }}-win-x64_AOT.zip
+
+    - name: Update nightly release (Windows)
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: '*.zip'
+        tag: nightly
+        overwrite: true
+        file_glob: true

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -17,7 +17,7 @@ on:
     - '*'
 
 jobs:
-  buildRelease:
+  buildReleaseLinux:
 
     runs-on: ubuntu-22.04
 
@@ -31,30 +31,55 @@ jobs:
       run: dotnet restore
     - name: Build
       run: dotnet build --no-restore
+      
     - name: Dotnet Publish Linux
-      run: dotnet publish -c Release -r linux-x64 Client/Client.csproj
-    - name: Dotnet Publish Windows
-      run: dotnet publish -c Release -r win-x64 Client/Client.csproj
-    - name: Dotnet Publish Linux Self-Contained
-      run: dotnet publish -c Release -r linux-x64 -p:SelfContainedRelease=true Client/Client.csproj
-    - name: Dotnet Publish Windows Self-Contained
-      run: dotnet publish -c Release -r win-x64 -p:SelfContainedRelease=true Client/Client.csproj
-    - name: Install zip
-      uses: montudor/action-zip@v1
-    - name: Zip Linux
-      run: zip -r ../../Helion-${{ github.ref_name }}-linux-x64.zip *
-      working-directory: Publish/linux-x64
+      run: dotnet publish -c Release -r linux-x64 Client/Client.csproj -p:SelfContainedRelease=true
+    - name: Dotnet Publish Linux AOT
+      run: dotnet publish -c Release -r linux-x64 Client/Client.csproj -p:AOT=true
+      
     - name: Zip Linux Self-Contained
       run: zip -r ../../Helion-${{ github.ref_name }}-linux-x64_SelfContained.zip *
       working-directory: Publish/linux-x64_SelfContained
-    - name: Zip Windows
-      run: zip -r ../../Helion-${{ github.ref_name }}-win-x64.zip *
-      working-directory: Publish/win-x64
-    - name: Zip Windows Self-Contained
-      run: zip -r ../../Helion-${{ github.ref_name }}-win-x64_SelfContained.zip *
-      working-directory: Publish/win-x64_SelfContained
+    - name: Zip Linux AOT
+      run: zip -r ../../Helion-${{ github.ref_name }}-linux-x64_AOT.zip *
+      working-directory: Publish/linux-x64_AOT
+      
     - name: Make Release
       uses: ncipollo/release-action@v1
       with:
         artifacts: "*.zip"
         bodyFile: "RELEASENOTES.md"
+  
+  buildReleaseWindows:
+    runs-on: windows-2022
+    needs: buildReleaseLinux
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 9.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore
+      
+    - name: Dotnet Publish Windows
+      run: dotnet publish -c Release -r win-x64 Client/Client.csproj -p:SelfContainedRelease=true
+    - name: Dotnet Publish Windows AOT
+      run: dotnet publish -c Release -r win-x64 Client/Client.csproj -p:AOT=true
+      
+    - name: Zip Windows Self-Contained
+      run: Compress-Archive -Path .\Publish\win-x64_SelfContained\* -DestinationPath .\Helion-${{ github.ref_name }}-win-x64_SelfContained.zip
+    - name: Zip Windows AOT
+      run: Compress-Archive -Path .\Publish\win-x64_AOT\* -DestinationPath .\Helion-${{ github.ref_name }}-win-x64_AOT.zip
+
+    - name: Add binaries to release (Windows)
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: '*.zip'
+        tag: ${{ github.ref }}
+        overwrite: true
+        file_glob: true


### PR DESCRIPTION
1.  Remove framework-dependent builds (trimmed self-contained are small enough)
2.  Add AOT builds (current machine target is x86-64v3, Haswell or similar)

This requires us to use a Windows container for the Windows build and a Linux container for the Linux build.  Some of the tools we were using were Linux-only, so some further rework was necessary.