### PR TITLE
Organize key binds

### DIFF
--- a/Core/Layer/Options/Sections/KeyBindingSection.cs
+++ b/Core/Layer/Options/Sections/KeyBindingSection.cs
@@ -361,15 +361,12 @@ public class KeyBindingSection : IOptionSection
 
         hud.Text("Press enter to start binding and press a key or button", Font, fontSize, (0, y), out Dimension enterArea,
             both: Align.TopMiddle, color: Color.Firebrick);
-        y += enterArea.Height + m_config.Window.GetMenuScaled(12);
+        y += enterArea.Height;
 
         int cmdIndex = 0;
-        int groupIndex = 0;
         foreach (string group in CommandsByGroup.Keys)
         {
-            if (groupIndex != 0)
-                y += m_config.Window.GetMenuScaled(12);
-            groupIndex++;
+            y += m_config.Window.GetMenuScaled(12);
 
             Dimension commandArea;
             hud.Text(group, Font, fontSize, (-xOffset, y), out commandArea,

--- a/Core/Layer/Options/Sections/KeyBindingSection.cs
+++ b/Core/Layer/Options/Sections/KeyBindingSection.cs
@@ -1,11 +1,13 @@
-﻿using Helion.Audio.Sounds;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Helion.Audio.Sounds;
 using Helion.Geometry;
 using Helion.Geometry.Boxes;
 using Helion.Geometry.Vectors;
 using Helion.Graphics;
 using Helion.Render.Common.Enums;
 using Helion.Render.Common.Renderers;
-using Helion.Util;
 using Helion.Util.Configs;
 using Helion.Util.Configs.Extensions;
 using Helion.Util.Configs.Impl;
@@ -14,11 +16,6 @@ using Helion.Util.Extensions;
 using Helion.Window;
 using Helion.Window.Input;
 using NLog;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Text;
 using static Helion.Util.Constants;
 
 namespace Helion.Layer.Options.Sections;
@@ -48,19 +45,6 @@ public class KeyBindingSection : IOptionSection
         }
     }
 
-    private static readonly Dictionary<string, string> RemapNames = new()
-    {
-        { Constants.Input.AutoMapIncrease, "AutoMap Zoom In" },
-        { Constants.Input.AutoMapDecrease, "AutoMap Zoom Out" },
-        { Constants.Input.AutoMapUp, "AutoMap Up" },
-        { Constants.Input.AutoMapDown, "AutoMap Down" },
-        { Constants.Input.AutoMapLeft, "AutoMap Left" },
-        { Constants.Input.AutoMapRight, "AutoMap Right" },
-        { Constants.Input.AutoMapAddMarker, "AutoMap Add Marker" },
-        { Constants.Input.AutoMapRemoveNearbyMarkers, "AutoMap Remove Nearby" },
-        { Constants.Input.AutoMapClearAllMarkers, "AutoMap Clear All" },
-    };
-
     private static readonly Logger Log = LogManager.GetCurrentClassLogger();
 
     public event EventHandler<LockEvent>? OnLockChanged;
@@ -75,8 +59,6 @@ public class KeyBindingSection : IOptionSection
     private readonly SoundManager m_soundManager;
     private readonly List<CommandKeys> m_commandToKeys = new();
     private readonly HashSet<string> m_mappedCommands = new();
-    private readonly HashSet<string> m_allCommands;
-    private readonly StringBuilder m_builder = new();
     private Vec2I m_mousePos;
     private int m_renderHeight;
     private (int, int) m_selectedRender;
@@ -91,7 +73,6 @@ public class KeyBindingSection : IOptionSection
     {
         m_config = config;
         m_soundManager = soundManager;
-        m_allCommands = GetAllCommandNames();
         m_configUpdated = true;
     }
 
@@ -99,33 +80,13 @@ public class KeyBindingSection : IOptionSection
     {
         OnRowChanged?.Invoke(this, new(m_currentRow, string.Empty));
         m_configUpdated = true;
+        CheckForConfigUpdates();
     }
 
     public void ResetSelection() => m_currentRow = 0;
 
     public bool OnClickableItem(Vec2I mousePosition) =>
         m_menuPositionList.GetIndex(mousePosition, out _);
-
-    private static HashSet<string> GetAllCommandNames()
-    {
-        HashSet<string> commandNames = new();
-
-        foreach (FieldInfo fieldInfo in typeof(Input).GetFields())
-        {
-            if (fieldInfo is not { IsPublic: true, IsStatic: true })
-                continue;
-
-            if (fieldInfo.GetValue(null) is not string commandName)
-            {
-                Log.Error($"Unable to get constant command name field '{fieldInfo.Name}' for options menu, should never happen");
-                continue;
-            }
-
-            commandNames.Add(commandName);
-        }
-
-        return commandNames;
-    }
 
     private void MapCommands()
     {
@@ -147,10 +108,7 @@ public class KeyBindingSection : IOptionSection
         if (string.IsNullOrWhiteSpace(command) || m_mappedCommands.Contains(command))
             return;
 
-        if (!RemapNames.TryGetValue(command, out var name))
-            name = command.WithWordSpaces(m_builder);
-
-        m_commandToKeys.Add(new(command, name));
+        m_commandToKeys.Add(new(command, CommandUILabels[command]));
         m_mappedCommands.Add(command);
     }
 
