### PR TITLE
Revert changes to Nightly build

### DIFF
--- a/.github/workflows/Nightly.yml
+++ b/.github/workflows/Nightly.yml
@@ -9,7 +9,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  buildNightlyLinux:
+  buildRelease:
+
     runs-on: ubuntu-22.04
 
     steps:
@@ -22,55 +23,32 @@ jobs:
       run: dotnet restore
     - name: Build
       run: dotnet build --no-restore
-      
     - name: Dotnet Publish Linux
-      run: dotnet publish -c Release -r linux-x64 Client/Client.csproj -p:SelfContainedRelease=true
-    - name: Dotnet Publish Linux AOT
-      run: dotnet publish -c Release -r linux-x64 Client/Client.csproj -p:AOT=true
-      
+      run: dotnet publish -c Release -r linux-x64 Client/Client.csproj
+    - name: Dotnet Publish Windows
+      run: dotnet publish -c Release -r win-x64 Client/Client.csproj
+    - name: Dotnet Publish Linux Self-Contained
+      run: dotnet publish -c Release -r linux-x64 -p:SelfContainedRelease=true Client/Client.csproj
+    - name: Dotnet Publish Windows Self-Contained
+      run: dotnet publish -c Release -r win-x64 -p:SelfContainedRelease=true Client/Client.csproj
+    - name: Install zip
+      uses: montudor/action-zip@v1
+    - name: Zip Linux
+      run: zip -r ../../Helion-${{ github.ref_name }}-linux-x64.zip *
+      working-directory: Publish/linux-x64
     - name: Zip Linux Self-Contained
       run: zip -r ../../Helion-${{ github.ref_name }}-linux-x64_SelfContained.zip *
       working-directory: Publish/linux-x64_SelfContained
-    - name: Zip Linux AOT
-      run: zip -r ../../Helion-${{ github.ref_name }}-linux-x64_AOT.zip *
-      working-directory: Publish/linux-x64_AOT
-
-    - name: Update nightly release (Linux)
+    - name: Zip Windows
+      run: zip -r ../../Helion-${{ github.ref_name }}-win-x64.zip *
+      working-directory: Publish/win-x64
+    - name: Zip Windows Self-Contained
+      run: zip -r ../../Helion-${{ github.ref_name }}-win-x64_SelfContained.zip *
+      working-directory: Publish/win-x64_SelfContained
+    - name: Update nightly release
       uses: pyTooling/Actions/releaser@r0
       with:
         tag: nightly
+        rm: true
         token: ${{ secrets.GITHUB_TOKEN }}
         files: '*.zip'
-        
-  buildNightlyWindows:
-    runs-on: windows-2022
-
-    steps:
-    - uses: actions/checkout@v4
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 9.0.x
-    - name: Restore dependencies
-      run: dotnet restore
-    - name: Build
-      run: dotnet build --no-restore
-      
-    - name: Dotnet Publish Windows
-      run: dotnet publish -c Release -r win-x64 Client/Client.csproj -p:SelfContainedRelease=true
-    - name: Dotnet Publish Windows AOT
-      run: dotnet publish -c Release -r win-x64 Client/Client.csproj -p:AOT=true
-      
-    - name: Zip Windows Self-Contained
-      run: Compress-Archive -Path .\Publish\win-x64_SelfContained\* -DestinationPath .\Helion-${{ github.ref_name }}-win-x64_SelfContained.zip
-    - name: Zip Windows AOT
-      run: Compress-Archive -Path .\Publish\win-x64_AOT\* -DestinationPath .\Helion-${{ github.ref_name }}-win-x64_AOT.zip
-
-    - name: Update nightly release (Windows)
-      uses: svenstaro/upload-release-action@v2
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: '*.zip'
-        tag: nightly
-        overwrite: true
-        file_glob: true


### PR DESCRIPTION
While the AOT stuff is nice, the Windows build host "costs" more, and we want to avoid blowing through our free compute quota.