### PR TITLE
Add `toggle` ccmd

### DIFF
--- a/Assets/Documentation/README.md
+++ b/Assets/Documentation/README.md
@@ -56,7 +56,7 @@ Command                         | Description
 --------------------------------|------------
 [option] [value]                | Changes a config option (e.g. hud.showfps 1)
 [option]                        | Prints the value of a config option
-toggle [option] [val1] [...]    | Cycles a config option through a list of values (e.g. toggle audio.musicvolume 1 0.5 0)
+toggle [option] [value1] [...]  | Cycles a config option through a list of values (e.g. toggle audio.musicvolume 1 0.5 0)
 chasecam                        | Toggles a 3rd person camera and pauses the game
 fly                             | Toggles fly mode
 god                             | Toggles god mode

--- a/Assets/Documentation/README.md
+++ b/Assets/Documentation/README.md
@@ -52,28 +52,29 @@ Option                        | Description
 Helion's console can be opened with the tilde key (~) and features tab-completion. Here is a non-exhaustive list of
 useful commands:
 
-Command                 | Description
-------------------------|------------
-[option] [value]        | Changes a config option (e.g. hud.showfps 1)
-[option]                | Prints the value of a config option
-chasecam                | Toggles a 3rd person camera and pauses the game
-fly                     | Toggles fly mode
-god                     | Toggles god mode
-noclip                  | Toggles noclip mode
-findexits               | Highlights exits on the automap
-findkeys                | Highlights keys on the automap
-findkeylines            | Highlights key lines on the automap
-marksecrets             | Toggles secret highlighting on the automap
-markspecials            | Toggles ingame and automap highlighting of specials (shown when crossing a line special or pressing use on a sector triggered by one)
-map [mapname]           | Changes the map (health/inventory are reset)
-exitlevel               | Exits to the next level (health/inventory are preserved)
-exitlevelsecret         | Exits to the next level, using the secret exit if one exists
-bind [key] [command]    | Sets a keybind, replacing any existing for the key
-bindadd [key] [command] | Adds an additional keybind for a key
-unbind [key]            | Removes keybinds for a key
-listmaps                | Lists available maps
-printmap                | Prints the current map name
-printgame               | Prints the current game/WAD name
+Command                         | Description
+--------------------------------|------------
+[option] [value]                | Changes a config option (e.g. hud.showfps 1)
+[option]                        | Prints the value of a config option
+toggle [option] [val1] [...]    | Cycles a config option through a list of values (e.g. toggle audio.musicvolume 1 0.5 0)
+chasecam                        | Toggles a 3rd person camera and pauses the game
+fly                             | Toggles fly mode
+god                             | Toggles god mode
+noclip                          | Toggles noclip mode
+findexits                       | Highlights exits on the automap
+findkeys                        | Highlights keys on the automap
+findkeylines                    | Highlights key lines on the automap
+marksecrets                     | Toggles secret highlighting on the automap
+markspecials                    | Toggles ingame and automap highlighting of specials (shown when crossing a line special or pressing use on a sector triggered by one)
+map [mapname]                   | Changes the map (health/inventory are reset)
+exitlevel                       | Exits to the next level (health/inventory are preserved)
+exitlevelsecret                 | Exits to the next level, using the secret exit if one exists
+bind [key] [command]            | Sets a keybind, replacing any existing for the key
+bindadd [key] [command]         | Adds an additional keybind for a key
+unbind [key]                    | Removes keybinds for a key
+listmaps                        | Lists available maps
+printmap                        | Prints the current map name
+printgame                       | Prints the current game/WAD name
 
 # Common issues
 

