### PR TITLE
Correct missile blocking checks to match original behavior 

### DIFF
--- a/Core/World/Entities/Entity.cs
+++ b/Core/World/Entities/Entity.cs
@@ -742,9 +742,13 @@ public partial class Entity : IDisposable, ITickable, ISoundSource
         if (Flags.Ripper)
             return false;
 
-        // Ignore solid checks for missiles
         if (Flags.Missile)
+        {
+            if (!other.Flags.Shootable && !other.Flags.Solid)
+                return false;
+
             return true;
+        }
 
         return other.Flags.Solid;
     }

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,3 +4,4 @@
 - Upgrade to .NET 9
 
 ## Bug fixes:
+- Correct missile blocking checks to match original behavior (fixes radsuits blocking rockets etc)

--- a/Tests/Unit/GameAction/Physics/Physics_Missile.cs
+++ b/Tests/Unit/GameAction/Physics/Physics_Missile.cs
@@ -123,7 +123,7 @@ namespace Helion.Tests.Unit.GameAction
             RunEntityDisposed(rocket);
         }
 
-        [Fact(DisplayName = "Missile hits non-shootable non-solid special")]
+        [Fact(DisplayName = "Missile doesn't hit non-shootable non-solid special")]
         public void MissileNonShootableNonSolidSpecial()
         {
             var entity = GameActions.CreateEntity(World, "Zombieman", MissileCenterPlayerPos + new Vec3D(0, 96, 0));
@@ -135,9 +135,9 @@ namespace Helion.Tests.Unit.GameAction
             rocket.Velocity = Vec3D.UnitSphere(rocket.AngleRadians, 0) * 16;
 
             RunMissileExplode(rocket);
-            rocket.Position.Should().Be(new Vec3D(1920, 960, 32));
-            rocket.BlockingEntity.Should().Be(entity);
-            entity.Velocity.ApproxEquals(new(0, 4.53125, 0));
+            rocket.Position.Should().Be(new Vec3D(1920, 1008, 32));
+            rocket.BlockingEntity.Should().BeNull();
+            entity.Velocity.Should().Be(Vec3D.Zero);
 
             RunEntityDisposed(rocket);
         }


### PR DESCRIPTION
Correct missile blocking behavior to ignore checking solid only if it's not shootable. Fixes radsuits blocking rockets etc