@@ -164,7 +122,7 @@ public class KeyBindingSection : IOptionSection
         foreach ((Key key, string command) in m_config.Keys.GetKeyMapping())
         {
             List<Key> keys;
-            string name = command.WithWordSpaces(m_builder);
+            string name = CommandUILabels[command];
 
             if (!m_mappedCommands.Contains(command))
                 continue;
@@ -189,9 +147,9 @@ public class KeyBindingSection : IOptionSection
                 keys.Add(key);
         }
 
-        foreach (string command in m_allCommands.Where(cmd => !m_mappedCommands.Contains(cmd)))
+        foreach (string command in BaseCommands.Where(cmd => !m_mappedCommands.Contains(cmd)))
         {
-            string name = command.WithWordSpaces(m_builder);
+            string name = CommandUILabels[command];
             m_commandToKeys.Add(new(command, name));
             m_mappedCommands.Add(command);
         }
@@ -405,71 +363,78 @@ public class KeyBindingSection : IOptionSection
             both: Align.TopMiddle, color: Color.Firebrick);
         y += enterArea.Height + m_config.Window.GetMenuScaled(12);
 
-        for (int cmdIndex = 0; cmdIndex < m_commandToKeys.Count; cmdIndex++)
+        int cmdIndex = 0;
+        int groupIndex = 0;
+        foreach (string group in CommandsByGroup.Keys)
         {
-            var commandKeys = m_commandToKeys[cmdIndex];
+            if (groupIndex != 0)
+                y += m_config.Window.GetMenuScaled(12);
+            groupIndex++;
 
             Dimension commandArea;
-            if (cmdIndex == m_currentRow && m_updatingKeyBinding)
-            {
-                hud.Text(commandKeys.Name, Font, fontSize, (-xOffset, y), out commandArea,
-                    window: Align.TopMiddle, anchor: Align.TopRight, color: Color.Yellow);
-            }
-            else
-            {
-                hud.Text(commandKeys.Name, Font, fontSize, (-xOffset, y), out commandArea,
-                    window: Align.TopMiddle, anchor: Align.TopRight, color: Color.Red);
-            }
+            hud.Text(group, Font, fontSize, (-xOffset, y), out commandArea,
+                window: Align.TopMiddle, anchor: Align.TopRight, color: Color.White);
+            y += commandArea.Height;
 
-            if (cmdIndex == m_currentRow)
-                m_selectedRender = (y - startY, y + commandArea.Height - startY);
-
-            if (cmdIndex == m_currentRow && !m_updatingKeyBinding)
+            foreach (string command in CommandsByGroup[group])
             {
-                var arrowSize = hud.MeasureText("<", Font, fontSize);
-                Vec2I arrowLeft = (-xOffset - commandArea.Width - m_config.Window.GetMenuScaled(2), y);
-                hud.Text(">", Font, fontSize, arrowLeft, window: Align.TopMiddle,
-                    anchor: Align.TopRight, color: Color.White);
-                Vec2I arrowRight = (-xOffset + arrowSize.Width + m_config.Window.GetMenuScaled(2), y);
-                hud.Text("<", Font, fontSize, arrowRight, window: Align.TopMiddle,
-                    anchor: Align.TopRight, color: Color.White);
-            }
+                hud.Text(CommandUILabels[command], Font, fontSize, (-xOffset, y), out commandArea,
+                    window: Align.TopMiddle, anchor: Align.TopRight,
+                    color: cmdIndex == m_currentRow && m_updatingKeyBinding ? Color.Yellow : Color.Red);
 
-            if (commandKeys.Keys.Empty())
-            {
-                hud.Text("No binding", Font, fontSize, (xOffset, y), out Dimension noBindingArea,
-                    window: Align.TopMiddle, anchor: Align.TopLeft, color: Color.Gray);
+                if (cmdIndex == m_currentRow)
+                    m_selectedRender = (y - startY, y + commandArea.Height - startY);
 
-                int rowHeight = Math.Max(noBindingArea.Height, commandArea.Height);
-                var rowDimensions = new Box2I((0, y), (hud.Dimension.Width, y + rowHeight));
-                m_menuPositionList.Add(rowDimensions, cmdIndex);
-                y += Math.Max(noBindingArea.Height, commandArea.Height);
-            }
-            else
-            {
-                Dimension totalKeyArea = (0, 0);
-                for (int keyIndex = 0; keyIndex < commandKeys.Keys.Count; keyIndex++)
+                if (cmdIndex == m_currentRow && !m_updatingKeyBinding)
                 {
-                    Key key = commandKeys.Keys[keyIndex];
-                    hud.Text(key.ToString(), Font, fontSize, (xOffset + totalKeyArea.Width, y),
-                        out Dimension keyArea,
-                        window: Align.TopMiddle, anchor: Align.TopLeft, color: Color.White);
-                    totalKeyArea.Width += keyArea.Width;
-
-                    if (keyIndex != commandKeys.Keys.Count - 1)
-                    {
-                        hud.Text(", ", Font, fontSize, (xOffset + totalKeyArea.Width, y),
-                            out Dimension commaArea,
-                            window: Align.TopMiddle, anchor: Align.TopLeft, color: Color.Red);
-                        totalKeyArea.Width += commaArea.Width;
-                    }
+                    var arrowSize = hud.MeasureText("<", Font, fontSize);
+                    Vec2I arrowLeft = (-xOffset - commandArea.Width - m_config.Window.GetMenuScaled(2), y);
+                    hud.Text(">", Font, fontSize, arrowLeft, window: Align.TopMiddle,
+                        anchor: Align.TopRight, color: Color.White);
+                    Vec2I arrowRight = (-xOffset + arrowSize.Width + m_config.Window.GetMenuScaled(2), y);
+                    hud.Text("<", Font, fontSize, arrowRight, window: Align.TopMiddle,
+                        anchor: Align.TopRight, color: Color.White);
                 }
 
-                int rowHeight = Math.Max(totalKeyArea.Height, commandArea.Height);
-                var rowDimensions = new Box2I((0, y), (hud.Dimension.Width, y + rowHeight));
-                m_menuPositionList.Add(rowDimensions, cmdIndex);
+                CommandKeys commandKeys = m_commandToKeys[cmdIndex];
 
-                y += rowHeight;
+                if (commandKeys.Keys.Empty())
+                {
+                    hud.Text("No binding", Font, fontSize, (xOffset, y), out Dimension noBindingArea,
+                        window: Align.TopMiddle, anchor: Align.TopLeft, color: Color.Gray);
+
+                    int rowHeight = Math.Max(noBindingArea.Height, commandArea.Height);
+                    var rowDimensions = new Box2I((0, y), (hud.Dimension.Width, y + rowHeight));
+                    m_menuPositionList.Add(rowDimensions, cmdIndex);
+                    y += Math.Max(noBindingArea.Height, commandArea.Height);
+                }
+                else
+                {
+                    Dimension totalKeyArea = (0, 0);
+                    for (int keyIndex = 0; keyIndex < commandKeys.Keys.Count; keyIndex++)
+                    {
+                        Key key = commandKeys.Keys[keyIndex];
+                        hud.Text(key.ToString(), Font, fontSize, (xOffset + totalKeyArea.Width, y),
+                            out Dimension keyArea,
+                            window: Align.TopMiddle, anchor: Align.TopLeft, color: Color.White);
+                        totalKeyArea.Width += keyArea.Width;
+
+                        if (keyIndex != commandKeys.Keys.Count - 1)
+                        {
+                            hud.Text(", ", Font, fontSize, (xOffset + totalKeyArea.Width, y),
+                                out Dimension commaArea,
+                                window: Align.TopMiddle, anchor: Align.TopLeft, color: Color.Red);
+                            totalKeyArea.Width += commaArea.Width;
+                        }
+                    }
+
+                    int rowHeight = Math.Max(totalKeyArea.Height, commandArea.Height);
+                    var rowDimensions = new Box2I((0, y), (hud.Dimension.Width, y + rowHeight));
+                    m_menuPositionList.Add(rowDimensions, cmdIndex);
+                    y += commandArea.Height;
+                }
+
+                cmdIndex++;
             }
         }
 
