### PR TITLE
fix potential issue where AudioStream might play garbage data

### DIFF
--- a/Client/Music/FluidSynthMusicPlayer.cs
+++ b/Client/Music/FluidSynthMusicPlayer.cs
@@ -122,6 +122,7 @@ public class FluidSynthMusicPlayer : IMusicPlayer
         }
         else
         {
+            Array.Clear(sampleBlock);
             return false;
         }
     }


### PR DESCRIPTION
`AudioStream` queues the block regardless of the status returned by the `FillBlock` callback. Therefore, even in cases where it returns false, it is safer to overwrite the block with silence (though it is unlikely that this part will actually be played).