### PR TITLE
fix code pointer list

### DIFF
--- a/Core/Dehacked/DehackedConstants.cs
+++ b/Core/Dehacked/DehackedConstants.cs
@@ -2135,7 +2135,7 @@ public partial class DehackedDefinition
         { ThingState.FATT_RUN10, "A_Chase" },
         { ThingState.FATT_RUN11, "A_Chase" },
         { ThingState.FATT_RUN12, "A_Chase" },
-        { ThingState.FATT_ATK1, "A_FatAttack1" },
+        { ThingState.FATT_ATK1, "A_FatRaise" },
         { ThingState.FATT_ATK2, "A_FatAttack1" },
         { ThingState.FATT_ATK3, "A_FaceTarget" },
         { ThingState.FATT_ATK4, "A_FaceTarget" },


### PR DESCRIPTION
I believe the action corresponding to the first frame of the mancubus attack is `A_FatRaise`, but in Helion's defined list of code pointers, it's listed as `A_FatAttack1`. Because of this, when using the `A_FatRaise` code pointer in a vanilla mod intended solely to trigger the mancubus attack sound, an actual attack occurs instead of just playing the attack sound.