@@ -492,6 +457,7 @@ public class KeyBindingSection : IOptionSection
             m_updateRow = false;
         }
     }
+
 
     private void ResetAllKeyBindings()
     {

--- a/Core/Util/Constants.cs
+++ b/Core/Util/Constants.cs
@@ -118,69 +118,158 @@ public static class Constants
         public const string Pickup = "Pickup";
     }
 
+    public enum InputType
+    {
+        Movement = 0,
+        WeaponsAndInventory = 1,
+        Automap = 2,
+        Files = 3,
+        HudAndUI = 4,
+        System = 5
+    };
+
+    [AttributeUsage(AttributeTargets.Field, AllowMultiple = false)]
+    public class InputGroupAttribute(InputType inputGroup): Attribute
+    {
+        public InputType InputGroup = inputGroup;
+    }
+
     public static class Input
     {
         // Movement
+        [InputGroup(InputType.Movement)]
         public const string Forward = "Forward";
+        [InputGroup(InputType.Movement)]
         public const string Backward = "Backward";
+        [InputGroup(InputType.Movement)]
         public const string Left = "Left";
+        [InputGroup(InputType.Movement)]
         public const string Right = "Right";
+        [InputGroup(InputType.Movement)]
         public const string Run = "Run";
+        [InputGroup(InputType.Movement)]
         public const string Strafe = "Strafe";
+        [InputGroup(InputType.Movement)]
         public const string TurnLeft = "TurnLeft";
+        [InputGroup(InputType.Movement)]
         public const string TurnRight = "TurnRight";
+        [InputGroup(InputType.Movement)]
         public const string LookUp = "LookUp";
+        [InputGroup(InputType.Movement)]
         public const string LookDown = "LookDown";
+        [InputGroup(InputType.Movement)]
         public const string CenterView = "CenterView";
+        [InputGroup(InputType.Movement)]
         public const string Jump = "Jump";
+        [InputGroup(InputType.Movement)]
         public const string Crouch = "Crouch";
-        public const string Attack = "Attack";
+        [InputGroup(InputType.Movement)]
+        public const string Attack = "Attack"; 
+        [InputGroup(InputType.Movement)]
         public const string Use = "Use";
+        [InputGroup(InputType.Movement)]
         public const string GyroButton = "GyroButton";
 
         // Weapons/inventory
+        [InputGroup(InputType.WeaponsAndInventory)]
         public const string NextWeapon = "NextWeapon";
+        [InputGroup(InputType.WeaponsAndInventory)]
         public const string PreviousWeapon = "PreviousWeapon";
+        [InputGroup(InputType.WeaponsAndInventory)]
         public const string WeaponSlot1 = "WeaponSlot1";
+        [InputGroup(InputType.WeaponsAndInventory)]
         public const string WeaponSlot2 = "WeaponSlot2";
+        [InputGroup(InputType.WeaponsAndInventory)]
         public const string WeaponSlot3 = "WeaponSlot3";
+        [InputGroup(InputType.WeaponsAndInventory)]
         public const string WeaponSlot4 = "WeaponSlot4";
+        [InputGroup(InputType.WeaponsAndInventory)]
         public const string WeaponSlot5 = "WeaponSlot5";
+        [InputGroup(InputType.WeaponsAndInventory)]
         public const string WeaponSlot6 = "WeaponSlot6";
+        [InputGroup(InputType.WeaponsAndInventory)]
         public const string WeaponSlot7 = "WeaponSlot7";
+        [InputGroup(InputType.WeaponsAndInventory)]
         public const string WeaponGroup1 = "WeaponGroup1";
+        [InputGroup(InputType.WeaponsAndInventory)]
         public const string WeaponGroup2 = "WeaponGroup2";
+        [InputGroup(InputType.WeaponsAndInventory)]
         public const string WeaponGroup3 = "WeaponGroup3";
+        [InputGroup(InputType.WeaponsAndInventory)]
         public const string WeaponGroup4 = "WeaponGroup4";
 
         // Automap
+        [InputGroup(InputType.Automap)]
         public const string Automap = "Automap";
+        [InputGroup(InputType.Automap)]
         public const string AutoMapIncrease = "AutoMapIncrease";
+        [InputGroup(InputType.Automap)]
         public const string AutoMapDecrease = "AutoMapDecrease";
+        [InputGroup(InputType.Automap)]
         public const string AutoMapUp = "AutoMapUp";
+        [InputGroup(InputType.Automap)]
         public const string AutoMapDown = "AutoMapDown";
+        [InputGroup(InputType.Automap)]
         public const string AutoMapLeft = "AutoMapLeft";
+        [InputGroup(InputType.Automap)]
         public const string AutoMapRight = "AutoMapRight";
+        [InputGroup(InputType.Automap)]
         public const string AutoMapAddMarker = "AutoMapAddMarker";
+        [InputGroup(InputType.Automap)]
         public const string AutoMapRemoveNearbyMarkers = "AutoMapRemoveNearbyMarkers";
+        [InputGroup(InputType.Automap)]
         public const string AutoMapClearAllMarkers = "AutoMapClearAllMarkers";
 
         // Files
+        [InputGroup(InputType.Files)]
         public const string Save = "Save";
+        [InputGroup(InputType.Files)]
         public const string QuickSave = "QuickSave";
+        [InputGroup(InputType.Files)]
         public const string Load = "Load";
 
         // HUD and in-game UI
+        [InputGroup(InputType.HudAndUI)]
         public const string HudIncrease = "HudIncrease";
+        [InputGroup(InputType.HudAndUI)]
         public const string HudDecrease = "HudDecrease";
+        [InputGroup(InputType.HudAndUI)]
         public const string GammaCorrection = "GammaCorrection";
 
         // System
+        [InputGroup(InputType.System)]
         public const string Pause = "Pause";
+        [InputGroup(InputType.System)]
         public const string Screenshot = "Screenshot";
+        [InputGroup(InputType.System)]
         public const string Console = "Console";
+        [InputGroup(InputType.System)]
         public const string OptionsMenu = "OptionsMenu";
+        [InputGroup(InputType.System)]
         public const string Menu = "Menu";
+    }
+
+    public static readonly HashSet<string> BaseCommands = new(
+        typeof(Input)
+            .GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
+            .Select(f => f.GetValue(null) as string ?? string.Empty),
+        StringComparer.OrdinalIgnoreCase);
+
+    public static readonly Dictionary<InputType?, string[]> CommandsByGroup =
+        typeof(Input)
+            .GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
+            .GroupBy(f => f.GetCustomAttributes(true).Select(a => (a as InputGroupAttribute)?.InputGroup).First())
+            .Where(g => g.Key != null)
+            .ToDictionary(
+                g => g.Key,
+                g => g.Select(f => f.GetValue(null) as string ?? string.Empty).ToArray());
+
+    public static readonly HashSet<string> InGameCommands =
+        new HashSet<string>(CommandsByGroup[InputType.Movement].Concat(CommandsByGroup[InputType.WeaponsAndInventory]), StringComparer.OrdinalIgnoreCase);
+
+    public static class ConsoleCommands
+    {
+        public const string Commands = "commands";
     }
 
     public static class Fonts
