### PR TITLE
Add option to disable auto-searching of Steam directory

### DIFF
--- a/Client/Client.Initialize.cs
+++ b/Client/Client.Initialize.cs
@@ -102,7 +102,7 @@ public partial class Client
 
     private void FindInstalledIWads()
     {
-        var iwadLocator = IWadLocator.CreateDefault(m_config.Files.Directories.Value);
+        var iwadLocator = IWadLocator.CreateDefault(m_config.Files.Directories.Value, m_config.Files.SearchCommonDirectories.Value);
         m_installedIwads.AddRange(iwadLocator.Locate());
     }
 

--- a/Core/Resources/Archives/Locator/FilesystemArchiveLocator.cs
+++ b/Core/Resources/Archives/Locator/FilesystemArchiveLocator.cs
@@ -48,12 +48,17 @@ public class FilesystemArchiveLocator : IArchiveLocator
     /// from.</param>
     public FilesystemArchiveLocator(IConfig config, IList<string> paths)
     {
-        List<string> allPaths = [
-            .. paths,
-            .. config.Files.Directories.Value,
-            .. WadPaths.GetFromSteamAndLinuxDirs(),
-            .. WadPaths.GetFromEnvVars()
-        ];
+        List<string> allPaths =
+            config.Files.SearchCommonDirectories
+            ? [
+                .. paths,
+                .. config.Files.Directories.Value,
+                .. WadPaths.GetFromSteamAndLinuxDirs(),
+                .. WadPaths.GetFromEnvVars()]
+            : [
+                .. paths,
+                .. config.Files.Directories.Value,
+                .. WadPaths.GetFromEnvVars()];
 
         m_paths.AddRange(allPaths.Where(p => !p.Empty()).Select(EnsureEndsWithDirectorySeparator).Distinct());
     }

--- a/Core/Resources/IWad/IWadLocator.cs
+++ b/Core/Resources/IWad/IWadLocator.cs
@@ -10,10 +10,18 @@ public class IWadLocator
 {
     private readonly List<string> m_directories;
 
-    public static IWadLocator CreateDefault(IEnumerable<string> configDirectories)
+    public static IWadLocator CreateDefault(IEnumerable<string> configDirectories, bool searchCommonDirectories)
     {
-        List<string> paths = [Directory.GetCurrentDirectory(), .. configDirectories,
-            .. WadPaths.GetFromSteamAndLinuxDirs(), .. WadPaths.GetFromEnvVars()];
+        List<string> paths = searchCommonDirectories
+            ? [
+                Directory.GetCurrentDirectory(),
+                .. configDirectories,
+                .. WadPaths.GetFromSteamAndLinuxDirs(),
+                .. WadPaths.GetFromEnvVars()]
+            : [
+                Directory.GetCurrentDirectory(),
+                .. configDirectories,
+                .. WadPaths.GetFromEnvVars()];
         return new IWadLocator(paths);
     }
 

--- a/Core/Util/Configs/Components/ConfigFiles.cs
+++ b/Core/Util/Configs/Components/ConfigFiles.cs
@@ -26,4 +26,7 @@ public class ConfigFiles: ConfigElement<ConfigFiles>
 
             return copy;
         });
+
+    [ConfigInfo("Search common directories, such as Steam install directory, for IWAD files.")]
+    public readonly ConfigValue<bool> SearchCommonDirectories = new(true);
 }


### PR DESCRIPTION
I have a dedicated directory where I store IWADs and I don't really _want_ Helion crawling through my Steam directories and such.  Finding and hashing all those files results in a slower startup.

I'm intentionally not putting this on the menu, as some of the other options here (such the default search paths) also aren't on the menu.  I think the default behavior is good enough for most users.