### PR TITLE
Clamp extended ranges of lines for pixel gap correction

### DIFF
--- a/Core/Render/Common/Shared/World/WorldTriangulator.cs
+++ b/Core/Render/Common/Shared/World/WorldTriangulator.cs
@@ -324,7 +324,8 @@ public static class WorldTriangulator
         var visibleBottomZ = (clipPlanes & SectorPlanes.Floor) == 0 ? bottomZ : Math.Max(bottomZ, opening.MinBottomZ);
         var visiblePrevBottomZ = (clipPlanes & SectorPlanes.Floor) == 0 ? prevBottomZ : Math.Max(prevBottomZ, prevOpening.MinBottomZ);
 
-        return new(bottomZ, topZ, visibleBottomZ, visibleTopZ, prevBottomZ, prevTopZ, visiblePrevBottomZ, visiblePrevTopZ);
+        return new(bottomZ - WorldStatic.LineVertexGap, topZ + WorldStatic.LineVertexGap, visibleBottomZ - WorldStatic.LineVertexGap, visibleTopZ + WorldStatic.LineVertexGap, 
+            prevBottomZ - WorldStatic.LineVertexGap, prevTopZ + WorldStatic.LineVertexGap, visiblePrevBottomZ - WorldStatic.LineVertexGap, visiblePrevTopZ + WorldStatic.LineVertexGap);
     }
 
     public static WallUV CalculateOneSidedWallUV(Line line, Side side, double length,
@@ -417,7 +418,7 @@ public static class WorldTriangulator
         if (side.Flags.WrapMidTex)
             return CalculateOneSidedWallUV(side.Line, side, length, textureUVInverse, visibleTopZ - visibleBottomZ, previous);
 
-        var offsetU = (side.Offset.X + side.Middle.Offset.X) * textureUVInverse.X / side.Middle.Scale.X;
+        var offsetU = (side.Offset.X + side.Middle.Offset.X) * textureUVInverse.X / side.Middle.Scale.X + (WorldStatic.LineVertexOffset * textureUVInverse.X);
         if (side.ScrollData != null)
         {
             if (previous)

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/CoverWallUtil.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/CoverWallUtil.cs
@@ -28,12 +28,13 @@ public class CoverWallUtil
             v->PrevZ += heights.Add;
             v++;
 
-            v->Z += heights.Add;
-            v->PrevZ += heights.Add;
-            v++;
 
             v->Z -= heights.Sub;
             v->PrevZ -= heights.Sub;
+            v++;
+
+            v->Z += heights.Add;
+            v->PrevZ += heights.Add;
             v++;
 
             v->Z -= heights.Sub;
@@ -86,10 +87,10 @@ public class CoverWallUtil
             staticVertices[index++] = new StaticVertex(v->X, v->Y, v->Z + heights.Add, v->U, v->V,
                 v->Options, v->LightLevelAdd, 0);
             v++;
-            staticVertices[index++] = new StaticVertex(v->X, v->Y, v->Z + heights.Add, v->U, v->V,
+            staticVertices[index++] = new StaticVertex(v->X, v->Y, v->Z - heights.Sub, v->U, v->V,
                 v->Options, v->LightLevelAdd, 0);
             v++;
-            staticVertices[index++] = new StaticVertex(v->X, v->Y, v->Z - heights.Sub, v->U, v->V,
+            staticVertices[index++] = new StaticVertex(v->X, v->Y, v->Z + heights.Add, v->U, v->V,
                 v->Options, v->LightLevelAdd, 0);
             v++;
             staticVertices[index++] = new StaticVertex(v->X, v->Y, v->Z - heights.Sub, v->U, v->V,

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
@@ -99,8 +99,9 @@ public class GeometryRenderer : IDisposable
         m_archiveCollection = archiveCollection;
         m_staticCacheGeometryRenderer = new(archiveCollection, glTextureManager, staticProgram, this);
 
+        var options = VertexOptions.World(1, 1, 1, 0, 0);
         for (int i = 0; i < m_wallVertices.Length; i++)
-            m_wallVertices[i].Options = VertexOptions.World(1, 0, 0);
+            m_wallVertices[i].Options = options;
 
         m_world = null!;
     }
@@ -1537,7 +1538,6 @@ public class GeometryRenderer : IDisposable
     private static unsafe void SetWallVertices(DynamicVertex[] data, in WallVertices wv, float lightLevelAdd, int lightBufferIndex, int colorMapIndex, byte wallLightLevel,
         float alpha = 1.0f, float addAlpha = 1.0f)
     {
-        var options = VertexOptions.World(alpha, addAlpha, lightBufferIndex);
         colorMapIndex = VertexOptions.ColorMapIndex(colorMapIndex, wallLightLevel);
         fixed (DynamicVertex* startVertex = &data[0])
         {
@@ -1552,7 +1552,7 @@ public class GeometryRenderer : IDisposable
             vertex->V = wv.TopLeft.V;
             vertex->PrevU = wv.TopLeft.PrevU;
             vertex->PrevV = wv.TopLeft.PrevV;
-            vertex->Options = options;
+            vertex->Options = VertexOptions.World(1, 1, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
 
@@ -1567,7 +1567,7 @@ public class GeometryRenderer : IDisposable
             vertex->V = wv.BottomRight.V;
             vertex->PrevU = wv.TopLeft.PrevU;
             vertex->PrevV = wv.BottomRight.PrevV;
-            vertex->Options = options;
+            vertex->Options = VertexOptions.World(0, 1, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
 
@@ -1582,7 +1582,7 @@ public class GeometryRenderer : IDisposable
             vertex->V = wv.TopLeft.V;
             vertex->PrevU = wv.BottomRight.PrevU;
             vertex->PrevV = wv.TopLeft.PrevV;
-            vertex->Options = options;
+            vertex->Options = VertexOptions.World(1, 0, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
 
@@ -1597,7 +1597,7 @@ public class GeometryRenderer : IDisposable
             vertex->V = wv.TopLeft.V;
             vertex->PrevU = wv.BottomRight.PrevU;
             vertex->PrevV = wv.TopLeft.PrevV;
-            vertex->Options = options;
+            vertex->Options = VertexOptions.World(1, 0, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
 
@@ -1612,7 +1612,7 @@ public class GeometryRenderer : IDisposable
             vertex->V = wv.BottomRight.V;
             vertex->PrevU = wv.TopLeft.PrevU;
             vertex->PrevV = wv.BottomRight.PrevV;
-            vertex->Options = options;
+            vertex->Options = VertexOptions.World(0, 1, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
 
@@ -1627,7 +1627,7 @@ public class GeometryRenderer : IDisposable
             vertex->V = wv.BottomRight.V;
             vertex->PrevU = wv.BottomRight.PrevU;
             vertex->PrevV = wv.BottomRight.PrevV;
-            vertex->Options = options;
+            vertex->Options = VertexOptions.World(0, 0, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
         }
@@ -1636,7 +1636,6 @@ public class GeometryRenderer : IDisposable
     private static unsafe DynamicVertex[] GetWallVertices(in WallVertices wv, float lightLevelAdd, int lightBufferIndex, int colorMapIndex, byte wallLightLevel,
         float alpha = 1.0f, float addAlpha = 1.0f)
     {
-        var options = VertexOptions.World(alpha, addAlpha, lightBufferIndex);
         colorMapIndex = VertexOptions.ColorMapIndex(colorMapIndex, wallLightLevel);
         var data = WorldStatic.DataCache.GetWallVertices();
         fixed (DynamicVertex* startVertex = &data[0])
@@ -1648,6 +1647,8 @@ public class GeometryRenderer : IDisposable
             //    |/  /|
             //    1  / |
             //      4--5
+
+            // 0
             vertex->X = wv.TopLeft.X;
             vertex->Y = wv.TopLeft.Y;
             vertex->Z = wv.TopLeft.Z;
@@ -1658,55 +1659,11 @@ public class GeometryRenderer : IDisposable
             vertex->V = wv.TopLeft.V;
             vertex->PrevU = wv.TopLeft.PrevU;
             vertex->PrevV = wv.TopLeft.PrevV;
-            vertex->Options = options;
+            vertex->Options = VertexOptions.World(1, 1, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
 
-            vertex++;
-            vertex->X = wv.TopLeft.X;
-            vertex->Y = wv.TopLeft.Y;
-            vertex->Z = wv.BottomRight.Z;
-            vertex->PrevX = wv.TopLeft.X;
-            vertex->PrevY = wv.TopLeft.Y;
-            vertex->PrevZ = wv.PrevBottomZ;
-            vertex->U = wv.TopLeft.U;
-            vertex->V = wv.BottomRight.V;
-            vertex->PrevU = wv.TopLeft.PrevU;
-            vertex->PrevV = wv.BottomRight.PrevV;
-            vertex->Options = options;
-            vertex->LightLevelAdd = lightLevelAdd;
-            vertex->ColorMapIndex = colorMapIndex;
-
-            vertex++;
-            vertex->X = wv.BottomRight.X;
-            vertex->Y = wv.BottomRight.Y;
-            vertex->Z = wv.TopLeft.Z;
-            vertex->PrevX = wv.BottomRight.X;
-            vertex->PrevY = wv.BottomRight.Y;
-            vertex->PrevZ = wv.PrevTopZ;
-            vertex->U = wv.BottomRight.U;
-            vertex->V = wv.TopLeft.V;
-            vertex->PrevU = wv.BottomRight.PrevU;
-            vertex->PrevV = wv.TopLeft.PrevV;
-            vertex->Options = options;
-            vertex->LightLevelAdd = lightLevelAdd;
-            vertex->ColorMapIndex = colorMapIndex;
-
-            vertex++;
-            vertex->X = wv.BottomRight.X;
-            vertex->Y = wv.BottomRight.Y;
-            vertex->Z = wv.TopLeft.Z;
-            vertex->PrevX = wv.BottomRight.X;
-            vertex->PrevY = wv.BottomRight.Y;
-            vertex->PrevZ = wv.PrevTopZ;
-            vertex->U = wv.BottomRight.U;
-            vertex->V = wv.TopLeft.V;
-            vertex->PrevU = wv.BottomRight.PrevU;
-            vertex->PrevV = wv.TopLeft.PrevV;
-            vertex->Options = options;
-            vertex->LightLevelAdd = lightLevelAdd;
-            vertex->ColorMapIndex = colorMapIndex;
-
+            // 1
             vertex++;
             vertex->X = wv.TopLeft.X;
             vertex->Y = wv.TopLeft.Y;
@@ -1718,10 +1675,59 @@ public class GeometryRenderer : IDisposable
             vertex->V = wv.BottomRight.V;
             vertex->PrevU = wv.TopLeft.PrevU;
             vertex->PrevV = wv.BottomRight.PrevV;
-            vertex->Options = options;
+            vertex->Options = VertexOptions.World(0, 1, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
 
+            // 2
+            vertex++;
+            vertex->X = wv.BottomRight.X;
+            vertex->Y = wv.BottomRight.Y;
+            vertex->Z = wv.TopLeft.Z;
+            vertex->PrevX = wv.BottomRight.X;
+            vertex->PrevY = wv.BottomRight.Y;
+            vertex->PrevZ = wv.PrevTopZ;
+            vertex->U = wv.BottomRight.U; 
+            vertex->V = wv.TopLeft.V;
+            vertex->PrevU = wv.BottomRight.PrevU;
+            vertex->PrevV = wv.TopLeft.PrevV;
+            vertex->Options = VertexOptions.World(1, 0, alpha, addAlpha, lightBufferIndex);
+            vertex->LightLevelAdd = lightLevelAdd;
+            vertex->ColorMapIndex = colorMapIndex;
+
+            // 3
+            vertex++;
+            vertex->X = wv.BottomRight.X;
+            vertex->Y = wv.BottomRight.Y;
+            vertex->Z = wv.TopLeft.Z;
+            vertex->PrevX = wv.BottomRight.X;
+            vertex->PrevY = wv.BottomRight.Y;
+            vertex->PrevZ = wv.PrevTopZ;
+            vertex->U = wv.BottomRight.U;
+            vertex->V = wv.TopLeft.V;
+            vertex->PrevU = wv.BottomRight.PrevU;
+            vertex->PrevV = wv.TopLeft.PrevV;
+            vertex->Options = VertexOptions.World(1, 0, alpha, addAlpha, lightBufferIndex);
+            vertex->LightLevelAdd = lightLevelAdd;
+            vertex->ColorMapIndex = colorMapIndex;
+
+            // 4
+            vertex++;
+            vertex->X = wv.TopLeft.X;
+            vertex->Y = wv.TopLeft.Y;
+            vertex->Z = wv.BottomRight.Z;
+            vertex->PrevX = wv.TopLeft.X;
+            vertex->PrevY = wv.TopLeft.Y;
+            vertex->PrevZ = wv.PrevBottomZ;
+            vertex->U = wv.TopLeft.U;
+            vertex->V = wv.BottomRight.V;
+            vertex->PrevU = wv.TopLeft.PrevU;
+            vertex->PrevV = wv.BottomRight.PrevV;
+            vertex->Options = VertexOptions.World(0, 1, alpha, addAlpha, lightBufferIndex);
+            vertex->LightLevelAdd = lightLevelAdd;
+            vertex->ColorMapIndex = colorMapIndex;
+
+            // 5
             vertex++;
             vertex->X = wv.BottomRight.X;
             vertex->Y = wv.BottomRight.Y;
@@ -1733,7 +1739,7 @@ public class GeometryRenderer : IDisposable
             vertex->V = wv.BottomRight.V;
             vertex->PrevU = wv.BottomRight.PrevU;
             vertex->PrevV = wv.BottomRight.PrevV;
-            vertex->Options = options;
+            vertex->Options = VertexOptions.World(0, 0, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
         }
@@ -1744,7 +1750,7 @@ public class GeometryRenderer : IDisposable
     private static unsafe void GetFlatVertices(DynamicVertex[] vertices, int startIndex, ref TriangulatedWorldVertex root, ref TriangulatedWorldVertex second, ref TriangulatedWorldVertex third,
         int lightLevelBufferIndex, int colorMapIndex, int flatLightLevel)
     {
-        var options = VertexOptions.World(1, 1, lightLevelBufferIndex);
+        var options = VertexOptions.World(0, 0, 1, 1, lightLevelBufferIndex);
         colorMapIndex = VertexOptions.ColorMapIndex(colorMapIndex, flatLightLevel);
         fixed (DynamicVertex* startVertex = &vertices[startIndex])
         {

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
@@ -61,6 +61,7 @@ public class GeometryRenderer : IDisposable
     private RenderContrastMode m_contrastMode;
     private bool m_vanillaRender;
     private bool m_renderCoverOnly;
+    private bool m_pixelGapCorrection;
     private GeometryRenderMode m_renderMode;
     private bool m_buffer = true;
     private Vec3D m_viewPosition;
@@ -131,6 +132,7 @@ public class GeometryRenderer : IDisposable
             m_skyRenderer.Reset();
 
         m_vanillaRender = world.Config.Render.VanillaRender;
+        m_pixelGapCorrection = world.Config.Render.PixelGapCorrection;
 
         PreloadAllTextures(world);
 
@@ -1112,7 +1114,8 @@ public class GeometryRenderer : IDisposable
         Wall middleWall = facingSide.Middle;
         GLLegacyTexture texture = m_glTextureManager.GetTexture(middleWall.TextureHandle, repeatY: facingSide.Flags.WrapMidTex);
 
-        float alpha = m_config.Render.TextureTransparency ? Math.Clamp(facingSide.Line.Alpha, 0, 1) : 1.0f;
+        var line = facingSide.Line;
+        float alpha = m_config.Render.TextureTransparency ? Math.Clamp(line.Alpha, 0, 1) : 1.0f;
         DynamicVertex[]? data = m_vertexLookup[facingSide.Id];
         var geometryType = alpha < 1 ? GeometryType.AlphaWall : GeometryType.TwoSidedMiddleWall;
 
@@ -1121,10 +1124,10 @@ public class GeometryRenderer : IDisposable
         if (facingSide.OffsetChanged || m_sectorChangedLine || data == null)
         {
             // Push forward to cover flood fill side and prevent z-fighting (ex Doom2 MAP25 bloodfall)
-            var segSave = facingSide.Line.Segment;
+            var segSave = line.Segment;
             // Don't push with flood plane. This is different from flood fill side and are already pushed.
             if (!facingSector.Flood)
-                PushSeg(facingSide.Line, facingSide, PushDir.Forward);
+                PushSeg(line, facingSide, PushDir.Forward);
 
             var opening = GetMidTexOpening(TextureManager, facingSide, facingSector, otherSector, false);
             var prevOpening = GetMidTexOpening(TextureManager, facingSide, facingSector, otherSector, true);
@@ -1136,6 +1139,16 @@ public class GeometryRenderer : IDisposable
 
             int colorMapIndex = Renderer.GetColorMapBufferIndex(facingSector, LightBufferType.Wall);
             int lightIndex = Renderer.GetLightBufferIndex(facingSide, facingSide.Middle, facingSector);
+            
+            // Restore the original position for alpha walls. Touching walls look bad with the overlap and it's not necessary.
+            if (m_pixelGapCorrection && alpha < 1)
+            {
+                var unit = Vec2D.UnitCircle(line.Segment.Start.Angle(line.Segment.End));
+                var push = unit * WorldStatic.LineVertexGap;
+                line.Segment.Start += push;
+                line.Segment.End -= push;
+            }
+
             WallVertices wall = default;
             WorldTriangulator.HandleTwoSidedMiddle(facingSide,
                 texture.Dimension, texture.UVInverse, opening, prevOpening, isFrontSide, ref wall, out _, offset, prevOffset, 
@@ -1147,7 +1160,7 @@ public class GeometryRenderer : IDisposable
                 SetWallVertices(data, wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Middle), alpha, addAlpha: 0);
 
             m_vertexLookup[facingSide.Id] = data;
-            facingSide.Line.Segment = segSave;
+            line.Segment = segSave;
         }
 
         // See RenderOneSided() for an ASCII image of why we do this.
@@ -1643,10 +1656,10 @@ public class GeometryRenderer : IDisposable
             DynamicVertex* vertex = startVertex;
             // Our triangle is added like:
             //    0--2
-            //    | /  3
+            //    | /  4
             //    |/  /|
             //    1  / |
-            //      4--5
+            //      5--3
 
             // 0
             vertex->X = wv.TopLeft.X;
@@ -1695,8 +1708,7 @@ public class GeometryRenderer : IDisposable
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
 
-
-            // 5
+            // 3
             vertex++;
             vertex->X = wv.BottomRight.X;
             vertex->Y = wv.BottomRight.Y;
@@ -1712,7 +1724,7 @@ public class GeometryRenderer : IDisposable
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
 
-            // 3
+            // 4
             vertex++;
             vertex->X = wv.BottomRight.X;
             vertex->Y = wv.BottomRight.Y;
@@ -1728,7 +1740,7 @@ public class GeometryRenderer : IDisposable
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
 
-            // 4
+            // 5
             vertex++;
             vertex->X = wv.TopLeft.X;
             vertex->Y = wv.TopLeft.Y;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
@@ -1589,6 +1589,21 @@ public class GeometryRenderer : IDisposable
             vertex++;
             vertex->X = wv.BottomRight.X;
             vertex->Y = wv.BottomRight.Y;
+            vertex->Z = wv.BottomRight.Z;
+            vertex->PrevX = wv.BottomRight.X;
+            vertex->PrevY = wv.BottomRight.Y;
+            vertex->PrevZ = wv.PrevBottomZ;
+            vertex->U = wv.BottomRight.U;
+            vertex->V = wv.BottomRight.V;
+            vertex->PrevU = wv.BottomRight.PrevU;
+            vertex->PrevV = wv.BottomRight.PrevV;
+            vertex->Options = VertexOptions.World(0, 0, alpha, addAlpha, lightBufferIndex);
+            vertex->LightLevelAdd = lightLevelAdd;
+            vertex->ColorMapIndex = colorMapIndex;
+
+            vertex++;
+            vertex->X = wv.BottomRight.X;
+            vertex->Y = wv.BottomRight.Y;
             vertex->Z = wv.TopLeft.Z;
             vertex->PrevX = wv.BottomRight.X;
             vertex->PrevY = wv.BottomRight.Y;
@@ -1613,21 +1628,6 @@ public class GeometryRenderer : IDisposable
             vertex->PrevU = wv.TopLeft.PrevU;
             vertex->PrevV = wv.BottomRight.PrevV;
             vertex->Options = VertexOptions.World(0, 1, alpha, addAlpha, lightBufferIndex);
-            vertex->LightLevelAdd = lightLevelAdd;
-            vertex->ColorMapIndex = colorMapIndex;
-
-            vertex++;
-            vertex->X = wv.BottomRight.X;
-            vertex->Y = wv.BottomRight.Y;
-            vertex->Z = wv.BottomRight.Z;
-            vertex->PrevX = wv.BottomRight.X;
-            vertex->PrevY = wv.BottomRight.Y;
-            vertex->PrevZ = wv.PrevBottomZ;
-            vertex->U = wv.BottomRight.U;
-            vertex->V = wv.BottomRight.V;
-            vertex->PrevU = wv.BottomRight.PrevU;
-            vertex->PrevV = wv.BottomRight.PrevV;
-            vertex->Options = VertexOptions.World(0, 0, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
         }
@@ -1695,6 +1695,23 @@ public class GeometryRenderer : IDisposable
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
 
+
+            // 5
+            vertex++;
+            vertex->X = wv.BottomRight.X;
+            vertex->Y = wv.BottomRight.Y;
+            vertex->Z = wv.BottomRight.Z;
+            vertex->PrevX = wv.BottomRight.X;
+            vertex->PrevY = wv.BottomRight.Y;
+            vertex->PrevZ = wv.PrevBottomZ;
+            vertex->U = wv.BottomRight.U;
+            vertex->V = wv.BottomRight.V;
+            vertex->PrevU = wv.BottomRight.PrevU;
+            vertex->PrevV = wv.BottomRight.PrevV;
+            vertex->Options = VertexOptions.World(0, 0, alpha, addAlpha, lightBufferIndex);
+            vertex->LightLevelAdd = lightLevelAdd;
+            vertex->ColorMapIndex = colorMapIndex;
+
             // 3
             vertex++;
             vertex->X = wv.BottomRight.X;
@@ -1724,22 +1741,6 @@ public class GeometryRenderer : IDisposable
             vertex->PrevU = wv.TopLeft.PrevU;
             vertex->PrevV = wv.BottomRight.PrevV;
             vertex->Options = VertexOptions.World(0, 1, alpha, addAlpha, lightBufferIndex);
-            vertex->LightLevelAdd = lightLevelAdd;
-            vertex->ColorMapIndex = colorMapIndex;
-
-            // 5
-            vertex++;
-            vertex->X = wv.BottomRight.X;
-            vertex->Y = wv.BottomRight.Y;
-            vertex->Z = wv.BottomRight.Z;
-            vertex->PrevX = wv.BottomRight.X;
-            vertex->PrevY = wv.BottomRight.Y;
-            vertex->PrevZ = wv.PrevBottomZ;
-            vertex->U = wv.BottomRight.U;
-            vertex->V = wv.BottomRight.V;
-            vertex->PrevU = wv.BottomRight.PrevU;
-            vertex->PrevV = wv.BottomRight.PrevV;
-            vertex->Options = VertexOptions.World(0, 0, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
         }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
@@ -115,7 +115,7 @@ public class GeometryRenderer : IDisposable
     public static void PushSeg(Line line, Side facingSide, PushDir dir)
     {
         // Push it out to prevent potential z-fighting. Default pushes out from the sector.
-        var angle = facingSide == line.Front ? line.Segment.Start.Angle(line.Segment.End) : line.Segment.End.Angle(line.Segment.Start);
+        var angle = facingSide == line.Front ? line.GetAngle() : line.GetAngle() + MathHelper.Pi;
         if (dir == PushDir.Forward)
             angle += MathHelper.Pi;
 
@@ -1143,7 +1143,7 @@ public class GeometryRenderer : IDisposable
             // Restore the original position for alpha walls. Touching walls look bad with the overlap and it's not necessary.
             if (m_pixelGapCorrection && alpha < 1)
             {
-                var unit = Vec2D.UnitCircle(line.Segment.Start.Angle(line.Segment.End));
+                var unit = Vec2D.UnitCircle(line.GetAngle());
                 var push = unit * WorldStatic.LineVertexGap;
                 line.Segment.Start += push;
                 line.Segment.End -= push;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
@@ -1112,7 +1112,7 @@ public class GeometryRenderer : IDisposable
         Wall middleWall = facingSide.Middle;
         GLLegacyTexture texture = m_glTextureManager.GetTexture(middleWall.TextureHandle, repeatY: facingSide.Flags.WrapMidTex);
 
-        float alpha = m_config.Render.TextureTransparency ? facingSide.Line.Alpha : 1.0f;
+        float alpha = m_config.Render.TextureTransparency ? Math.Clamp(facingSide.Line.Alpha, 0, 1) : 1.0f;
         DynamicVertex[]? data = m_vertexLookup[facingSide.Id];
         var geometryType = alpha < 1 ? GeometryType.AlphaWall : GeometryType.TwoSidedMiddleWall;
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
@@ -99,7 +99,7 @@ public class GeometryRenderer : IDisposable
         m_archiveCollection = archiveCollection;
         m_staticCacheGeometryRenderer = new(archiveCollection, glTextureManager, staticProgram, this);
 
-        var options = VertexOptions.World(1, 1, 1, 0, 0);
+        var options = VertexOptions.World(1, 1, 0, 0);
         for (int i = 0; i < m_wallVertices.Length; i++)
             m_wallVertices[i].Options = options;
 
@@ -1552,7 +1552,7 @@ public class GeometryRenderer : IDisposable
             vertex->V = wv.TopLeft.V;
             vertex->PrevU = wv.TopLeft.PrevU;
             vertex->PrevV = wv.TopLeft.PrevV;
-            vertex->Options = VertexOptions.World(1, 1, alpha, addAlpha, lightBufferIndex);
+            vertex->Options = VertexOptions.World(1, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
 
@@ -1567,7 +1567,7 @@ public class GeometryRenderer : IDisposable
             vertex->V = wv.BottomRight.V;
             vertex->PrevU = wv.TopLeft.PrevU;
             vertex->PrevV = wv.BottomRight.PrevV;
-            vertex->Options = VertexOptions.World(0, 1, alpha, addAlpha, lightBufferIndex);
+            vertex->Options = VertexOptions.World(1, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
 
@@ -1582,7 +1582,7 @@ public class GeometryRenderer : IDisposable
             vertex->V = wv.TopLeft.V;
             vertex->PrevU = wv.BottomRight.PrevU;
             vertex->PrevV = wv.TopLeft.PrevV;
-            vertex->Options = VertexOptions.World(1, 0, alpha, addAlpha, lightBufferIndex);
+            vertex->Options = VertexOptions.World(1, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
 
@@ -1597,7 +1597,7 @@ public class GeometryRenderer : IDisposable
             vertex->V = wv.BottomRight.V;
             vertex->PrevU = wv.BottomRight.PrevU;
             vertex->PrevV = wv.BottomRight.PrevV;
-            vertex->Options = VertexOptions.World(0, 0, alpha, addAlpha, lightBufferIndex);
+            vertex->Options = VertexOptions.World(0, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
 
@@ -1612,7 +1612,7 @@ public class GeometryRenderer : IDisposable
             vertex->V = wv.TopLeft.V;
             vertex->PrevU = wv.BottomRight.PrevU;
             vertex->PrevV = wv.TopLeft.PrevV;
-            vertex->Options = VertexOptions.World(1, 0, alpha, addAlpha, lightBufferIndex);
+            vertex->Options = VertexOptions.World(0, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
 
@@ -1627,7 +1627,7 @@ public class GeometryRenderer : IDisposable
             vertex->V = wv.BottomRight.V;
             vertex->PrevU = wv.TopLeft.PrevU;
             vertex->PrevV = wv.BottomRight.PrevV;
-            vertex->Options = VertexOptions.World(0, 1, alpha, addAlpha, lightBufferIndex);
+            vertex->Options = VertexOptions.World(0, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
         }
@@ -1659,7 +1659,7 @@ public class GeometryRenderer : IDisposable
             vertex->V = wv.TopLeft.V;
             vertex->PrevU = wv.TopLeft.PrevU;
             vertex->PrevV = wv.TopLeft.PrevV;
-            vertex->Options = VertexOptions.World(1, 1, alpha, addAlpha, lightBufferIndex);
+            vertex->Options = VertexOptions.World(1, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
 
@@ -1675,7 +1675,7 @@ public class GeometryRenderer : IDisposable
             vertex->V = wv.BottomRight.V;
             vertex->PrevU = wv.TopLeft.PrevU;
             vertex->PrevV = wv.BottomRight.PrevV;
-            vertex->Options = VertexOptions.World(0, 1, alpha, addAlpha, lightBufferIndex);
+            vertex->Options = VertexOptions.World(1, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
 
@@ -1691,7 +1691,7 @@ public class GeometryRenderer : IDisposable
             vertex->V = wv.TopLeft.V;
             vertex->PrevU = wv.BottomRight.PrevU;
             vertex->PrevV = wv.TopLeft.PrevV;
-            vertex->Options = VertexOptions.World(1, 0, alpha, addAlpha, lightBufferIndex);
+            vertex->Options = VertexOptions.World(1, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
 
@@ -1708,7 +1708,7 @@ public class GeometryRenderer : IDisposable
             vertex->V = wv.BottomRight.V;
             vertex->PrevU = wv.BottomRight.PrevU;
             vertex->PrevV = wv.BottomRight.PrevV;
-            vertex->Options = VertexOptions.World(0, 0, alpha, addAlpha, lightBufferIndex);
+            vertex->Options = VertexOptions.World(0, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
 
@@ -1724,7 +1724,7 @@ public class GeometryRenderer : IDisposable
             vertex->V = wv.TopLeft.V;
             vertex->PrevU = wv.BottomRight.PrevU;
             vertex->PrevV = wv.TopLeft.PrevV;
-            vertex->Options = VertexOptions.World(1, 0, alpha, addAlpha, lightBufferIndex);
+            vertex->Options = VertexOptions.World(0, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
 
@@ -1740,7 +1740,7 @@ public class GeometryRenderer : IDisposable
             vertex->V = wv.BottomRight.V;
             vertex->PrevU = wv.TopLeft.PrevU;
             vertex->PrevV = wv.BottomRight.PrevV;
-            vertex->Options = VertexOptions.World(0, 1, alpha, addAlpha, lightBufferIndex);
+            vertex->Options = VertexOptions.World(0, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
         }
@@ -1751,7 +1751,7 @@ public class GeometryRenderer : IDisposable
     private static unsafe void GetFlatVertices(DynamicVertex[] vertices, int startIndex, ref TriangulatedWorldVertex root, ref TriangulatedWorldVertex second, ref TriangulatedWorldVertex third,
         int lightLevelBufferIndex, int colorMapIndex, int flatLightLevel)
     {
-        var options = VertexOptions.World(0, 0, 1, 1, lightLevelBufferIndex);
+        var options = VertexOptions.World(0, 1, 1, lightLevelBufferIndex);
         colorMapIndex = VertexOptions.ColorMapIndex(colorMapIndex, flatLightLevel);
         fixed (DynamicVertex* startVertex = &vertices[startIndex])
         {

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/PortalRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/PortalRenderer.cs
@@ -240,18 +240,6 @@ public class PortalRenderer : IDisposable
         return result;
     }
 
-    private static void PushSeg(Line line, Side facingSide, PushDir dir, double amount)
-    {
-        // Push it out to prevent potential z-fighting. Default pushes out from the sector.
-        var angle = facingSide == line.Front ? line.Segment.Start.Angle(line.Segment.End) : line.Segment.End.Angle(line.Segment.Start);
-        if (dir == PushDir.Forward)
-            angle += MathHelper.Pi;
-
-        var pushUnit = Vec2D.UnitCircle(angle + MathHelper.HalfPi) * amount;
-        line.Segment.Start += pushUnit;
-        line.Segment.End += pushUnit;
-    }
-
     private bool IgnoreAltFloodFill(Side facingSide, Side otherSide, SectorPlaneFace face)
     {
         return IsSky(facingSide.Sector.GetSectorPlane(face)) || IsSky(otherSide.Sector.GetSectorPlane(face));

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
@@ -123,7 +123,7 @@ public class StaticCacheGeometryRenderer : IDisposable
             var line = world.Lines[i];
             if (WorldStatic.LineVertexGap > 0 && !world.SameAsPreviousMap)
             {
-                var unit = Vec2D.UnitCircle(line.Segment.Start.Angle(line.Segment.End));
+                var unit = Vec2D.UnitCircle(line.GetAngle());
                 var push = unit * WorldStatic.LineVertexGap;
                 line.Segment.Start -= push;
                 line.Segment.End += push;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
@@ -91,8 +91,6 @@ public class InterpolationShader : RenderProgram
         flat out float addAlphaFrag;
         flat out float colorMapIndexFrag;
         flat out float vertexLightLevelFrag;
-        flat out float topFrag;
-        flat out float leftFrag;
         ${VertexGapVariables}
 
         ${SectorColorMapVertexFragVariables}
@@ -141,8 +139,6 @@ public class InterpolationShader : RenderProgram
         flat in vec2 uvFlatFrag;
         flat in float alphaFrag;
         flat in float addAlphaFrag;
-        flat in float topFrag;
-        flat in float leftFrag;
         ${VertexGapVariables}
 
         ${OutFragColor}

--- a/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
@@ -115,7 +115,7 @@ public class InterpolationShader : RenderProgram
             leftFrag = splitOptions;
 
             uvFrag = mix(prevUV, uv, timeFrac);
-            uvFlatFrag = uv;
+            uvFlatFrag = uvFrag;
 
             colorMapIndexFrag = trunc(colorMapIndex / 256);
             vertexLightLevelFrag = colorMapIndex - (colorMapIndexFrag * 256);
@@ -152,7 +152,7 @@ public class InterpolationShader : RenderProgram
         uniform vec3 colorMix;
         uniform int paletteIndex;
         uniform int colormapIndex;
-        uniform float vertexGapClampUV;
+        uniform int vertexGapClampUV;
 
         ${LightLevelFragVariables}
         ${SectorColorMapFragVariables}

--- a/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
@@ -83,10 +83,13 @@ public class InterpolationShader : RenderProgram
         layout(location = 6) in float colorMapIndex;
 
         out vec2 uvFrag;
+        flat out vec2 uvFlatFrag;
         flat out float alphaFrag;
         flat out float addAlphaFrag;
         flat out float colorMapIndexFrag;
         flat out float vertexLightLevelFrag;
+        flat out float topFrag;
+        flat out float leftFrag;
 
         ${SectorColorMapVertexFragVariables}
         ${LightLevelVertexVariables}
@@ -98,11 +101,18 @@ public class InterpolationShader : RenderProgram
 
         void main() {
             float splitOptions = options;
-            float lightLevelBufferIndex = trunc(splitOptions / 4);
-            splitOptions -= (lightLevelBufferIndex * 4);
-            addAlphaFrag = trunc(splitOptions / 2);
-            alphaFrag = splitOptions - (addAlphaFrag * 2);
+            float lightLevelBufferIndex = trunc(splitOptions / 16);
+            splitOptions -= (lightLevelBufferIndex * 16);
+            addAlphaFrag = trunc(splitOptions / 8);
+            splitOptions -= (addAlphaFrag * 8);
+            alphaFrag = trunc(splitOptions / 4);
+            splitOptions -= (alphaFrag * 4);
+            topFrag = trunc(splitOptions / 2);
+            splitOptions -= (topFrag * 2);
+            leftFrag = splitOptions;
+
             uvFrag = mix(prevUV, uv, timeFrac);
+            uvFlatFrag = uv;
 
             colorMapIndexFrag = trunc(colorMapIndex / 256);
             vertexLightLevelFrag = colorMapIndex - (colorMapIndexFrag * 256);
@@ -126,8 +136,11 @@ public class InterpolationShader : RenderProgram
         #version 330
 
         in vec2 uvFrag;
+        flat in vec2 uvFlatFrag;
         flat in float alphaFrag;
         flat in float addAlphaFrag;
+        flat in float topFrag;
+        flat in float leftFrag;
 
         ${OutFragColor}
 
@@ -149,7 +162,7 @@ public class InterpolationShader : RenderProgram
     "
     .Replace("${LightLevelFragFunction}", LightLevel.FragFunction)
     .Replace("${LightLevelFragVariables}", LightLevel.FragVariables(LightLevelOptions.Default))
-    .Replace("${FragColorFunction}", FragFunction.FragColorFunction(FragColorFunctionOptions.AddAlpha | FragColorFunctionOptions.Colormap, oitOptions: GetOitOptions()))
+    .Replace("${FragColorFunction}", FragFunction.FragColorFunction(FragColorFunctionOptions.AddAlpha | FragColorFunctionOptions.Colormap | FragColorFunctionOptions.VertexGapClampUV, oitOptions: GetOitOptions()))
     .Replace("${SectorColorMapFragVariables}", SectorColorMap.FragVariables)
     .Replace("${SectorColorMapFragFunction}", SectorColorMap.FragFunction)
     .Replace("${OitVariables}", FragFunction.OitFragVariables(GetOitOptions()))

--- a/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
@@ -72,7 +72,7 @@ public class InterpolationShader : RenderProgram
     public void ColorMapIndex(int index) => Uniforms.Set(index, m_colorMapIndexLocation);
     public void LightMode(RenderLightMode mode) => Uniforms.Set((int)mode, m_lightModeLocation);
     public void GammaCorrection(float value) => Uniforms.Set(value, m_gammaCorrectionLocation);
-    public void VertexGapClampUV(bool value) => Uniforms.Set(value, m_vertexGapClampUV);
+    public void VertexGapClampUV(float value) => Uniforms.Set(value, m_vertexGapClampUV);
 
     protected override string VertexShader() => @"
         #version 330
@@ -99,7 +99,7 @@ public class InterpolationShader : RenderProgram
 
         uniform mat4 mvp;
         uniform float timeFrac;
-        uniform int vertexGapClampUV;
+        uniform float vertexGapClampUV;
         uniform sampler2D boundTexture;
 
         void main() {

--- a/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
@@ -102,19 +102,11 @@ public class InterpolationShader : RenderProgram
 
         uniform mat4 mvp;
         uniform float timeFrac;
+        uniform int vertexGapClampUV;
         uniform sampler2D boundTexture;
 
         void main() {
-            float splitOptions = options;
-            float lightLevelBufferIndex = trunc(splitOptions / 16);
-            splitOptions -= (lightLevelBufferIndex * 16);
-            addAlphaFrag = trunc(splitOptions / 8);
-            splitOptions -= (addAlphaFrag * 8);
-            alphaFrag = trunc(splitOptions / 4);
-            splitOptions -= (alphaFrag * 4);
-            topFrag = trunc(splitOptions / 2);
-            splitOptions -= (topFrag * 2);
-            leftFrag = splitOptions;
+            ${VertexOptionsSet}
 
             uvFrag = mix(prevUV, uv, timeFrac);
             uvFlatFrag = uvFrag;
@@ -139,7 +131,8 @@ public class InterpolationShader : RenderProgram
     .Replace("${SectorColorMapVertexUniformVariables}", SectorColorMap.VertexUniformVariables)
     .Replace("${SectorColorMapVertexFunction}", SectorColorMap.VertexFunction)
     .Replace("${VertexGapVariables}", VertexFunction.VertexGapVariables)
-    .Replace("${VertexGapSet}", VertexFunction.VertexGapSet);
+    .Replace("${VertexGapSet}", VertexFunction.VertexGapSet)
+    .Replace("${VertexOptionsSet}", VertexFunction.VertexOptionsSet);
 
     protected override string FragmentShader() => @"
         #version 330
@@ -159,7 +152,6 @@ public class InterpolationShader : RenderProgram
         uniform vec3 colorMix;
         uniform int paletteIndex;
         uniform int colormapIndex;
-        uniform int vertexGapClampUV;
 
         ${LightLevelFragVariables}
         ${SectorColorMapFragVariables}

--- a/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
@@ -86,7 +86,6 @@ public class InterpolationShader : RenderProgram
         layout(location = 6) in float colorMapIndex;
 
         out vec2 uvFrag;
-        flat out vec2 uvFlatFrag;
         flat out float alphaFrag;
         flat out float addAlphaFrag;
         flat out float colorMapIndexFrag;
@@ -107,7 +106,6 @@ public class InterpolationShader : RenderProgram
             ${VertexOptionsSet}
 
             uvFrag = mix(prevUV, uv, timeFrac);
-            uvFlatFrag = uvFrag;
 
             colorMapIndexFrag = trunc(colorMapIndex / 256);
             vertexLightLevelFrag = colorMapIndex - (colorMapIndexFrag * 256);
@@ -136,7 +134,6 @@ public class InterpolationShader : RenderProgram
         #version 330
 
         in vec2 uvFrag;
-        flat in vec2 uvFlatFrag;
         flat in float alphaFrag;
         flat in float addAlphaFrag;
         ${VertexGapVariables}

--- a/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
@@ -93,6 +93,7 @@ public class InterpolationShader : RenderProgram
         flat out float vertexLightLevelFrag;
         flat out float topFrag;
         flat out float leftFrag;
+        ${VertexGapVariables}
 
         ${SectorColorMapVertexFragVariables}
         ${LightLevelVertexVariables}
@@ -101,6 +102,7 @@ public class InterpolationShader : RenderProgram
 
         uniform mat4 mvp;
         uniform float timeFrac;
+        uniform sampler2D boundTexture;
 
         void main() {
             float splitOptions = options;
@@ -119,6 +121,8 @@ public class InterpolationShader : RenderProgram
 
             colorMapIndexFrag = trunc(colorMapIndex / 256);
             vertexLightLevelFrag = colorMapIndex - (colorMapIndexFrag * 256);
+
+            ${VertexGapSet}
             
             vec4 mixPos = vec4(mix(prevPos, pos, timeFrac), 1.0);
             ${VertexLightBuffer}
@@ -133,7 +137,9 @@ public class InterpolationShader : RenderProgram
     .Replace("${LightLevelVertexDist}", LightLevel.VertexDist("mixPos"))
     .Replace("${SectorColorMapVertexFragVariables}", SectorColorMap.VertexFragVariables)
     .Replace("${SectorColorMapVertexUniformVariables}", SectorColorMap.VertexUniformVariables)
-    .Replace("${SectorColorMapVertexFunction}", SectorColorMap.VertexFunction);
+    .Replace("${SectorColorMapVertexFunction}", SectorColorMap.VertexFunction)
+    .Replace("${VertexGapVariables}", VertexFunction.VertexGapVariables)
+    .Replace("${VertexGapSet}", VertexFunction.VertexGapSet);
 
     protected override string FragmentShader() => @"
         #version 330
@@ -144,6 +150,7 @@ public class InterpolationShader : RenderProgram
         flat in float addAlphaFrag;
         flat in float topFrag;
         flat in float leftFrag;
+        ${VertexGapVariables}
 
         ${OutFragColor}
 
@@ -170,7 +177,8 @@ public class InterpolationShader : RenderProgram
     .Replace("${SectorColorMapFragVariables}", SectorColorMap.FragVariables)
     .Replace("${SectorColorMapFragFunction}", SectorColorMap.FragFunction)
     .Replace("${OitVariables}", FragFunction.OitFragVariables(GetOitOptions()))
-    .Replace("${OutFragColor}", GetOutFragColor());
+    .Replace("${OutFragColor}", GetOutFragColor())
+    .Replace("${VertexGapVariables}", FragFunction.VertexGapVariables);
 
     private OitOptions GetOitOptions()
     {

--- a/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
@@ -72,7 +72,7 @@ public class InterpolationShader : RenderProgram
     public void ColorMapIndex(int index) => Uniforms.Set(index, m_colorMapIndexLocation);
     public void LightMode(RenderLightMode mode) => Uniforms.Set((int)mode, m_lightModeLocation);
     public void GammaCorrection(float value) => Uniforms.Set(value, m_gammaCorrectionLocation);
-    public void VertexGapClampUV(float value) => Uniforms.Set(value, m_vertexGapClampUV);
+    public void VertexGapClampUV(bool value) => Uniforms.Set(value, m_vertexGapClampUV);
 
     protected override string VertexShader() => @"
         #version 330
@@ -99,7 +99,7 @@ public class InterpolationShader : RenderProgram
 
         uniform mat4 mvp;
         uniform float timeFrac;
-        uniform float vertexGapClampUV;
+        uniform int vertexGapClampUV;
         uniform sampler2D boundTexture;
 
         void main() {

--- a/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
@@ -28,6 +28,7 @@ public class InterpolationShader : RenderProgram
     private readonly int m_gammaCorrectionLocation;
     private readonly int m_accumTextureLocation;
     private readonly int m_accumCountTextureLocation;
+    private readonly int m_vertexGapClampUV;
 
     public InterpolationShader() : base("World")
     {
@@ -49,6 +50,7 @@ public class InterpolationShader : RenderProgram
         m_gammaCorrectionLocation = Uniforms.GetLocation("gammaCorrection");
         m_accumTextureLocation = Uniforms.GetLocation("accum");
         m_accumCountTextureLocation = Uniforms.GetLocation("accumCount");
+        m_vertexGapClampUV = Uniforms.GetLocation("vertexGapClampUV");
     }
 
     public void BoundTexture(TextureUnit unit) => Uniforms.Set(unit, m_boundTextureLocation);
@@ -70,6 +72,7 @@ public class InterpolationShader : RenderProgram
     public void ColorMapIndex(int index) => Uniforms.Set(index, m_colorMapIndexLocation);
     public void LightMode(RenderLightMode mode) => Uniforms.Set((int)mode, m_lightModeLocation);
     public void GammaCorrection(float value) => Uniforms.Set(value, m_gammaCorrectionLocation);
+    public void VertexGapClampUV(bool value) => Uniforms.Set(value, m_vertexGapClampUV);
 
     protected override string VertexShader() => @"
         #version 330
@@ -149,6 +152,7 @@ public class InterpolationShader : RenderProgram
         uniform vec3 colorMix;
         uniform int paletteIndex;
         uniform int colormapIndex;
+        uniform float vertexGapClampUV;
 
         ${LightLevelFragVariables}
         ${SectorColorMapFragVariables}

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -277,7 +277,9 @@ public class LegacyWorldRenderer : WorldRenderer
             m_interpolationProgram.Bind();
             GL.ActiveTexture(TextureUnit.Texture0);
             SetInterpolationUniforms(m_interpolationProgram, renderInfo);
+            SetRenderWalls();
             m_worldDataManager.RenderWalls();
+            SetRenderFlats();
             m_worldDataManager.RenderFlats();
 
             if (m_renderStatic)
@@ -285,10 +287,13 @@ public class LegacyWorldRenderer : WorldRenderer
                 m_staticProgram.Bind();
                 GL.ActiveTexture(TextureUnit.Texture0);
                 SetStaticUniforms(renderInfo);
+                SetRenderWalls();
                 m_geometryRenderer.RenderStaticGeometryWalls();
+                SetRenderFlats();
                 m_geometryRenderer.RenderStaticGeometryFlats();
             }
 
+            SetRenderWalls();
             RenderTwoSidedMiddleWalls(renderInfo);
             m_entityRenderer.RenderOpaque(renderInfo);
             RenderTransparent(renderInfo, framebuffer, false);
@@ -299,7 +304,9 @@ public class LegacyWorldRenderer : WorldRenderer
         m_interpolationProgram.Bind();
         GL.ActiveTexture(TextureUnit.Texture0);
         SetInterpolationUniforms(m_interpolationProgram, renderInfo);
+        SetRenderWalls();
         m_worldDataManager.RenderWalls();
+        SetRenderFlats();
         m_worldDataManager.RenderFlats();
 
         if (m_renderStatic)
@@ -307,10 +314,13 @@ public class LegacyWorldRenderer : WorldRenderer
             m_staticProgram.Bind();
             GL.ActiveTexture(TextureUnit.Texture0);
             SetStaticUniforms(renderInfo);
+            SetRenderWalls();
             m_geometryRenderer.RenderStaticGeometryWalls();
+            SetRenderFlats();
             m_geometryRenderer.RenderStaticGeometryFlats();
         }
 
+        SetRenderWalls();
         RenderTwoSidedMiddleWalls(renderInfo);
 
         GL.Clear(ClearBufferMask.DepthBufferBit);
@@ -556,6 +566,22 @@ public class LegacyWorldRenderer : WorldRenderer
         m_staticProgram.ColorMapIndex(renderInfo.Uniforms.ColorMapUniforms.GlobalIndex);
         m_staticProgram.LightMode(renderInfo.Uniforms.LightMode);
         m_staticProgram.GammaCorrection(renderInfo.Uniforms.GammaCorrection);
+    }
+
+    private void SetRenderWalls()
+    {
+        m_staticProgram.VertexGapClampUV(true);
+        m_interpolationProgram.VertexGapClampUV(true);
+        m_interpolationCompositeProgram.VertexGapClampUV(true);
+        m_interpolationTransparentProgram.VertexGapClampUV(true);
+    }
+
+    private void SetRenderFlats()
+    {
+        m_staticProgram.VertexGapClampUV(false);
+        m_interpolationProgram.VertexGapClampUV(false);
+        m_interpolationCompositeProgram.VertexGapClampUV(false);
+        m_interpolationTransparentProgram.VertexGapClampUV(false);
     }
 
     private void ReleaseUnmanagedResources()

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -389,7 +389,7 @@ public class LegacyWorldRenderer : WorldRenderer
             RenderFlatsToDepth(renderInfo);
 
         m_interpolationTransparentProgram.Bind();
-        m_interpolationTransparentProgram.VertexGapClampUV(false);
+        m_interpolationTransparentProgram.VertexGapClampUV(m_pixelGapCorrection);
         SetInterpolationUniforms(m_interpolationTransparentProgram, renderInfo);
         GL.ActiveTexture(TextureUnit.Texture0);
         m_worldDataManager.RenderAlphaWalls();
@@ -405,7 +405,7 @@ public class LegacyWorldRenderer : WorldRenderer
                 RenderFlatsToDepth(renderInfo);
 
             m_interpolationCompositeProgram.Bind();
-            m_interpolationCompositeProgram.VertexGapClampUV(false);
+            m_interpolationCompositeProgram.VertexGapClampUV(m_pixelGapCorrection);
             SetInterpolationUniforms(m_interpolationCompositeProgram, renderInfo);
             GL.ActiveTexture(TextureUnit.Texture0);
             m_worldDataManager.RenderAlphaWalls();

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -389,7 +389,8 @@ public class LegacyWorldRenderer : WorldRenderer
             RenderFlatsToDepth(renderInfo);
 
         m_interpolationTransparentProgram.Bind();
-        m_interpolationTransparentProgram.VertexGapClampUV(m_pixelGapCorrection);
+        // Alpha walls are the exception to pixel gap correction. Only required for opaque walls.
+        m_interpolationTransparentProgram.VertexGapClampUV(false);
         SetInterpolationUniforms(m_interpolationTransparentProgram, renderInfo);
         GL.ActiveTexture(TextureUnit.Texture0);
         m_worldDataManager.RenderAlphaWalls();
@@ -405,7 +406,7 @@ public class LegacyWorldRenderer : WorldRenderer
                 RenderFlatsToDepth(renderInfo);
 
             m_interpolationCompositeProgram.Bind();
-            m_interpolationCompositeProgram.VertexGapClampUV(m_pixelGapCorrection);
+            m_interpolationCompositeProgram.VertexGapClampUV(false);
             SetInterpolationUniforms(m_interpolationCompositeProgram, renderInfo);
             GL.ActiveTexture(TextureUnit.Texture0);
             m_worldDataManager.RenderAlphaWalls();

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -41,6 +41,7 @@ public class LegacyWorldRenderer : WorldRenderer
     private bool m_occlude;
     private bool m_vanillaRender;
     private bool m_renderStatic;
+    private bool m_pixelGapCorrection;
     private int m_lastTicker = -1;
     private Entity? m_viewerEntity;
     private IWorld? m_previousWorld;
@@ -251,6 +252,7 @@ public class LegacyWorldRenderer : WorldRenderer
         // If the transfer height view is not the middle then the cached static geometry cannot be used.
         // Render all sectors dynamically instead.
         m_renderStatic = renderInfo.TransferHeightView == TransferHeightView.Middle;
+        m_pixelGapCorrection = m_config.Render.PixelGapCorrection.Value;
         Clear(world, renderInfo);
 
         if (framebuffer.DepthTexture == null)
@@ -570,18 +572,18 @@ public class LegacyWorldRenderer : WorldRenderer
 
     private void SetRenderWalls()
     {
-        m_staticProgram.VertexGapClampUV(true);
-        m_interpolationProgram.VertexGapClampUV(true);
-        m_interpolationCompositeProgram.VertexGapClampUV(true);
-        m_interpolationTransparentProgram.VertexGapClampUV(true);
+        // Always push one pixel to ensure it doesn't roll over to the next row/column
+        float gapCorrection = m_pixelGapCorrection ? (float)Math.Ceiling(Constants.VertexGapPush) : 0f;
+        m_staticProgram.VertexGapClampUV(gapCorrection);
+        m_interpolationProgram.VertexGapClampUV(gapCorrection);
+        m_interpolationTransparentProgram.VertexGapClampUV(gapCorrection);
     }
 
     private void SetRenderFlats()
     {
-        m_staticProgram.VertexGapClampUV(false);
-        m_interpolationProgram.VertexGapClampUV(false);
-        m_interpolationCompositeProgram.VertexGapClampUV(false);
-        m_interpolationTransparentProgram.VertexGapClampUV(false);
+        m_staticProgram.VertexGapClampUV(0);
+        m_interpolationProgram.VertexGapClampUV(0);
+        m_interpolationTransparentProgram.VertexGapClampUV(0);
     }
 
     private void ReleaseUnmanagedResources()

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -41,7 +41,6 @@ public class LegacyWorldRenderer : WorldRenderer
     private bool m_occlude;
     private bool m_vanillaRender;
     private bool m_renderStatic;
-    private bool m_pixelGapCorrection;
     private int m_lastTicker = -1;
     private Entity? m_viewerEntity;
     private IWorld? m_previousWorld;
@@ -252,7 +251,6 @@ public class LegacyWorldRenderer : WorldRenderer
         // If the transfer height view is not the middle then the cached static geometry cannot be used.
         // Render all sectors dynamically instead.
         m_renderStatic = renderInfo.TransferHeightView == TransferHeightView.Middle;
-        m_pixelGapCorrection = m_config.Render.PixelGapCorrection.Value;
         Clear(world, renderInfo);
 
         if (framebuffer.DepthTexture == null)
@@ -572,18 +570,18 @@ public class LegacyWorldRenderer : WorldRenderer
 
     private void SetRenderWalls()
     {
-        // Always push one pixel to ensure it doesn't roll over to the next row/column
-        float gapCorrection = m_pixelGapCorrection ? (float)Math.Ceiling(Constants.VertexGapPush) : 0f;
-        m_staticProgram.VertexGapClampUV(gapCorrection);
-        m_interpolationProgram.VertexGapClampUV(gapCorrection);
-        m_interpolationTransparentProgram.VertexGapClampUV(gapCorrection);
+        m_staticProgram.VertexGapClampUV(true);
+        m_interpolationProgram.VertexGapClampUV(true);
+        m_interpolationCompositeProgram.VertexGapClampUV(true);
+        m_interpolationTransparentProgram.VertexGapClampUV(true);
     }
 
     private void SetRenderFlats()
     {
-        m_staticProgram.VertexGapClampUV(0);
-        m_interpolationProgram.VertexGapClampUV(0);
-        m_interpolationTransparentProgram.VertexGapClampUV(0);
+        m_staticProgram.VertexGapClampUV(false);
+        m_interpolationProgram.VertexGapClampUV(false);
+        m_interpolationCompositeProgram.VertexGapClampUV(false);
+        m_interpolationTransparentProgram.VertexGapClampUV(false);
     }
 
     private void ReleaseUnmanagedResources()

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -41,6 +41,7 @@ public class LegacyWorldRenderer : WorldRenderer
     private bool m_occlude;
     private bool m_vanillaRender;
     private bool m_renderStatic;
+    private bool m_pixelGapCorrection;
     private int m_lastTicker = -1;
     private Entity? m_viewerEntity;
     private IWorld? m_previousWorld;
@@ -94,6 +95,7 @@ public class LegacyWorldRenderer : WorldRenderer
         world.OnResetInterpolation += World_OnResetInterpolation;
         m_previousWorld = world;
         m_lastTicker = -1;
+        m_pixelGapCorrection = m_config.Render.PixelGapCorrection.Value;
 
         m_stopwatch.Stop();
         Log.Info($"Completed level geometry {m_stopwatch.Elapsed}");
@@ -277,9 +279,9 @@ public class LegacyWorldRenderer : WorldRenderer
             m_interpolationProgram.Bind();
             GL.ActiveTexture(TextureUnit.Texture0);
             SetInterpolationUniforms(m_interpolationProgram, renderInfo);
-            SetRenderWalls();
+            m_interpolationProgram.VertexGapClampUV(m_pixelGapCorrection);
             m_worldDataManager.RenderWalls();
-            SetRenderFlats();
+            m_interpolationProgram.VertexGapClampUV(false);
             m_worldDataManager.RenderFlats();
 
             if (m_renderStatic)
@@ -287,13 +289,12 @@ public class LegacyWorldRenderer : WorldRenderer
                 m_staticProgram.Bind();
                 GL.ActiveTexture(TextureUnit.Texture0);
                 SetStaticUniforms(renderInfo);
-                SetRenderWalls();
+                m_staticProgram.VertexGapClampUV(m_pixelGapCorrection);
                 m_geometryRenderer.RenderStaticGeometryWalls();
-                SetRenderFlats();
+                m_staticProgram.VertexGapClampUV(false);
                 m_geometryRenderer.RenderStaticGeometryFlats();
             }
 
-            SetRenderWalls();
             RenderTwoSidedMiddleWalls(renderInfo);
             m_entityRenderer.RenderOpaque(renderInfo);
             RenderTransparent(renderInfo, framebuffer, false);
@@ -304,9 +305,9 @@ public class LegacyWorldRenderer : WorldRenderer
         m_interpolationProgram.Bind();
         GL.ActiveTexture(TextureUnit.Texture0);
         SetInterpolationUniforms(m_interpolationProgram, renderInfo);
-        SetRenderWalls();
+        m_interpolationProgram.VertexGapClampUV(m_pixelGapCorrection);
         m_worldDataManager.RenderWalls();
-        SetRenderFlats();
+        m_interpolationProgram.VertexGapClampUV(false);
         m_worldDataManager.RenderFlats();
 
         if (m_renderStatic)
@@ -314,13 +315,12 @@ public class LegacyWorldRenderer : WorldRenderer
             m_staticProgram.Bind();
             GL.ActiveTexture(TextureUnit.Texture0);
             SetStaticUniforms(renderInfo);
-            SetRenderWalls();
+            m_staticProgram.VertexGapClampUV(m_pixelGapCorrection);
             m_geometryRenderer.RenderStaticGeometryWalls();
-            SetRenderFlats();
+            m_staticProgram.VertexGapClampUV(false);
             m_geometryRenderer.RenderStaticGeometryFlats();
         }
 
-        SetRenderWalls();
         RenderTwoSidedMiddleWalls(renderInfo);
 
         GL.Clear(ClearBufferMask.DepthBufferBit);
@@ -389,6 +389,7 @@ public class LegacyWorldRenderer : WorldRenderer
             RenderFlatsToDepth(renderInfo);
 
         m_interpolationTransparentProgram.Bind();
+        m_interpolationTransparentProgram.VertexGapClampUV(false);
         SetInterpolationUniforms(m_interpolationTransparentProgram, renderInfo);
         GL.ActiveTexture(TextureUnit.Texture0);
         m_worldDataManager.RenderAlphaWalls();
@@ -404,6 +405,7 @@ public class LegacyWorldRenderer : WorldRenderer
                 RenderFlatsToDepth(renderInfo);
 
             m_interpolationCompositeProgram.Bind();
+            m_interpolationCompositeProgram.VertexGapClampUV(false);
             SetInterpolationUniforms(m_interpolationCompositeProgram, renderInfo);
             GL.ActiveTexture(TextureUnit.Texture0);
             m_worldDataManager.RenderAlphaWalls();
@@ -447,6 +449,7 @@ public class LegacyWorldRenderer : WorldRenderer
     {
         m_interpolationProgram.Bind();
         GL.ActiveTexture(TextureUnit.Texture0);
+        m_interpolationProgram.VertexGapClampUV(m_pixelGapCorrection);
         m_worldDataManager.RenderTwoSidedMiddleWalls();
 
         if (m_renderStatic)
@@ -454,6 +457,7 @@ public class LegacyWorldRenderer : WorldRenderer
             m_staticProgram.Bind();
             GL.ActiveTexture(TextureUnit.Texture0);
             SetStaticUniforms(renderInfo);
+            m_staticProgram.VertexGapClampUV(m_pixelGapCorrection);
             m_geometryRenderer.RenderStaticTwoSidedWalls();
         }
     }
@@ -525,6 +529,7 @@ public class LegacyWorldRenderer : WorldRenderer
 
     private void SetInterpolationUniforms(InterpolationShader program, RenderInfo renderInfo)
     {
+        program.Bind();
         program.BoundTexture(TextureUnit.Texture0);
         program.SectorLightTexture(TextureUnit.Texture1);
         program.ColormapTexture(TextureUnit.Texture2);
@@ -566,22 +571,6 @@ public class LegacyWorldRenderer : WorldRenderer
         m_staticProgram.ColorMapIndex(renderInfo.Uniforms.ColorMapUniforms.GlobalIndex);
         m_staticProgram.LightMode(renderInfo.Uniforms.LightMode);
         m_staticProgram.GammaCorrection(renderInfo.Uniforms.GammaCorrection);
-    }
-
-    private void SetRenderWalls()
-    {
-        m_staticProgram.VertexGapClampUV(true);
-        m_interpolationProgram.VertexGapClampUV(true);
-        m_interpolationCompositeProgram.VertexGapClampUV(true);
-        m_interpolationTransparentProgram.VertexGapClampUV(true);
-    }
-
-    private void SetRenderFlats()
-    {
-        m_staticProgram.VertexGapClampUV(false);
-        m_interpolationProgram.VertexGapClampUV(false);
-        m_interpolationCompositeProgram.VertexGapClampUV(false);
-        m_interpolationTransparentProgram.VertexGapClampUV(false);
     }
 
     private void ReleaseUnmanagedResources()

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/FragFunction.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/FragFunction.cs
@@ -10,7 +10,8 @@ public enum FragColorFunctionOptions
     AddAlpha = 1,
     Alpha = 2,
     Fuzz = 4,
-    Colormap = 8
+    Colormap = 8,
+    VertexGapClampUV = 16
 }
 
 public enum ColorMapFetchContext { Default, Hud, Entity }
@@ -146,12 +147,42 @@ public class FragFunction
                 .Replace("${IndexAdd}", indexAdd);
     }
 
+    private static string GetTextureMappingClamp(FragColorFunctionOptions options)
+    {
+        if ((options & FragColorFunctionOptions.VertexGapClampUV) == 0)
+            return "vec2 texUV = uvFrag;";
+
+        return @"
+            const float VertexGap = 0.015;
+            ivec2 texSize = textureSize(boundTexture, 0);
+            float gapX = VertexGap / texSize.x;
+            float gapY = VertexGap / texSize.y;
+            vec2 uvClampMin = vec2(-999, -999);
+            vec2 uvClampMax = vec2(999, 999);
+
+            if (topFrag == 1)
+                uvClampMin.y = uvFlatFrag.y + gapY;
+            else
+                uvClampMax.y = uvFlatFrag.y - gapY;
+            
+            if (leftFrag == 1)
+                uvClampMin.x = uvFlatFrag.x + gapX;
+            else
+                uvClampMax.x = uvFlatFrag.x - gapX;
+
+            vec2 texUV = clamp(uvFrag, uvClampMin, uvClampMax);
+        ";
+    }
+
     public static string FragColorFunction(FragColorFunctionOptions options, ColorMapFetchContext ctx = ColorMapFetchContext.Default,
         OitOptions oitOptions = OitOptions.None, string postProcess = "")
     {
-        var fragColor = @"fragColor = texture(boundTexture, uvFrag.st);";
-        if (oitOptions == OitOptions.OitTransparentPass)
-            fragColor = "vec4 fragColor = texture(boundTexture, uvFrag.st);";
+        var declareFragColor = oitOptions == OitOptions.OitTransparentPass ? "vec4 fragColor" : "fragColor";
+        var textureMappingClamp = GetTextureMappingClamp(options);
+
+        var fragColor = @$"
+        {textureMappingClamp}
+        {declareFragColor} = texture(boundTexture, texUV);";
 
         return
             fragColor +

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/FragFunction.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/FragFunction.cs
@@ -153,24 +153,28 @@ public class FragFunction
             return "vec2 texUV = uvFrag;";
 
         return @"
-            const float VertexGap = 0.015;
-            ivec2 texSize = textureSize(boundTexture, 0);
-            float gapX = VertexGap / texSize.x;
-            float gapY = VertexGap / texSize.y;
-            vec2 uvClampMin = vec2(-999, -999);
-            vec2 uvClampMax = vec2(999, 999);
+            vec2 texUV = uvFrag;
+            if (vertexGapClampUV == 1)
+            {
+                const float VertexGap = 0.015;
+                ivec2 texSize = textureSize(boundTexture, 0);
+                float gapX = VertexGap / texSize.x;
+                float gapY = VertexGap / texSize.y;
+                vec2 uvClampMin = vec2(-999, -999);
+                vec2 uvClampMax = vec2(999, 999);
 
-            if (topFrag == 1)
-                uvClampMin.y = uvFlatFrag.y + gapY;
-            else
-                uvClampMax.y = uvFlatFrag.y - gapY;
+                if (topFrag == 1)
+                    uvClampMin.y = uvFlatFrag.y + gapY;
+                else
+                    uvClampMax.y = uvFlatFrag.y - gapY;
             
-            if (leftFrag == 1)
-                uvClampMin.x = uvFlatFrag.x + gapX;
-            else
-                uvClampMax.x = uvFlatFrag.x - gapX;
+                if (leftFrag == 1)
+                    uvClampMin.x = uvFlatFrag.x + gapX;
+                else
+                    uvClampMax.x = uvFlatFrag.x - gapX;
 
-            vec2 texUV = clamp(uvFrag, uvClampMin, uvClampMax);
+                texUV = clamp(uvFrag, uvClampMin, uvClampMax);
+            }
         ";
     }
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/FragFunction.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/FragFunction.cs
@@ -152,23 +152,7 @@ public class FragFunction
         if ((options & FragColorFunctionOptions.VertexGapClampUV) == 0)
             return "vec2 texUV = uvFrag;";
 
-        return @"
-            vec2 texUV = uvFrag;
-            if (vertexGapClampUV == 1)
-            {
-                vec2 uvClampMin = vec2(-1.0 / 0.0, -1.0 / 0.0);
-                vec2 uvClampMax = vec2(1.0 / 0.0, 1.0 / 0.0);
-
-                // These are only based off the first vertex of the triangle
-                uvClampMin.y = mix(uvClampMin.y, uvFlatFrag.y + gapFrag.y, topFrag == 1);
-                uvClampMax.y = mix(uvClampMax.y, uvFlatFrag.y - gapFrag.y, topFrag == 0);
-
-                uvClampMin.x = mix(uvClampMin.x, uvFlatFrag.x + gapFrag.x, topFrag == 1);
-                uvClampMax.x = mix(uvClampMax.x, uvFlatFrag.x - gapFrag.x, topFrag == 0);
-
-                texUV = clamp(uvFrag, uvClampMin, uvClampMax);
-            }
-        ";
+        return @"vec2 texUV = clamp(uvFrag, uvClampMinFrag, uvClampMaxFrag);";
     }
 
     public static string FragColorFunction(FragColorFunctionOptions options, ColorMapFetchContext ctx = ColorMapFetchContext.Default,
@@ -342,5 +326,5 @@ public class FragFunction
     }
 ";
 
-    public static string VertexGapVariables => "flat in vec2 gapFrag;";
+    public static string VertexGapVariables => "flat in vec2 uvClampMinFrag; flat in vec2 uvClampMaxFrag;";
 }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/FragFunction.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/FragFunction.cs
@@ -156,22 +156,15 @@ public class FragFunction
             vec2 texUV = uvFrag;
             if (vertexGapClampUV == 1)
             {
-                const float VertexGap = 0.015 * 2;
-                ivec2 texSize = textureSize(boundTexture, 0);
-                float gapX = VertexGap / texSize.x;
-                float gapY = VertexGap / texSize.y;
                 vec2 uvClampMin = vec2(-1.0 / 0.0, -1.0 / 0.0);
                 vec2 uvClampMax = vec2(1.0 / 0.0, 1.0 / 0.0);
 
-                if (topFrag == 1)
-                    uvClampMin.y = uvFlatFrag.y + gapY;
-                else
-                    uvClampMax.y = uvFlatFrag.y - gapY;
-            
-                if (leftFrag == 1)
-                    uvClampMin.x = uvFlatFrag.x + gapX;
-                else
-                    uvClampMax.x = uvFlatFrag.x - gapX;
+                // These are only based off the first vertex of the triangle
+                uvClampMin.y = mix(uvClampMin.y, uvFlatFrag.y + gapFrag.y, topFrag == 1);
+                uvClampMax.y = mix(uvClampMax.y, uvFlatFrag.y - gapFrag.y, topFrag == 0);
+
+                uvClampMin.x = mix(uvClampMin.x, uvFlatFrag.x + gapFrag.x, topFrag == 1);
+                uvClampMax.x = mix(uvClampMax.x, uvFlatFrag.x - gapFrag.x, topFrag == 0);
 
                 texUV = clamp(uvFrag, uvClampMin, uvClampMax);
             }
@@ -348,4 +341,6 @@ public class FragFunction
         fragColor.xyz = vec3(gray, gray, gray);
     }
 ";
+
+    public static string VertexGapVariables => "flat in vec2 gapFrag;";
 }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/FragFunction.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/FragFunction.cs
@@ -156,12 +156,12 @@ public class FragFunction
             vec2 texUV = uvFrag;
             if (vertexGapClampUV == 1)
             {
-                const float VertexGap = 0.015;
+                const float VertexGap = 0.015 * 2;
                 ivec2 texSize = textureSize(boundTexture, 0);
                 float gapX = VertexGap / texSize.x;
                 float gapY = VertexGap / texSize.y;
-                vec2 uvClampMin = vec2(-999, -999);
-                vec2 uvClampMax = vec2(999, 999);
+                vec2 uvClampMin = vec2(-1.0 / 0.0, -1.0 / 0.0);
+                vec2 uvClampMax = vec2(1.0 / 0.0, 1.0 / 0.0);
 
                 if (topFrag == 1)
                     uvClampMin.y = uvFlatFrag.y + gapY;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/VertexFunction.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/VertexFunction.cs
@@ -2,10 +2,37 @@
 
 public static class VertexFunction
 {
-    public static string VertexGapVariables => "flat out vec2 gapFrag;";
+    public static string VertexGapVariables => "flat out vec2 uvClampMinFrag; flat out vec2 uvClampMaxFrag;";
 
     public static string VertexGapSet =>
-    @"      const float VertexGap = 0.015*4;
+    @"      
+            const float VertexGap = 0.015*4;
             ivec2 texSize = textureSize(boundTexture, 0);
-            gapFrag = vec2(VertexGap / texSize.x, VertexGap / texSize.y);";
+            vec2 uvGap = vec2(VertexGap / texSize.x, VertexGap / texSize.y);
+
+            uvClampMinFrag = vec2(-1.0 / 0.0, -1.0 / 0.0);
+            uvClampMaxFrag = vec2(1.0 / 0.0, 1.0 / 0.0);
+
+            if (vertexGapClampUV == 1) {
+                // These are only based off the first vertex of the triangle
+                uvClampMinFrag.y = mix(uvClampMinFrag.y, uvFlatFrag.y + uvGap.y, topFrag == 1);
+                uvClampMaxFrag.y = mix(uvClampMaxFrag.y, uvFlatFrag.y - uvGap.y, topFrag == 0);
+
+                uvClampMinFrag.x = mix(uvClampMinFrag.x, uvFlatFrag.x + uvGap.x, topFrag == 1);
+                uvClampMaxFrag.x = mix(uvClampMaxFrag.x, uvFlatFrag.x - uvGap.x, topFrag == 0);
+            }
+";
+
+    public static string VertexOptionsSet =>
+        @"  
+            float splitOptions = options;
+            float lightLevelBufferIndex = trunc(splitOptions / 16);
+            splitOptions -= (lightLevelBufferIndex * 16);
+            addAlphaFrag = trunc(splitOptions / 8);
+            splitOptions -= (addAlphaFrag * 8);
+            alphaFrag = trunc(splitOptions / 4);
+            splitOptions -= (alphaFrag * 4);
+            topFrag = trunc(splitOptions / 2);
+            splitOptions -= (topFrag * 2);
+            leftFrag = splitOptions;";
 }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/VertexFunction.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/VertexFunction.cs
@@ -34,6 +34,6 @@ public static class VertexFunction
             splitOptions -= (lightLevelBufferIndex * 8);
             addAlphaFrag = trunc(splitOptions / 4);
             splitOptions -= (addAlphaFrag * 4);
-            alphaFrag = trunc(splitOptions / 2);
-            float topLeft = splitOptions - (alphaFrag * 2);";
+            float topLeft = trunc(splitOptions / 2);
+            alphaFrag = splitOptions - (topLeft * 2);";
 }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/VertexFunction.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/VertexFunction.cs
@@ -1,0 +1,11 @@
+﻿namespace Helion.Render.OpenGL.Renderers.Legacy.World.Shader;
+
+public static class VertexFunction
+{
+    public static string VertexGapVariables => "flat out vec2 gapFrag;";
+
+    public static string VertexGapSet =>
+    @"      const float VertexGap = 0.015*4;
+            ivec2 texSize = textureSize(boundTexture, 0);
+            gapFrag = vec2(VertexGap / texSize.x, VertexGap / texSize.y);";
+}

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/VertexFunction.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/VertexFunction.cs
@@ -12,9 +12,10 @@ public static class VertexFunction
             uvClampMinFrag = vec2(-1.0 / 0.0, -1.0 / 0.0);
             uvClampMaxFrag = vec2(1.0 / 0.0, 1.0 / 0.0);
 
-            if (vertexGapClampUV > 0) {
+            if (vertexGapClampUV == 1) {
+                const float VertexGap = 0.015*4;
                 ivec2 texSize = textureSize(boundTexture, 0);
-                vec2 uvGap = vec2(vertexGapClampUV / texSize.x, vertexGapClampUV / texSize.y);
+                vec2 uvGap = vec2(VertexGap / texSize.x, VertexGap / texSize.y);
                 
                 uvClampMinFrag.x = mix(uvClampMinFrag.x, uvFrag.x + uvGap.x, topLeft == 1);
                 uvClampMinFrag.y = mix(uvClampMinFrag.y, uvFrag.y + uvGap.y, topLeft == 1);

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/VertexFunction.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/VertexFunction.cs
@@ -12,10 +12,9 @@ public static class VertexFunction
             uvClampMinFrag = vec2(-1.0 / 0.0, -1.0 / 0.0);
             uvClampMaxFrag = vec2(1.0 / 0.0, 1.0 / 0.0);
 
-            if (vertexGapClampUV == 1) {
-                const float VertexGap = 0.015*4;
+            if (vertexGapClampUV > 0) {
                 ivec2 texSize = textureSize(boundTexture, 0);
-                vec2 uvGap = vec2(VertexGap / texSize.x, VertexGap / texSize.y);
+                vec2 uvGap = vec2(vertexGapClampUV / texSize.x, vertexGapClampUV / texSize.y);
                 
                 uvClampMinFrag.x = mix(uvClampMinFrag.x, uvFrag.x + uvGap.x, topLeft == 1);
                 uvClampMinFrag.y = mix(uvClampMinFrag.y, uvFrag.y + uvGap.y, topLeft == 1);

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/VertexFunction.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/VertexFunction.cs
@@ -6,33 +6,30 @@ public static class VertexFunction
 
     public static string VertexGapSet =>
     @"      
-            const float VertexGap = 0.015*4;
-            ivec2 texSize = textureSize(boundTexture, 0);
-            vec2 uvGap = vec2(VertexGap / texSize.x, VertexGap / texSize.y);
-
             uvClampMinFrag = vec2(-1.0 / 0.0, -1.0 / 0.0);
             uvClampMaxFrag = vec2(1.0 / 0.0, 1.0 / 0.0);
 
             if (vertexGapClampUV == 1) {
+                const float VertexGap = 0.015*4;
+                ivec2 texSize = textureSize(boundTexture, 0);
+                vec2 uvGap = vec2(VertexGap / texSize.x, VertexGap / texSize.y);
+                
                 // These are only based off the first vertex of the triangle
-                uvClampMinFrag.y = mix(uvClampMinFrag.y, uvFlatFrag.y + uvGap.y, topFrag == 1);
-                uvClampMaxFrag.y = mix(uvClampMaxFrag.y, uvFlatFrag.y - uvGap.y, topFrag == 0);
+                uvClampMinFrag.x = mix(uvClampMinFrag.x, uvFlatFrag.x + uvGap.x, topLeft == 1);
+                uvClampMinFrag.y = mix(uvClampMinFrag.y, uvFlatFrag.y + uvGap.y, topLeft == 1);
 
-                uvClampMinFrag.x = mix(uvClampMinFrag.x, uvFlatFrag.x + uvGap.x, topFrag == 1);
-                uvClampMaxFrag.x = mix(uvClampMaxFrag.x, uvFlatFrag.x - uvGap.x, topFrag == 0);
+                uvClampMaxFrag.x = mix(uvClampMaxFrag.x, uvFlatFrag.x - uvGap.x, topLeft == 0);
+                uvClampMaxFrag.y = mix(uvClampMaxFrag.y, uvFlatFrag.y - uvGap.y, topLeft == 0);
             }
 ";
 
     public static string VertexOptionsSet =>
         @"  
             float splitOptions = options;
-            float lightLevelBufferIndex = trunc(splitOptions / 16);
-            splitOptions -= (lightLevelBufferIndex * 16);
-            addAlphaFrag = trunc(splitOptions / 8);
-            splitOptions -= (addAlphaFrag * 8);
-            alphaFrag = trunc(splitOptions / 4);
-            splitOptions -= (alphaFrag * 4);
-            topFrag = trunc(splitOptions / 2);
-            splitOptions -= (topFrag * 2);
-            leftFrag = splitOptions;";
+            float lightLevelBufferIndex = trunc(splitOptions / 8);
+            splitOptions -= (lightLevelBufferIndex * 8);
+            addAlphaFrag = trunc(splitOptions / 4);
+            splitOptions -= (addAlphaFrag * 4);
+            alphaFrag = trunc(splitOptions / 2);
+            float topLeft = splitOptions - (alphaFrag * 2);";
 }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/VertexFunction.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/VertexFunction.cs
@@ -9,8 +9,9 @@ public static class VertexFunction
     // This means it can only clamp by the top left and bottom right values, making the top right and bottom left edges incorrect.
     public static string VertexGapSet =>
     @"      
-            uvClampMinFrag = vec2(-1.0 / 0.0, -1.0 / 0.0);
-            uvClampMaxFrag = vec2(1.0 / 0.0, 1.0 / 0.0);
+            const float MaxValue = 1e30;
+            uvClampMinFrag = vec2(-MaxValue, -MaxValue);
+            uvClampMaxFrag = vec2(MaxValue, MaxValue);
 
             if (vertexGapClampUV == 1) {
                 // Push y further since it's more likely to show t-junction issue with subsector flat splits.

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/VertexFunction.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/VertexFunction.cs
@@ -13,9 +13,11 @@ public static class VertexFunction
             uvClampMaxFrag = vec2(1.0 / 0.0, 1.0 / 0.0);
 
             if (vertexGapClampUV == 1) {
-                const float VertexGap = 0.015*4;
+                // Push y further since it's more likely to show t-junction issue with subsector flat splits.
+                const float VertexGapX = 0.1;
+                const float VertexGapY = 0.9;
                 ivec2 texSize = textureSize(boundTexture, 0);
-                vec2 uvGap = vec2(VertexGap / texSize.x, VertexGap / texSize.y);
+                vec2 uvGap = vec2(VertexGapX / texSize.x, VertexGapY / texSize.y);
                 
                 uvClampMinFrag.x = mix(uvClampMinFrag.x, uvFrag.x + uvGap.x, topLeft == 1);
                 uvClampMinFrag.y = mix(uvClampMinFrag.y, uvFrag.y + uvGap.y, topLeft == 1);

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/VertexFunction.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/VertexFunction.cs
@@ -4,6 +4,9 @@ public static class VertexFunction
 {
     public static string VertexGapVariables => "flat out vec2 uvClampMinFrag; flat out vec2 uvClampMaxFrag;";
 
+    // Clamps the uv coordintes so that the extended ranges repeat pixels instead of reading the next row/col of pixels.
+    // The uv clamp frag variables are not interpolated but are only set by the provoking vertex.
+    // This means it can only clamp by the top left and bottom right values, making the top right and bottom left edges incorrect.
     public static string VertexGapSet =>
     @"      
             uvClampMinFrag = vec2(-1.0 / 0.0, -1.0 / 0.0);
@@ -14,12 +17,11 @@ public static class VertexFunction
                 ivec2 texSize = textureSize(boundTexture, 0);
                 vec2 uvGap = vec2(VertexGap / texSize.x, VertexGap / texSize.y);
                 
-                // These are only based off the first vertex of the triangle
-                uvClampMinFrag.x = mix(uvClampMinFrag.x, uvFlatFrag.x + uvGap.x, topLeft == 1);
-                uvClampMinFrag.y = mix(uvClampMinFrag.y, uvFlatFrag.y + uvGap.y, topLeft == 1);
+                uvClampMinFrag.x = mix(uvClampMinFrag.x, uvFrag.x + uvGap.x, topLeft == 1);
+                uvClampMinFrag.y = mix(uvClampMinFrag.y, uvFrag.y + uvGap.y, topLeft == 1);
 
-                uvClampMaxFrag.x = mix(uvClampMaxFrag.x, uvFlatFrag.x - uvGap.x, topLeft == 0);
-                uvClampMaxFrag.y = mix(uvClampMaxFrag.y, uvFlatFrag.y - uvGap.y, topLeft == 0);
+                uvClampMaxFrag.x = mix(uvClampMaxFrag.x, uvFrag.x - uvGap.x, topLeft == 0);
+                uvClampMaxFrag.y = mix(uvClampMaxFrag.y, uvFrag.y - uvGap.y, topLeft == 0);
             }
 ";
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
@@ -90,22 +90,14 @@ public class StaticShader : RenderProgram
 
         uniform mat4 mvp;
         uniform float timeFrac;
+        uniform int vertexGapClampUV;
         uniform sampler2D boundTexture;
 
         void main() {
             uvFrag = uv;
             uvFlatFrag = uv;
 
-            float splitOptions = options;
-            float lightLevelBufferIndex = trunc(splitOptions / 16);
-            splitOptions -= (lightLevelBufferIndex * 16);
-            addAlphaFrag = trunc(splitOptions / 8);
-            splitOptions -= (addAlphaFrag * 8);
-            alphaFrag = trunc(splitOptions / 4);
-            splitOptions -= (alphaFrag * 4);
-            topFrag = trunc(splitOptions / 2);
-            splitOptions -= (topFrag * 2);
-            leftFrag = splitOptions;
+            ${VertexOptionsSet}
 
             colorMapIndexFrag = trunc(colorMapIndex / 256);
             vertexLightLevelFrag = colorMapIndex - (colorMapIndexFrag * 256);
@@ -127,7 +119,8 @@ public class StaticShader : RenderProgram
     .Replace("${SectorColorMapVertexUniformVariables}", SectorColorMap.VertexUniformVariables)
     .Replace("${SectorColorMapVertexFunction}", SectorColorMap.VertexFunction)
     .Replace("${VertexGapVariables}", VertexFunction.VertexGapVariables)
-    .Replace("${VertexGapSet}", VertexFunction.VertexGapSet);
+    .Replace("${VertexGapSet}", VertexFunction.VertexGapSet)
+    .Replace("${VertexOptionsSet}", VertexFunction.VertexOptionsSet);
 
     protected override string FragmentShader() => @"
         #version 330
@@ -147,7 +140,6 @@ public class StaticShader : RenderProgram
         uniform vec3 colorMix;
         uniform int paletteIndex;
         uniform int colormapIndex;
-        uniform int vertexGapClampUV;
 
         ${LightLevelFragVariables}
         ${SectorColorMapFragVariables}

--- a/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
@@ -62,7 +62,7 @@ public class StaticShader : RenderProgram
     public void ColorMapIndex(int index) => Uniforms.Set(index, m_colorMapIndexLocation);
     public void LightMode(RenderLightMode mode) => Uniforms.Set((int)mode, m_lightModeLocation);
     public void GammaCorrection(float value) => Uniforms.Set(value, m_gammaCorrectionLocation);
-    public void VertexGapClampUV(bool value) => Uniforms.Set(value, m_vertexGapClampUV);
+    public void VertexGapClampUV(float value) => Uniforms.Set(value, m_vertexGapClampUV);
 
     protected override string VertexShader() => @"
         #version 330
@@ -87,7 +87,7 @@ public class StaticShader : RenderProgram
 
         uniform mat4 mvp;
         uniform float timeFrac;
-        uniform int vertexGapClampUV;
+        uniform float vertexGapClampUV;
         uniform sampler2D boundTexture;
 
         void main() {

--- a/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
@@ -140,7 +140,7 @@ public class StaticShader : RenderProgram
         uniform vec3 colorMix;
         uniform int paletteIndex;
         uniform int colormapIndex;
-        uniform float vertexGapClampUV;
+        uniform int vertexGapClampUV;
 
         ${LightLevelFragVariables}
         ${SectorColorMapFragVariables}

--- a/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
@@ -79,8 +79,6 @@ public class StaticShader : RenderProgram
         flat out float addAlphaFrag;
         flat out float colorMapIndexFrag;
         flat out float vertexLightLevelFrag;
-        flat out float topFrag;
-        flat out float leftFrag;
         ${VertexGapVariables}
 
         ${SectorColorMapVertexFragVariables}
@@ -129,8 +127,6 @@ public class StaticShader : RenderProgram
         flat in vec2 uvFlatFrag;
         flat in float alphaFrag;
         flat in float addAlphaFrag;
-        flat in float topFrag;
-        flat in float leftFrag;
         ${VertexGapVariables}
 
         out vec4 fragColor;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
@@ -81,6 +81,7 @@ public class StaticShader : RenderProgram
         flat out float vertexLightLevelFrag;
         flat out float topFrag;
         flat out float leftFrag;
+        ${VertexGapVariables}
 
         ${SectorColorMapVertexFragVariables}
         ${LightLevelVertexVariables}
@@ -89,6 +90,7 @@ public class StaticShader : RenderProgram
 
         uniform mat4 mvp;
         uniform float timeFrac;
+        uniform sampler2D boundTexture;
 
         void main() {
             uvFrag = uv;
@@ -108,6 +110,8 @@ public class StaticShader : RenderProgram
             colorMapIndexFrag = trunc(colorMapIndex / 256);
             vertexLightLevelFrag = colorMapIndex - (colorMapIndexFrag * 256);
             
+            ${VertexGapSet}
+            
             vec4 mixPos = vec4(pos, 1.0);
             ${VertexLightBuffer}
             ${LightLevelVertexDist}
@@ -121,7 +125,9 @@ public class StaticShader : RenderProgram
     .Replace("${LightLevelVertexDist}", LightLevel.VertexDist("mixPos"))
     .Replace("${SectorColorMapVertexFragVariables}", SectorColorMap.VertexFragVariables)
     .Replace("${SectorColorMapVertexUniformVariables}", SectorColorMap.VertexUniformVariables)
-    .Replace("${SectorColorMapVertexFunction}", SectorColorMap.VertexFunction);
+    .Replace("${SectorColorMapVertexFunction}", SectorColorMap.VertexFunction)
+    .Replace("${VertexGapVariables}", VertexFunction.VertexGapVariables)
+    .Replace("${VertexGapSet}", VertexFunction.VertexGapSet);
 
     protected override string FragmentShader() => @"
         #version 330
@@ -132,6 +138,7 @@ public class StaticShader : RenderProgram
         flat in float addAlphaFrag;
         flat in float topFrag;
         flat in float leftFrag;
+        ${VertexGapVariables}
 
         out vec4 fragColor;
 
@@ -155,5 +162,6 @@ public class StaticShader : RenderProgram
     .Replace("${LightLevelFragVariables}", LightLevel.FragVariables(LightLevelOptions.Default))
     .Replace("${FragColorFunction}", FragFunction.FragColorFunction(FragColorFunctionOptions.AddAlpha | FragColorFunctionOptions.Colormap | FragColorFunctionOptions.VertexGapClampUV))
     .Replace("${SectorColorMapFragVariables}", SectorColorMap.FragVariables)
-    .Replace("${SectorColorMapFragFunction}", SectorColorMap.FragFunction);
+    .Replace("${SectorColorMapFragFunction}", SectorColorMap.FragFunction)
+    .Replace("${VertexGapVariables}", FragFunction.VertexGapVariables);
 }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
@@ -24,6 +24,7 @@ public class StaticShader : RenderProgram
     private readonly int m_colorMapIndexLocation;
     private readonly int m_lightModeLocation;
     private readonly int m_gammaCorrectionLocation;
+    private readonly int m_vertexGapClampUV;
 
     public StaticShader() : base("WorldStatic")
     {
@@ -42,6 +43,7 @@ public class StaticShader : RenderProgram
         m_colorMapIndexLocation = Uniforms.GetLocation("colormapIndex");
         m_lightModeLocation = Uniforms.GetLocation("lightMode");
         m_gammaCorrectionLocation = Uniforms.GetLocation("gammaCorrection");
+        m_vertexGapClampUV = Uniforms.GetLocation("vertexGapClampUV");
     }
 
     public void BoundTexture(TextureUnit unit) => Uniforms.Set(unit, m_boundTextureLocation);
@@ -60,6 +62,7 @@ public class StaticShader : RenderProgram
     public void ColorMapIndex(int index) => Uniforms.Set(index, m_colorMapIndexLocation);
     public void LightMode(RenderLightMode mode) => Uniforms.Set((int)mode, m_lightModeLocation);
     public void GammaCorrection(float value) => Uniforms.Set(value, m_gammaCorrectionLocation);
+    public void VertexGapClampUV(bool value) => Uniforms.Set(value, m_vertexGapClampUV);
 
     protected override string VertexShader() => @"
         #version 330
@@ -137,6 +140,7 @@ public class StaticShader : RenderProgram
         uniform vec3 colorMix;
         uniform int paletteIndex;
         uniform int colormapIndex;
+        uniform float vertexGapClampUV;
 
         ${LightLevelFragVariables}
         ${SectorColorMapFragVariables}

--- a/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
@@ -65,16 +65,19 @@ public class StaticShader : RenderProgram
         #version 330
 
         layout(location = 0) in vec3 pos;
-        layout(location = 1) in vec2 uv; 
+        layout(location = 1) in vec2 uv;
         layout(location = 2) in float lightLevelAdd;
         layout(location = 3) in float options;
         layout(location = 4) in float colorMapIndex;
 
         out vec2 uvFrag;
+        flat out vec2 uvFlatFrag;
         flat out float alphaFrag;
         flat out float addAlphaFrag;
         flat out float colorMapIndexFrag;
         flat out float vertexLightLevelFrag;
+        flat out float topFrag;
+        flat out float leftFrag;
 
         ${SectorColorMapVertexFragVariables}
         ${LightLevelVertexVariables}
@@ -86,12 +89,18 @@ public class StaticShader : RenderProgram
 
         void main() {
             uvFrag = uv;
+            uvFlatFrag = uv;
 
             float splitOptions = options;
-            float lightLevelBufferIndex = trunc(splitOptions / 4);
-            splitOptions -= (lightLevelBufferIndex * 4);
-            addAlphaFrag = trunc(splitOptions / 2);
-            alphaFrag = splitOptions - (addAlphaFrag * 2);  
+            float lightLevelBufferIndex = trunc(splitOptions / 16);
+            splitOptions -= (lightLevelBufferIndex * 16);
+            addAlphaFrag = trunc(splitOptions / 8);
+            splitOptions -= (addAlphaFrag * 8);
+            alphaFrag = trunc(splitOptions / 4);
+            splitOptions -= (alphaFrag * 4);
+            topFrag = trunc(splitOptions / 2);
+            splitOptions -= (topFrag * 2);
+            leftFrag = splitOptions;
 
             colorMapIndexFrag = trunc(colorMapIndex / 256);
             vertexLightLevelFrag = colorMapIndex - (colorMapIndexFrag * 256);
@@ -115,8 +124,11 @@ public class StaticShader : RenderProgram
         #version 330
 
         in vec2 uvFrag;
+        flat in vec2 uvFlatFrag;
         flat in float alphaFrag;
         flat in float addAlphaFrag;
+        flat in float topFrag;
+        flat in float leftFrag;
 
         out vec4 fragColor;
 
@@ -137,7 +149,7 @@ public class StaticShader : RenderProgram
     "
     .Replace("${LightLevelFragFunction}", LightLevel.FragFunction)
     .Replace("${LightLevelFragVariables}", LightLevel.FragVariables(LightLevelOptions.Default))
-    .Replace("${FragColorFunction}", FragFunction.FragColorFunction(FragColorFunctionOptions.AddAlpha | FragColorFunctionOptions.Colormap))
+    .Replace("${FragColorFunction}", FragFunction.FragColorFunction(FragColorFunctionOptions.AddAlpha | FragColorFunctionOptions.Colormap | FragColorFunctionOptions.VertexGapClampUV))
     .Replace("${SectorColorMapFragVariables}", SectorColorMap.FragVariables)
     .Replace("${SectorColorMapFragFunction}", SectorColorMap.FragFunction);
 }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
@@ -62,7 +62,7 @@ public class StaticShader : RenderProgram
     public void ColorMapIndex(int index) => Uniforms.Set(index, m_colorMapIndexLocation);
     public void LightMode(RenderLightMode mode) => Uniforms.Set((int)mode, m_lightModeLocation);
     public void GammaCorrection(float value) => Uniforms.Set(value, m_gammaCorrectionLocation);
-    public void VertexGapClampUV(float value) => Uniforms.Set(value, m_vertexGapClampUV);
+    public void VertexGapClampUV(bool value) => Uniforms.Set(value, m_vertexGapClampUV);
 
     protected override string VertexShader() => @"
         #version 330
@@ -87,7 +87,7 @@ public class StaticShader : RenderProgram
 
         uniform mat4 mvp;
         uniform float timeFrac;
-        uniform float vertexGapClampUV;
+        uniform int vertexGapClampUV;
         uniform sampler2D boundTexture;
 
         void main() {

--- a/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
@@ -74,7 +74,6 @@ public class StaticShader : RenderProgram
         layout(location = 4) in float colorMapIndex;
 
         out vec2 uvFrag;
-        flat out vec2 uvFlatFrag;
         flat out float alphaFrag;
         flat out float addAlphaFrag;
         flat out float colorMapIndexFrag;
@@ -93,7 +92,6 @@ public class StaticShader : RenderProgram
 
         void main() {
             uvFrag = uv;
-            uvFlatFrag = uv;
 
             ${VertexOptionsSet}
 
@@ -124,7 +122,6 @@ public class StaticShader : RenderProgram
         #version 330
 
         in vec2 uvFrag;
-        flat in vec2 uvFlatFrag;
         flat in float alphaFrag;
         flat in float addAlphaFrag;
         ${VertexGapVariables}

--- a/Core/Render/OpenGL/Renderers/Legacy/World/VertexOptions.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/VertexOptions.cs
@@ -1,45 +1,13 @@
-﻿using System;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 
 namespace Helion.Render.OpenGL.Renderers.Legacy.World;
-
-public struct VertexOptionsOut
-{
-    public float LightBufferIndex;
-    public float AddAlpha;
-    public float Alpha;
-    public float Left;
-    public float Top;
-}
 
 public static class VertexOptions
 {
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static float World(float top, float left, float alpha, float addAlpha, int lightLevelBufferIndex)
+    public static float World(float topLeft, float alpha, float addAlpha, int lightLevelBufferIndex)
     {
-        return left + (top * 2) + (alpha * 4) + (addAlpha * 8) + (lightLevelBufferIndex * 16);
-    }    
-
-    public static VertexOptionsOut GetOptions(float options)
-    {
-        float splitOptions = options;
-        float lightLevelBufferIndex = (float)Math.Floor(splitOptions / 16);
-        splitOptions -= (lightLevelBufferIndex * 16);
-        float addAlphaFrag = (float)Math.Floor(splitOptions / 8);
-        splitOptions -= (addAlphaFrag * 8);
-        float alphaFrag = (float)Math.Floor(splitOptions / 4);
-        splitOptions -= (alphaFrag * 4);
-        float leftFrag = (float)Math.Floor(splitOptions / 2);
-        float topFrag = splitOptions - (leftFrag * 2);
-
-        return new VertexOptionsOut()
-        {
-            LightBufferIndex = lightLevelBufferIndex,
-            AddAlpha = addAlphaFrag,
-            Alpha = alphaFrag,
-            Left = leftFrag,
-            Top = topFrag
-        };
+        return topLeft + (alpha * 2) + (addAlpha * 4) + (lightLevelBufferIndex * 8);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Core/Render/OpenGL/Renderers/Legacy/World/VertexOptions.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/VertexOptions.cs
@@ -7,7 +7,8 @@ public static class VertexOptions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static float World(float topLeft, float alpha, float addAlpha, int lightLevelBufferIndex)
     {
-        return topLeft + (alpha * 2) + (addAlpha * 4) + (lightLevelBufferIndex * 8);
+        // Alpha must be first since it's < 1
+        return alpha + (topLeft * 2) + (addAlpha * 4) + (lightLevelBufferIndex * 8);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Core/Render/OpenGL/Renderers/Legacy/World/VertexOptions.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/VertexOptions.cs
@@ -1,13 +1,45 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System;
+using System.Runtime.CompilerServices;
 
 namespace Helion.Render.OpenGL.Renderers.Legacy.World;
+
+public struct VertexOptionsOut
+{
+    public float LightBufferIndex;
+    public float AddAlpha;
+    public float Alpha;
+    public float Left;
+    public float Top;
+}
 
 public static class VertexOptions
 {
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static float World(float alpha, float addAlpha, int lightLevelBufferIndex)
+    public static float World(float top, float left, float alpha, float addAlpha, int lightLevelBufferIndex)
     {
-        return alpha + (addAlpha * 2) + (lightLevelBufferIndex * 4);
+        return left + (top * 2) + (alpha * 4) + (addAlpha * 8) + (lightLevelBufferIndex * 16);
+    }    
+
+    public static VertexOptionsOut GetOptions(float options)
+    {
+        float splitOptions = options;
+        float lightLevelBufferIndex = (float)Math.Floor(splitOptions / 16);
+        splitOptions -= (lightLevelBufferIndex * 16);
+        float addAlphaFrag = (float)Math.Floor(splitOptions / 8);
+        splitOptions -= (addAlphaFrag * 8);
+        float alphaFrag = (float)Math.Floor(splitOptions / 4);
+        splitOptions -= (alphaFrag * 4);
+        float leftFrag = (float)Math.Floor(splitOptions / 2);
+        float topFrag = splitOptions - (leftFrag * 2);
+
+        return new VertexOptionsOut()
+        {
+            LightBufferIndex = lightLevelBufferIndex,
+            AddAlpha = addAlphaFrag,
+            Alpha = alphaFrag,
+            Left = leftFrag,
+            Top = topFrag
+        };
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Core/Render/Renderer.cs
+++ b/Core/Render/Renderer.cs
@@ -89,8 +89,6 @@ public partial class Renderer : IDisposable
         SetGLDebugger();
         SetShaderVars();
 
-        GL.ProvokingVertex(ProvokingVertexMode.FirstVertexConvention);
-
         Textures = new LegacyGLTextureManager(config, archiveCollection);
         m_worldRenderer = new LegacyWorldRenderer(config, archiveCollection, Textures);
         m_hudRenderer = new LegacyHudRenderer(config, Textures, archiveCollection.DataCache);
@@ -477,6 +475,9 @@ public partial class Renderer : IDisposable
         GL.FrontFace(FrontFaceDirection.Ccw);
         GL.CullFace(CullFaceMode.Back);
         GL.PolygonMode(MaterialFace.FrontAndBack, PolygonMode.Fill);
+
+        // Required for uv clamping in the vertex shader for pixel gap correction
+        GL.ProvokingVertex(ProvokingVertexMode.FirstVertexConvention);
     }
 
     private void SetGLDebugger()

--- a/Core/Render/Renderer.cs
+++ b/Core/Render/Renderer.cs
@@ -89,6 +89,8 @@ public partial class Renderer : IDisposable
         SetGLDebugger();
         SetShaderVars();
 
+        GL.ProvokingVertex(ProvokingVertexMode.FirstVertexConvention);
+
         Textures = new LegacyGLTextureManager(config, archiveCollection);
         m_worldRenderer = new LegacyWorldRenderer(config, archiveCollection, Textures);
         m_hudRenderer = new LegacyHudRenderer(config, Textures, archiveCollection.DataCache);

--- a/Core/Util/Constants.cs
+++ b/Core/Util/Constants.cs
@@ -42,7 +42,7 @@ public static class Constants
 
     public const short ClearBlock = short.MaxValue;
 
-    public const double VertexGapPush = 0.015f;
+    public const double VertexGapPush = 0.015;
 
     /// <summary>
     /// The name of the decorate player class.

--- a/Core/Util/Constants.cs
+++ b/Core/Util/Constants.cs
@@ -42,7 +42,7 @@ public static class Constants
 
     public const short ClearBlock = short.MaxValue;
 
-    public const double VertexGapPush = 0.015;
+    public const double VertexGapPush = 0.01;
 
     /// <summary>
     /// The name of the decorate player class.

--- a/Core/World/Geometry/Lines/Line.cs
+++ b/Core/World/Geometry/Lines/Line.cs
@@ -33,7 +33,8 @@ public sealed class Line
     public int PhysicsCount;
     public string? MusicChangeFront;
     public string? MusicChangeBack;
-    private double? m_length;
+    private double m_length;
+    private double m_angle;
 
     public Vec2D StartPosition => Segment.Start;
     public Vec2D EndPosition => Segment.End;
@@ -66,6 +67,9 @@ public sealed class Line
             back.Line = this;
             back.Sector.Lines.Add(this);
         }
+
+        m_length = -1;
+        m_angle = double.MinValue;
     }
 
     public void Reset()
@@ -83,11 +87,21 @@ public sealed class Line
     // Same as Segment.Length, but caches the value.
     public double GetLength()
     {
-        if (m_length.HasValue)
-            return m_length.Value;
+        if (m_length != -1)
+            return m_length;
 
         m_length = Segment.Length();
-        return m_length.Value;
+        return m_length;
+    }
+
+    // Same as Segment.Start.Angle(Segment.End), but caches the value.
+    public double GetAngle()
+    {
+        if (m_angle != double.MinValue)
+            return m_angle;
+
+        m_angle = Segment.Start.Angle(Segment.End);
+        return m_angle;
     }
 
     public LineModel ToLineModel(IWorld world)

--- a/Core/World/Impl/SinglePlayer/MarkSpecials.cs
+++ b/Core/World/Impl/SinglePlayer/MarkSpecials.cs
@@ -296,7 +296,7 @@ public class MarkSpecials
     private static Vec3D GetActivatedLinePoint(IWorld world, Line line)
     {
         var lineCenter = line.Segment.FromTime(0.5);
-        var lineAngle = line.Segment.Start.Angle(line.Segment.End);
+        var lineAngle = line.GetAngle();
         lineCenter = lineCenter + Vec2D.UnitCircle(lineAngle - MathHelper.HalfPi) * 8;
 
         if (line.Back == null)

--- a/Core/World/Special/SpecialManager.cs
+++ b/Core/World/Special/SpecialManager.cs
@@ -833,7 +833,7 @@ public sealed class SpecialManager : ITickable, IDisposable
     {
         SectorPlanes planes = (SectorPlanes)line.Args.Arg1;
         var sectors = GetSectorsFromSpecialLine(line);
-        var rotate = -line.StartPosition.Angle(line.EndPosition);
+        var rotate = -line.GetAngle();
         for (int i = 0; i < sectors.Count; i++)
         {
             var sector = sectors.GetSector(i);


### PR DESCRIPTION
Clamps uv coordinates of the extended ranges of the line segments so that the pixels repeat. This fixes issue where the next row of pixels from textures are sometimes shown.