@@ -204,46 +293,6 @@ public static class Constants
         public const int CeilingOffset = 1;
         public const int WallOffset = 2;
         public const int ColorMapCount = 32;
-    }
-
-    public static readonly HashSet<string> BaseCommands = new(
-        typeof(Input)
-            .GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
-            .Select(f => f.GetValue(null) as string ?? string.Empty),
-        StringComparer.OrdinalIgnoreCase);
-
-    public static readonly HashSet<string> InGameCommands = new(StringComparer.OrdinalIgnoreCase)
-    {
-        Input.Forward,
-        Input.Backward,
-        Input.Left,
-        Input.Right,
-        Input.Use,
-        Input.Run,
-        Input.Strafe,
-        Input.TurnLeft,
-        Input.TurnRight,
-        Input.LookUp,
-        Input.LookDown,
-        Input.Jump,
-        Input.Crouch,
-        Input.Attack,
-        Input.NextWeapon,
-        Input.PreviousWeapon,
-        Input.WeaponSlot1,
-        Input.WeaponSlot2,
-        Input.WeaponSlot3,
-        Input.WeaponSlot4,
-        Input.WeaponSlot5,
-        Input.WeaponSlot6,
-        Input.WeaponSlot7,
-        Input.CenterView,
-        Input.GyroButton,
-    };
-
-    public static class ConsoleCommands
-    {
-        public const string Commands = "commands";
     }
 
     public const double Epsilon = 0.00001;