--- a/Client/Client.Commands.Toggle.cs
+++ b/Client/Client.Commands.Toggle.cs
@@ -1,12 +1,60 @@
-﻿using Helion.Util.Consoles.Commands;
+﻿using Helion.Util.Configs.Components;
+using Helion.Util.Configs.Values;
+using Helion.Util.Consoles.Commands;
 using Helion.Util.Consoles;
 using Helion.Util.Loggers;
 using Helion.Util;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Helion.Client;
 
 public partial class Client
 {
+    /// <summary>
+    /// Cycles a config setting's value through the provided values (optional if boolean).
+    /// If the current value is not in the list, the first one is used.
+    /// </summary>
+    [ConsoleCommand("toggle", "Toggles a config setting")]
+    private void Toggle(ConsoleCommandEventArgs args)
+    {
+        string? configKey = args.Args.FirstOrDefault();
+        if (configKey == null)
+        {
+            HelionLog.Error("Config setting not provided");
+            return;
+        }
+        if (!m_config.TryGetComponent(configKey, out ConfigComponent? component))
+        {
+            HelionLog.Error($"Config setting {configKey} not found");
+            return;
+        }
+
+        // if boolean, allow toggling without providing values
+        if (args.Args.Count == 1)
+        {
+            if (component.Value is ConfigValue<bool> boolConfigVal)
+                TryHandleConfigVariableCommand(new ConsoleCommandEventArgs($"{configKey} {!boolConfigVal.Value}"));
+            else
+                HelionLog.Error($"Must provide values for {configKey}, since it is not a True/False config setting");
+        }
+        else
+        {
+            List<object> parsedValues = [];
+            foreach (string arg in args.Args[1..])
+            {
+                if (!component.Value.TryConvert(arg, out object? parsedVal) || parsedVal == null)
+                {
+                    HelionLog.Error($"Invalid value '{arg}' provided for {configKey}");
+                    return;
+                }
+                parsedValues.Add(parsedVal);
+            }
+            int nextIndex = (parsedValues.IndexOf(component.Value.ObjectValue) + 1) % parsedValues.Count;
+            TryHandleConfigVariableCommand(new ConsoleCommandEventArgs($"{configKey} {parsedValues[nextIndex]}"));
+        }
+    }
+
     [ConsoleCommand("mouselook", "Toggle mouselook")]
     private void ToggleMouselook(ConsoleCommandEventArgs args)
     {

--- a/Core/Util/Configs/Values/ConfigValue.cs
+++ b/Core/Util/Configs/Values/ConfigValue.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Helion.Util.Extensions;
 using static Helion.Util.Assertion.Assert;
 using static Helion.Util.Configs.Values.ConfigConverters;
@@ -89,26 +90,9 @@ public class ConfigValue<T> : IConfigValue where T : notnull
 
     public ConfigSetResult Set(object newValue, bool writeToConfig = true)
     {
-        try
-        {
-            if (typeof(T) == newValue.GetType())
-            {
-                return Set((T)newValue, writeToConfig);
-            }
-
-            if (typeof(T) == typeof(bool) && newValue is string str && str.Length == 1 && str[0] == '*')
-            {
-                bool value = Convert.ToBoolean(Value);
-                return Set(!value, writeToConfig);
-            }
-
-            T converted = ObjectToTypeConverterOrThrow(newValue);
-            return Set(converted, writeToConfig);
-        }
-        catch
-        {
-            return ConfigSetResult.NotSetByBadConversion;
-        }
+        return TryConvert(newValue, out T? convertedValue)
+            ? Set(convertedValue, writeToConfig)
+            : ConfigSetResult.NotSetByBadConversion;
     }
 
     public ConfigSetResult Set(T newValue, bool writeToConfig = true)
@@ -125,6 +109,39 @@ public class ConfigValue<T> : IConfigValue where T : notnull
             HasTemporaryValue = true;
         }
         return result;
+    }
+
+    public bool TryConvert(object value, [NotNullWhen(true)] out object? converted)
+    {
+        try
+        {
+            if (typeof(T) == value.GetType())
+            {
+                converted = value;
+                return true;
+            }
+
+            if (typeof(T) == typeof(bool) && value is string str && str == "*")
+            {
+                converted = !Convert.ToBoolean(Value);
+                return true;
+            }
+
+            converted = ObjectToTypeConverterOrThrow(value);
+            return true;
+        }
+        catch
+        {
+            converted = null;
+            return false;
+        }
+    }
+
+    public bool TryConvert(object value, [NotNullWhen(true)] out T? converted)
+    {
+        bool successful = TryConvert(value, out object? convertedObj);
+        converted = (T?)convertedObj;
+        return successful;
     }
 
     public void ResetToUserValue()
@@ -184,7 +201,7 @@ public class ConfigValue<T> : IConfigValue where T : notnull
     }
 
     public IConfigValue Clone()
-    {        
+    {
         return new ConfigValue<T>(Value, m_filter!);
     }
 }

--- a/Core/Util/Configs/Values/IConfigValue.cs
+++ b/Core/Util/Configs/Values/IConfigValue.cs
@@ -58,6 +58,11 @@ public interface IConfigValue
     ConfigSetResult Set(object newValue, bool writeToConfig = true);
 
     /// <summary>
+    /// Attempts to parse a new value without setting it.
+    /// </summary>
+    bool TryConvert(object value, out object? converted);
+
+    /// <summary>
     /// Applies the queued changes, if any.
     /// </summary>
     /// <param name="flagType">The mask which must be present. This requires all


### PR DESCRIPTION
Cycles a config setting's value through the provided values (optional if boolean). If the current value is not in the list, the first one is used. There are already some specific toggle ccmds but I wanted to add something more general.

Examples:
`toggle hud.showfps`
`toggle audio.musicvolume 1 0`
`toggle audio.musicvolume 1 0.5 0`

Invalid usages:
`toggle audio.musicvolume`
> Must provide values for audio.musicvolume, since it is not a True/False config setting

`toggle audio.musicvolume a b`
> Invalid value 'a' provided for audio.musicvolume