### PR TITLE
always check for pause/resume when a layer is added or removed

### DIFF
--- a/Core/Layer/GameLayerManager.cs
+++ b/Core/Layer/GameLayerManager.cs
@@ -233,6 +233,8 @@ public class GameLayerManager : IGameLayerManager
             gameLayer.OnShow();
             GameLayerAdded?.Invoke(this, gameLayer);
         }
+
+        WorldLayer?.CheckPauseOrResume();
     }
 
     private void World_OnTick(object? sender, EventArgs e)
@@ -356,6 +358,8 @@ public class GameLayerManager : IGameLayerManager
             EndoomLayer?.Dispose();
             EndoomLayer = null;
         }
+
+        WorldLayer?.CheckPauseOrResume();
     }
 
     private void RemoveAnimatedLayer(object layer)
@@ -390,6 +394,8 @@ public class GameLayerManager : IGameLayerManager
             LoadingLayer?.Dispose();
             LoadingLayer = null;
         }
+
+        WorldLayer?.CheckPauseOrResume();
     }
 
     private void ResetAndGrabMouse()

--- a/Core/Layer/Worlds/WorldLayer.Logic.cs
+++ b/Core/Layer/Worlds/WorldLayer.Logic.cs
@@ -35,7 +35,7 @@ public partial class WorldLayer
             return;
 
         TickWorld(tickerInfo);
-        HandlePauseOrResume();
+        CheckPauseOrResume();
     }
 
     public bool StartRecording(IDemoRecorder recorder)
@@ -210,7 +210,7 @@ public partial class WorldLayer
         return true;
     }
 
-    private void HandlePauseOrResume()
+    public void CheckPauseOrResume()
     {
         if (m_stopped)
             return;

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -29,3 +29,4 @@
 - Fix transfer heights movement issue when a sector completes movement before it's control sector completes
 - Fix changing skill during gameplay to correctly set on next level load
 - Fix setting skill from command line changing the skill level from a save when a new map is loaded
+- Fix issue where players view can be unintentionally changed from mouse input during melt transition


### PR DESCRIPTION
 fixes tick gap issue on level start that can mess up mouse input