--- a/Core/Util/Constants.cs
+++ b/Core/Util/Constants.cs
@@ -1,7 +1,10 @@
-using Helion.World.Sound;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
+using System.Text;
+using Helion.Util.Extensions;
+using Helion.World.Sound;
 
 namespace Helion.Util;
 
@@ -120,152 +123,171 @@ public static class Constants
 
     public enum InputType
     {
-        Movement = 0,
-        WeaponsAndInventory = 1,
-        Automap = 2,
-        Files = 3,
-        HudAndUI = 4,
-        System = 5
+        Uncategorized = 0,
+        Movement = 1,
+        WeaponsAndInventory = 2,
+        Automap = 3,
+        Files = 4,
+        HudAndUI = 5,
+        System = 6,
     };
 
     [AttributeUsage(AttributeTargets.Field, AllowMultiple = false)]
-    public class InputGroupAttribute(InputType inputGroup): Attribute
+    public class InputAttribute(InputType inputGroup, string? uiString = null) : Attribute
     {
         public InputType InputGroup = inputGroup;
+        public string? UIString = uiString;
     }
 
     public static class Input
     {
         // Movement
-        [InputGroup(InputType.Movement)]
+        [Input(InputType.Movement)]
         public const string Forward = "Forward";
-        [InputGroup(InputType.Movement)]
+        [Input(InputType.Movement)]
         public const string Backward = "Backward";
-        [InputGroup(InputType.Movement)]
+        [Input(InputType.Movement)]
         public const string Left = "Left";
-        [InputGroup(InputType.Movement)]
+        [Input(InputType.Movement)]
         public const string Right = "Right";
-        [InputGroup(InputType.Movement)]
+        [Input(InputType.Movement)]
         public const string Run = "Run";
-        [InputGroup(InputType.Movement)]
+        [Input(InputType.Movement)]
         public const string Strafe = "Strafe";
-        [InputGroup(InputType.Movement)]
+        [Input(InputType.Movement)]
         public const string TurnLeft = "TurnLeft";
-        [InputGroup(InputType.Movement)]
+        [Input(InputType.Movement)]
         public const string TurnRight = "TurnRight";
-        [InputGroup(InputType.Movement)]
+        [Input(InputType.Movement)]
         public const string LookUp = "LookUp";
-        [InputGroup(InputType.Movement)]
+        [Input(InputType.Movement)]
         public const string LookDown = "LookDown";
-        [InputGroup(InputType.Movement)]
+        [Input(InputType.Movement)]
         public const string CenterView = "CenterView";
-        [InputGroup(InputType.Movement)]
+        [Input(InputType.Movement)]
         public const string Jump = "Jump";
-        [InputGroup(InputType.Movement)]
+        [Input(InputType.Movement)]
         public const string Crouch = "Crouch";
-        [InputGroup(InputType.Movement)]
-        public const string Attack = "Attack"; 
-        [InputGroup(InputType.Movement)]
+        [Input(InputType.Movement)]
+        public const string Attack = "Attack";
+        [Input(InputType.Movement)]
         public const string Use = "Use";
-        [InputGroup(InputType.Movement)]
+        [Input(InputType.Movement)]
         public const string GyroButton = "GyroButton";
 
         // Weapons/inventory
-        [InputGroup(InputType.WeaponsAndInventory)]
+        [Input(InputType.WeaponsAndInventory)]
         public const string NextWeapon = "NextWeapon";
-        [InputGroup(InputType.WeaponsAndInventory)]
+        [Input(InputType.WeaponsAndInventory)]
         public const string PreviousWeapon = "PreviousWeapon";
-        [InputGroup(InputType.WeaponsAndInventory)]
+        [Input(InputType.WeaponsAndInventory)]
         public const string WeaponSlot1 = "WeaponSlot1";
-        [InputGroup(InputType.WeaponsAndInventory)]
+        [Input(InputType.WeaponsAndInventory)]
         public const string WeaponSlot2 = "WeaponSlot2";
-        [InputGroup(InputType.WeaponsAndInventory)]
+        [Input(InputType.WeaponsAndInventory)]
         public const string WeaponSlot3 = "WeaponSlot3";
-        [InputGroup(InputType.WeaponsAndInventory)]
+        [Input(InputType.WeaponsAndInventory)]
         public const string WeaponSlot4 = "WeaponSlot4";
-        [InputGroup(InputType.WeaponsAndInventory)]
+        [Input(InputType.WeaponsAndInventory)]
         public const string WeaponSlot5 = "WeaponSlot5";
-        [InputGroup(InputType.WeaponsAndInventory)]
+        [Input(InputType.WeaponsAndInventory)]
         public const string WeaponSlot6 = "WeaponSlot6";
-        [InputGroup(InputType.WeaponsAndInventory)]
+        [Input(InputType.WeaponsAndInventory)]
         public const string WeaponSlot7 = "WeaponSlot7";
-        [InputGroup(InputType.WeaponsAndInventory)]
+        [Input(InputType.WeaponsAndInventory)]
         public const string WeaponGroup1 = "WeaponGroup1";
-        [InputGroup(InputType.WeaponsAndInventory)]
+        [Input(InputType.WeaponsAndInventory)]
         public const string WeaponGroup2 = "WeaponGroup2";
-        [InputGroup(InputType.WeaponsAndInventory)]
+        [Input(InputType.WeaponsAndInventory)]
         public const string WeaponGroup3 = "WeaponGroup3";
-        [InputGroup(InputType.WeaponsAndInventory)]
+        [Input(InputType.WeaponsAndInventory)]
         public const string WeaponGroup4 = "WeaponGroup4";
 
         // Automap
-        [InputGroup(InputType.Automap)]
+        [Input(InputType.Automap, "Automap")]
         public const string Automap = "Automap";
-        [InputGroup(InputType.Automap)]
+        [Input(InputType.Automap, "Automap Zoom In")]
         public const string AutoMapIncrease = "AutoMapIncrease";
-        [InputGroup(InputType.Automap)]
+        [Input(InputType.Automap, "Automap Zoom Out")]
         public const string AutoMapDecrease = "AutoMapDecrease";
-        [InputGroup(InputType.Automap)]
+        [Input(InputType.Automap, "Automap Up")]
         public const string AutoMapUp = "AutoMapUp";
-        [InputGroup(InputType.Automap)]
+        [Input(InputType.Automap, "Automap Down")]
         public const string AutoMapDown = "AutoMapDown";
-        [InputGroup(InputType.Automap)]
+        [Input(InputType.Automap, "Automap Left")]
         public const string AutoMapLeft = "AutoMapLeft";
-        [InputGroup(InputType.Automap)]
+        [Input(InputType.Automap, "Automap Right")]
         public const string AutoMapRight = "AutoMapRight";
-        [InputGroup(InputType.Automap)]
+        [Input(InputType.Automap, "Automap Add Marker")]
         public const string AutoMapAddMarker = "AutoMapAddMarker";
-        [InputGroup(InputType.Automap)]
+        [Input(InputType.Automap, "Automap Remove Nearby Markers")]
         public const string AutoMapRemoveNearbyMarkers = "AutoMapRemoveNearbyMarkers";
-        [InputGroup(InputType.Automap)]
+        [Input(InputType.Automap, "Automap Clear All Markers")]
         public const string AutoMapClearAllMarkers = "AutoMapClearAllMarkers";
 
         // Files
-        [InputGroup(InputType.Files)]
+        [Input(InputType.Files)]
         public const string Save = "Save";
-        [InputGroup(InputType.Files)]
+        [Input(InputType.Files)]
         public const string QuickSave = "QuickSave";
-        [InputGroup(InputType.Files)]
+        [Input(InputType.Files)]
         public const string Load = "Load";
 
         // HUD and in-game UI
-        [InputGroup(InputType.HudAndUI)]
+        [Input(InputType.HudAndUI)]
         public const string HudIncrease = "HudIncrease";
-        [InputGroup(InputType.HudAndUI)]
+        [Input(InputType.HudAndUI)]
         public const string HudDecrease = "HudDecrease";
-        [InputGroup(InputType.HudAndUI)]
+        [Input(InputType.HudAndUI)]
         public const string GammaCorrection = "GammaCorrection";
 
         // System
-        [InputGroup(InputType.System)]
+        [Input(InputType.System)]
         public const string Pause = "Pause";
-        [InputGroup(InputType.System)]
+        [Input(InputType.System)]
         public const string Screenshot = "Screenshot";
-        [InputGroup(InputType.System)]
+        [Input(InputType.System)]
         public const string Console = "Console";
-        [InputGroup(InputType.System)]
+        [Input(InputType.System)]
         public const string OptionsMenu = "OptionsMenu";
-        [InputGroup(InputType.System)]
+        [Input(InputType.System)]
         public const string Menu = "Menu";
     }
 
+    private static StringBuilder m_builder = new();
+
+    /// <summary>
+    /// All regular, bindable commands available in the game
+    /// </summary>
     public static readonly HashSet<string> BaseCommands = new(
         typeof(Input)
-            .GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
             .Select(f => f.GetValue(null) as string ?? string.Empty),
         StringComparer.OrdinalIgnoreCase);
 
-    public static readonly Dictionary<InputType?, string[]> CommandsByGroup =
+    /// <summary>
+    /// Commands, grouped by purpose (e.g. movement)
+    /// </summary>
+    public static readonly Dictionary<string, string[]> CommandsByGroup =
         typeof(Input)
-            .GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
-            .GroupBy(f => f.GetCustomAttributes(true).Select(a => (a as InputGroupAttribute)?.InputGroup).First())
-            .Where(g => g.Key != null)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .GroupBy(f => f.GetCustomAttribute<InputAttribute>()?.InputGroup ?? InputType.Uncategorized)
             .ToDictionary(
-                g => g.Key,
-                g => g.Select(f => f.GetValue(null) as string ?? string.Empty).ToArray());
+                g => StringExtensions.WithWordSpaces(g.Key.ToString(), m_builder),
+                g => g.Select(f => f.GetValue(null) as string ?? string.Empty).ToArray(),
+                StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Commands, with their corresponding UI labels, if specified (else, just spaces added before each upper-case letter)
+    /// </summary>
+    public static readonly Dictionary<string, string> CommandUILabels =
+        typeof(Input)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .GroupBy(f => f.GetValue(null) as string ?? string.Empty)
+            .ToDictionary(g => g.Key, g => g.First().GetCustomAttribute<InputAttribute>()?.UIString ?? StringExtensions.WithWordSpaces(g.Key, m_builder));
 
     public static readonly HashSet<string> InGameCommands =
-        new HashSet<string>(CommandsByGroup[InputType.Movement].Concat(CommandsByGroup[InputType.WeaponsAndInventory]), StringComparer.OrdinalIgnoreCase);
+        new HashSet<string>(CommandsByGroup["Movement"].Concat(CommandsByGroup["Weapons And Inventory"]), StringComparer.OrdinalIgnoreCase);
 
     public static class ConsoleCommands
     {

--- a/Core/Util/Constants.cs
+++ b/Core/Util/Constants.cs
@@ -1,6 +1,7 @@
 using Helion.World.Sound;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Helion.Util;
 
@@ -119,21 +120,25 @@ public static class Constants
 
     public static class Input
     {
+        // Movement
         public const string Forward = "Forward";
         public const string Backward = "Backward";
         public const string Left = "Left";
         public const string Right = "Right";
-        public const string Use = "Use";
         public const string Run = "Run";
         public const string Strafe = "Strafe";
         public const string TurnLeft = "TurnLeft";
         public const string TurnRight = "TurnRight";
         public const string LookUp = "LookUp";
         public const string LookDown = "LookDown";
+        public const string CenterView = "CenterView";
         public const string Jump = "Jump";
         public const string Crouch = "Crouch";
-        public const string Console = "Console";
         public const string Attack = "Attack";
+        public const string Use = "Use";
+        public const string GyroButton = "GyroButton";
+
+        // Weapons/inventory
         public const string NextWeapon = "NextWeapon";
         public const string PreviousWeapon = "PreviousWeapon";
         public const string WeaponSlot1 = "WeaponSlot1";
@@ -147,9 +152,9 @@ public static class Constants
         public const string WeaponGroup2 = "WeaponGroup2";
         public const string WeaponGroup3 = "WeaponGroup3";
         public const string WeaponGroup4 = "WeaponGroup4";
-        public const string Screenshot = "Screenshot";
-        public const string HudIncrease = "HudIncrease";
-        public const string HudDecrease = "HudDecrease";
+
+        // Automap
+        public const string Automap = "Automap";
         public const string AutoMapIncrease = "AutoMapIncrease";
         public const string AutoMapDecrease = "AutoMapDecrease";
         public const string AutoMapUp = "AutoMapUp";
@@ -159,16 +164,23 @@ public static class Constants
         public const string AutoMapAddMarker = "AutoMapAddMarker";
         public const string AutoMapRemoveNearbyMarkers = "AutoMapRemoveNearbyMarkers";
         public const string AutoMapClearAllMarkers = "AutoMapClearAllMarkers";
+
+        // Files
         public const string Save = "Save";
-        public const string Load = "Load";
-        public const string Automap = "Automap";
-        public const string CenterView = "CenterView";
-        public const string Pause = "Pause";
         public const string QuickSave = "QuickSave";
+        public const string Load = "Load";
+
+        // HUD and in-game UI
+        public const string HudIncrease = "HudIncrease";
+        public const string HudDecrease = "HudDecrease";
+        public const string GammaCorrection = "GammaCorrection";
+
+        // System
+        public const string Pause = "Pause";
+        public const string Screenshot = "Screenshot";
+        public const string Console = "Console";
         public const string OptionsMenu = "OptionsMenu";
         public const string Menu = "Menu";
-        public const string GammaCorrection = "GammaCorrection";
-        public const string GyroButton = "GyroButton";
     }
 
     public static class Fonts
@@ -194,58 +206,11 @@ public static class Constants
         public const int ColorMapCount = 32;
     }
 
-    public static readonly HashSet<string> BaseCommands = new(StringComparer.OrdinalIgnoreCase)
-    {
-        Input.Forward,
-        Input.Backward,
-        Input.Left,
-        Input.Right,
-        Input.Use,
-        Input.Run,
-        Input.Strafe,
-        Input.TurnLeft,
-        Input.TurnRight,
-        Input.LookUp,
-        Input.LookDown,
-        Input.Jump,
-        Input.Crouch,
-        Input.Console,
-        Input.Attack,
-        Input.NextWeapon,
-        Input.PreviousWeapon,
-        Input.WeaponSlot1,
-        Input.WeaponSlot2,
-        Input.WeaponSlot3,
-        Input.WeaponSlot4,
-        Input.WeaponSlot5,
-        Input.WeaponSlot6,
-        Input.WeaponSlot7,
-        Input.WeaponGroup1,
-        Input.WeaponGroup2,
-        Input.WeaponGroup3,
-        Input.WeaponGroup4,
-        Input.Screenshot,
-        Input.HudIncrease,
-        Input.HudDecrease,
-        Input.AutoMapIncrease,
-        Input.AutoMapDecrease,
-        Input.AutoMapUp,
-        Input.AutoMapDown,
-        Input.AutoMapLeft,
-        Input.AutoMapRight,
-        Input.AutoMapAddMarker,
-        Input.AutoMapRemoveNearbyMarkers,
-        Input.AutoMapClearAllMarkers,
-        Input.Save,
-        Input.Load,
-        Input.Automap,
-        Input.Pause,
-        Input.QuickSave,
-        Input.OptionsMenu,
-        Input.Menu,
-        Input.CenterView,
-        Input.GyroButton,
-    };
+    public static readonly HashSet<string> BaseCommands = new(
+        typeof(Input)
+            .GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
+            .Select(f => f.GetValue(null) as string ?? string.Empty),
+        StringComparer.OrdinalIgnoreCase);
 
     public static readonly HashSet<string> InGameCommands = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -317,7 +282,7 @@ public static class Constants
     public const float DoomVirtualAspectRatio = 1.33333337f;
 
     public const int MaxTextureHeight = 16384;
-  
+
     public const double DoomSlowCrushSpeed = 0.125;
 
     public static readonly int MaxSoundChannels = Enum.GetValues<SoundChannel>().Length;


### PR DESCRIPTION
I find the key binding options section a bit annoying to navigate, both because it hasn't always had the most sensible ordering (things have gotten jumbled a bit when commands have been added), and because it doesn't have any section breaks whatsoever.

In this change, I'm organizing the key bindings into simple groups like "movement", "inventory", "automap", etc.