### PR TITLE
Emulate vanilla sprite clipping behavior with walls

### DIFF
--- a/Core/Layer/Worlds/WorldLayer.Render.Hud.cs
+++ b/Core/Layer/Worlds/WorldLayer.Render.Hud.cs
@@ -337,14 +337,15 @@ public partial class WorldLayer
         if (!Player.Cheats.IsCheatActive(Helion.World.Cheats.CheatType.ShowPosition))
             return;
 
-        DrawCoordinate(hud, "X", Player.Position.X, ref topRightY);
-        DrawCoordinate(hud, "Y", Player.Position.Y, ref topRightY);
-        DrawCoordinate(hud, "Z", Player.Position.Z, ref topRightY);
-        DrawCoordinate(hud, "A", Player.AngleRadians % Math.PI * 180 / MathHelper.Pi, ref topRightY);
-        DrawCoordinate(hud, "P", Player.PitchRadians % Math.PI * 180 / MathHelper.Pi, ref topRightY);
-        DrawCoordinate(hud, "VX", Player.Velocity.X, ref topRightY);
-        DrawCoordinate(hud, "VY", Player.Velocity.Y, ref topRightY);
-        DrawCoordinate(hud, "VZ", Player.Velocity.Z, ref topRightY);
+        var player = Player.World.GetCameraPlayer();
+        DrawCoordinate(hud, "X", player.Position.X, ref topRightY);
+        DrawCoordinate(hud, "Y", player.Position.Y, ref topRightY);
+        DrawCoordinate(hud, "Z", player.Position.Z, ref topRightY);
+        DrawCoordinate(hud, "A", player.AngleRadians % Math.PI * 180 / MathHelper.Pi, ref topRightY);
+        DrawCoordinate(hud, "P", player.PitchRadians % Math.PI * 180 / MathHelper.Pi, ref topRightY);
+        DrawCoordinate(hud, "VX", player.Velocity.X, ref topRightY);
+        DrawCoordinate(hud, "VY", player.Velocity.Y, ref topRightY);
+        DrawCoordinate(hud, "VZ", player.Velocity.Z, ref topRightY);
         topRightY += m_padding;
     }
 

--- a/Core/Render/BindTextures.cs
+++ b/Core/Render/BindTextures.cs
@@ -1,0 +1,11 @@
+﻿
+using OpenTK.Graphics.OpenGL;
+
+namespace Helion.Render;
+
+public static class BindTextures
+{
+    public const TextureUnit WallClipTexture = TextureUnit.Texture8;
+    public const TextureUnit MapLineData = TextureUnit.Texture9;
+    public const TextureUnit PlaneClipTexture = TextureUnit.Texture10;
+}

--- a/Core/Render/BindTextures.cs
+++ b/Core/Render/BindTextures.cs
@@ -5,6 +5,14 @@ namespace Helion.Render;
 
 public static class BindTextures
 {
+    public const TextureUnit BoundTexture = TextureUnit.Texture0;
+    public const TextureUnit SectorLight = TextureUnit.Texture1;
+    public const TextureUnit Colormap = TextureUnit.Texture2;
+    public const TextureUnit SectorColormap = TextureUnit.Texture3;
+    public const TextureUnit AccumTexture = TextureUnit.Texture4;
+    public const TextureUnit AccumCountTexture = TextureUnit.Texture5;
+    public const TextureUnit FuzzTexture = TextureUnit.Texture6;
+    public const TextureUnit OpaqueTexture = TextureUnit.Texture7;
     public const TextureUnit WallClipTexture = TextureUnit.Texture8;
     public const TextureUnit MapLineData = TextureUnit.Texture9;
     public const TextureUnit PlaneClipTexture = TextureUnit.Texture10;

--- a/Core/Render/BindTextures.cs
+++ b/Core/Render/BindTextures.cs
@@ -16,4 +16,5 @@ public static class BindTextures
     public const TextureUnit WallClipTexture = TextureUnit.Texture8;
     public const TextureUnit MapLineData = TextureUnit.Texture9;
     public const TextureUnit PlaneClipTexture = TextureUnit.Texture10;
+    public const TextureUnit LineHeights = TextureUnit.Texture11;
 }

--- a/Core/Render/OpenGL/Framebuffer/PlaneClipFrameBuffer.cs
+++ b/Core/Render/OpenGL/Framebuffer/PlaneClipFrameBuffer.cs
@@ -52,7 +52,7 @@ public class PlaneClipFrameBuffer : IDisposable
     public unsafe void Clear()
     {
         GL.Clear(ClearBufferMask.DepthBufferBit);
-        var clear = stackalloc float[2] { -1e30f, -1e30f };
+        var clear = stackalloc float[2] { -1e30f, 1e30f };
         GL.ClearBuffer(ClearBuffer.Color, 0, clear);
         GL.Clear(ClearBufferMask.DepthBufferBit);
     }

--- a/Core/Render/OpenGL/Framebuffer/PlaneClipFrameBuffer.cs
+++ b/Core/Render/OpenGL/Framebuffer/PlaneClipFrameBuffer.cs
@@ -27,7 +27,7 @@ public class PlaneClipFrameBuffer : IDisposable
         m_texture = GL.GenTexture();
         GL.BindTexture(TextureTarget.Texture2D, m_texture);
         GLHelper.ObjectLabel(ObjectLabelIdentifier.Texture, m_texture, "PlaneClip Texture");
-        GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rg32f, width, height, 0, PixelFormat.Rg, PixelType.Float, IntPtr.Zero);
+        GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgb32f, width, height, 0, PixelFormat.Rgb, PixelType.Float, IntPtr.Zero);
         GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int)TextureMinFilter.Linear);
         GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int)TextureMagFilter.Linear);
         GL.BindTexture(TextureTarget.Texture2D, 0);
@@ -49,19 +49,22 @@ public class PlaneClipFrameBuffer : IDisposable
             throw new Exception("Failed to complete PlaneClip framebuffer");
     }
 
-    public unsafe void StartRender()
+    public unsafe void Clear()
     {
-        // Writes plane z to r, depth to g
-        var clear = stackalloc float[2] { -1e30f, -1e30f };
-        BindFrameBuffer();
-
+        GL.Clear(ClearBufferMask.DepthBufferBit);
+        // Writes plane z to r, depth to g, type (0 = floor/ceiling, 1 = wall)
+        var clear = stackalloc float[3] { -1e30f, -1e30f, 0 };
         GL.ClearBuffer(ClearBuffer.Color, 0, clear);
         GL.Clear(ClearBufferMask.DepthBufferBit);
+    }
+
+    public unsafe void StartRender()
+    {
         GL.BlendEquation(BlendEquationMode.FuncAdd);
         GL.BlendFunc(BlendingFactor.One, BlendingFactor.Zero);
     }
 
-    public void BindPlaneZTexture(TextureUnit textureUnit)
+    public void BindPlaneTexture(TextureUnit textureUnit)
     {
         GL.ActiveTexture(textureUnit);
         GL.BindTexture(TextureTarget.Texture2D, m_texture);

--- a/Core/Render/OpenGL/Framebuffer/PlaneClipFrameBuffer.cs
+++ b/Core/Render/OpenGL/Framebuffer/PlaneClipFrameBuffer.cs
@@ -13,7 +13,7 @@ public class PlaneClipFrameBuffer : IDisposable
     private Dimension m_dimension;
     private GLTexture2D? m_depthTexture;
 
-    public void CreateOrUpdate(Dimension dimension)
+    public void CreateOrUpdate(string name, Dimension dimension)
     {
         if (m_framebuffer != 0 && dimension.Width == m_dimension.Width && dimension.Height == m_dimension.Height)
             return;
@@ -26,19 +26,19 @@ public class PlaneClipFrameBuffer : IDisposable
 
         m_texture = GL.GenTexture();
         GL.BindTexture(TextureTarget.Texture2D, m_texture);
-        GLHelper.ObjectLabel(ObjectLabelIdentifier.Texture, m_texture, "PlaneClip Texture");
-        GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rg32f, width, height, 0, PixelFormat.Rg, PixelType.Float, IntPtr.Zero);
+        GLHelper.ObjectLabel(ObjectLabelIdentifier.Texture, m_texture, $"{name} Texture");
+        GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgb32f, width, height, 0, PixelFormat.Rgb, PixelType.Float, IntPtr.Zero);
         GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int)TextureMinFilter.Linear);
         GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int)TextureMagFilter.Linear);
         GL.BindTexture(TextureTarget.Texture2D, 0);
 
-        m_depthTexture = new GLTexture2D("PlaneClip Depth Stencil Attachment", dimension);
+        m_depthTexture = new GLTexture2D($"{name} Depth Stencil Attachment", dimension);
         m_depthTexture.Bind();
         GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Depth32fStencil8, width, height, 0, PixelFormat.DepthStencil, PixelType.Float32UnsignedInt248Rev, IntPtr.Zero);
         m_depthTexture.Unbind();
 
         m_framebuffer = GL.GenFramebuffer();
-        GLHelper.ObjectLabel(ObjectLabelIdentifier.Framebuffer, m_framebuffer, "PlaneClip Framebuffer");
+        GLHelper.ObjectLabel(ObjectLabelIdentifier.Framebuffer, m_framebuffer, $"{name} Framebuffer");
         GL.BindFramebuffer(FramebufferTarget.Framebuffer, m_framebuffer);
         GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment0, TextureTarget.Texture2D, m_texture, 0);
         GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.DepthStencilAttachment, TextureTarget.Texture2D, m_depthTexture.Name, 0);
@@ -52,7 +52,7 @@ public class PlaneClipFrameBuffer : IDisposable
     public unsafe void Clear()
     {
         GL.Clear(ClearBufferMask.DepthBufferBit);
-        var clear = stackalloc float[2] { -1e30f, 1e30f };
+        var clear = stackalloc float[3] { -1e30f, 1e30f, -1 };
         GL.ClearBuffer(ClearBuffer.Color, 0, clear);
         GL.Clear(ClearBufferMask.DepthBufferBit);
     }

--- a/Core/Render/OpenGL/Framebuffer/PlaneClipFrameBuffer.cs
+++ b/Core/Render/OpenGL/Framebuffer/PlaneClipFrameBuffer.cs
@@ -27,7 +27,7 @@ public class PlaneClipFrameBuffer : IDisposable
         m_texture = GL.GenTexture();
         GL.BindTexture(TextureTarget.Texture2D, m_texture);
         GLHelper.ObjectLabel(ObjectLabelIdentifier.Texture, m_texture, "PlaneClip Texture");
-        GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgb32f, width, height, 0, PixelFormat.Rgb, PixelType.Float, IntPtr.Zero);
+        GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rg32f, width, height, 0, PixelFormat.Rg, PixelType.Float, IntPtr.Zero);
         GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int)TextureMinFilter.Linear);
         GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int)TextureMagFilter.Linear);
         GL.BindTexture(TextureTarget.Texture2D, 0);
@@ -52,8 +52,7 @@ public class PlaneClipFrameBuffer : IDisposable
     public unsafe void Clear()
     {
         GL.Clear(ClearBufferMask.DepthBufferBit);
-        // Writes plane z to r, depth to g, type (0 = floor/ceiling, 1 = wall)
-        var clear = stackalloc float[3] { -1e30f, -1e30f, 0 };
+        var clear = stackalloc float[2] { -1e30f, -1e30f };
         GL.ClearBuffer(ClearBuffer.Color, 0, clear);
         GL.Clear(ClearBufferMask.DepthBufferBit);
     }

--- a/Core/Render/OpenGL/Renderers/BasicFramebufferRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/BasicFramebufferRenderer.cs
@@ -54,9 +54,9 @@ public class BasicFramebufferRenderer : IDisposable
 
         m_program.Bind();
 
-        GL.ActiveTexture(TextureUnit.Texture0);
+        GL.ActiveTexture(BindTextures.BoundTexture);
         buffer.ColorAttachment0.Bind();
-        m_program.BoundTexture(TextureUnit.Texture0);
+        m_program.BoundTexture(BindTextures.BoundTexture);
         m_program.Mvp(mat4.Identity);
 
         m_vao.Bind();

--- a/Core/Render/OpenGL/Renderers/FramebufferRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/FramebufferRenderer.cs
@@ -156,9 +156,9 @@ public class FramebufferRenderer : IDisposable
 
         m_program.Bind();
 
-        GL.ActiveTexture(TextureUnit.Texture0);
+        GL.ActiveTexture(BindTextures.BoundTexture);
         Framebuffer.ColorAttachment0.Bind();
-        m_program.BoundTexture(TextureUnit.Texture0);
+        m_program.BoundTexture(BindTextures.BoundTexture);
         m_program.Mvp(mvp);
 
         m_vao.Bind();

--- a/Core/Render/OpenGL/Renderers/Legacy/Hud/LegacyHudRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/Hud/LegacyHudRenderer.cs
@@ -116,10 +116,10 @@ public class LegacyHudRenderer : HudRenderer
     {
         m_program.Bind();
 
-        GL.ActiveTexture(TextureUnit.Texture0);
-        m_program.BoundTexture(TextureUnit.Texture0);
-        m_program.ColormapTexture(TextureUnit.Texture2);
-        m_program.OpaqueTexture(TextureUnit.Texture7);
+        GL.ActiveTexture(BindTextures.BoundTexture);
+        m_program.BoundTexture(BindTextures.BoundTexture);
+        m_program.ColormapTexture(BindTextures.Colormap);
+        m_program.OpaqueTexture(BindTextures.OpaqueTexture);
         m_program.Mvp(CreateMvp(viewport));
         m_program.FuzzFrac(Renderer.GetTimeFrac());
         m_program.FuzzDiv(Renderer.GetFuzzDiv(m_config.Render, viewport));

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Data/RenderWorldDataManager.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Data/RenderWorldDataManager.cs
@@ -79,13 +79,7 @@ public class RenderWorldDataManager : IDisposable
 
     public void RenderFlats()
     {
-        m_lookup.Get(GeometryType.Floor).Draw();
-        m_lookup.Get(GeometryType.Ceiling).Draw();
-    }
-
-    public void RenderFloors()
-    {
-        m_lookup.Get(GeometryType.Floor).Draw();
+        m_lookup.Get(GeometryType.Flat).Draw();
     }
 
     public void RenderCoverWalls()

--- a/Core/Render/OpenGL/Renderers/Legacy/World/DynamicVertex.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/DynamicVertex.cs
@@ -32,7 +32,4 @@ public struct DynamicVertex
 
     [VertexAttribute(required: false)]
     public float ColorMapIndex;
-
-    [VertexAttribute(required: false)]
-    public float MapId;
 }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/DynamicVertex.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/DynamicVertex.cs
@@ -32,4 +32,7 @@ public struct DynamicVertex
 
     [VertexAttribute(required: false)]
     public float ColorMapIndex;
+
+    [VertexAttribute(required: false)]
+    public float MapId;
 }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
@@ -126,9 +126,9 @@ public class EntityProgram : RenderProgram
         layout(location = 1) in float lightLevel;
         layout(location = 2) in float options;
         layout(location = 3) in vec3 prevPos;
-        layout(location = 4) in float offsetZ;
-        layout(location = 5) in vec3 centerPos;
-        layout(location = 6) in vec3 sectorIndex;
+        layout(location = 4) in float offsetXY;
+        layout(location = 5) in float offsetZ;
+        layout(location = 6) in float sectorIndex;
 
         out float lightLevelOut;
         out float alphaOut;
@@ -137,7 +137,7 @@ public class EntityProgram : RenderProgram
         out float colorMapTranslationOut;
         out float positionZOut;
         out float offsetZOut;
-        out vec3 centerPosOut;
+        out float offsetXYOut;
         ${SectorColorMapVar}
 
         uniform float timeFrac;
@@ -159,7 +159,7 @@ public class EntityProgram : RenderProgram
             flipUOut = flipU;
             colorMapTranslationOut = colorMapTranslation;
             offsetZOut = offsetZ;
-            centerPosOut = centerPos;
+            offsetXYOut = offsetXY;
             ${SectorColorMap}
             gl_Position = vec4(mix(prevPos, pos, timeFrac), 1.0);
             positionZOut = gl_Position.z;
@@ -184,7 +184,7 @@ public class EntityProgram : RenderProgram
         in float colorMapTranslationOut[];
         in float positionZOut[];
         in float offsetZOut[];
-        in vec3 centerPosOut[];
+        in float offsetXYOut[];
         ${SectorColorMapVar}
 
         out vec2 uvFrag;
@@ -225,17 +225,16 @@ public class EntityProgram : RenderProgram
             pos.z += offsetZOut[0];
             ivec2 textureDim = textureSize(boundTexture, 0);
             vec3 posMoveDir = vec3(mix(prevViewRightNormal, viewRightNormal, timeFrac), 0);
-            vec3 minPos = pos;
-            vec3 maxPos = pos + (posMoveDir * textureDim.x) + (vec3(0, 0, 1) * textureDim.y);
+            vec3 offsetXY = vec3(posMoveDir.xy * offsetXYOut[0], 0);
+            vec3 minPos = pos - offsetXY;
+            vec3 maxPos = pos + (posMoveDir * textureDim.x) + (vec3(0, 0, 1) * textureDim.y) - offsetXY;
 
             if (healthBarMode == 1) {
+                minPos = pos;
+                maxPos = pos;
                 minPos -= (posMoveDir * HalfBoxWidth) + (vec3(0, 0, 1) * 2) + (posMoveDir * colorMapTranslationOut[0]);
                 maxPos += (posMoveDir * HalfBoxWidth) + (vec3(0, 0, 1) * 2) + (posMoveDir * colorMapTranslationOut[0]);
             }
-
-            // Triangle strip ordering is: v0 v1 v2, v2 v1 v3
-            // We also need to be going counter-clockwise.
-            // Also the UV's are inverted, so draw from 1 down to 0 along the Y.
 
             // fuzzDist is going to be the center of min/max.
             // This keeps the fuzz consistent across the texture.
@@ -245,7 +244,7 @@ public class EntityProgram : RenderProgram
             // Render distance squared in 2d space for fade in/out effect
             renderDistSquared = distSquared(viewPos.xy, pos.xy);
 
-            centerPosFrag = centerPosOut[0];
+            centerPosFrag = pos;
             zPosDepthFrag = (mvp * vec4(centerPosFrag.x, centerPosFrag.y, centerPosFrag.z, 1)).${Depth};
 
             lightLevelFrag = lightLevelOut[0];

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
@@ -367,12 +367,12 @@ public class EntityProgram : RenderProgram
     private static string GetDiscardPlaneClipFunction()
     {
         return @"
-        bool lineIntersection(vec2 A, vec2 B, vec2 C, vec2 D) {
-            vec2 dir1 = B - A;
-            vec2 dir2 = D - C;
-            float d = dir1.x * -dir2.y + dir1.y * dir2.x;
-            float t = ((C.x - A.x) * (C.y - D.y) - (C.y - A.y) * (C.x - D.x)) / d;
-            float u = ((C.x - A.x) * (A.y - B.y) - (C.y - A.y) * (A.x - B.x)) / d;            
+        bool lineIntersection(vec2 startA, vec2 endA, vec2 startB, vec2 endB) {
+            vec2 deltaA = endA - startA;
+            vec2 deltaB = endB - startB;
+            float d = deltaA.x * -deltaB.y + deltaA.y * deltaB.x;
+            float t = ((startB.x - startA.x) * (startB.y - endB.y) - (startB.y - startA.y) * (startB.x - endB.x)) / d;
+            float u = ((startB.x - startA.x) * (startA.y - endA.y) - (startB.y - startA.y) * (startA.x - endA.x)) / d;
             return t >= 0.0 && t <= 1.0 && u >= 0.0 && u <= 1.0;
         }
 
@@ -380,42 +380,37 @@ public class EntityProgram : RenderProgram
             ivec2 getCoords = ivec2(gl_FragCoord.xy);
             vec3 planeClip = texelFetch(planeClipTexture, getCoords, 0).rgb;
 
-            if (planeClip.g < depthFrag) {
+            // 0 = floor, 1 = line
+            if (planeClip.b == 0) {
                 // If floor this pixel would be discarded to depth and the plane is higher than the z position then discard.
-                if (planeClip.b == 0 && planeClip.r > zPosFrag)
-                    return true;
-
-                // If wall this pixel would be discarded to depth check which side of the line the camera is on
-                if (planeClip.b == 1) {
-                    vec4 linePoints = texelFetch(mapDataTexture, int(planeClip.r));
-                    vec2 lineStart = linePoints.rg;
-                    vec2 lineEnd = linePoints.ba;
-                    vec2 lineDelta = lineEnd - lineStart;
-
-                    float viewDotProduct = (lineDelta.x * (viewPos.y - lineStart.y)) - (lineDelta.y * (viewPos.x - lineStart.x));                
-                    float entityDotProduct = (lineDelta.x * (centerPosFrag.y - lineStart.y)) - (lineDelta.y * (centerPosFrag.x - lineStart.x));
-
-                    // If the sprite isn't on the same side of the line as the camera then discard
-                    bool viewFront = viewDotProduct < 0;
-                    bool entityFront = entityDotProduct < 0;
-                    if (viewFront != entityFront)
-                        return true;
-
-                    if (!lineIntersection(lineStart, lineEnd, minPosFrag.xy, maxPosFrag.xy))
-                        return true;
-                }
+                return planeClip.g < depthFrag && planeClip.r > zPosFrag;
             }
-            else if (planeClip.b == 1) {
+            else {
                 vec4 linePoints = texelFetch(mapDataTexture, int(planeClip.r));
                 vec2 lineStart = linePoints.rg;
                 vec2 lineEnd = linePoints.ba;
                 vec2 lineDelta = lineEnd - lineStart;
+
+                float viewDotProduct = (lineDelta.x * (viewPos.y - lineStart.y)) - (lineDelta.y * (viewPos.x - lineStart.x));                
                 float entityDotProduct = (lineDelta.x * (centerPosFrag.y - lineStart.y)) - (lineDelta.y * (centerPosFrag.x - lineStart.x));
+
+                bool viewFront = viewDotProduct < 0;
                 bool entityFront = entityDotProduct < 0;
 
-                float dotProductStart = (centerPosFrag.x - lineStart.x) * (lineDelta.x) + (centerPosFrag.y - lineStart.y) * (lineDelta.y);
-                float dotProductEnd = (centerPosFrag.x - lineEnd.x) * (-lineDelta.x) + (centerPosFrag.y - lineEnd.y) * (-lineDelta.y);
-                return (dotProductStart < 0 || dotProductEnd < 0) && !entityFront && lineIntersection(lineStart, lineEnd, minPosFrag.xy, maxPosFrag.xy);
+                if (planeClip.g < depthFrag) {
+                    // If the sprite isn't on the same side of the line as the camera then discard
+                    if (viewFront != entityFront)
+                        return true;
+
+                    // Discard to depth when the sprite line doesn't intersect the line
+                    return !lineIntersection(lineStart, lineEnd, minPosFrag.xy, maxPosFrag.xy);
+                }
+                else {
+                    float dotProductStart = (centerPosFrag.x - lineStart.x) * (lineDelta.x) + (centerPosFrag.y - lineStart.y) * (lineDelta.y);
+                    float dotProductEnd = (centerPosFrag.x - lineEnd.x) * (-lineDelta.x) + (centerPosFrag.y - lineEnd.y) * (-lineDelta.y);
+                    // If the sprite is behind the line and is not within the line bounds and intersects then discard
+                    return (dotProductStart < 0 || dotProductEnd < 0) && !entityFront && lineIntersection(lineStart, lineEnd, minPosFrag.xy, maxPosFrag.xy);
+                }
             }
             
             return false;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
@@ -413,7 +413,7 @@ public class EntityProgram : RenderProgram
                     float dotProductStart = (centerPosFrag.x - lineStart.x) * (lineDelta.x) + (centerPosFrag.y - lineStart.y) * (lineDelta.y);
                     float dotProductEnd = (centerPosFrag.x - lineEnd.x) * (-lineDelta.x) + (centerPosFrag.y - lineEnd.y) * (-lineDelta.y);
                     // If the sprite is behind the line and is not within the line bounds and intersects then discard
-                    return (dotProductStart < 0 || dotProductEnd < 0) && !entityFront && lineIntersection(lineStart, lineEnd, minPosFrag.xy, maxPosFrag.xy);
+                    return (dotProductStart < 0 || dotProductEnd < 0) && viewFront != entityFront && lineIntersection(lineStart, lineEnd, minPosFrag.xy, maxPosFrag.xy);
                 }
             }
             

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
@@ -384,9 +384,14 @@ public class EntityProgram : RenderProgram
         bool discardPlaneClip() {
             ivec2 getCoords = ivec2(gl_FragCoord.xy);
             vec2 wallClip = texelFetch(wallClipTexture, getCoords, 0).rg;
-            vec2 planeClip = texelFetch(planeClipTexture, getCoords, 0).rg;
+            vec3 planeClip = texelFetch(planeClipTexture, getCoords, 0).rgb;
 
-            if (planeClip.g < depthFrag && planeClip.r > zPosFrag)
+            // Floor
+            if (planeClip.b == 0 && planeClip.g < depthFrag && planeClip.r > zPosFrag)
+                return true;
+
+            // Ceiling
+            if (planeClip.b == 1 && planeClip.g < depthFrag && zPosFrag >= planeClip.r)
                 return true;
 
             if (wallClip.r >= 0) {

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
@@ -339,6 +339,9 @@ public class EntityProgram : RenderProgram
 
         void main()
         {
+            if (checkPlaneClip == 1 && discardPlaneClip())
+                discard;
+
             ${HealthBarCheck}
             ${LightLevelFragFunction}
             ${SectorColorMapFragFunction}
@@ -358,7 +361,8 @@ public class EntityProgram : RenderProgram
 
     private static string GetDiscardPlaneClipFunction()
     {
-        return @"bool discardPlaneClip(ivec2 getCoords) {
+        return @"bool discardPlaneClip() {
+            ivec2 getCoords = ivec2(gl_FragCoord.xy);
             vec3 planeClip = texelFetch(planeClipTexture, getCoords, 0).rgb;
 
             if (planeClip.g < depthFrag) {
@@ -404,10 +408,7 @@ public class EntityProgram : RenderProgram
         if (GetOitOptions() != OitOptions.None)
             clearAlpha = string.Empty;
 
-        return clearAlpha + @"
-        if (checkPlaneClip == 1 && discardPlaneClip(ivec2(gl_FragCoord.xy)))
-            discard;        
-       
+        return clearAlpha + @"   
         ${HealthBar}
 
         float fade = (maxDistanceSquared - renderDistSquared) / fadeDistance;
@@ -418,10 +419,6 @@ public class EntityProgram : RenderProgram
     private static string GetHealthBar() => @"
         }
         if (healthBarMode == 1) {
-            ivec2 getCoords = ivec2(gl_FragCoord.xy);
-            if (checkPlaneClip == 1 && discardPlaneClip(getCoords))
-                discard;
-
             fragColor = vec4(0, 0, 0, 1);
             const float RedAmount = 0.33;
             const float YellowAmount = 0.66;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
@@ -335,6 +335,7 @@ public class EntityProgram : RenderProgram
 
         ${OitVariables}
         ${FuzzFunction}
+        ${DiscardPlaneClipFunction}
 
         void main()
         {
@@ -352,27 +353,18 @@ public class EntityProgram : RenderProgram
     .Replace("${OitVariables}", FragFunction.OitFragVariables(GetOitOptions()))
     .Replace("${OutFragColor}", GetOutFragColor())
     .Replace("${BoxDefines}", BoxDefines)
-    .Replace("${HealthBarCheck}", GetOitOptions() == OitOptions.None ? "if (healthBarMode == 0) {" : "");
+    .Replace("${HealthBarCheck}", GetOitOptions() == OitOptions.None ? "if (healthBarMode == 0) {" : "")
+    .Replace("${DiscardPlaneClipFunction}", GetDiscardPlaneClipFunction());
 
-    private string GetPostProcess() 
+    private static string GetDiscardPlaneClipFunction()
     {
-        string clearAlpha = @"
-        fragColor.a = mix(0.0, 1.0, float(fragColor.a > 0.5));
-        if (fragColor.a <= 0)
-            discard;";
-
-        if (GetOitOptions() != OitOptions.None)
-            clearAlpha = string.Empty;
-
-        return clearAlpha + @"
-        if (checkPlaneClip == 1) {
-            ivec2 getCoords = ivec2(gl_FragCoord.xy);
+        return @"bool discardPlaneClip(ivec2 getCoords) {
             vec3 planeClip = texelFetch(planeClipTexture, getCoords, 0).rgb;
 
             if (planeClip.g < depthFrag) {
                 // If floor this pixel would be discarded to depth and the plane is higher than the z position then discard.
                 if (planeClip.b == 0 && planeClip.r > zPosFrag)
-                    discard;
+                    return true;
 
                 // If wall this pixel would be discarded to depth check which side of the line the camera is on
                 if (planeClip.b == 1) {
@@ -388,16 +380,33 @@ public class EntityProgram : RenderProgram
                     float viewFront = float(viewDotProduct <= 0);
                     float entityFront = float(entityDotProduct <= 0);
                     if (viewFront != entityFront)
-                        discard;
+                        return true;
                     
                     // If the sprite isn't between the lines start and end points then discard
                     float dotProductStart = (centerPosFrag.x - lineStart.x) * (lineDelta.x) + (centerPosFrag.y - lineStart.y) * (lineDelta.y);
                     float dotProductEnd = (centerPosFrag.x - lineEnd.x) * (-lineDelta.x) + (centerPosFrag.y - lineEnd.y) * (-lineDelta.y);
                     if (dotProductStart < 0 || dotProductEnd < 0)
-                        discard;
+                        return true;
                 }
             }
-        }
+            
+            return false;
+        }";
+    }
+
+    private string GetPostProcess() 
+    {
+        string clearAlpha = @"
+        fragColor.a = mix(0.0, 1.0, float(fragColor.a > 0.5));
+        if (fragColor.a <= 0)
+            discard;";
+
+        if (GetOitOptions() != OitOptions.None)
+            clearAlpha = string.Empty;
+
+        return clearAlpha + @"
+        if (checkPlaneClip == 1 && discardPlaneClip(ivec2(gl_FragCoord.xy)))
+            discard;        
        
         ${HealthBar}
 
@@ -409,8 +418,11 @@ public class EntityProgram : RenderProgram
     private static string GetHealthBar() => @"
         }
         if (healthBarMode == 1) {
-            fragColor = vec4(0, 0, 0, 1);
             ivec2 getCoords = ivec2(gl_FragCoord.xy);
+            if (checkPlaneClip == 1 && discardPlaneClip(getCoords))
+                discard;
+
+            fragColor = vec4(0, 0, 0, 1);
             const float RedAmount = 0.33;
             const float YellowAmount = 0.66;
             const float BorderThickness = 1.5;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
@@ -324,6 +324,7 @@ public class EntityProgram : RenderProgram
         uniform ivec2 screenBounds;
         uniform int checkPlaneClip;
         uniform int healthBarMode;
+        uniform vec3 viewPos;
 
         uniform sampler2D planeZTexture;
         uniform samplerBuffer mapDataTexture;
@@ -364,19 +365,27 @@ public class EntityProgram : RenderProgram
             ivec2 getCoords = ivec2(gl_FragCoord.xy);
             // r = floor's z position, g = floor's depth value
             vec3 planeClip = texelFetch(planeZTexture, getCoords, 0).rgb;
-            // If floor this pixel would be discarded to depth and the plane is higher than the z position then discard.
-            if (planeClip.b == 0 && planeClip.r > zPosFrag && planeClip.g < depthFrag)
-                discard;
 
-            // If wall this pixel would be discarded to depth check which side of the line the camera is on
-            if (planeClip.b == 1 && planeClip.g < depthFrag) {
-                vec4 linePoints = texelFetch(mapDataTexture, int(planeClip.r));
-                vec2 lineStart = linePoints.rg;
-                vec2 lineDelta = linePoints.ba;
-                
-                float entityDotProduct = (lineDelta.x * (centerPosFrag.y - lineStart.y)) - (lineDelta.y * (centerPosFrag.x - lineStart.x));
-                if (entityDotProduct > 0)
+            if (planeClip.g < depthFrag) {
+                // If floor this pixel would be discarded to depth and the plane is higher than the z position then discard.
+                if (planeClip.b == 0 && planeClip.r > zPosFrag)
                     discard;
+
+                // If wall this pixel would be discarded to depth check which side of the line the camera is on
+                if (planeClip.b == 1) {
+                    vec4 linePoints = texelFetch(mapDataTexture, int(planeClip.r));
+                    vec2 lineStart = linePoints.rg;
+                    vec2 lineDelta = linePoints.ba;
+
+                    float viewDotProduct = (lineDelta.x * (viewPos.y - lineStart.y)) - (lineDelta.y * (viewPos.x - lineStart.x));                
+                    float entityDotProduct = (lineDelta.x * (centerPosFrag.y - lineStart.y)) - (lineDelta.y * (centerPosFrag.x - lineStart.x));
+
+                    // If the sprite isn't on the same side of the line as the camera discard
+                    float viewFront = float(viewDotProduct < 0);
+                    float entityFront = float(entityDotProduct < 0);
+                    if (viewFront != entityFront)
+                        discard;
+                }
             }
         }
        

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
@@ -77,7 +77,7 @@ public class EntityProgram : RenderProgram
         m_planeZTextureLocation = Uniforms.GetLocation("planeZTexture");
         m_checkPlaneClipLocation = Uniforms.GetLocation("checkPlaneClip");
         m_healthBarModeLocation = Uniforms.GetLocation("healthBarMode");
-        m_mapDataTextureLoaction = Uniforms.GetLocation("mapData");
+        m_mapDataTextureLoaction = Uniforms.GetLocation("mapDataTexture");
     }
     
     public void BoundTexture(TextureUnit unit) => Uniforms.Set(unit, m_boundTextureLocation);
@@ -192,6 +192,8 @@ public class EntityProgram : RenderProgram
         flat out float fuzzFrag;
         flat out float colorMapTranslationFrag;
         flat out float zPosFrag;
+        flat out float zPosDepthFrag;
+        out vec3 centerPosFrag;
         out float depthFrag;
         ${SectorColorMapFrag}
 
@@ -238,6 +240,9 @@ public class EntityProgram : RenderProgram
             fuzzDist = (glPosMin.${Depth} + glPosMax.${Depth}) / 2;
             // Render distance squared in 2d space for fade in/out effect
             renderDistSquared = distSquared(viewPos.xy, pos.xy);
+
+            centerPosFrag = minPos + ((maxPos - minPos) / 2);    
+            zPosDepthFrag = (mvp * vec4(centerPosFrag.x, centerPosFrag.y, centerPosFrag.z, 1)).${Depth};
 
             lightLevelFrag = lightLevelOut[0];
             alphaFrag = alphaOut[0];
@@ -291,6 +296,8 @@ public class EntityProgram : RenderProgram
         flat in float fuzzFrag;
         flat in float colorMapTranslationFrag;
         flat in float zPosFrag;
+        flat in float zPosDepthFrag;
+        in vec3 centerPosFrag;
         in float depthFrag;
 
         ${SectorColorMapFragVariables}
@@ -319,7 +326,7 @@ public class EntityProgram : RenderProgram
         uniform int healthBarMode;
 
         uniform sampler2D planeZTexture;
-        uniform samplerBuffer mapData;
+        uniform samplerBuffer mapDataTexture;
 
         ${OitVariables}
         ${FuzzFunction}
@@ -357,14 +364,19 @@ public class EntityProgram : RenderProgram
             ivec2 getCoords = ivec2(gl_FragCoord.xy);
             // r = floor's z position, g = floor's depth value
             vec3 planeClip = texelFetch(planeZTexture, getCoords, 0).rgb;
-            // If this pixel would be discarded to depth and the plane is higher than the z position then discard.
+            // If floor this pixel would be discarded to depth and the plane is higher than the z position then discard.
             if (planeClip.b == 0 && planeClip.r > zPosFrag && planeClip.g < depthFrag)
                 discard;
 
-            // zPosDepthFrag is the distance from the thing's center pointer. If the wall is in front then we can discard to depth.
-            if (planeClip.b == 1) {
-                vec2 lineNormal = texelFetch(mapData, int(planeClip.r) * 2).rg;
-                //discard;
+            // If wall this pixel would be discarded to depth check which side of the line the camera is on
+            if (planeClip.b == 1 && planeClip.g < depthFrag) {
+                vec4 linePoints = texelFetch(mapDataTexture, int(planeClip.r));
+                vec2 lineStart = linePoints.rg;
+                vec2 lineDelta = linePoints.ba;
+                
+                float entityDotProduct = (lineDelta.x * (centerPosFrag.y - lineStart.y)) - (lineDelta.y * (centerPosFrag.x - lineStart.x));
+                if (entityDotProduct > 0)
+                    discard;
             }
         }
        

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
@@ -362,8 +362,7 @@ public class EntityProgram : RenderProgram
             return t >= 0.0 && t <= 1.0 && u >= 0.0 && u <= 1.0;
         }
         
-        vec2 closestPoint(vec2 point, vec2 lineStart, vec2 lineEnd) {
-            vec2 lineDelta = lineEnd - lineStart;
+        vec2 closestPoint(vec2 point, vec2 lineStart, vec2 lineDelta) {
             vec2 pointDelta = point - lineStart;    
             float t = clamp(dot(pointDelta, lineDelta) / dot(lineDelta, lineDelta), 0.0, 1.0);    
             return lineStart + t * lineDelta;
@@ -375,11 +374,11 @@ public class EntityProgram : RenderProgram
             vec3 planeClip = texelFetch(planeClipTexture, getCoords, 0).rgb;
 
             // Floor
-            if (planeClip.b == 0 && planeClip.g < depthFrag && planeClip.r > zPosFrag)
+            if (planeClip.b == 1 && planeClip.g < depthFrag && planeClip.r > zPosFrag)
                 return true;
 
             // Ceiling
-            if (planeClip.b == 1 && planeClip.g < depthFrag && zPosFrag >= planeClip.r)
+            if (planeClip.b == 2 && planeClip.g < depthFrag && zPosFrag >= planeClip.r)
                 return true;
             
             if (wallClip.r >= 0) {
@@ -391,7 +390,7 @@ public class EntityProgram : RenderProgram
 
                 float viewDotProduct = (lineDelta.x * (viewPos.y - lineStart.y)) - (lineDelta.y * (viewPos.x - lineStart.x));                
                 float entityDotProduct = (lineDelta.x * (centerPosFrag.y - lineStart.y)) - (lineDelta.y * (centerPosFrag.x - lineStart.x));
-                float distanceToWall = distance(centerPosFrag.xy, closestPoint(centerPosFrag.xy, lineStart, lineEnd));                
+                float distanceToWall = distance(centerPosFrag.xy, closestPoint(centerPosFrag.xy, lineStart, lineDelta));                
 
                 bool viewFront = viewDotProduct < 0;
                 bool entityFront = entityDotProduct < 0;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
@@ -361,6 +361,20 @@ public class EntityProgram : RenderProgram
             float u = ((startB.x - startA.x) * (startA.y - endA.y) - (startB.y - startA.y) * (startA.x - endA.x)) / d;
             return t >= 0.0 && t <= 1.0 && u >= 0.0 && u <= 1.0;
         }
+        
+        float pointToSegmentDistance(vec2 P, vec2 A, vec2 B) {
+            vec2 AB = B - A;
+            vec2 AP = P - A;
+    
+            // Compute projection scalar t (clamped between 0 and 1)
+            float t = clamp(dot(AP, AB) / dot(AB, AB), 0.0, 1.0);
+    
+            // Compute closest point on the segment
+            vec2 closestPoint = A + t * AB;
+    
+            // Return distance from point to closest point
+            return distance(P, closestPoint);
+        }
 
         bool discardPlaneClip() {
             ivec2 getCoords = ivec2(gl_FragCoord.xy);
@@ -384,17 +398,17 @@ public class EntityProgram : RenderProgram
 
                 float viewDotProduct = (lineDelta.x * (viewPos.y - lineStart.y)) - (lineDelta.y * (viewPos.x - lineStart.x));                
                 float entityDotProduct = (lineDelta.x * (centerPosFrag.y - lineStart.y)) - (lineDelta.y * (centerPosFrag.x - lineStart.x));
-                float distanceToWall = fuzzDist - wallClip.g;                
+                float distanceToWall = pointToSegmentDistance(centerPosFrag.xy, lineStart, lineEnd);                
 
                 bool viewFront = viewDotProduct < 0;
                 bool entityFront = entityDotProduct < 0;
 
                 // lower wall
-                if (distanceToWall < textureWidthFrag && viewFront && wallClip.b == 1 && viewPos.z > centerPosFrag.z && lineHeights.r <= zPosFrag)
+                if (distanceToWall <= max(textureWidthFrag,32) && wallClip.b == 1 && viewPos.z > lineHeights.r && lineHeights.r <= zPosFrag)
                     return false;
 
                 // upper wall
-                if (distanceToWall < textureWidthFrag && viewFront && wallClip.b == 2 && viewPos.z < lineHeights.g)// && lineHeights.g >= zPosFrag)
+                if (distanceToWall <= max(textureWidthFrag,32) && wallClip.b == 2 && viewPos.z < lineHeights.g)// && lineHeights.g >= zPosFrag)
                     return false;
 
                 if (wallClip.g < depthFrag) {

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
@@ -42,6 +42,7 @@ public class EntityProgram : RenderProgram
     private readonly int m_checkPlaneClipLocation;
     private readonly int m_healthBarModeLocation;
     private readonly int m_mapDataTextureLoaction;
+    private readonly int m_wallClipTextureLocation;
 
     public EntityProgram(string name) : base($"Entity - {name}")
     {
@@ -78,6 +79,7 @@ public class EntityProgram : RenderProgram
         m_checkPlaneClipLocation = Uniforms.GetLocation("checkPlaneClip");
         m_healthBarModeLocation = Uniforms.GetLocation("healthBarMode");
         m_mapDataTextureLoaction = Uniforms.GetLocation("mapDataTexture");
+        m_wallClipTextureLocation = Uniforms.GetLocation("wallClipTexture");
     }
     
     public void BoundTexture(TextureUnit unit) => Uniforms.Set(unit, m_boundTextureLocation);
@@ -88,6 +90,7 @@ public class EntityProgram : RenderProgram
     public void FuzzTexture(TextureUnit unit) => Uniforms.Set(unit, m_fuzzTextureLocation);
     public void OpaqueTexture(TextureUnit unit) => Uniforms.Set(unit, m_opaqueTextureLocation);
     public void PlaneClipTexture(TextureUnit unit) => Uniforms.Set(unit, m_planeClipTextureLocation);
+    public void WallClipTexture(TextureUnit unit) => Uniforms.Set(unit, m_wallClipTextureLocation);
     public void MapDataTexture(TextureUnit unit) => Uniforms.Set(unit, m_mapDataTextureLoaction);
     public void ExtraLight(int extraLight) => Uniforms.Set(extraLight, m_extraLightLocation);
     public void HasInvulnerability(bool invul) => Uniforms.Set(invul, m_hasInvulnerabilityLocation);
@@ -336,6 +339,7 @@ public class EntityProgram : RenderProgram
         uniform vec3 viewPos;
 
         uniform sampler2D planeClipTexture;
+        uniform sampler2D wallClipTexture;
         uniform samplerBuffer mapDataTexture;
 
         ${OitVariables}
@@ -378,15 +382,15 @@ public class EntityProgram : RenderProgram
 
         bool discardPlaneClip() {
             ivec2 getCoords = ivec2(gl_FragCoord.xy);
-            vec3 planeClip = texelFetch(planeClipTexture, getCoords, 0).rgb;
+            vec2 wallClip = texelFetch(wallClipTexture, getCoords, 0).rg;
 
             // 0 = floor, 1 = line
-            if (planeClip.b == 0) {
-                // If floor this pixel would be discarded to depth and the plane is higher than the z position then discard.
-                return planeClip.g < depthFrag && planeClip.r > zPosFrag;
-            }
-            else {
-                vec4 linePoints = texelFetch(mapDataTexture, int(planeClip.r));
+            //if (planeClip.b == 0) {
+            //    // If floor this pixel would be discarded to depth and the plane is higher than the z position then discard.
+            //    return planeClip.g < depthFrag && planeClip.r > zPosFrag;
+            //}
+            //else {
+                vec4 linePoints = texelFetch(mapDataTexture, int(wallClip.r));
                 vec2 lineStart = linePoints.rg;
                 vec2 lineEnd = linePoints.ba;
                 vec2 lineDelta = lineEnd - lineStart;
@@ -397,7 +401,7 @@ public class EntityProgram : RenderProgram
                 bool viewFront = viewDotProduct < 0;
                 bool entityFront = entityDotProduct < 0;
 
-                if (planeClip.g < depthFrag) {
+                if (wallClip.g < depthFrag) {
                     // If the sprite isn't on the same side of the line as the camera then discard
                     if (viewFront != entityFront)
                         return true;
@@ -411,7 +415,7 @@ public class EntityProgram : RenderProgram
                     // If the sprite is behind the line and is not within the line bounds and intersects then discard
                     return (dotProductStart < 0 || dotProductEnd < 0) && !entityFront && lineIntersection(lineStart, lineEnd, minPosFrag.xy, maxPosFrag.xy);
                 }
-            }
+            //}
             
             return false;
         }";

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
@@ -362,18 +362,11 @@ public class EntityProgram : RenderProgram
             return t >= 0.0 && t <= 1.0 && u >= 0.0 && u <= 1.0;
         }
         
-        float pointToSegmentDistance(vec2 P, vec2 A, vec2 B) {
-            vec2 AB = B - A;
-            vec2 AP = P - A;
-    
-            // Compute projection scalar t (clamped between 0 and 1)
-            float t = clamp(dot(AP, AB) / dot(AB, AB), 0.0, 1.0);
-    
-            // Compute closest point on the segment
-            vec2 closestPoint = A + t * AB;
-    
-            // Return distance from point to closest point
-            return distance(P, closestPoint);
+        vec2 closestPoint(vec2 point, vec2 lineStart, vec2 lineEnd) {
+            vec2 lineDelta = lineEnd - lineStart;
+            vec2 pointDelta = point - lineStart;    
+            float t = clamp(dot(pointDelta, lineDelta) / dot(lineDelta, lineDelta), 0.0, 1.0);    
+            return lineStart + t * lineDelta;
         }
 
         bool discardPlaneClip() {
@@ -391,24 +384,20 @@ public class EntityProgram : RenderProgram
             
             if (wallClip.r >= 0) {
                 vec4 linePoints = texelFetch(mapDataTexture, int(wallClip.r));
-                vec2 lineHeights = texelFetch(lineHeightsTexture, int(wallClip.r)).rg;
+                float floorHeight = texelFetch(lineHeightsTexture, int(wallClip.r)).r;
                 vec2 lineStart = linePoints.rg;
                 vec2 lineEnd = linePoints.ba;
                 vec2 lineDelta = lineEnd - lineStart;
 
                 float viewDotProduct = (lineDelta.x * (viewPos.y - lineStart.y)) - (lineDelta.y * (viewPos.x - lineStart.x));                
                 float entityDotProduct = (lineDelta.x * (centerPosFrag.y - lineStart.y)) - (lineDelta.y * (centerPosFrag.x - lineStart.x));
-                float distanceToWall = pointToSegmentDistance(centerPosFrag.xy, lineStart, lineEnd);                
+                float distanceToWall = distance(centerPosFrag.xy, closestPoint(centerPosFrag.xy, lineStart, lineEnd));                
 
                 bool viewFront = viewDotProduct < 0;
                 bool entityFront = entityDotProduct < 0;
 
                 // lower wall
-                if (distanceToWall <= max(textureWidthFrag,32) && wallClip.b == 1 && viewPos.z > lineHeights.r && lineHeights.r <= zPosFrag)
-                    return false;
-
-                // upper wall
-                if (distanceToWall <= max(textureWidthFrag,32) && wallClip.b == 2 && viewPos.z < lineHeights.g)// && lineHeights.g >= zPosFrag)
+                if (distanceToWall <= max(40, textureWidthFrag) && wallClip.b == 1 && viewPos.z > floorHeight && floorHeight <= zPosFrag)
                     return false;
 
                 if (wallClip.g < depthFrag) {

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
@@ -198,6 +198,8 @@ public class EntityProgram : RenderProgram
         flat out float zPosFrag;
         flat out float zPosDepthFrag;
         out vec3 centerPosFrag;
+        out vec3 minPosFrag;
+        out vec3 maxPosFrag;
         out float depthFrag;
         ${SectorColorMapFrag}
 
@@ -245,6 +247,8 @@ public class EntityProgram : RenderProgram
             renderDistSquared = distSquared(viewPos.xy, pos.xy);
 
             centerPosFrag = pos;
+            minPosFrag = minPos;
+            maxPosFrag = maxPos;
             zPosDepthFrag = (mvp * vec4(centerPosFrag.x, centerPosFrag.y, centerPosFrag.z, 1)).${Depth};
 
             lightLevelFrag = lightLevelOut[0];
@@ -301,6 +305,8 @@ public class EntityProgram : RenderProgram
         flat in float zPosFrag;
         flat in float zPosDepthFrag;
         in vec3 centerPosFrag;
+        in vec3 minPosFrag;
+        in vec3 maxPosFrag;
         in float depthFrag;
 
         ${SectorColorMapFragVariables}
@@ -360,7 +366,17 @@ public class EntityProgram : RenderProgram
 
     private static string GetDiscardPlaneClipFunction()
     {
-        return @"bool discardPlaneClip() {
+        return @"
+        bool lineIntersection(vec2 A, vec2 B, vec2 C, vec2 D) {
+            vec2 dir1 = B - A;
+            vec2 dir2 = D - C;
+            float d = dir1.x * -dir2.y + dir1.y * dir2.x;
+            float t = ((C.x - A.x) * (C.y - D.y) - (C.y - A.y) * (C.x - D.x)) / d;
+            float u = ((C.x - A.x) * (A.y - B.y) - (C.y - A.y) * (A.x - B.x)) / d;            
+            return t >= 0.0 && t <= 1.0 && u >= 0.0 && u <= 1.0;
+        }
+
+        bool discardPlaneClip() {
             ivec2 getCoords = ivec2(gl_FragCoord.xy);
             vec3 planeClip = texelFetch(planeClipTexture, getCoords, 0).rgb;
 
@@ -380,17 +396,26 @@ public class EntityProgram : RenderProgram
                     float entityDotProduct = (lineDelta.x * (centerPosFrag.y - lineStart.y)) - (lineDelta.y * (centerPosFrag.x - lineStart.x));
 
                     // If the sprite isn't on the same side of the line as the camera then discard
-                    float viewFront = float(viewDotProduct <= 0);
-                    float entityFront = float(entityDotProduct <= 0);
+                    bool viewFront = viewDotProduct < 0;
+                    bool entityFront = entityDotProduct < 0;
                     if (viewFront != entityFront)
                         return true;
-                    
-                    // If the sprite isn't between the lines start and end points then discard
-                    float dotProductStart = (centerPosFrag.x - lineStart.x) * (lineDelta.x) + (centerPosFrag.y - lineStart.y) * (lineDelta.y);
-                    float dotProductEnd = (centerPosFrag.x - lineEnd.x) * (-lineDelta.x) + (centerPosFrag.y - lineEnd.y) * (-lineDelta.y);
-                    if (dotProductStart < 0 || dotProductEnd < 0)
+
+                    if (!lineIntersection(lineStart, lineEnd, minPosFrag.xy, maxPosFrag.xy))
                         return true;
                 }
+            }
+            else if (planeClip.b == 1) {
+                vec4 linePoints = texelFetch(mapDataTexture, int(planeClip.r));
+                vec2 lineStart = linePoints.rg;
+                vec2 lineEnd = linePoints.ba;
+                vec2 lineDelta = lineEnd - lineStart;
+                float entityDotProduct = (lineDelta.x * (centerPosFrag.y - lineStart.y)) - (lineDelta.y * (centerPosFrag.x - lineStart.x));
+                bool entityFront = entityDotProduct < 0;
+
+                float dotProductStart = (centerPosFrag.x - lineStart.x) * (lineDelta.x) + (centerPosFrag.y - lineStart.y) * (lineDelta.y);
+                float dotProductEnd = (centerPosFrag.x - lineEnd.x) * (-lineDelta.x) + (centerPosFrag.y - lineEnd.y) * (-lineDelta.y);
+                return (dotProductStart < 0 || dotProductEnd < 0) && !entityFront && lineIntersection(lineStart, lineEnd, minPosFrag.xy, maxPosFrag.xy);
             }
             
             return false;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
@@ -38,7 +38,7 @@ public class EntityProgram : RenderProgram
     private readonly int m_renderFuzzLocation;
     private readonly int m_renderFuzzRefractionColorLocation;
     private readonly int m_screenBoundsLocation;
-    private readonly int m_planeZTextureLocation;
+    private readonly int m_planeClipTextureLocation;
     private readonly int m_checkPlaneClipLocation;
     private readonly int m_healthBarModeLocation;
     private readonly int m_mapDataTextureLoaction;
@@ -74,7 +74,7 @@ public class EntityProgram : RenderProgram
         m_renderFuzzLocation = Uniforms.GetLocation("renderFuzz");
         m_renderFuzzRefractionColorLocation = Uniforms.GetLocation("renderFuzzRefractionColor");
         m_screenBoundsLocation = Uniforms.GetLocation("screenBounds");
-        m_planeZTextureLocation = Uniforms.GetLocation("planeZTexture");
+        m_planeClipTextureLocation = Uniforms.GetLocation("planeClipTexture");
         m_checkPlaneClipLocation = Uniforms.GetLocation("checkPlaneClip");
         m_healthBarModeLocation = Uniforms.GetLocation("healthBarMode");
         m_mapDataTextureLoaction = Uniforms.GetLocation("mapDataTexture");
@@ -87,7 +87,7 @@ public class EntityProgram : RenderProgram
     public void AccumCountTextre(TextureUnit unit) => Uniforms.Set(unit, m_accumCountTextureLocation);
     public void FuzzTexture(TextureUnit unit) => Uniforms.Set(unit, m_fuzzTextureLocation);
     public void OpaqueTexture(TextureUnit unit) => Uniforms.Set(unit, m_opaqueTextureLocation);
-    public void PlaneZTexture(TextureUnit unit) => Uniforms.Set(unit, m_planeZTextureLocation);
+    public void PlaneClipTexture(TextureUnit unit) => Uniforms.Set(unit, m_planeClipTextureLocation);
     public void MapDataTexture(TextureUnit unit) => Uniforms.Set(unit, m_mapDataTextureLoaction);
     public void ExtraLight(int extraLight) => Uniforms.Set(extraLight, m_extraLightLocation);
     public void HasInvulnerability(bool invul) => Uniforms.Set(invul, m_hasInvulnerabilityLocation);
@@ -127,7 +127,8 @@ public class EntityProgram : RenderProgram
         layout(location = 2) in float options;
         layout(location = 3) in vec3 prevPos;
         layout(location = 4) in float offsetZ;
-        layout(location = 5) in vec3 sectorIndex;
+        layout(location = 5) in vec3 centerPos;
+        layout(location = 6) in vec3 sectorIndex;
 
         out float lightLevelOut;
         out float alphaOut;
@@ -136,6 +137,7 @@ public class EntityProgram : RenderProgram
         out float colorMapTranslationOut;
         out float positionZOut;
         out float offsetZOut;
+        out vec3 centerPosOut;
         ${SectorColorMapVar}
 
         uniform float timeFrac;
@@ -157,6 +159,7 @@ public class EntityProgram : RenderProgram
             flipUOut = flipU;
             colorMapTranslationOut = colorMapTranslation;
             offsetZOut = offsetZ;
+            centerPosOut = centerPos;
             ${SectorColorMap}
             gl_Position = vec4(mix(prevPos, pos, timeFrac), 1.0);
             positionZOut = gl_Position.z;
@@ -181,6 +184,7 @@ public class EntityProgram : RenderProgram
         in float colorMapTranslationOut[];
         in float positionZOut[];
         in float offsetZOut[];
+        in vec3 centerPosOut[];
         ${SectorColorMapVar}
 
         out vec2 uvFrag;
@@ -241,7 +245,7 @@ public class EntityProgram : RenderProgram
             // Render distance squared in 2d space for fade in/out effect
             renderDistSquared = distSquared(viewPos.xy, pos.xy);
 
-            centerPosFrag = minPos + ((maxPos - minPos) / 2);    
+            centerPosFrag = centerPosOut[0];
             zPosDepthFrag = (mvp * vec4(centerPosFrag.x, centerPosFrag.y, centerPosFrag.z, 1)).${Depth};
 
             lightLevelFrag = lightLevelOut[0];
@@ -326,7 +330,7 @@ public class EntityProgram : RenderProgram
         uniform int healthBarMode;
         uniform vec3 viewPos;
 
-        uniform sampler2D planeZTexture;
+        uniform sampler2D planeClipTexture;
         uniform samplerBuffer mapDataTexture;
 
         ${OitVariables}
@@ -363,8 +367,7 @@ public class EntityProgram : RenderProgram
         return clearAlpha + @"
         if (checkPlaneClip == 1) {
             ivec2 getCoords = ivec2(gl_FragCoord.xy);
-            // r = floor's z position, g = floor's depth value
-            vec3 planeClip = texelFetch(planeZTexture, getCoords, 0).rgb;
+            vec3 planeClip = texelFetch(planeClipTexture, getCoords, 0).rgb;
 
             if (planeClip.g < depthFrag) {
                 // If floor this pixel would be discarded to depth and the plane is higher than the z position then discard.
@@ -375,15 +378,22 @@ public class EntityProgram : RenderProgram
                 if (planeClip.b == 1) {
                     vec4 linePoints = texelFetch(mapDataTexture, int(planeClip.r));
                     vec2 lineStart = linePoints.rg;
-                    vec2 lineDelta = linePoints.ba;
+                    vec2 lineEnd = linePoints.ba;
+                    vec2 lineDelta = lineEnd - lineStart;
 
                     float viewDotProduct = (lineDelta.x * (viewPos.y - lineStart.y)) - (lineDelta.y * (viewPos.x - lineStart.x));                
                     float entityDotProduct = (lineDelta.x * (centerPosFrag.y - lineStart.y)) - (lineDelta.y * (centerPosFrag.x - lineStart.x));
 
-                    // If the sprite isn't on the same side of the line as the camera discard
-                    float viewFront = float(viewDotProduct < 0);
-                    float entityFront = float(entityDotProduct < 0);
+                    // If the sprite isn't on the same side of the line as the camera then discard
+                    float viewFront = float(viewDotProduct <= 0);
+                    float entityFront = float(entityDotProduct <= 0);
                     if (viewFront != entityFront)
+                        discard;
+                    
+                    // If the sprite isn't between the lines start and end points then discard
+                    float dotProductStart = (centerPosFrag.x - lineStart.x) * (lineDelta.x) + (centerPosFrag.y - lineStart.y) * (lineDelta.y);
+                    float dotProductEnd = (centerPosFrag.x - lineEnd.x) * (-lineDelta.x) + (centerPosFrag.y - lineEnd.y) * (-lineDelta.y);
+                    if (dotProductStart < 0 || dotProductEnd < 0)
                         discard;
                 }
             }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
@@ -43,6 +43,7 @@ public class EntityProgram : RenderProgram
     private readonly int m_healthBarModeLocation;
     private readonly int m_mapDataTextureLoaction;
     private readonly int m_wallClipTextureLocation;
+    private readonly int m_lineHeightsTextureLocation;
 
     public EntityProgram(string name) : base($"Entity - {name}")
     {
@@ -80,6 +81,7 @@ public class EntityProgram : RenderProgram
         m_healthBarModeLocation = Uniforms.GetLocation("healthBarMode");
         m_mapDataTextureLoaction = Uniforms.GetLocation("mapDataTexture");
         m_wallClipTextureLocation = Uniforms.GetLocation("wallClipTexture");
+        m_lineHeightsTextureLocation = Uniforms.GetLocation("lineHeightsTexture");
     }
     
     public void BoundTexture(TextureUnit unit) => Uniforms.Set(unit, m_boundTextureLocation);
@@ -92,6 +94,7 @@ public class EntityProgram : RenderProgram
     public void PlaneClipTexture(TextureUnit unit) => Uniforms.Set(unit, m_planeClipTextureLocation);
     public void WallClipTexture(TextureUnit unit) => Uniforms.Set(unit, m_wallClipTextureLocation);
     public void MapDataTexture(TextureUnit unit) => Uniforms.Set(unit, m_mapDataTextureLoaction);
+    public void LineHeightsTexture(TextureUnit unit) => Uniforms.Set(unit, m_lineHeightsTextureLocation);
 
     public void ExtraLight(int extraLight) => Uniforms.Set(extraLight, m_extraLightLocation);
     public void HasInvulnerability(bool invul) => Uniforms.Set(invul, m_hasInvulnerabilityLocation);
@@ -201,6 +204,7 @@ public class EntityProgram : RenderProgram
         flat out float colorMapTranslationFrag;
         flat out float zPosFrag;
         flat out float zPosDepthFrag;
+        flat out float textureWidthFrag;
         out vec3 centerPosFrag;
         out vec3 minPosFrag;
         out vec3 maxPosFrag;
@@ -250,6 +254,7 @@ public class EntityProgram : RenderProgram
             // Render distance squared in 2d space for fade in/out effect
             renderDistSquared = distSquared(viewPos.xy, pos.xy);
 
+            textureWidthFrag = textureDim.x;
             centerPosFrag = pos;
             minPosFrag = minPos;
             maxPosFrag = maxPos;
@@ -308,6 +313,7 @@ public class EntityProgram : RenderProgram
         flat in float colorMapTranslationFrag;
         flat in float zPosFrag;
         flat in float zPosDepthFrag;
+        flat in float textureWidthFrag;
         in vec3 centerPosFrag;
         in vec3 minPosFrag;
         in vec3 maxPosFrag;
@@ -342,10 +348,67 @@ public class EntityProgram : RenderProgram
         uniform sampler2D planeClipTexture;
         uniform sampler2D wallClipTexture;
         uniform samplerBuffer mapDataTexture;
+        uniform samplerBuffer lineHeightsTexture;
 
         ${OitVariables}
         ${FuzzFunction}
-        ${DiscardPlaneClipFunction}
+
+        bool lineIntersection(vec2 startA, vec2 endA, vec2 startB, vec2 endB) {
+            vec2 deltaA = endA - startA;
+            vec2 deltaB = endB - startB;
+            float d = deltaA.x * -deltaB.y + deltaA.y * deltaB.x;
+            float t = ((startB.x - startA.x) * (startB.y - endB.y) - (startB.y - startA.y) * (startB.x - endB.x)) / d;
+            float u = ((startB.x - startA.x) * (startA.y - endA.y) - (startB.y - startA.y) * (startA.x - endA.x)) / d;
+            return t >= 0.0 && t <= 1.0 && u >= 0.0 && u <= 1.0;
+        }
+
+        bool discardPlaneClip() {
+            ivec2 getCoords = ivec2(gl_FragCoord.xy);
+            vec3 wallClip = texelFetch(wallClipTexture, getCoords, 0).rgb;
+            vec3 planeClip = texelFetch(planeClipTexture, getCoords, 0).rgb;
+
+            // Floor
+            if (planeClip.b == 0 && planeClip.g < depthFrag && planeClip.r > zPosFrag)
+                return true;
+
+            // Ceiling
+            if (planeClip.b == 1 && planeClip.g < depthFrag && zPosFrag >= planeClip.r)
+                return true;
+            
+            if (wallClip.r >= 0) {
+                vec4 linePoints = texelFetch(mapDataTexture, int(wallClip.r));
+                vec2 lineHeights = texelFetch(lineHeightsTexture, int(wallClip.r)).rg;
+                vec2 lineStart = linePoints.rg;
+                vec2 lineEnd = linePoints.ba;
+                vec2 lineDelta = lineEnd - lineStart;
+
+                float viewDotProduct = (lineDelta.x * (viewPos.y - lineStart.y)) - (lineDelta.y * (viewPos.x - lineStart.x));                
+                float entityDotProduct = (lineDelta.x * (centerPosFrag.y - lineStart.y)) - (lineDelta.y * (centerPosFrag.x - lineStart.x));
+                float distanceToWall = fuzzDist - wallClip.g;                
+
+                bool viewFront = viewDotProduct < 0;
+                bool entityFront = entityDotProduct < 0;
+
+                // lower wall
+                if (distanceToWall < textureWidthFrag && viewFront && wallClip.b == 1 && viewPos.z > centerPosFrag.z && lineHeights.r <= zPosFrag)
+                    return false;
+
+                // upper wall
+                if (distanceToWall < textureWidthFrag && viewFront && wallClip.b == 2 && viewPos.z < lineHeights.g)// && lineHeights.g >= zPosFrag)
+                    return false;
+
+                if (wallClip.g < depthFrag) {
+                    // Discard if the sprite isn't on the same side of the line as the camera or when the sprite line doesn't intersect the line
+                    return viewFront != entityFront || !lineIntersection(lineStart, lineEnd, minPosFrag.xy, maxPosFrag.xy);
+                }
+                else {
+                    // Discard if the sprite is behind the line and intersects
+                    return viewFront != entityFront && lineIntersection(lineStart, lineEnd, minPosFrag.xy, maxPosFrag.xy);
+                }
+            }
+            
+            return false;
+        }
 
         void main()
         {
@@ -366,65 +429,7 @@ public class EntityProgram : RenderProgram
     .Replace("${OitVariables}", FragFunction.OitFragVariables(GetOitOptions()))
     .Replace("${OutFragColor}", GetOutFragColor())
     .Replace("${BoxDefines}", BoxDefines)
-    .Replace("${HealthBarCheck}", GetOitOptions() == OitOptions.None ? "if (healthBarMode == 0) {" : "")
-    .Replace("${DiscardPlaneClipFunction}", GetDiscardPlaneClipFunction());
-
-    private static string GetDiscardPlaneClipFunction()
-    {
-        return @"
-        bool lineIntersection(vec2 startA, vec2 endA, vec2 startB, vec2 endB) {
-            vec2 deltaA = endA - startA;
-            vec2 deltaB = endB - startB;
-            float d = deltaA.x * -deltaB.y + deltaA.y * deltaB.x;
-            float t = ((startB.x - startA.x) * (startB.y - endB.y) - (startB.y - startA.y) * (startB.x - endB.x)) / d;
-            float u = ((startB.x - startA.x) * (startA.y - endA.y) - (startB.y - startA.y) * (startA.x - endA.x)) / d;
-            return t >= 0.0 && t <= 1.0 && u >= 0.0 && u <= 1.0;
-        }
-
-        bool discardPlaneClip() {
-            ivec2 getCoords = ivec2(gl_FragCoord.xy);
-            vec2 wallClip = texelFetch(wallClipTexture, getCoords, 0).rg;
-            vec3 planeClip = texelFetch(planeClipTexture, getCoords, 0).rgb;
-
-            // Floor
-            if (planeClip.b == 0 && planeClip.g < depthFrag && planeClip.r > zPosFrag)
-                return true;
-
-            // Ceiling
-            if (planeClip.b == 1 && planeClip.g < depthFrag && zPosFrag >= planeClip.r)
-                return true;
-
-            if (wallClip.r >= 0) {
-                vec4 linePoints = texelFetch(mapDataTexture, int(wallClip.r));
-                vec2 lineStart = linePoints.rg;
-                vec2 lineEnd = linePoints.ba;
-                vec2 lineDelta = lineEnd - lineStart;
-
-                float viewDotProduct = (lineDelta.x * (viewPos.y - lineStart.y)) - (lineDelta.y * (viewPos.x - lineStart.x));                
-                float entityDotProduct = (lineDelta.x * (centerPosFrag.y - lineStart.y)) - (lineDelta.y * (centerPosFrag.x - lineStart.x));
-
-                bool viewFront = viewDotProduct < 0;
-                bool entityFront = entityDotProduct < 0;
-
-                if (wallClip.g < depthFrag) {
-                    // If the sprite isn't on the same side of the line as the camera then discard
-                    if (viewFront != entityFront)
-                        return true;
-
-                    // Discard to depth when the sprite line doesn't intersect the line
-                    return !lineIntersection(lineStart, lineEnd, minPosFrag.xy, maxPosFrag.xy);
-                }
-                else {
-                    float dotProductStart = (centerPosFrag.x - lineStart.x) * (lineDelta.x) + (centerPosFrag.y - lineStart.y) * (lineDelta.y);
-                    float dotProductEnd = (centerPosFrag.x - lineEnd.x) * (-lineDelta.x) + (centerPosFrag.y - lineEnd.y) * (-lineDelta.y);
-                    // If the sprite is behind the line and is not within the line bounds and intersects then discard
-                    return (dotProductStart < 0 || dotProductEnd < 0) && viewFront != entityFront && lineIntersection(lineStart, lineEnd, minPosFrag.xy, maxPosFrag.xy);
-                }
-            }
-            
-            return false;
-        }";
-    }
+    .Replace("${HealthBarCheck}", GetOitOptions() == OitOptions.None ? "if (healthBarMode == 0) {" : "");
 
     private string GetPostProcess() 
     {

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
@@ -92,6 +92,7 @@ public class EntityProgram : RenderProgram
     public void PlaneClipTexture(TextureUnit unit) => Uniforms.Set(unit, m_planeClipTextureLocation);
     public void WallClipTexture(TextureUnit unit) => Uniforms.Set(unit, m_wallClipTextureLocation);
     public void MapDataTexture(TextureUnit unit) => Uniforms.Set(unit, m_mapDataTextureLoaction);
+
     public void ExtraLight(int extraLight) => Uniforms.Set(extraLight, m_extraLightLocation);
     public void HasInvulnerability(bool invul) => Uniforms.Set(invul, m_hasInvulnerabilityLocation);
     public void LightLevelMix(float lightLevelMix) => Uniforms.Set(lightLevelMix, m_lightLevelMixLocation);
@@ -383,13 +384,12 @@ public class EntityProgram : RenderProgram
         bool discardPlaneClip() {
             ivec2 getCoords = ivec2(gl_FragCoord.xy);
             vec2 wallClip = texelFetch(wallClipTexture, getCoords, 0).rg;
+            vec2 planeClip = texelFetch(planeClipTexture, getCoords, 0).rg;
 
-            // 0 = floor, 1 = line
-            //if (planeClip.b == 0) {
-            //    // If floor this pixel would be discarded to depth and the plane is higher than the z position then discard.
-            //    return planeClip.g < depthFrag && planeClip.r > zPosFrag;
-            //}
-            //else {
+            if (planeClip.g < depthFrag && planeClip.r > zPosFrag)
+                return true;
+
+            if (wallClip.r >= 0) {
                 vec4 linePoints = texelFetch(mapDataTexture, int(wallClip.r));
                 vec2 lineStart = linePoints.rg;
                 vec2 lineEnd = linePoints.ba;
@@ -415,7 +415,7 @@ public class EntityProgram : RenderProgram
                     // If the sprite is behind the line and is not within the line bounds and intersects then discard
                     return (dotProductStart < 0 || dotProductEnd < 0) && !entityFront && lineIntersection(lineStart, lineEnd, minPosFrag.xy, maxPosFrag.xy);
                 }
-            //}
+            }
             
             return false;
         }";

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
@@ -41,6 +41,7 @@ public class EntityProgram : RenderProgram
     private readonly int m_planeZTextureLocation;
     private readonly int m_checkPlaneClipLocation;
     private readonly int m_healthBarModeLocation;
+    private readonly int m_mapDataTextureLoaction;
 
     public EntityProgram(string name) : base($"Entity - {name}")
     {
@@ -76,6 +77,7 @@ public class EntityProgram : RenderProgram
         m_planeZTextureLocation = Uniforms.GetLocation("planeZTexture");
         m_checkPlaneClipLocation = Uniforms.GetLocation("checkPlaneClip");
         m_healthBarModeLocation = Uniforms.GetLocation("healthBarMode");
+        m_mapDataTextureLoaction = Uniforms.GetLocation("mapData");
     }
     
     public void BoundTexture(TextureUnit unit) => Uniforms.Set(unit, m_boundTextureLocation);
@@ -86,6 +88,7 @@ public class EntityProgram : RenderProgram
     public void FuzzTexture(TextureUnit unit) => Uniforms.Set(unit, m_fuzzTextureLocation);
     public void OpaqueTexture(TextureUnit unit) => Uniforms.Set(unit, m_opaqueTextureLocation);
     public void PlaneZTexture(TextureUnit unit) => Uniforms.Set(unit, m_planeZTextureLocation);
+    public void MapDataTexture(TextureUnit unit) => Uniforms.Set(unit, m_mapDataTextureLoaction);
     public void ExtraLight(int extraLight) => Uniforms.Set(extraLight, m_extraLightLocation);
     public void HasInvulnerability(bool invul) => Uniforms.Set(invul, m_hasInvulnerabilityLocation);
     public void LightLevelMix(float lightLevelMix) => Uniforms.Set(lightLevelMix, m_lightLevelMixLocation);
@@ -316,6 +319,7 @@ public class EntityProgram : RenderProgram
         uniform int healthBarMode;
 
         uniform sampler2D planeZTexture;
+        uniform samplerBuffer mapData;
 
         ${OitVariables}
         ${FuzzFunction}
@@ -352,10 +356,16 @@ public class EntityProgram : RenderProgram
         if (checkPlaneClip == 1) {
             ivec2 getCoords = ivec2(gl_FragCoord.xy);
             // r = floor's z position, g = floor's depth value
-            vec2 planeZ = texelFetch(planeZTexture, getCoords, 0).rg;
+            vec3 planeClip = texelFetch(planeZTexture, getCoords, 0).rgb;
             // If this pixel would be discarded to depth and the plane is higher than the z position then discard.
-            if (planeZ.r > zPosFrag && planeZ.g < depthFrag)
+            if (planeClip.b == 0 && planeClip.r > zPosFrag && planeClip.g < depthFrag)
                 discard;
+
+            // zPosDepthFrag is the distance from the thing's center pointer. If the wall is in front then we can discard to depth.
+            if (planeClip.b == 1) {
+                vec2 lineNormal = texelFetch(mapData, int(planeClip.r) * 2).rg;
+                //discard;
+            }
         }
        
         ${HealthBar}

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
@@ -309,9 +309,9 @@ public class EntityRenderer : IDisposable
 
     private void SetUniforms(EntityProgram program, RenderInfo renderInfo)
     {
-        program.BoundTexture(TextureUnit.Texture0);
-        program.ColormapTexture(TextureUnit.Texture2);
-        program.SectorColormapTexture(TextureUnit.Texture3);
+        program.BoundTexture(BindTextures.BoundTexture);
+        program.ColormapTexture(BindTextures.Colormap);
+        program.SectorColormapTexture(BindTextures.SectorColormap);
         program.ExtraLight(renderInfo.Uniforms.ExtraLight);
         program.HasInvulnerability(renderInfo.Uniforms.DrawInvulnerability);
         program.LightLevelMix(renderInfo.Uniforms.Mix);
@@ -339,16 +339,16 @@ public class EntityRenderer : IDisposable
 
         if (program is EntityCompositeProgram)
         {
-            program.AccumTexture(TextureUnit.Texture4);
-            program.AccumCountTextre(TextureUnit.Texture5);
+            program.AccumTexture(BindTextures.AccumTexture);
+            program.AccumCountTextre(BindTextures.AccumCountTexture);
         }
 
         if (program is EntityFuzzRefractionProgram)
         {
-            program.AccumTexture(TextureUnit.Texture4);
-            program.AccumCountTextre(TextureUnit.Texture5);
-            program.FuzzTexture(TextureUnit.Texture6);
-            program.OpaqueTexture(TextureUnit.Texture7);
+            program.AccumTexture(BindTextures.AccumTexture);
+            program.AccumCountTextre(BindTextures.AccumCountTexture);
+            program.FuzzTexture(BindTextures.FuzzTexture);
+            program.OpaqueTexture(BindTextures.OpaqueTexture);
         }
 
         program.WallClipTexture(BindTextures.WallClipTexture);
@@ -359,7 +359,7 @@ public class EntityRenderer : IDisposable
     public void RenderOpaque(RenderInfo renderInfo)
     {
         m_program.Bind();
-        GL.ActiveTexture(TextureUnit.Texture0);
+        GL.ActiveTexture(BindTextures.BoundTexture);
         SetUniforms(m_program, renderInfo);
         m_program.HealthBarMode(false);
         m_dataManager.RenderNonAlpha(PrimitiveType.Points);
@@ -377,7 +377,7 @@ public class EntityRenderer : IDisposable
     {
         m_programTransparent.Bind();
         m_programTransparent.RenderFuzz(false);
-        GL.ActiveTexture(TextureUnit.Texture0);
+        GL.ActiveTexture(BindTextures.BoundTexture);
         SetUniforms(m_programTransparent, renderInfo);
         m_dataManager.RenderAlpha(PrimitiveType.Points);
         m_dataManager.RenderFuzz(PrimitiveType.Points);
@@ -388,7 +388,7 @@ public class EntityRenderer : IDisposable
     {
         m_programTransparent.Bind();
         m_programTransparent.RenderFuzz(true);
-        GL.ActiveTexture(TextureUnit.Texture0);
+        GL.ActiveTexture(BindTextures.BoundTexture);
         SetUniforms(m_programTransparent, renderInfo);
         m_dataManager.RenderFuzz(PrimitiveType.Points);
         m_programTransparent.Unbind();
@@ -397,7 +397,7 @@ public class EntityRenderer : IDisposable
     public void RenderOitCompositePass(RenderInfo renderInfo)
     {
         m_programComposite.Bind();
-        GL.ActiveTexture(TextureUnit.Texture0);
+        GL.ActiveTexture(BindTextures.BoundTexture);
         SetUniforms(m_programComposite, renderInfo);
         m_dataManager.RenderAlpha(PrimitiveType.Points);
         m_programComposite.Unbind();
@@ -406,7 +406,7 @@ public class EntityRenderer : IDisposable
     public void RenderOitFuzzRefractionPass(RenderInfo renderInfo, bool renderColor)
     {
         m_programFuzzRefraction.Bind();
-        GL.ActiveTexture(TextureUnit.Texture0);
+        GL.ActiveTexture(BindTextures.BoundTexture);
         m_programFuzzRefraction.RenderFuzzRefractionColor(renderColor);
         SetUniforms(m_programFuzzRefraction, renderInfo);
         m_dataManager.RenderFuzz(PrimitiveType.Points);
@@ -416,7 +416,7 @@ public class EntityRenderer : IDisposable
     public void RenderTransparent(RenderInfo renderInfo)
     {
         m_program.Bind();
-        GL.ActiveTexture(TextureUnit.Texture0);
+        GL.ActiveTexture(BindTextures.BoundTexture);
         SetUniforms(m_program, renderInfo);
         m_dataManager.RenderAlpha(PrimitiveType.Points);
         m_dataManager.RenderFuzz(PrimitiveType.Points);

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
@@ -354,6 +354,7 @@ public class EntityRenderer : IDisposable
         program.WallClipTexture(BindTextures.WallClipTexture);
         program.PlaneClipTexture(BindTextures.PlaneClipTexture);
         program.MapDataTexture(BindTextures.MapLineData);
+        program.LineHeightsTexture(BindTextures.LineHeights);
     }
 
     public void RenderOpaque(RenderInfo renderInfo)

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
@@ -352,6 +352,7 @@ public class EntityRenderer : IDisposable
         }
 
         program.WallClipTexture(BindTextures.WallClipTexture);
+        program.PlaneClipTexture(BindTextures.PlaneClipTexture);
         program.MapDataTexture(BindTextures.MapLineData);
     }
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
@@ -241,15 +241,15 @@ public class EntityRenderer : IDisposable
         // Multiply the X offset by the rightNormal X/Y to move the sprite according to the player's view
         // Doom graphics are drawn left to right and not centered
         vertex.Pos = new Vec3F(
-            (float)(entity.Position.X - nudgeAmount.X) - (m_viewRightNormal.X * texture.Offset.X),
-            (float)(entity.Position.Y - nudgeAmount.Y) - (m_viewRightNormal.Y * texture.Offset.X),
+            (float)(entity.Position.X - nudgeAmount.X),
+            (float)(entity.Position.Y - nudgeAmount.Y),
             (float)entity.Position.Z);
         vertex.PrevPos = new Vec3F(
-            (float)(entity.PrevPosition.X - nudgeAmount.X) - (m_prevViewRightNormal.X * texture.Offset.X),
-            (float)(entity.PrevPosition.Y - nudgeAmount.Y) - (m_prevViewRightNormal.Y * texture.Offset.X),
+            (float)(entity.PrevPosition.X - nudgeAmount.X),
+            (float)(entity.PrevPosition.Y - nudgeAmount.Y),
             (float)entity.PrevPosition.Z);
-        vertex.CenterPos = entity.Position.Float;
         vertex.OffsetZ = offsetZ;
+        vertex.OffsetXY = texture.Offset.X;
         vertex.LightLevel = entity.Flags.Bright || entity.FrameState.Frame.Properties.Bright ? 255 :
             ((sector.TransferFloorLightSector.LightLevel + sector.TransferCeilingLightSector.LightLevel) / 2);
         vertex.Options = VertexOptions.Entity(alpha, fuzz, spriteRotation.FlipU, colorMapIndex);
@@ -258,10 +258,10 @@ public class EntityRenderer : IDisposable
         arrayData.Length = length + 1;
 
         if (m_healthBars && entity.Flags.Shootable && (m_healthBarLimit <= 0 || m_healthBarLimit <= entity.Properties.Health))
-            RenderHealthBar(entity, texture, offsetZ, nudgeAmount);
+            RenderHealthBar(entity, texture, offsetZ, vertex);
     }
 
-    private void RenderHealthBar(Entity entity, GLLegacyTexture texture, float offsetZ, Vec2D nudgeAmount)
+    private void RenderHealthBar(Entity entity, GLLegacyTexture texture, float offsetZ, in EntityVertex entityVertex)
     {
         // Don't let the bar bounce back and forth in height (eg Lost Soul)
         var offset = (int)offsetZ + texture.Height - texture.BlankRowsFromTop + 4;
@@ -283,13 +283,10 @@ public class EntityRenderer : IDisposable
         // Normalized health percent
         vertex.LightLevel = Math.Max(min, entity.Health / (float)entity.Properties.Health);
         vertex.Options = VertexOptions.Entity(1, attackFlash ? 1 : 0, 0, entity.Properties.HealthBarWidth);
+        vertex.Pos = entityVertex.Pos;
+        vertex.PrevPos = entityVertex.PrevPos;
         vertex.OffsetZ = offset;
-        vertex.Pos.X = (float)(entity.Position.X + nudgeAmount.X);
-        vertex.Pos.Y = (float)(entity.Position.Y + nudgeAmount.Y);
-        vertex.Pos.Z = (float)entity.Position.Z;
-        vertex.PrevPos.X = (float)(entity.PrevPosition.X + nudgeAmount.X);
-        vertex.PrevPos.Y = (float)(entity.PrevPosition.Y + nudgeAmount.Y);
-        vertex.PrevPos.Z = (float)entity.PrevPosition.Z;
+        vertex.OffsetXY = 0;
 
         array.SetLength(array.Length + 1);
     }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
@@ -358,19 +358,6 @@ public class EntityRenderer : IDisposable
         program.MapDataTexture(TextureUnit.Texture9);
     }
 
-    public void RenderHealthBars(RenderInfo renderInfo)
-    {
-        if (!m_healthBars)
-            return;
-
-        m_program.Bind();
-        GL.ActiveTexture(TextureUnit.Texture0);
-        SetUniforms(m_program, renderInfo);
-        m_program.HealthBarMode(true);
-        m_dataManager.RenderHealthBars();
-        m_program.Unbind();
-    }
-
     public void RenderOpaque(RenderInfo renderInfo)
     {
         m_program.Bind();
@@ -378,6 +365,13 @@ public class EntityRenderer : IDisposable
         SetUniforms(m_program, renderInfo);
         m_program.HealthBarMode(false);
         m_dataManager.RenderNonAlpha(PrimitiveType.Points);
+
+        if (m_healthBars)
+        {
+            m_program.HealthBarMode(true);
+            m_dataManager.RenderHealthBars();
+        }
+
         m_program.Unbind();
     }
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
@@ -354,6 +354,7 @@ public class EntityRenderer : IDisposable
         }
 
         program.PlaneZTexture(TextureUnit.Texture8);
+        program.MapDataTexture(TextureUnit.Texture9);
     }
 
     public void RenderHealthBars(RenderInfo renderInfo)

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
@@ -351,8 +351,8 @@ public class EntityRenderer : IDisposable
             program.OpaqueTexture(TextureUnit.Texture7);
         }
 
-        program.PlaneClipTexture(TextureUnit.Texture8);
-        program.MapDataTexture(TextureUnit.Texture9);
+        program.WallClipTexture(BindTextures.WallClipTexture);
+        program.MapDataTexture(BindTextures.MapLineData);
     }
 
     public void RenderOpaque(RenderInfo renderInfo)

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
@@ -248,6 +248,7 @@ public class EntityRenderer : IDisposable
             (float)(entity.PrevPosition.X - nudgeAmount.X) - (m_prevViewRightNormal.X * texture.Offset.X),
             (float)(entity.PrevPosition.Y - nudgeAmount.Y) - (m_prevViewRightNormal.Y * texture.Offset.X),
             (float)entity.PrevPosition.Z);
+        vertex.CenterPos = entity.Position.Float;
         vertex.OffsetZ = offsetZ;
         vertex.LightLevel = entity.Flags.Bright || entity.FrameState.Frame.Properties.Bright ? 255 :
             ((sector.TransferFloorLightSector.LightLevel + sector.TransferCeilingLightSector.LightLevel) / 2);
@@ -353,7 +354,7 @@ public class EntityRenderer : IDisposable
             program.OpaqueTexture(TextureUnit.Texture7);
         }
 
-        program.PlaneZTexture(TextureUnit.Texture8);
+        program.PlaneClipTexture(TextureUnit.Texture8);
         program.MapDataTexture(TextureUnit.Texture9);
     }
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
@@ -253,7 +253,7 @@ public class EntityRenderer : IDisposable
         vertex.LightLevel = entity.Flags.Bright || entity.FrameState.Frame.Properties.Bright ? 255 :
             ((sector.TransferFloorLightSector.LightLevel + sector.TransferCeilingLightSector.LightLevel) / 2);
         vertex.Options = VertexOptions.Entity(alpha, fuzz, spriteRotation.FlipU, colorMapIndex);
-        vertex.SectorIndex = Renderer.GetColorMapBufferIndex(sector, LightBufferType.Floor);
+        vertex.ColorMapIndex = Renderer.GetColorMapBufferIndex(sector, LightBufferType.Floor);
         
         arrayData.Length = length + 1;
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityVertex.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityVertex.cs
@@ -24,6 +24,9 @@ public struct EntityVertex
     [VertexAttribute]
     public float OffsetZ;
 
+    [VertexAttribute]
+    public Vec3F CenterPos;
+
     [VertexAttribute(required: false)]
     public float SectorIndex;
 }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityVertex.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityVertex.cs
@@ -28,5 +28,5 @@ public struct EntityVertex
     public float OffsetZ;
 
     [VertexAttribute(required: false)]
-    public float SectorIndex;
+    public float ColorMapIndex;
 }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityVertex.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityVertex.cs
@@ -22,10 +22,10 @@ public struct EntityVertex
     public Vec3F PrevPos;
 
     [VertexAttribute]
-    public float OffsetZ;
+    public float OffsetXY;
 
     [VertexAttribute]
-    public Vec3F CenterPos;
+    public float OffsetZ;
 
     [VertexAttribute(required: false)]
     public float SectorIndex;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/CoverWallUtil.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/CoverWallUtil.cs
@@ -51,22 +51,22 @@ public class CoverWallUtil
         {
             DynamicVertex* v = startVertex;
             staticVertices.Data[staticStartIndex++] = new StaticVertex(v->X, v->Y, v->Z + heights.Add, v->U, v->V,
-                v->Options, v->LightLevelAdd, 0);
+                v->Options, v->LightLevelAdd, 0, v->MapId);
             v++;
             staticVertices.Data[staticStartIndex++] = new StaticVertex(v->X, v->Y, v->Z - heights.Sub, v->U, v->V,
-                v->Options, v->LightLevelAdd, 0);
+                v->Options, v->LightLevelAdd, 0, v->MapId);
             v++;
             staticVertices.Data[staticStartIndex++] = new StaticVertex(v->X, v->Y, v->Z + heights.Add, v->U, v->V,
-                v->Options, v->LightLevelAdd, 0);
+                v->Options, v->LightLevelAdd, 0, v->MapId);
             v++;
             staticVertices.Data[staticStartIndex++] = new StaticVertex(v->X, v->Y, v->Z + heights.Add, v->U, v->V,
-                v->Options, v->LightLevelAdd, 0);
+                v->Options, v->LightLevelAdd, 0, v->MapId);
             v++;
             staticVertices.Data[staticStartIndex++] = new StaticVertex(v->X, v->Y, v->Z - heights.Sub, v->U, v->V,
-                v->Options, v->LightLevelAdd, 0);
+                v->Options, v->LightLevelAdd, 0, v->MapId);
             v++;
             staticVertices.Data[staticStartIndex++] = new StaticVertex(v->X, v->Y, v->Z - heights.Sub, v->U, v->V,
-                v->Options, v->LightLevelAdd, 0);
+                v->Options, v->LightLevelAdd, 0, v->MapId);
 
             staticVertices.SetLength(staticVertices.Length + 6);
         }
@@ -79,22 +79,22 @@ public class CoverWallUtil
         {
             DynamicVertex* v = startVertex;
             staticVertices[index++] = new StaticVertex(v->X, v->Y, v->Z + heights.Add, v->U, v->V,
-                v->Options, v->LightLevelAdd, 0);
+                v->Options, v->LightLevelAdd, 0, v->MapId);
             v++;
             staticVertices[index++] = new StaticVertex(v->X, v->Y, v->Z - heights.Sub, v->U, v->V,
-                v->Options, v->LightLevelAdd, 0);
+                v->Options, v->LightLevelAdd, 0, v->MapId);
             v++;
             staticVertices[index++] = new StaticVertex(v->X, v->Y, v->Z + heights.Add, v->U, v->V,
-                v->Options, v->LightLevelAdd, 0);
+                v->Options, v->LightLevelAdd, 0, v->MapId);
             v++;
             staticVertices[index++] = new StaticVertex(v->X, v->Y, v->Z - heights.Sub, v->U, v->V,
-                v->Options, v->LightLevelAdd, 0);
+                v->Options, v->LightLevelAdd, 0, v->MapId);
             v++;
             staticVertices[index++] = new StaticVertex(v->X, v->Y, v->Z + heights.Add, v->U, v->V,
-                v->Options, v->LightLevelAdd, 0);
+                v->Options, v->LightLevelAdd, 0, v->MapId);
             v++;
             staticVertices[index++] = new StaticVertex(v->X, v->Y, v->Z - heights.Sub, v->U, v->V,
-                v->Options, v->LightLevelAdd, 0);
+                v->Options, v->LightLevelAdd, 0, v->MapId);
         }
     }
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/CoverWallUtil.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/CoverWallUtil.cs
@@ -51,22 +51,22 @@ public class CoverWallUtil
         {
             DynamicVertex* v = startVertex;
             staticVertices.Data[staticStartIndex++] = new StaticVertex(v->X, v->Y, v->Z + heights.Add, v->U, v->V,
-                v->Options, v->LightLevelAdd, 0, v->MapId);
+                v->Options, v->LightLevelAdd, 0);
             v++;
             staticVertices.Data[staticStartIndex++] = new StaticVertex(v->X, v->Y, v->Z - heights.Sub, v->U, v->V,
-                v->Options, v->LightLevelAdd, 0, v->MapId);
+                v->Options, v->LightLevelAdd, 0);
             v++;
             staticVertices.Data[staticStartIndex++] = new StaticVertex(v->X, v->Y, v->Z + heights.Add, v->U, v->V,
-                v->Options, v->LightLevelAdd, 0, v->MapId);
+                v->Options, v->LightLevelAdd, 0);
             v++;
             staticVertices.Data[staticStartIndex++] = new StaticVertex(v->X, v->Y, v->Z + heights.Add, v->U, v->V,
-                v->Options, v->LightLevelAdd, 0, v->MapId);
+                v->Options, v->LightLevelAdd, 0);
             v++;
             staticVertices.Data[staticStartIndex++] = new StaticVertex(v->X, v->Y, v->Z - heights.Sub, v->U, v->V,
-                v->Options, v->LightLevelAdd, 0, v->MapId);
+                v->Options, v->LightLevelAdd, 0);
             v++;
             staticVertices.Data[staticStartIndex++] = new StaticVertex(v->X, v->Y, v->Z - heights.Sub, v->U, v->V,
-                v->Options, v->LightLevelAdd, 0, v->MapId);
+                v->Options, v->LightLevelAdd, 0);
 
             staticVertices.SetLength(staticVertices.Length + 6);
         }
@@ -79,22 +79,22 @@ public class CoverWallUtil
         {
             DynamicVertex* v = startVertex;
             staticVertices[index++] = new StaticVertex(v->X, v->Y, v->Z + heights.Add, v->U, v->V,
-                v->Options, v->LightLevelAdd, 0, v->MapId);
+                v->Options, v->LightLevelAdd, 0);
             v++;
             staticVertices[index++] = new StaticVertex(v->X, v->Y, v->Z - heights.Sub, v->U, v->V,
-                v->Options, v->LightLevelAdd, 0, v->MapId);
+                v->Options, v->LightLevelAdd, 0);
             v++;
             staticVertices[index++] = new StaticVertex(v->X, v->Y, v->Z + heights.Add, v->U, v->V,
-                v->Options, v->LightLevelAdd, 0, v->MapId);
+                v->Options, v->LightLevelAdd, 0);
             v++;
             staticVertices[index++] = new StaticVertex(v->X, v->Y, v->Z - heights.Sub, v->U, v->V,
-                v->Options, v->LightLevelAdd, 0, v->MapId);
+                v->Options, v->LightLevelAdd, 0);
             v++;
             staticVertices[index++] = new StaticVertex(v->X, v->Y, v->Z + heights.Add, v->U, v->V,
-                v->Options, v->LightLevelAdd, 0, v->MapId);
+                v->Options, v->LightLevelAdd, 0);
             v++;
             staticVertices[index++] = new StaticVertex(v->X, v->Y, v->Z - heights.Sub, v->U, v->V,
-                v->Options, v->LightLevelAdd, 0, v->MapId);
+                v->Options, v->LightLevelAdd, 0);
         }
     }
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
@@ -635,9 +635,9 @@ public class GeometryRenderer : IDisposable
             int lightIndex = Renderer.GetLightBufferIndex(side, side.Middle, renderSector);
             WorldTriangulator.HandleOneSided(side, floor, ceiling, texture.UVInverse, ref wall, isFront: isFront);
             if (data == null)
-                data = GetWallVertices(wall, GetLightLevelAdd(side), lightIndex, colorMapIndex, GetWallLightLevel(side, side.Middle));
+                data = GetWallVertices(wall, GetLightLevelAdd(side), lightIndex, colorMapIndex, GetWallLightLevel(side, side.Middle), side.Id);
             else
-                SetWallVertices(data, wall, GetLightLevelAdd(side), lightIndex, colorMapIndex, GetWallLightLevel(side, side.Middle));
+                SetWallVertices(data, wall, GetLightLevelAdd(side), lightIndex, colorMapIndex, GetWallLightLevel(side, side.Middle), side.Id);
 
             m_vertexLookup[side.Id] = data;
         }
@@ -873,9 +873,9 @@ public class GeometryRenderer : IDisposable
 
                 WorldTriangulator.HandleTwoSidedLower(facingSide, top, bottom, texture.UVInverse, isFrontSide, ref wall);
                 if (data == null)
-                    data = GetWallVertices(wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Lower));
+                    data = GetWallVertices(wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Lower), facingSide.Id);
                 else
-                    SetWallVertices(data, wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Lower));
+                    SetWallVertices(data, wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Lower), facingSide.Id);
 
                 m_vertexLowerLookup[facingSide.Id] = data;
             }
@@ -986,9 +986,9 @@ public class GeometryRenderer : IDisposable
                 int lightIndex = Renderer.GetLightBufferIndex(facingSide, facingSide.Upper, facingSector);
                 WorldTriangulator.HandleTwoSidedUpper(facingSide, top, bottom, texture.UVInverse, isFrontSide, ref wall);
                 if (data == null)
-                    data = GetWallVertices(wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Upper));
+                    data = GetWallVertices(wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Upper), facingSide.Id);
                 else
-                    SetWallVertices(data, wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Upper));
+                    SetWallVertices(data, wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Upper), facingSide.Id);
 
                 m_vertexUpperLookup[facingSide.Id] = data;
             }
@@ -1039,7 +1039,7 @@ public class GeometryRenderer : IDisposable
             WorldTriangulator.HandleTwoSidedUpper(facingSide, facingSector.Ceiling, otherSector.Ceiling, texture.UVInverse, isFrontSide, ref wall);
         else
             WorldTriangulator.HandleTwoSidedLower(facingSide, otherSector.Floor, facingSector.Floor, texture.UVInverse, isFrontSide, ref wall);
-        SetWallVertices(m_wallVertices, wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, 0);
+        SetWallVertices(m_wallVertices, wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, 0, facingSide.Id);
         return m_wallVertices;
     }
 
@@ -1552,7 +1552,7 @@ public class GeometryRenderer : IDisposable
     }
 
     private static unsafe void SetWallVertices(DynamicVertex[] data, in WallVertices wv, float lightLevelAdd, int lightBufferIndex, int colorMapIndex, byte wallLightLevel,
-        float alpha = 1.0f, float addAlpha = 1.0f)
+        float mapId, float alpha = 1.0f, float addAlpha = 1.0f)
     {
         colorMapIndex = VertexOptions.ColorMapIndex(colorMapIndex, wallLightLevel);
         fixed (DynamicVertex* startVertex = &data[0])
@@ -1650,7 +1650,7 @@ public class GeometryRenderer : IDisposable
     }
 
     private static unsafe DynamicVertex[] GetWallVertices(in WallVertices wv, float lightLevelAdd, int lightBufferIndex, int colorMapIndex, byte wallLightLevel,
-        float alpha = 1.0f, float addAlpha = 1.0f)
+        float mapId,  float alpha = 1.0f, float addAlpha = 1.0f)
     {
         colorMapIndex = VertexOptions.ColorMapIndex(colorMapIndex, wallLightLevel);
         var data = WorldStatic.DataCache.GetWallVertices();
@@ -1678,6 +1678,7 @@ public class GeometryRenderer : IDisposable
             vertex->Options = VertexOptions.World(1, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
+            vertex->MapId = mapId;
 
             // 1
             vertex++;
@@ -1694,6 +1695,7 @@ public class GeometryRenderer : IDisposable
             vertex->Options = VertexOptions.World(1, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
+            vertex->MapId = mapId;
 
             // 2
             vertex++;
@@ -1710,6 +1712,7 @@ public class GeometryRenderer : IDisposable
             vertex->Options = VertexOptions.World(1, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
+            vertex->MapId = mapId;
 
             // 3
             vertex++;
@@ -1726,6 +1729,7 @@ public class GeometryRenderer : IDisposable
             vertex->Options = VertexOptions.World(0, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
+            vertex->MapId = mapId;
 
             // 4
             vertex++;
@@ -1742,6 +1746,7 @@ public class GeometryRenderer : IDisposable
             vertex->Options = VertexOptions.World(0, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
+            vertex->MapId = mapId;
 
             // 5
             vertex++;
@@ -1758,6 +1763,7 @@ public class GeometryRenderer : IDisposable
             vertex->Options = VertexOptions.World(0, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
+            vertex->MapId = mapId;
         }
 
         return data;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
@@ -359,6 +359,9 @@ public class GeometryRenderer : IDisposable
     public void RenderPortals(RenderInfo renderInfo) =>
         Portals.Render(renderInfo);
 
+    public void RenderWallClipPortals(RenderInfo renderInfo) =>
+        Portals.RenderWallClip(renderInfo);
+
     public void RenderSector(Sector sector, in Vec3D viewPosition, in Vec3D prevViewPosition)
     {
         m_buffer = true;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
@@ -29,6 +29,7 @@ using Helion.World.Geometry.Subsectors;
 using Helion.World.Geometry.Walls;
 using Helion.World.Physics;
 using Helion.World.Static;
+using NLog;
 using static Helion.World.Geometry.Sectors.Sector;
 
 namespace Helion.Render.OpenGL.Renderers.Legacy.World.Geometry;
@@ -100,7 +101,7 @@ public class GeometryRenderer : IDisposable
         m_archiveCollection = archiveCollection;
         m_staticCacheGeometryRenderer = new(archiveCollection, glTextureManager, staticProgram, this);
 
-        var options = VertexOptions.World(1, 1, 0, 0);
+        var options = VertexOptions.World(1, 1, 0, 0, 0, 0);
         for (int i = 0; i < m_wallVertices.Length; i++)
             m_wallVertices[i].Options = options;
 
@@ -638,9 +639,9 @@ public class GeometryRenderer : IDisposable
             int lightIndex = Renderer.GetLightBufferIndex(side, side.Middle, renderSector);
             WorldTriangulator.HandleOneSided(side, floor, ceiling, texture.UVInverse, ref wall, isFront: isFront);
             if (data == null)
-                data = GetWallVertices(wall, GetLightLevelAdd(side), lightIndex, colorMapIndex, GetWallLightLevel(side, side.Middle), side.Line.Id);
+                data = GetWallVertices(wall, GetLightLevelAdd(side), lightIndex, colorMapIndex, GetWallLightLevel(side, side.Middle), side.Line.Id, WallLocation.Middle);
             else
-                SetWallVertices(data, wall, GetLightLevelAdd(side), lightIndex, colorMapIndex, GetWallLightLevel(side, side.Middle), side.Line.Id);
+                SetWallVertices(data, wall, GetLightLevelAdd(side), lightIndex, colorMapIndex, GetWallLightLevel(side, side.Middle), side.Line.Id, WallLocation.Middle);
 
             m_vertexLookup[side.Id] = data;
         }
@@ -876,9 +877,9 @@ public class GeometryRenderer : IDisposable
 
                 WorldTriangulator.HandleTwoSidedLower(facingSide, top, bottom, texture.UVInverse, isFrontSide, ref wall);
                 if (data == null)
-                    data = GetWallVertices(wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Lower), facingSide.Line.Id);
+                    data = GetWallVertices(wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Lower), facingSide.Line.Id, WallLocation.Lower);
                 else
-                    SetWallVertices(data, wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Lower), facingSide.Line.Id);
+                    SetWallVertices(data, wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Lower), facingSide.Line.Id, WallLocation.Lower);
 
                 m_vertexLowerLookup[facingSide.Id] = data;
             }
@@ -989,9 +990,9 @@ public class GeometryRenderer : IDisposable
                 int lightIndex = Renderer.GetLightBufferIndex(facingSide, facingSide.Upper, facingSector);
                 WorldTriangulator.HandleTwoSidedUpper(facingSide, top, bottom, texture.UVInverse, isFrontSide, ref wall);
                 if (data == null)
-                    data = GetWallVertices(wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Upper), facingSide.Line.Id);
+                    data = GetWallVertices(wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Upper), facingSide.Line.Id, WallLocation.Upper);
                 else
-                    SetWallVertices(data, wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Upper), facingSide.Line.Id);
+                    SetWallVertices(data, wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Upper), facingSide.Line.Id, WallLocation.Upper);
 
                 m_vertexUpperLookup[facingSide.Id] = data;
             }
@@ -1042,7 +1043,7 @@ public class GeometryRenderer : IDisposable
             WorldTriangulator.HandleTwoSidedUpper(facingSide, facingSector.Ceiling, otherSector.Ceiling, texture.UVInverse, isFrontSide, ref wall);
         else
             WorldTriangulator.HandleTwoSidedLower(facingSide, otherSector.Floor, facingSector.Floor, texture.UVInverse, isFrontSide, ref wall);
-        SetWallVertices(m_wallVertices, wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, 0, facingSide.Line.Id);
+        SetWallVertices(m_wallVertices, wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, 0, facingSide.Line.Id, location);
         return m_wallVertices;
     }
 
@@ -1161,9 +1162,9 @@ public class GeometryRenderer : IDisposable
                 clipPlanes: GetTwoSidedMiddleClipPlanes(facingSide, otherSide, facingSector, otherSector));
 
             if (data == null)
-                data = GetWallVertices(wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Middle), line.Id, alpha, addAlpha: 0);
+                data = GetWallVertices(wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Middle), line.Id, WallLocation.None, alpha, addAlpha: 0);
             else
-                SetWallVertices(data, wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Middle), line.Id, alpha, addAlpha: 0);
+                SetWallVertices(data, wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Middle), line.Id, WallLocation.None, alpha, addAlpha: 0);
 
             m_vertexLookup[facingSide.Id] = data;
             line.Segment = segSave;
@@ -1555,10 +1556,12 @@ public class GeometryRenderer : IDisposable
     }
 
     private static unsafe void SetWallVertices(DynamicVertex[] data, in WallVertices wv, float lightLevelAdd, int lightBufferIndex, int colorMapIndex, byte wallLightLevel,
-        int mapId, float alpha = 1.0f, float addAlpha = 1.0f)
+        int mapId, WallLocation location, float alpha = 1.0f, float addAlpha = 1.0f)
     {
         colorMapIndex = VertexOptions.ColorMapIndex(colorMapIndex, wallLightLevel);
         lightLevelAdd = VertexOptions.LightLevelAdd(mapId, lightLevelAdd);
+        int lower = location == WallLocation.Lower ? 1 : 0;
+        int upper = location == WallLocation.Upper ? 1 : 0;
         fixed (DynamicVertex* startVertex = &data[0])
         {
             DynamicVertex* vertex = startVertex;
@@ -1572,7 +1575,7 @@ public class GeometryRenderer : IDisposable
             vertex->V = wv.TopLeft.V;
             vertex->PrevU = wv.TopLeft.PrevU;
             vertex->PrevV = wv.TopLeft.PrevV;
-            vertex->Options = VertexOptions.World(1, alpha, addAlpha, lightBufferIndex);
+            vertex->Options = VertexOptions.World(1, alpha, addAlpha, upper, lower, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
 
@@ -1587,7 +1590,7 @@ public class GeometryRenderer : IDisposable
             vertex->V = wv.BottomRight.V;
             vertex->PrevU = wv.TopLeft.PrevU;
             vertex->PrevV = wv.BottomRight.PrevV;
-            vertex->Options = VertexOptions.World(1, alpha, addAlpha, lightBufferIndex);
+            vertex->Options = VertexOptions.World(1, alpha, addAlpha, upper, lower, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
 
@@ -1602,7 +1605,7 @@ public class GeometryRenderer : IDisposable
             vertex->V = wv.TopLeft.V;
             vertex->PrevU = wv.BottomRight.PrevU;
             vertex->PrevV = wv.TopLeft.PrevV;
-            vertex->Options = VertexOptions.World(1, alpha, addAlpha, lightBufferIndex);
+            vertex->Options = VertexOptions.World(1, alpha, addAlpha, upper, lower, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
 
@@ -1617,7 +1620,7 @@ public class GeometryRenderer : IDisposable
             vertex->V = wv.BottomRight.V;
             vertex->PrevU = wv.BottomRight.PrevU;
             vertex->PrevV = wv.BottomRight.PrevV;
-            vertex->Options = VertexOptions.World(0, alpha, addAlpha, lightBufferIndex);
+            vertex->Options = VertexOptions.World(0, alpha, addAlpha, upper, lower, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
 
@@ -1632,7 +1635,7 @@ public class GeometryRenderer : IDisposable
             vertex->V = wv.TopLeft.V;
             vertex->PrevU = wv.BottomRight.PrevU;
             vertex->PrevV = wv.TopLeft.PrevV;
-            vertex->Options = VertexOptions.World(0, alpha, addAlpha, lightBufferIndex);
+            vertex->Options = VertexOptions.World(0, alpha, addAlpha, upper, lower, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
 
@@ -1647,17 +1650,19 @@ public class GeometryRenderer : IDisposable
             vertex->V = wv.BottomRight.V;
             vertex->PrevU = wv.TopLeft.PrevU;
             vertex->PrevV = wv.BottomRight.PrevV;
-            vertex->Options = VertexOptions.World(0, alpha, addAlpha, lightBufferIndex);
+            vertex->Options = VertexOptions.World(0, alpha, addAlpha, upper, lower, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
         }
     }
 
     private static unsafe DynamicVertex[] GetWallVertices(in WallVertices wv, float lightLevelAdd, int lightBufferIndex, int colorMapIndex, byte wallLightLevel,
-        int mapId,  float alpha = 1.0f, float addAlpha = 1.0f)
+        int mapId, WallLocation location, float alpha = 1.0f, float addAlpha = 1.0f)
     {
         colorMapIndex = VertexOptions.ColorMapIndex(colorMapIndex, wallLightLevel);
         lightLevelAdd = VertexOptions.LightLevelAdd(mapId, lightLevelAdd);
+        int lower = location == WallLocation.Lower ? 1 : 0;
+        int upper = location == WallLocation.Upper ? 1 : 0;
         var data = WorldStatic.DataCache.GetWallVertices();
         fixed (DynamicVertex* startVertex = &data[0])
         {
@@ -1680,7 +1685,7 @@ public class GeometryRenderer : IDisposable
             vertex->V = wv.TopLeft.V;
             vertex->PrevU = wv.TopLeft.PrevU;
             vertex->PrevV = wv.TopLeft.PrevV;
-            vertex->Options = VertexOptions.World(1, alpha, addAlpha, lightBufferIndex);
+            vertex->Options = VertexOptions.World(1, alpha, addAlpha, upper, lower, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
 
@@ -1696,7 +1701,7 @@ public class GeometryRenderer : IDisposable
             vertex->V = wv.BottomRight.V;
             vertex->PrevU = wv.TopLeft.PrevU;
             vertex->PrevV = wv.BottomRight.PrevV;
-            vertex->Options = VertexOptions.World(1, alpha, addAlpha, lightBufferIndex);
+            vertex->Options = VertexOptions.World(1, alpha, addAlpha, upper, lower, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
 
@@ -1712,7 +1717,7 @@ public class GeometryRenderer : IDisposable
             vertex->V = wv.TopLeft.V;
             vertex->PrevU = wv.BottomRight.PrevU;
             vertex->PrevV = wv.TopLeft.PrevV;
-            vertex->Options = VertexOptions.World(1, alpha, addAlpha, lightBufferIndex);
+            vertex->Options = VertexOptions.World(1, alpha, addAlpha, upper, lower, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
 
@@ -1728,7 +1733,7 @@ public class GeometryRenderer : IDisposable
             vertex->V = wv.BottomRight.V;
             vertex->PrevU = wv.BottomRight.PrevU;
             vertex->PrevV = wv.BottomRight.PrevV;
-            vertex->Options = VertexOptions.World(0, alpha, addAlpha, lightBufferIndex);
+            vertex->Options = VertexOptions.World(0, alpha, addAlpha, upper, lower, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
 
@@ -1744,7 +1749,7 @@ public class GeometryRenderer : IDisposable
             vertex->V = wv.TopLeft.V;
             vertex->PrevU = wv.BottomRight.PrevU;
             vertex->PrevV = wv.TopLeft.PrevV;
-            vertex->Options = VertexOptions.World(0, alpha, addAlpha, lightBufferIndex);
+            vertex->Options = VertexOptions.World(0, alpha, addAlpha, upper, lower, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
 
@@ -1760,7 +1765,7 @@ public class GeometryRenderer : IDisposable
             vertex->V = wv.BottomRight.V;
             vertex->PrevU = wv.TopLeft.PrevU;
             vertex->PrevV = wv.BottomRight.PrevV;
-            vertex->Options = VertexOptions.World(0, alpha, addAlpha, lightBufferIndex);
+            vertex->Options = VertexOptions.World(0, alpha, addAlpha, upper, lower, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
         }
@@ -1771,7 +1776,7 @@ public class GeometryRenderer : IDisposable
     private static unsafe void GetFlatVertices(DynamicVertex[] vertices, int startIndex, ref TriangulatedWorldVertex root, ref TriangulatedWorldVertex second, ref TriangulatedWorldVertex third,
         int lightLevelBufferIndex, int colorMapIndex, int flatLightLevel)
     {
-        var options = VertexOptions.World(0, 1, 1, lightLevelBufferIndex);
+        var options = VertexOptions.World(0, 1, 1, 0, 0, lightLevelBufferIndex);
         colorMapIndex = VertexOptions.ColorMapIndex(colorMapIndex, flatLightLevel);
         fixed (DynamicVertex* startVertex = &vertices[startIndex])
         {

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
@@ -1158,9 +1158,9 @@ public class GeometryRenderer : IDisposable
                 clipPlanes: GetTwoSidedMiddleClipPlanes(facingSide, otherSide, facingSector, otherSector));
 
             if (data == null)
-                data = GetWallVertices(wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Middle), alpha, addAlpha: 0);
+                data = GetWallVertices(wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Middle), facingSide.Id, alpha, addAlpha: 0);
             else
-                SetWallVertices(data, wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Middle), alpha, addAlpha: 0);
+                SetWallVertices(data, wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Middle), facingSide.Id, alpha, addAlpha: 0);
 
             m_vertexLookup[facingSide.Id] = data;
             line.Segment = segSave;
@@ -1552,7 +1552,7 @@ public class GeometryRenderer : IDisposable
     }
 
     private static unsafe void SetWallVertices(DynamicVertex[] data, in WallVertices wv, float lightLevelAdd, int lightBufferIndex, int colorMapIndex, byte wallLightLevel,
-        float mapId, float alpha = 1.0f, float addAlpha = 1.0f)
+        int mapId, float alpha = 1.0f, float addAlpha = 1.0f)
     {
         colorMapIndex = VertexOptions.ColorMapIndex(colorMapIndex, wallLightLevel);
         fixed (DynamicVertex* startVertex = &data[0])
@@ -1571,6 +1571,7 @@ public class GeometryRenderer : IDisposable
             vertex->Options = VertexOptions.World(1, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
+            vertex->MapId = mapId;
 
             vertex++;
             vertex->X = wv.TopLeft.X;
@@ -1586,6 +1587,7 @@ public class GeometryRenderer : IDisposable
             vertex->Options = VertexOptions.World(1, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
+            vertex->MapId = mapId;
 
             vertex++;
             vertex->X = wv.BottomRight.X;
@@ -1601,6 +1603,7 @@ public class GeometryRenderer : IDisposable
             vertex->Options = VertexOptions.World(1, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
+            vertex->MapId = mapId;
 
             vertex++;
             vertex->X = wv.BottomRight.X;
@@ -1616,6 +1619,7 @@ public class GeometryRenderer : IDisposable
             vertex->Options = VertexOptions.World(0, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
+            vertex->MapId = mapId;
 
             vertex++;
             vertex->X = wv.BottomRight.X;
@@ -1631,6 +1635,7 @@ public class GeometryRenderer : IDisposable
             vertex->Options = VertexOptions.World(0, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
+            vertex->MapId = mapId;
 
             vertex++;
             vertex->X = wv.TopLeft.X;
@@ -1646,11 +1651,12 @@ public class GeometryRenderer : IDisposable
             vertex->Options = VertexOptions.World(0, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
+            vertex->MapId = mapId;
         }
     }
 
     private static unsafe DynamicVertex[] GetWallVertices(in WallVertices wv, float lightLevelAdd, int lightBufferIndex, int colorMapIndex, byte wallLightLevel,
-        float mapId,  float alpha = 1.0f, float addAlpha = 1.0f)
+        int mapId,  float alpha = 1.0f, float addAlpha = 1.0f)
     {
         colorMapIndex = VertexOptions.ColorMapIndex(colorMapIndex, wallLightLevel);
         var data = WorldStatic.DataCache.GetWallVertices();

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
@@ -335,12 +335,6 @@ public class GeometryRenderer : IDisposable
     public void RenderStaticGeometryFlats() =>
         m_staticCacheGeometryRenderer.RenderFlats();
 
-    public void RenderStaticGeometryFloors() =>
-        m_staticCacheGeometryRenderer.RenderFloors();
-
-    public void RenderStaticGeometryCeilings() =>
-        m_staticCacheGeometryRenderer.RenderCeilings();
-
     public void RenderStaticCoverWalls() =>
         m_staticCacheGeometryRenderer.RenderCoverWalls();
 
@@ -1295,7 +1289,7 @@ public class GeometryRenderer : IDisposable
     {
         bool isSky = TextureManager.IsSkyTexture(flat.TextureHandle);
         GLLegacyTexture texture = m_glTextureManager.GetTexture(flat.TextureHandle);
-        RenderWorldData renderData = m_worldDataManager.GetRenderData(texture, m_program, floor ? GeometryType.Floor : GeometryType.Ceiling);
+        RenderWorldData renderData = m_worldDataManager.GetRenderData(texture, m_program, GeometryType.Flat);
         bool flatChanged = FlatChanged(flat);
         var sector = subsectors[0].Sector;
         int id = sector.Id;
@@ -1361,6 +1355,8 @@ public class GeometryRenderer : IDisposable
                 }
 
                 var flatLightLevel = (byte)Math.Clamp(lightPlane.LightLevelAbsolute ? lightPlane.LightLevel : (short)0, (short)0, (short)255);
+                int upper = floor ? 0 : 1;
+                int lower = 1 - upper;
 
                 for (int j = 0; j < subsectors.Length; j++)
                 {
@@ -1375,7 +1371,7 @@ public class GeometryRenderer : IDisposable
                     {
                         ref var second = ref m_subsectorVertices.Data[i];
                         ref var third = ref m_subsectorVertices.Data[i + 1];
-                        GetFlatVertices(lookupData, indexStart, ref root, ref second, ref third, lightIndex, colorMapIndex, flatLightLevel);
+                        GetFlatVertices(lookupData, indexStart, ref root, ref second, ref third, lightIndex, colorMapIndex, flatLightLevel, upper, lower);
                         indexStart += 3;
                     }
                 }
@@ -1777,9 +1773,9 @@ public class GeometryRenderer : IDisposable
     }
 
     private static unsafe void GetFlatVertices(DynamicVertex[] vertices, int startIndex, ref TriangulatedWorldVertex root, ref TriangulatedWorldVertex second, ref TriangulatedWorldVertex third,
-        int lightLevelBufferIndex, int colorMapIndex, int flatLightLevel)
+        int lightLevelBufferIndex, int colorMapIndex, int flatLightLevel, int upper, int lower)
     {
-        var options = VertexOptions.World(0, 1, 1, 0, 0, lightLevelBufferIndex);
+        var options = VertexOptions.World(0, 1, 1, upper, lower, lightLevelBufferIndex);
         colorMapIndex = VertexOptions.ColorMapIndex(colorMapIndex, flatLightLevel);
         fixed (DynamicVertex* startVertex = &vertices[startIndex])
         {

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
@@ -635,9 +635,9 @@ public class GeometryRenderer : IDisposable
             int lightIndex = Renderer.GetLightBufferIndex(side, side.Middle, renderSector);
             WorldTriangulator.HandleOneSided(side, floor, ceiling, texture.UVInverse, ref wall, isFront: isFront);
             if (data == null)
-                data = GetWallVertices(wall, GetLightLevelAdd(side), lightIndex, colorMapIndex, GetWallLightLevel(side, side.Middle), side.Id);
+                data = GetWallVertices(wall, GetLightLevelAdd(side), lightIndex, colorMapIndex, GetWallLightLevel(side, side.Middle), side.Line.Id);
             else
-                SetWallVertices(data, wall, GetLightLevelAdd(side), lightIndex, colorMapIndex, GetWallLightLevel(side, side.Middle), side.Id);
+                SetWallVertices(data, wall, GetLightLevelAdd(side), lightIndex, colorMapIndex, GetWallLightLevel(side, side.Middle), side.Line.Id);
 
             m_vertexLookup[side.Id] = data;
         }
@@ -873,9 +873,9 @@ public class GeometryRenderer : IDisposable
 
                 WorldTriangulator.HandleTwoSidedLower(facingSide, top, bottom, texture.UVInverse, isFrontSide, ref wall);
                 if (data == null)
-                    data = GetWallVertices(wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Lower), facingSide.Id);
+                    data = GetWallVertices(wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Lower), facingSide.Line.Id);
                 else
-                    SetWallVertices(data, wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Lower), facingSide.Id);
+                    SetWallVertices(data, wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Lower), facingSide.Line.Id);
 
                 m_vertexLowerLookup[facingSide.Id] = data;
             }
@@ -986,9 +986,9 @@ public class GeometryRenderer : IDisposable
                 int lightIndex = Renderer.GetLightBufferIndex(facingSide, facingSide.Upper, facingSector);
                 WorldTriangulator.HandleTwoSidedUpper(facingSide, top, bottom, texture.UVInverse, isFrontSide, ref wall);
                 if (data == null)
-                    data = GetWallVertices(wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Upper), facingSide.Id);
+                    data = GetWallVertices(wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Upper), facingSide.Line.Id);
                 else
-                    SetWallVertices(data, wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Upper), facingSide.Id);
+                    SetWallVertices(data, wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Upper), facingSide.Line.Id);
 
                 m_vertexUpperLookup[facingSide.Id] = data;
             }
@@ -1039,7 +1039,7 @@ public class GeometryRenderer : IDisposable
             WorldTriangulator.HandleTwoSidedUpper(facingSide, facingSector.Ceiling, otherSector.Ceiling, texture.UVInverse, isFrontSide, ref wall);
         else
             WorldTriangulator.HandleTwoSidedLower(facingSide, otherSector.Floor, facingSector.Floor, texture.UVInverse, isFrontSide, ref wall);
-        SetWallVertices(m_wallVertices, wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, 0, facingSide.Id);
+        SetWallVertices(m_wallVertices, wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, 0, facingSide.Line.Id);
         return m_wallVertices;
     }
 
@@ -1158,9 +1158,9 @@ public class GeometryRenderer : IDisposable
                 clipPlanes: GetTwoSidedMiddleClipPlanes(facingSide, otherSide, facingSector, otherSector));
 
             if (data == null)
-                data = GetWallVertices(wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Middle), facingSide.Id, alpha, addAlpha: 0);
+                data = GetWallVertices(wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Middle), line.Id, alpha, addAlpha: 0);
             else
-                SetWallVertices(data, wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Middle), facingSide.Id, alpha, addAlpha: 0);
+                SetWallVertices(data, wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Middle), line.Id, alpha, addAlpha: 0);
 
             m_vertexLookup[facingSide.Id] = data;
             line.Segment = segSave;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
@@ -337,6 +337,9 @@ public class GeometryRenderer : IDisposable
     public void RenderStaticGeometryFloors() =>
         m_staticCacheGeometryRenderer.RenderFloors();
 
+    public void RenderStaticGeometryCeilings() =>
+        m_staticCacheGeometryRenderer.RenderCeilings();
+
     public void RenderStaticCoverWalls() =>
         m_staticCacheGeometryRenderer.RenderCoverWalls();
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
@@ -1555,6 +1555,7 @@ public class GeometryRenderer : IDisposable
         int mapId, float alpha = 1.0f, float addAlpha = 1.0f)
     {
         colorMapIndex = VertexOptions.ColorMapIndex(colorMapIndex, wallLightLevel);
+        lightLevelAdd = VertexOptions.LightLevelAdd(mapId, lightLevelAdd);
         fixed (DynamicVertex* startVertex = &data[0])
         {
             DynamicVertex* vertex = startVertex;
@@ -1571,7 +1572,6 @@ public class GeometryRenderer : IDisposable
             vertex->Options = VertexOptions.World(1, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
-            vertex->MapId = mapId;
 
             vertex++;
             vertex->X = wv.TopLeft.X;
@@ -1587,7 +1587,6 @@ public class GeometryRenderer : IDisposable
             vertex->Options = VertexOptions.World(1, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
-            vertex->MapId = mapId;
 
             vertex++;
             vertex->X = wv.BottomRight.X;
@@ -1603,7 +1602,6 @@ public class GeometryRenderer : IDisposable
             vertex->Options = VertexOptions.World(1, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
-            vertex->MapId = mapId;
 
             vertex++;
             vertex->X = wv.BottomRight.X;
@@ -1619,7 +1617,6 @@ public class GeometryRenderer : IDisposable
             vertex->Options = VertexOptions.World(0, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
-            vertex->MapId = mapId;
 
             vertex++;
             vertex->X = wv.BottomRight.X;
@@ -1635,7 +1632,6 @@ public class GeometryRenderer : IDisposable
             vertex->Options = VertexOptions.World(0, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
-            vertex->MapId = mapId;
 
             vertex++;
             vertex->X = wv.TopLeft.X;
@@ -1651,7 +1647,6 @@ public class GeometryRenderer : IDisposable
             vertex->Options = VertexOptions.World(0, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
-            vertex->MapId = mapId;
         }
     }
 
@@ -1659,6 +1654,7 @@ public class GeometryRenderer : IDisposable
         int mapId,  float alpha = 1.0f, float addAlpha = 1.0f)
     {
         colorMapIndex = VertexOptions.ColorMapIndex(colorMapIndex, wallLightLevel);
+        lightLevelAdd = VertexOptions.LightLevelAdd(mapId, lightLevelAdd);
         var data = WorldStatic.DataCache.GetWallVertices();
         fixed (DynamicVertex* startVertex = &data[0])
         {
@@ -1684,7 +1680,6 @@ public class GeometryRenderer : IDisposable
             vertex->Options = VertexOptions.World(1, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
-            vertex->MapId = mapId;
 
             // 1
             vertex++;
@@ -1701,7 +1696,6 @@ public class GeometryRenderer : IDisposable
             vertex->Options = VertexOptions.World(1, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
-            vertex->MapId = mapId;
 
             // 2
             vertex++;
@@ -1718,7 +1712,6 @@ public class GeometryRenderer : IDisposable
             vertex->Options = VertexOptions.World(1, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
-            vertex->MapId = mapId;
 
             // 3
             vertex++;
@@ -1735,7 +1728,6 @@ public class GeometryRenderer : IDisposable
             vertex->Options = VertexOptions.World(0, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
-            vertex->MapId = mapId;
 
             // 4
             vertex++;
@@ -1752,7 +1744,6 @@ public class GeometryRenderer : IDisposable
             vertex->Options = VertexOptions.World(0, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
-            vertex->MapId = mapId;
 
             // 5
             vertex++;
@@ -1769,7 +1760,6 @@ public class GeometryRenderer : IDisposable
             vertex->Options = VertexOptions.World(0, alpha, addAlpha, lightBufferIndex);
             vertex->LightLevelAdd = lightLevelAdd;
             vertex->ColorMapIndex = colorMapIndex;
-            vertex->MapId = mapId;
         }
 
         return data;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryType.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryType.cs
@@ -4,8 +4,7 @@ public enum GeometryType
 {
     Wall,
     TwoSidedMiddleWall,
-    Floor,
-    Ceiling,
+    Flat,
     AlphaWall,
     Count
 }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillProgram.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillProgram.cs
@@ -27,7 +27,7 @@ public class FloodFillProgram : RenderProgram
     private readonly int m_lightModeLocation;
     private readonly int m_gammaCorrectionLocation;
 
-    public FloodFillProgram() : base("Flood fill plane")
+    public FloodFillProgram(string name) : base($"FloodFill - {name}")
     {
         m_boundTextureLocation = Uniforms.GetLocation("boundTexture");
         m_sectorLightTextureLocation = Uniforms.GetLocation("sectorLightTexture");
@@ -76,14 +76,19 @@ public class FloodFillProgram : RenderProgram
         layout(location = 3) in float maxViewZ;
         layout(location = 4) in float prevZ;
         layout(location = 5) in float prevPlaneZ;
-        layout(location = 6) in float lightLevelBufferIndex;
+        layout(location = 6) in float options;
         layout(location = 7) in float colorMapIndex;
+        layout(location = 8) in float mapId;
 
         flat out float planeZFrag;
         out vec3 vertexPosFrag;
         flat out float distanceOffsetFrag;
         flat out float colorMapIndexFrag;
         flat out float vertexLightLevelFrag;
+        flat out float mapIdFrag;
+        flat out float upperFrag;
+        flat out float lowerFrag;
+        out float depthFrag;
 
         ${SectorColorMapVertexFragVariables}
         ${LightLevelVertexVariables}
@@ -99,9 +104,14 @@ public class FloodFillProgram : RenderProgram
             vec3 prevPos = vec3(pos.x, pos.y, prevZ);
             planeZFrag = mix(prevPlaneZ, planeZ, timeFrac);
             vertexPosFrag = mix(prevPos, pos, timeFrac);
+            mapIdFrag = mapId;
 
             colorMapIndexFrag = trunc(colorMapIndex / 256);
             vertexLightLevelFrag = colorMapIndex - (colorMapIndexFrag * 256);
+
+            float alphaFrag;
+            float addAlphaFrag;
+            ${VertexOptionsSet}
 
             ${VertexLightBuffer}
             ${SectorColorMapVertexFunction}
@@ -109,7 +119,9 @@ public class FloodFillProgram : RenderProgram
             if (camera.z <= minViewZ || camera.z >= maxViewZ)
                 gl_Position = vec4(0, 0, 0, 1);
             else
-                gl_Position = mvp * vec4(vertexPosFrag, 1.0); 
+                gl_Position = mvp * vec4(vertexPosFrag, 1.0);
+            
+            depthFrag = gl_Position.${Depth};
         }
     "
     .Replace("${LightLevelVertexVariables}", LightLevel.VertexVariables(LightLevelOptions.NoDist))
@@ -117,49 +129,60 @@ public class FloodFillProgram : RenderProgram
     .Replace("${VertexLightBuffer}", LightLevel.VertexLightBuffer(VertexLightBufferOptions.Default))
     .Replace("${SectorColorMapVertexFragVariables}", SectorColorMap.VertexFragVariables)
     .Replace("${SectorColorMapVertexUniformVariables}", SectorColorMap.VertexUniformVariables)
-    .Replace("${SectorColorMapVertexFunction}", SectorColorMap.VertexFunction);
+    .Replace("${SectorColorMapVertexFunction}", SectorColorMap.VertexFunction)
+    .Replace("${VertexOptionsSet}", VertexFunction.VertexOptionsSet)
+    .Replace("${Depth}", ShaderVars.Depth);
 
-    protected override string FragmentShader() => @"
-        #version 330
+    protected override string FragmentShader()
+    {
+        if (this is FloodFillWallClipProgram)
+            return PlaneClip.WriteWallFragFunction();
 
-        flat in float planeZFrag;
-        in vec3 vertexPosFrag;
+        return @"
+            #version 330
 
-        out vec4 fragColor;
+            flat in float planeZFrag;
+            flat in float mapIdFrag;
+            flat in float upperFrag;
+            flat in float lowerFrag;
+            in vec3 vertexPosFrag;
 
-        uniform sampler2D boundTexture;
-        uniform vec3 camera;
-        uniform mat4 mvpNoPitch;
-        uniform int hasInvulnerability;
-        uniform vec3 colorMix;
-        uniform int paletteIndex;
-        uniform int colormapIndex;
+            out vec4 fragColor;
 
-        ${LightLevelFragVariables}
-        ${SectorColorMapFragVariables}
+            uniform sampler2D boundTexture;
+            uniform vec3 camera;
+            uniform mat4 mvpNoPitch;
+            uniform int hasInvulnerability;
+            uniform vec3 colorMix;
+            uniform int paletteIndex;
+            uniform int colormapIndex;
 
-        void main()
-        {
-            vec3 planeNormal = vec3(0, 0, 1);
-            vec3 pointOnPlane = vec3(0, 0, planeZFrag);
-            vec3 lookDir = normalize(vertexPosFrag - camera);
-            float planeDot = dot(pointOnPlane - camera, planeNormal) / dot(lookDir, planeNormal);
-            vec3 planePos = camera + (lookDir * planeDot);
-            vec2 texDim = textureSize(boundTexture, 0);
-            vec2 uvFrag = vec2(planePos.x / texDim.x, planePos.y / texDim.y);
+            ${LightLevelFragVariables}
+            ${SectorColorMapFragVariables}
 
-            uvFrag.y = -uvFrag.y; // Vanilla textures are drawn top-down.
+            void main()
+            {
+                vec3 planeNormal = vec3(0, 0, 1);
+                vec3 pointOnPlane = vec3(0, 0, planeZFrag);
+                vec3 lookDir = normalize(vertexPosFrag - camera);
+                float planeDot = dot(pointOnPlane - camera, planeNormal) / dot(lookDir, planeNormal);
+                vec3 planePos = camera + (lookDir * planeDot);
+                vec2 texDim = textureSize(boundTexture, 0);
+                vec2 uvFrag = vec2(planePos.x / texDim.x, planePos.y / texDim.y);
 
-            float dist = (mvpNoPitch * vec4(planePos, 1.0)).${Depth};
-            ${LightLevelFragFunction}
-            ${SectorColorMapFragFunction}
-            ${FragColorFunction}
-        }
-    "
-    .Replace("${LightLevelFragFunction}", LightLevel.FragFunction)
-    .Replace("${LightLevelFragVariables}", LightLevel.FragVariables(LightLevelOptions.NoDist))
-    .Replace("${FragColorFunction}", FragFunction.FragColorFunction(FragColorFunctionOptions.Colormap))
-    .Replace("${Depth}", ShaderVars.Depth)
-    .Replace("${SectorColorMapFragVariables}", SectorColorMap.FragVariables)
-    .Replace("${SectorColorMapFragFunction}", SectorColorMap.FragFunction);
+                uvFrag.y = -uvFrag.y; // Vanilla textures are drawn top-down.
+
+                float dist = (mvpNoPitch * vec4(planePos, 1.0)).${Depth};
+                ${LightLevelFragFunction}
+                ${SectorColorMapFragFunction}
+                ${FragColorFunction}
+            }
+        "
+        .Replace("${LightLevelFragFunction}", LightLevel.FragFunction)
+        .Replace("${LightLevelFragVariables}", LightLevel.FragVariables(LightLevelOptions.NoDist))
+        .Replace("${FragColorFunction}", FragFunction.FragColorFunction(FragColorFunctionOptions.Colormap))
+        .Replace("${Depth}", ShaderVars.Depth)
+        .Replace("${SectorColorMapFragVariables}", SectorColorMap.FragVariables)
+        .Replace("${SectorColorMapFragFunction}", SectorColorMap.FragFunction);
+    }
 }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillRenderer.cs
@@ -294,11 +294,11 @@ public class FloodFillRenderer(LegacyGLTextureManager glTextureManager, FloodFil
     {
         m_program.Bind();
 
-        GL.ActiveTexture(TextureUnit.Texture0);
-        m_program.BoundTexture(TextureUnit.Texture0);
-        m_program.SectorLightTexture(TextureUnit.Texture1);
-        m_program.ColormapTexture(TextureUnit.Texture2);
-        m_program.SectorColormapTexture(TextureUnit.Texture3);
+        GL.ActiveTexture(BindTextures.BoundTexture);
+        m_program.BoundTexture(BindTextures.BoundTexture);
+        m_program.SectorLightTexture(BindTextures.SectorLight);
+        m_program.ColormapTexture(BindTextures.Colormap);
+        m_program.SectorColormapTexture(BindTextures.SectorColormap);
         m_program.Camera(renderInfo.Camera.PositionInterpolated);
         m_program.Mvp(renderInfo.Uniforms.Mvp);
         m_program.TimeFrac(renderInfo.TickFraction);

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillRenderer.cs
@@ -13,6 +13,8 @@ using Helion.Util;
 using Helion.Util.Container;
 using Helion.World;
 using Helion.World.Geometry.Sectors;
+using Helion.World.Geometry.Walls;
+using Helion.World.Static;
 using OpenTK.Graphics.OpenGL;
 
 namespace Helion.Render.OpenGL.Renderers.Legacy.World.Geometry.Portals.FloodFill;
@@ -24,7 +26,8 @@ public class FloodFillRenderer(LegacyGLTextureManager glTextureManager, FloodFil
 
     private readonly LegacyGLTextureManager m_glTextureManager = glTextureManager;
     private readonly FloodFillRenderMode m_renderMode = renderMode;
-    private readonly FloodFillProgram m_program = new();
+    private readonly FloodFillProgram m_program = new("Main");
+    private readonly FloodFillWallClipProgram m_wallClipProgram = new();
     private readonly List<FloodFillInfo> m_floodFillInfos = [];
     private readonly Dictionary<int, int> m_textureHandleToFloodFillInfoIndex = [];
     private readonly DynamicArray<FloodGeometry> m_floodGeometry = new();
@@ -79,18 +82,18 @@ public class FloodFillRenderer(LegacyGLTextureManager glTextureManager, FloodFil
     }
 
     public void UpdateStaticWall(int floodKey, SectorPlane floodPlane, WallVertices vertices, double minPlaneZ, double maxPlaneZ, 
-        bool isFloodFillPlane = false)
+        SideTexture sideTexture, int mapId, bool isFloodFillPlane = false)
     {
         if (m_renderMode == FloodFillRenderMode.Dynamic)
         {
-            AddStaticWall(floodPlane, vertices, minPlaneZ, maxPlaneZ, isFloodFillPlane);
+            AddStaticWall(floodPlane, vertices, minPlaneZ, maxPlaneZ, sideTexture, mapId, isFloodFillPlane);
             return;
         }
 
         ref var data = ref TryGetFloodGeometry(floodKey, out var success);
         if (!success)
         {
-            AddStaticWall(floodPlane, vertices, minPlaneZ, maxPlaneZ, isFloodFillPlane);
+            AddStaticWall(floodPlane, vertices, minPlaneZ, maxPlaneZ, sideTexture, mapId, isFloodFillPlane);
             return;
         }
 
@@ -108,14 +111,18 @@ public class FloodFillRenderer(LegacyGLTextureManager glTextureManager, FloodFil
         float prevTopZ = vertices.PrevTopZ;
         float prevBottomZ = vertices.PrevBottomZ;
 
+        var upper = sideTexture == SideTexture.Upper ? 1 : 0;
+        var lower = sideTexture == SideTexture.Lower ? 1 : 0;
+        var options = VertexOptions.World(0, 0, 0, upper, lower, data.LightIndex);
+
         FloodFillVertex topLeft = new((vertices.TopLeft.X, vertices.TopLeft.Y, topZ),
-            prevTopZ, planeZ, prevPlaneZ, minZ, maxZ, data.LightIndex, data.ColorMapIndex);
+            prevTopZ, planeZ, prevPlaneZ, minZ, maxZ, options, data.ColorMapIndex, mapId);
         FloodFillVertex topRight = new((vertices.BottomRight.X, vertices.BottomRight.Y, topZ),
-            prevTopZ, planeZ, prevPlaneZ, minZ, maxZ, data.LightIndex, data.ColorMapIndex);
+            prevTopZ, planeZ, prevPlaneZ, minZ, maxZ, options, data.ColorMapIndex, mapId);
         FloodFillVertex bottomLeft = new((vertices.TopLeft.X, vertices.TopLeft.Y, bottomZ),
-            prevBottomZ, planeZ, prevPlaneZ, minZ, maxZ, data.LightIndex, data.ColorMapIndex);
+            prevBottomZ, planeZ, prevPlaneZ, minZ, maxZ, options, data.ColorMapIndex, mapId);
         FloodFillVertex bottomRight = new((vertices.BottomRight.X, vertices.BottomRight.Y, bottomZ),
-            prevBottomZ, planeZ, prevPlaneZ, minZ, maxZ, data.LightIndex, data.ColorMapIndex);
+            prevBottomZ, planeZ, prevPlaneZ, minZ, maxZ, options, data.ColorMapIndex, mapId);
 
         var vbo = floodInfo.Vertices.Vbo;
         vbo.Data[data.VboOffset] = topLeft;
@@ -127,14 +134,14 @@ public class FloodFillRenderer(LegacyGLTextureManager glTextureManager, FloodFil
 
         if (isFloodFillPlane)
             ProjectFloodPlane(vbo, data.VboOffset + VerticesPerWall, vertices, minZ, maxZ, planeZ, prevPlaneZ, data.LightIndex,
-                maxPlaneZ > Constants.MaxTextureHeight ? -Constants.MaxTextureHeight : Constants.MaxTextureHeight, false, data.ColorMapIndex);
+                maxPlaneZ > Constants.MaxTextureHeight ? -Constants.MaxTextureHeight : Constants.MaxTextureHeight, false, data.ColorMapIndex, mapId);
 
         vbo.Bind();
         vbo.UploadSubData(data.VboOffset, data.Vertices);
     }
 
     public int AddStaticWall(SectorPlane sectorPlane, WallVertices vertices, double minPlaneZ, double maxPlaneZ,
-        bool isFloodFillPlane = false)
+        SideTexture sideTexture, int mapId, bool isFloodFillPlane = false)
     {
         if (m_textureManager != null && m_textureManager.IsSkyTexture(sectorPlane.TextureHandle))
             return 0;
@@ -171,7 +178,7 @@ public class FloodFillRenderer(LegacyGLTextureManager glTextureManager, FloodFil
             m_freeNodes.Add(node);
 
             m_floodGeometry[data.Key - 1] = new(data.Key, data.TextureHandle, lightIndex, colorMapIndex, data.VboOffset, data.Vertices);
-            UpdateStaticWall(data.Key, sectorPlane, vertices, minPlaneZ, maxPlaneZ);
+            UpdateStaticWall(data.Key, sectorPlane, vertices, minPlaneZ, maxPlaneZ, sideTexture, mapId);
             return data.Key;
         }
 
@@ -181,14 +188,18 @@ public class FloodFillRenderer(LegacyGLTextureManager glTextureManager, FloodFil
 
         m_floodGeometry.Add(new FloodGeometry(newKey, floodFillInfo.TextureHandle, lightIndex, colorMapIndex, vbo.Count, vertexCount));
 
+        var upper = sideTexture == SideTexture.Upper ? 1 : 0;
+        var lower = sideTexture == SideTexture.Lower ? 1 : 0;
+        var options = VertexOptions.World(0, 0, 0, upper, lower, lightIndex);
+
         FloodFillVertex topLeft = new((vertices.TopLeft.X, vertices.TopLeft.Y, vertices.TopLeft.Z),
-            vertices.TopLeft.Z, planeZ, prevPlaneZ, minZ, maxZ, lightIndex, colorMapIndex);
+            vertices.TopLeft.Z, planeZ, prevPlaneZ, minZ, maxZ, options, colorMapIndex, mapId);
         FloodFillVertex topRight = new((vertices.BottomRight.X, vertices.BottomRight.Y, vertices.TopLeft.Z),
-            vertices.TopLeft.Z, planeZ, prevPlaneZ, minZ, maxZ, lightIndex, colorMapIndex);
+            vertices.TopLeft.Z, planeZ, prevPlaneZ, minZ, maxZ, options, colorMapIndex, mapId);
         FloodFillVertex bottomLeft = new((vertices.TopLeft.X, vertices.TopLeft.Y, vertices.BottomRight.Z),
-            vertices.BottomRight.Z, planeZ, prevPlaneZ, minZ, maxZ, lightIndex, colorMapIndex);
+            vertices.BottomRight.Z, planeZ, prevPlaneZ, minZ, maxZ, options, colorMapIndex, mapId);
         FloodFillVertex bottomRight = new((vertices.BottomRight.X, vertices.BottomRight.Y, vertices.BottomRight.Z),
-            vertices.BottomRight.Z, planeZ, prevPlaneZ, minZ, maxZ, lightIndex, colorMapIndex);
+            vertices.BottomRight.Z, planeZ, prevPlaneZ, minZ, maxZ, options, colorMapIndex, mapId);
 
         int offset = vbo.Data.Length;
         int newLength = vbo.Data.Length + VerticesPerWall;
@@ -204,7 +215,7 @@ public class FloodFillRenderer(LegacyGLTextureManager glTextureManager, FloodFil
 
         if (isFloodFillPlane)
             ProjectFloodPlane(vbo, vbo.Data.Length, vertices, minZ, maxZ, planeZ, prevPlaneZ, lightIndex, 
-                maxPlaneZ > Constants.MaxTextureHeight ? -Constants.MaxTextureHeight : Constants.MaxTextureHeight, true, colorMapIndex);
+                maxPlaneZ > Constants.MaxTextureHeight ? -Constants.MaxTextureHeight : Constants.MaxTextureHeight, true, colorMapIndex, mapId);
 
         if (m_renderMode == FloodFillRenderMode.Dynamic)
             return 0;
@@ -213,7 +224,7 @@ public class FloodFillRenderer(LegacyGLTextureManager glTextureManager, FloodFil
     }
 
     private static unsafe void ProjectFloodPlane(VertexBufferObject<FloodFillVertex> vbo, int startIndex,
-       WallVertices vertices, float minZ, float maxZ, float planeZ, float prevPlaneZ, int lightIndex, int addHeight, bool add, int colorMapIndex)
+       WallVertices vertices, float minZ, float maxZ, float planeZ, float prevPlaneZ, int lightIndex, int addHeight, bool add, int colorMapIndex, int mapId)
     {
         int newLength = startIndex + FloodPlaneAddCount * VerticesPerWall;
         vbo.Data.EnsureCapacity(newLength);
@@ -227,14 +238,15 @@ public class FloodFillRenderer(LegacyGLTextureManager glTextureManager, FloodFil
             float prevTopZ = vertices.PrevTopZ + currentAddHeight;
             float prevBottomZ = vertices.PrevBottomZ + currentAddHeight;
 
+            var options = VertexOptions.World(0, 0, 0, 0, 0, lightIndex);
             FloodFillVertex topLeft = new((vertices.TopLeft.X, vertices.TopLeft.Y, topLeftZ),
-                prevTopZ, planeZ, prevPlaneZ, minZ, maxZ, lightIndex, colorMapIndex);
+                prevTopZ, planeZ, prevPlaneZ, minZ, maxZ, options, colorMapIndex, mapId);
             FloodFillVertex topRight = new((vertices.BottomRight.X, vertices.BottomRight.Y, topLeftZ),
-                prevTopZ, planeZ, prevPlaneZ, minZ, maxZ, lightIndex, colorMapIndex);
+                prevTopZ, planeZ, prevPlaneZ, minZ, maxZ, options, colorMapIndex, mapId);
             FloodFillVertex bottomLeft = new((vertices.TopLeft.X, vertices.TopLeft.Y, bottomRightZ),
-                prevBottomZ, planeZ, prevPlaneZ, minZ, maxZ, lightIndex, colorMapIndex);
+                prevBottomZ, planeZ, prevPlaneZ, minZ, maxZ, lightIndex, colorMapIndex, mapId);
             FloodFillVertex bottomRight = new((vertices.BottomRight.X, vertices.BottomRight.Y, bottomRightZ),
-                prevBottomZ, planeZ, prevPlaneZ, minZ, maxZ, lightIndex, colorMapIndex);
+                prevBottomZ, planeZ, prevPlaneZ, minZ, maxZ, options, colorMapIndex, mapId);
 
             buffer[startIndex++] = topLeft;
             buffer[startIndex++] = bottomLeft;
@@ -283,36 +295,21 @@ public class FloodFillRenderer(LegacyGLTextureManager glTextureManager, FloodFil
         for (int i = 0; i < vertices; i++)
         {
             int index = bufferOffset + i;
-            vbo.Data.Data[index] = new(Vec3F.Zero, 0, 0, 0, float.MaxValue, float.MinValue, 0, 0);
+            vbo.Data.Data[index] = new(Vec3F.Zero, 0, 0, 0, float.MaxValue, float.MinValue, 0, 0, -1);
         }
 
         vbo.Bind();
         vbo.UploadSubData(bufferOffset, vertices);
     }
 
-    public void Render(RenderInfo renderInfo)
-    {
-        m_program.Bind();
+    public void Render(RenderInfo renderInfo) => Render(m_program, renderInfo);
 
-        GL.ActiveTexture(BindTextures.BoundTexture);
-        m_program.BoundTexture(BindTextures.BoundTexture);
-        m_program.SectorLightTexture(BindTextures.SectorLight);
-        m_program.ColormapTexture(BindTextures.Colormap);
-        m_program.SectorColormapTexture(BindTextures.SectorColormap);
-        m_program.Camera(renderInfo.Camera.PositionInterpolated);
-        m_program.Mvp(renderInfo.Uniforms.Mvp);
-        m_program.TimeFrac(renderInfo.TickFraction);
-        m_program.HasInvulnerability(renderInfo.Uniforms.DrawInvulnerability);
-        m_program.MvpNoPitch(renderInfo.Uniforms.MvpNoPitch);
-        m_program.TimeFrac(renderInfo.TickFraction);
-        m_program.LightLevelMix(renderInfo.Uniforms.Mix);
-        m_program.ExtraLight(renderInfo.Uniforms.ExtraLight);
-        m_program.DistanceOffset(renderInfo.Uniforms.DistanceOffset);
-        m_program.ColorMix(renderInfo.Uniforms.ColorMix.Global);
-        m_program.PaletteIndex((int)renderInfo.Uniforms.PaletteIndex);
-        m_program.ColorMapIndex(renderInfo.Uniforms.ColorMapUniforms.GlobalIndex);
-        m_program.LightMode(renderInfo.Uniforms.LightMode);
-        m_program.GammaCorrection(renderInfo.Uniforms.GammaCorrection);
+    public void RenderWallClip(RenderInfo renderInfo) => Render(m_wallClipProgram, renderInfo);
+
+    private void Render(FloodFillProgram program, RenderInfo renderInfo)
+    {
+        program.Bind();
+        SetUniforms(program, renderInfo);
 
         for (int i = 0; i < m_floodFillInfos.Count; i++)
         {
@@ -327,6 +324,29 @@ public class FloodFillRenderer(LegacyGLTextureManager glTextureManager, FloodFil
             info.Vertices.Vao.Bind();
             info.Vertices.Vbo.DrawArrays();
         }
+    }
+
+    private static void SetUniforms(FloodFillProgram program, RenderInfo renderInfo)
+    {
+        GL.ActiveTexture(BindTextures.BoundTexture);
+        program.BoundTexture(BindTextures.BoundTexture);
+        program.SectorLightTexture(BindTextures.SectorLight);
+        program.ColormapTexture(BindTextures.Colormap);
+        program.SectorColormapTexture(BindTextures.SectorColormap);
+        program.Camera(renderInfo.Camera.PositionInterpolated);
+        program.Mvp(renderInfo.Uniforms.Mvp);
+        program.TimeFrac(renderInfo.TickFraction);
+        program.HasInvulnerability(renderInfo.Uniforms.DrawInvulnerability);
+        program.MvpNoPitch(renderInfo.Uniforms.MvpNoPitch);
+        program.TimeFrac(renderInfo.TickFraction);
+        program.LightLevelMix(renderInfo.Uniforms.Mix);
+        program.ExtraLight(renderInfo.Uniforms.ExtraLight);
+        program.DistanceOffset(renderInfo.Uniforms.DistanceOffset);
+        program.ColorMix(renderInfo.Uniforms.ColorMix.Global);
+        program.PaletteIndex((int)renderInfo.Uniforms.PaletteIndex);
+        program.ColorMapIndex(renderInfo.Uniforms.ColorMapUniforms.GlobalIndex);
+        program.LightMode(renderInfo.Uniforms.LightMode);
+        program.GammaCorrection(renderInfo.Uniforms.GammaCorrection);
     }
 
     public void ClearVertices()

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillVertex.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillVertex.cs
@@ -5,41 +5,32 @@ using Helion.Render.OpenGL.Vertex;
 namespace Helion.Render.OpenGL.Renderers.Legacy.World.Geometry.Portals.FloodFill;
 
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public struct FloodFillVertex
+public struct FloodFillVertex(Vec3F pos, float prevZ, float planeZ, float prevPlaneZ, float minPlaneZ, float maxPlaneZ, float options, int colorMapIndex, int mapId)
 {
     [VertexAttribute("pos", size: 3)]
-    public Vec3F Pos;
+    public Vec3F Pos = pos;
     
     [VertexAttribute("planeZ", size: 1)]
-    public float PlaneZ;
+    public float PlaneZ = planeZ;
     
     [VertexAttribute("minViewZ", size: 1)]
-    public float MinViewZ;
+    public float MinViewZ = minPlaneZ;
     
     [VertexAttribute("maxViewZ", size: 1)]
-    public float MaxViewZ;
+    public float MaxViewZ = maxPlaneZ;
 
     [VertexAttribute("prevZ", size: 1)]
-    public float PrevZ;
+    public float PrevZ = prevZ;
 
     [VertexAttribute("prevPlaneZ", size: 1)]
-    public float PrevPlaneZ;
+    public float PrevPlaneZ = prevPlaneZ;
 
-    [VertexAttribute("lightLevelBufferIndex", size: 1)]
-    public float LightLevelBufferIndex;
+    [VertexAttribute("options", size: 1)]
+    public float Options = options;
 
     [VertexAttribute("colorMapIndex", size: 1, required: false)]
-    public float ColorMapIndex;
+    public float ColorMapIndex = colorMapIndex;
 
-    public FloodFillVertex(Vec3F pos, float prevZ, float planeZ, float prevPlaneZ, float minPlaneZ, float maxPlaneZ, int lightIndex, int colorMapIndex)
-    {
-        Pos = pos;
-        PrevZ = prevZ;
-        PlaneZ = planeZ;
-        PrevPlaneZ = prevPlaneZ;
-        MinViewZ = minPlaneZ;
-        MaxViewZ = maxPlaneZ;
-        LightLevelBufferIndex = lightIndex;
-        ColorMapIndex = colorMapIndex;
-    }
+    [VertexAttribute("mapId", size: 1, required: false)]
+    public float MapId = mapId;
 }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillWallClipProgram.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillWallClipProgram.cs
@@ -1,0 +1,9 @@
+﻿namespace Helion.Render.OpenGL.Renderers.Legacy.World.Geometry.Portals.FloodFill;
+
+public class FloodFillWallClipProgram : FloodFillProgram
+{
+    public FloodFillWallClipProgram() : base("WallClip")
+    {
+
+    }
+}

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/PortalRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/PortalRenderer.cs
@@ -13,6 +13,7 @@ using Helion.Render.OpenGL.Renderers.Legacy.World.Geometry.Portals.FloodFill;
 using Helion.Util;
 using Helion.World.Geometry.Lines;
 using Helion.Resources;
+using Helion.World.Geometry.Walls;
 
 namespace Helion.Render.OpenGL.Renderers.Legacy.World.Geometry.Portals;
 
@@ -111,9 +112,9 @@ public class PortalRenderer : IDisposable
             WorldTriangulator.HandleTwoSidedLower(facingSide, top, m_fakeFloor, Vec2F.Zero, isFront, ref wall);
 
             if (update || m_transferHeightView != TransferHeightView.Middle)
-                renderer.UpdateStaticWall(facingSide.FloorFloodKey, floodSector.Floor, wall, top.Z, double.MaxValue, isFloodFillPlane: true);
+                renderer.UpdateStaticWall(facingSide.FloorFloodKey, floodSector.Floor, wall, top.Z, double.MaxValue, SideTexture.None, -1, isFloodFillPlane: true);
             else
-                facingSide.FloorFloodKey = renderer.AddStaticWall(floodSector.Floor, wall, top.Z, double.MaxValue, isFloodFillPlane: true);
+                facingSide.FloorFloodKey = renderer.AddStaticWall(floodSector.Floor, wall, top.Z, double.MaxValue, SideTexture.None, -1, isFloodFillPlane: true);
         }
         else
         {
@@ -126,9 +127,9 @@ public class PortalRenderer : IDisposable
             WorldTriangulator.HandleTwoSidedUpper(facingSide, m_fakeCeiling, bottom, Vec2F.Zero, isFront, ref wall);
 
             if (update || m_transferHeightView != TransferHeightView.Middle)
-                renderer.UpdateStaticWall(facingSide.CeilingFloodKey, floodSector.Ceiling, wall, double.MinValue, bottom.Z, isFloodFillPlane: true);
+                renderer.UpdateStaticWall(facingSide.CeilingFloodKey, floodSector.Ceiling, wall, double.MinValue, bottom.Z, SideTexture.None, -1, isFloodFillPlane: true);
             else
-                facingSide.CeilingFloodKey = renderer.AddStaticWall(floodSector.Ceiling, wall, double.MinValue, bottom.Z, isFloodFillPlane: true);
+                facingSide.CeilingFloodKey = renderer.AddStaticWall(floodSector.Ceiling, wall, double.MinValue, bottom.Z, SideTexture.None, -1, isFloodFillPlane: true);
         }
 
         line.Segment.Start = saveStart;
@@ -147,6 +148,7 @@ public class PortalRenderer : IDisposable
         var line = facingSide.Line;
         var saveStart = line.Segment.Start;
         var saveEnd = line.Segment.End;
+        var lineId = line.Id;
 
         if (sideTexture == SideTexture.Upper)
         {
@@ -158,9 +160,9 @@ public class PortalRenderer : IDisposable
             {
                 result |= FloodSet.Normal;
                 if (update || m_transferHeightView != TransferHeightView.Middle)
-                    renderer.UpdateStaticWall(facingSide.UpperFloodKeys.Key1, floodSector.Ceiling, wall, double.MinValue, floodMaxZ);
+                    renderer.UpdateStaticWall(facingSide.UpperFloodKeys.Key1, floodSector.Ceiling, wall, double.MinValue, floodMaxZ, sideTexture, lineId);
                 else
-                    facingSide.UpperFloodKeys.Key1 = renderer.AddStaticWall(floodSector.Ceiling, wall, double.MinValue, floodMaxZ);
+                    facingSide.UpperFloodKeys.Key1 = renderer.AddStaticWall(floodSector.Ceiling, wall, double.MinValue, floodMaxZ, sideTexture, lineId);
             }
 
             if (IgnoreAltFloodFill(facingSide, otherSide, SectorPlaneFace.Ceiling))
@@ -183,9 +185,9 @@ public class PortalRenderer : IDisposable
             var max = double.MaxValue;
 
             if (update || m_transferHeightView != TransferHeightView.Middle)
-                renderer.UpdateStaticWall(facingSide.UpperFloodKeys.Key2, facingSector.Ceiling, wall, min, max);
+                renderer.UpdateStaticWall(facingSide.UpperFloodKeys.Key2, facingSector.Ceiling, wall, min, max, sideTexture, lineId);
             else
-                facingSide.UpperFloodKeys.Key2 = renderer.AddStaticWall(facingSector.Ceiling, wall, min, max);
+                facingSide.UpperFloodKeys.Key2 = renderer.AddStaticWall(facingSector.Ceiling, wall, min, max, sideTexture, lineId);
         }
         else
         {
@@ -205,9 +207,9 @@ public class PortalRenderer : IDisposable
             {
                 result |= FloodSet.Normal;
                 if (update || m_transferHeightView != TransferHeightView.Middle)
-                    renderer.UpdateStaticWall(facingSide.LowerFloodKeys.Key1, floodSector.Floor, wall, floodMinZ, double.MaxValue);
+                    renderer.UpdateStaticWall(facingSide.LowerFloodKeys.Key1, floodSector.Floor, wall, floodMinZ, double.MaxValue, sideTexture, lineId);
                 else
-                    facingSide.LowerFloodKeys.Key1 = renderer.AddStaticWall(floodSector.Floor, wall, floodMinZ, double.MaxValue);
+                    facingSide.LowerFloodKeys.Key1 = renderer.AddStaticWall(floodSector.Floor, wall, floodMinZ, double.MaxValue, sideTexture, lineId);
             }
 
             if (IgnoreAltFloodFill(facingSide, otherSide, SectorPlaneFace.Floor))
@@ -230,9 +232,9 @@ public class PortalRenderer : IDisposable
             var max = floodMinZ;
 
             if (update || m_transferHeightView != TransferHeightView.Middle)
-                renderer.UpdateStaticWall(facingSide.LowerFloodKeys.Key2, facingSector.Floor, wall, min, max);
+                renderer.UpdateStaticWall(facingSide.LowerFloodKeys.Key2, facingSector.Floor, wall, min, max, sideTexture, lineId);
             else
-                facingSide.LowerFloodKeys.Key2 = renderer.AddStaticWall(facingSector.Floor, wall, min, max);
+                facingSide.LowerFloodKeys.Key2 = renderer.AddStaticWall(facingSector.Floor, wall, min, max, sideTexture, lineId);
         }
 
         facingSide.Line.Segment.Start = saveStart;
@@ -248,6 +250,11 @@ public class PortalRenderer : IDisposable
     public void Render(RenderInfo renderInfo)
     {
         m_floodFillRenderer.Render(renderInfo);
+    }
+
+    public void RenderWallClip(RenderInfo renderInfo)
+    {
+        m_floodFillRenderer.RenderWallClip(renderInfo);
     }
 
     protected virtual void Dispose(bool disposing)

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
@@ -680,6 +680,11 @@ public class StaticCacheGeometryRenderer : IDisposable
         RenderCoverInternal(m_coverFlatGeometry);
     }
 
+    public void RenderCoverFlats()
+    {
+        RenderCoverInternal(m_coverFlatGeometry);
+    }
+
     private static void RenderCoverInternal(GeometryData? data)
     {
         if (data == null)

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
@@ -690,7 +690,7 @@ public class StaticCacheGeometryRenderer : IDisposable
         if (data == null)
             return;
 
-        GL.ActiveTexture(TextureUnit.Texture0);
+        GL.ActiveTexture(BindTextures.BoundTexture);
         GLLegacyTexture texture = data.Texture;
         texture.Bind();
 
@@ -707,7 +707,7 @@ public class StaticCacheGeometryRenderer : IDisposable
         {
             var data = geometry[i];
 
-            GL.ActiveTexture(TextureUnit.Texture0);
+            GL.ActiveTexture(BindTextures.BoundTexture);
             // Special case for one-sided walls with no texture. Uses black texture to block rendering so use directly.
             var texture = data.TextureHandle <= Constants.NullCompatibilityTextureIndex ? data.Texture :
                 m_textureManager.GetTexture(data.TextureHandle, (data.Texture.Flags & TextureFlags.ClampY) == 0);

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
@@ -671,6 +671,9 @@ public class StaticCacheGeometryRenderer : IDisposable
     public void RenderFloors() =>
         RenderGeometry(m_geometry.GetGeometry(GeometryType.Floor));
 
+    public void RenderCeilings() =>
+        RenderGeometry(m_geometry.GetGeometry(GeometryType.Ceiling));
+
     public void RenderCoverWalls() =>
         RenderCoverInternal(m_coverWallGeometry);
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
@@ -163,7 +163,7 @@ public class StaticCacheGeometryRenderer : IDisposable
         // Cover flat geometry is always allocated to ensure sprites are covered/clipped to transfer heights
         if (!world.SameAsPreviousMap)
         {
-            m_coverFlatGeometry = AllocateGeometryData(GeometryType.Floor, textureIndex,
+            m_coverFlatGeometry = AllocateGeometryData(GeometryType.Flat, textureIndex,
                 repeat: true, addToGeometry: false, overrideTexture: texture);
         }
 
@@ -638,10 +638,8 @@ public class StaticCacheGeometryRenderer : IDisposable
             return;
         }
 
-        var type = floor ? GeometryType.Floor : GeometryType.Ceiling;
-
-        var vertices = GetTextureVertices(type, renderPlane.TextureHandle, true);
-        if (m_textureToGeometryLookup.TryGetValue(type, renderPlane.TextureHandle, true, out var geometryData))
+        var vertices = GetTextureVertices(GeometryType.Flat, renderPlane.TextureHandle, true);
+        if (m_textureToGeometryLookup.TryGetValue(GeometryType.Flat, renderPlane.TextureHandle, true, out var geometryData))
         {
             plane.Static.GeometryData = geometryData;
             plane.Static.Index = vertices.Length;
@@ -662,17 +660,8 @@ public class StaticCacheGeometryRenderer : IDisposable
         RenderGeometry(m_geometry.GetGeometry(GeometryType.TwoSidedMiddleWall));
     }
 
-    public void RenderFlats()
-    {
-        RenderGeometry(m_geometry.GetGeometry(GeometryType.Floor));
-        RenderGeometry(m_geometry.GetGeometry(GeometryType.Ceiling));
-    }
-
-    public void RenderFloors() =>
-        RenderGeometry(m_geometry.GetGeometry(GeometryType.Floor));
-
-    public void RenderCeilings() =>
-        RenderGeometry(m_geometry.GetGeometry(GeometryType.Ceiling));
+    public void RenderFlats() => 
+        RenderGeometry(m_geometry.GetGeometry(GeometryType.Flat));
 
     public void RenderCoverWalls() =>
         RenderCoverInternal(m_coverWallGeometry);
@@ -905,7 +894,7 @@ public class StaticCacheGeometryRenderer : IDisposable
     private void UpdateVertices(GeometryData? geometryData, int textureHandle, int startIndex, DynamicVertex[] vertices,
         SectorPlane? plane, Side? side, Wall? wall, bool repeat, Sector sector, GLLegacyTexture? texture = null)
     {
-        var geometryType = side != null && wall != null ? GetWallType(side, wall) : (plane == null || plane.Facing == SectorPlaneFace.Floor ? GeometryType.Floor : GeometryType.Ceiling);
+        var geometryType = side != null && wall != null ? GetWallType(side, wall) : GeometryType.Flat;
         if (side != null && wall != null && geometryType != GeometryType.TwoSidedMiddleWall)
             AddOrUpdateCoverWall(side, wall, vertices);
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
@@ -476,7 +476,7 @@ public class StaticCacheGeometryRenderer : IDisposable
             {
                 DynamicVertex* v = startVertex + i;
                 staticVertices.Data[staticStartIndex + i] = new StaticVertex(v->X, v->Y, v->Z, v->U, v->V,
-                    v->Options, v->LightLevelAdd, v->ColorMapIndex);
+                    v->Options, v->LightLevelAdd, v->ColorMapIndex, v->MapId);
             }
 
             staticVertices.SetLength(staticVertices.Length + vertices.Length);
@@ -491,7 +491,7 @@ public class StaticCacheGeometryRenderer : IDisposable
             {
                 DynamicVertex* v = startVertex + i;
                 staticVertices[index + i] = new StaticVertex(v->X, v->Y, v->Z, v->U, v->V,
-                    v->Options, v->LightLevelAdd, v->ColorMapIndex);
+                    v->Options, v->LightLevelAdd, v->ColorMapIndex, v->MapId);
             }
         }
     }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
@@ -476,7 +476,7 @@ public class StaticCacheGeometryRenderer : IDisposable
             {
                 DynamicVertex* v = startVertex + i;
                 staticVertices.Data[staticStartIndex + i] = new StaticVertex(v->X, v->Y, v->Z, v->U, v->V,
-                    v->Options, v->LightLevelAdd, v->ColorMapIndex, v->MapId);
+                    v->Options, v->LightLevelAdd, v->ColorMapIndex);
             }
 
             staticVertices.SetLength(staticVertices.Length + vertices.Length);
@@ -491,7 +491,7 @@ public class StaticCacheGeometryRenderer : IDisposable
             {
                 DynamicVertex* v = startVertex + i;
                 staticVertices[index + i] = new StaticVertex(v->X, v->Y, v->Z, v->U, v->V,
-                    v->Options, v->LightLevelAdd, v->ColorMapIndex, v->MapId);
+                    v->Options, v->LightLevelAdd, v->ColorMapIndex);
             }
         }
     }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
@@ -30,6 +30,7 @@ public class InterpolationShader : RenderProgram
     private readonly int m_vertexGapClampUV;
     private readonly int m_planeClipTextureLocation;
     private readonly int m_checkPlaneClipLocation;
+    private readonly int m_wallClipTextureLocation;
 
     public InterpolationShader(string name) : base($"World Interpolation - {name}")
     {
@@ -54,6 +55,7 @@ public class InterpolationShader : RenderProgram
         m_vertexGapClampUV = Uniforms.GetLocation("vertexGapClampUV");
         m_planeClipTextureLocation = Uniforms.GetLocation("planeClipTexture");
         m_checkPlaneClipLocation = Uniforms.GetLocation("checkPlaneClip");
+        m_wallClipTextureLocation = Uniforms.GetLocation("wallClipTexture");
     }
 
     public void BoundTexture(TextureUnit unit) => Uniforms.Set(unit, m_boundTextureLocation);
@@ -63,6 +65,7 @@ public class InterpolationShader : RenderProgram
     public void AccumTexture(TextureUnit unit) => Uniforms.Set(unit, m_accumTextureLocation);
     public void AccumCountTextre(TextureUnit unit) => Uniforms.Set(unit, m_accumCountTextureLocation);
     public void PlaneClipTexture(TextureUnit unit) => Uniforms.Set(unit, m_planeClipTextureLocation);
+    public void WallClipTexture(TextureUnit unit) => Uniforms.Set(unit, m_wallClipTextureLocation);
 
     public void HasInvulnerability(bool invul) => Uniforms.Set(invul, m_hasInvulnerabilityLocation);
     public void Mvp(mat4 mvp) => Uniforms.Set(mvp, m_mvpLocation);
@@ -173,6 +176,7 @@ public class InterpolationShader : RenderProgram
             uniform int paletteIndex;
             uniform int colormapIndex;
             uniform sampler2D planeClipTexture;
+            uniform sampler2D wallClipTexture;
             uniform int checkPlaneClip;
 
             ${LightLevelFragVariables}
@@ -182,10 +186,11 @@ public class InterpolationShader : RenderProgram
             void main() {
                 if (checkPlaneClip == 1) {
                     ivec2 getCoords = ivec2(gl_FragCoord.xy);
-                    float planeClipDepth = texelFetch(planeClipTexture, getCoords, 0).g;
+                    float wallClipDepth = texelFetch(wallClipTexture, getCoords, 0).g;
+                    //float planeClipDepth = texelFetch(planeClipTexture, getCoords, 0).g;
                     // This is for alpha walls and vanilla rendering
                     // There is no depth buffer at this point so sample the plane clip texture to discard
-                    if (planeClipDepth < depthFrag)
+                    if (wallClipDepth < depthFrag)// || planeClipDepth < depthFrag)
                         discard;
                 }
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
@@ -28,6 +28,8 @@ public class InterpolationShader : RenderProgram
     private readonly int m_accumTextureLocation;
     private readonly int m_accumCountTextureLocation;
     private readonly int m_vertexGapClampUV;
+    private readonly int m_planeClipTextureLocation;
+    private readonly int m_checkPlaneClipLocation;
 
     public InterpolationShader(string name) : base($"World Interpolation - {name}")
     {
@@ -50,6 +52,8 @@ public class InterpolationShader : RenderProgram
         m_accumTextureLocation = Uniforms.GetLocation("accum");
         m_accumCountTextureLocation = Uniforms.GetLocation("accumCount");
         m_vertexGapClampUV = Uniforms.GetLocation("vertexGapClampUV");
+        m_planeClipTextureLocation = Uniforms.GetLocation("planeClipTexture");
+        m_checkPlaneClipLocation = Uniforms.GetLocation("checkPlaneClip");
     }
 
     public void BoundTexture(TextureUnit unit) => Uniforms.Set(unit, m_boundTextureLocation);
@@ -58,6 +62,7 @@ public class InterpolationShader : RenderProgram
     public void SectorColormapTexture(TextureUnit unit) => Uniforms.Set(unit, m_sectorColormapTextureLocation);
     public void AccumTexture(TextureUnit unit) => Uniforms.Set(unit, m_accumTextureLocation);
     public void AccumCountTextre(TextureUnit unit) => Uniforms.Set(unit, m_accumCountTextureLocation);
+    public void PlaneClipTexture(TextureUnit unit) => Uniforms.Set(unit, m_planeClipTextureLocation);
 
     public void HasInvulnerability(bool invul) => Uniforms.Set(invul, m_hasInvulnerabilityLocation);
     public void Mvp(mat4 mvp) => Uniforms.Set(mvp, m_mvpLocation);
@@ -72,6 +77,7 @@ public class InterpolationShader : RenderProgram
     public void LightMode(RenderLightMode mode) => Uniforms.Set((int)mode, m_lightModeLocation);
     public void GammaCorrection(float value) => Uniforms.Set(value, m_gammaCorrectionLocation);
     public void VertexGapClampUV(bool value) => Uniforms.Set(value, m_vertexGapClampUV);
+    public void CheckPlaneClip(bool value) => Uniforms.Set(value, m_checkPlaneClipLocation);
 
     protected override string VertexShader() => @"
         #version 330
@@ -156,6 +162,7 @@ public class InterpolationShader : RenderProgram
             flat in float addAlphaFrag;
             flat in float zPos;
             flat in float distFrag;
+            in float depthFrag;
             ${VertexGapVariables}
 
             ${OutFragColor}
@@ -165,12 +172,23 @@ public class InterpolationShader : RenderProgram
             uniform vec3 colorMix;
             uniform int paletteIndex;
             uniform int colormapIndex;
+            uniform sampler2D planeClipTexture;
+            uniform int checkPlaneClip;
 
             ${LightLevelFragVariables}
             ${SectorColorMapFragVariables}
             ${OitVariables}
 
             void main() {
+                if (checkPlaneClip == 1) {
+                    ivec2 getCoords = ivec2(gl_FragCoord.xy);
+                    float planeClipDepth = texelFetch(planeClipTexture, getCoords, 0).g;
+                    // This is for alpha walls and vanilla rendering
+                    // There is no depth buffer at this point so sample the plane clip texture to discard
+                    if (planeClipDepth < depthFrag)
+                        discard;
+                }
+
                 ${LightLevelFragFunction}
                 ${SectorColorMapFragFunction}
                 ${FragColorFunction}

--- a/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
@@ -127,9 +127,10 @@ public class InterpolationShader : RenderProgram
             float lightLevelAddValue = lightLevelAdd - (mapIdFrag * 256);
             mapIdFrag = abs(mapIdFrag);
 
+            vec4 mixPos = vec4(mix(prevPos, pos, timeFrac), 1.0);
+
             ${VertexGapSet}
             
-            vec4 mixPos = vec4(mix(prevPos, pos, timeFrac), 1.0);
             ${VertexLightBuffer}
             ${LightLevelVertexDist}
             ${SectorColorMapVertexFunction}

--- a/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
@@ -100,6 +100,8 @@ public class InterpolationShader : RenderProgram
         flat out float vertexLightLevelFrag;
         flat out float zPos;
         flat out float mapIdFrag;
+        flat out float upperFrag;
+        flat out float lowerFrag;
         out float depthFrag;
         ${VertexGapVariables}
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
@@ -83,6 +83,7 @@ public class InterpolationShader : RenderProgram
         layout(location = 4) in vec3 prevPos;
         layout(location = 5) in vec2 prevUV;
         layout(location = 6) in float colorMapIndex;
+        layout(location = 7) in float mapId;
 
         out vec2 uvFrag;
         flat out float alphaFrag;
@@ -90,6 +91,7 @@ public class InterpolationShader : RenderProgram
         flat out float colorMapIndexFrag;
         flat out float vertexLightLevelFrag;
         flat out float zPos;
+        flat out float mapIdFrag;
         out float depthFrag;
         ${VertexGapVariables}
 
@@ -107,6 +109,7 @@ public class InterpolationShader : RenderProgram
             ${VertexOptionsSet}
 
             uvFrag = mix(prevUV, uv, timeFrac);
+            mapIdFrag = mapId;
 
             colorMapIndexFrag = trunc(colorMapIndex / 256);
             vertexLightLevelFrag = colorMapIndex - (colorMapIndexFrag * 256);
@@ -138,6 +141,9 @@ public class InterpolationShader : RenderProgram
     {
         if (this is InterpolationPlaneClipShader)
             return PlaneClip.WritePlaneFragFunction();
+
+        if (this is InterpolationWallClipShader)
+            return PlaneClip.WriteWallFragFunction();
 
         return
             @"

--- a/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
@@ -187,10 +187,10 @@ public class InterpolationShader : RenderProgram
                 if (checkPlaneClip == 1) {
                     ivec2 getCoords = ivec2(gl_FragCoord.xy);
                     float wallClipDepth = texelFetch(wallClipTexture, getCoords, 0).g;
-                    //float planeClipDepth = texelFetch(planeClipTexture, getCoords, 0).g;
+                    float planeClipDepth = texelFetch(planeClipTexture, getCoords, 0).g;
                     // This is for alpha walls and vanilla rendering
                     // There is no depth buffer at this point so sample the plane clip texture to discard
-                    if (wallClipDepth < depthFrag)// || planeClipDepth < depthFrag)
+                    if (wallClipDepth < depthFrag || planeClipDepth < depthFrag)
                         discard;
                 }
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
@@ -83,7 +83,6 @@ public class InterpolationShader : RenderProgram
         layout(location = 4) in vec3 prevPos;
         layout(location = 5) in vec2 prevUV;
         layout(location = 6) in float colorMapIndex;
-        layout(location = 7) in float mapId;
 
         out vec2 uvFrag;
         flat out float alphaFrag;
@@ -109,10 +108,13 @@ public class InterpolationShader : RenderProgram
             ${VertexOptionsSet}
 
             uvFrag = mix(prevUV, uv, timeFrac);
-            mapIdFrag = mapId;
 
             colorMapIndexFrag = trunc(colorMapIndex / 256);
             vertexLightLevelFrag = colorMapIndex - (colorMapIndexFrag * 256);
+
+            mapIdFrag = trunc(lightLevelAdd / 256);
+            float lightLevelAddValue = lightLevelAdd - (mapIdFrag * 256);
+            mapIdFrag = abs(mapIdFrag);
 
             ${VertexGapSet}
             

--- a/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationWallClipShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationWallClipShader.cs
@@ -1,0 +1,9 @@
+﻿namespace Helion.Render.OpenGL.Renderers.Legacy.World;
+
+public class InterpolationWallClipShader : InterpolationShader
+{
+    public InterpolationWallClipShader() : base("WallClip")
+    {
+
+    }
+}

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -345,33 +345,8 @@ public class LegacyWorldRenderer : WorldRenderer
 
         GL.Clear(ClearBufferMask.DepthBufferBit);
         GL.ColorMask(false, false, false, false);
-
         // Write two-sided middle walls to depth as these generally look better with normal discard handling
         RenderTwoSidedMiddleWalls(renderInfo);
-
-        //GL.Disable(EnableCap.CullFace);
-
-        //if (m_renderStatic)
-        //{
-        //    m_staticProgram.Bind();
-        //    GL.ActiveTexture(TextureUnit.Texture0);
-        //    m_geometryRenderer.RenderStaticCoverWalls();
-        //}
-
-        //m_interpolationProgram.Bind();
-        //m_worldDataManager.RenderCoverWalls();
-        //// Need to render flood fill again. Sprites need to be blocked by flood filling if visible.
-        //m_geometryRenderer.Portals.Render(renderInfo);
-        //GL.Enable(EnableCap.CullFace);
-
-        //if (m_renderStatic)
-        //{
-        //    m_staticProgram.Bind();
-        //    GL.ActiveTexture(TextureUnit.Texture0);
-        //    m_geometryRenderer.RenderStaticOneSidedCoverWalls();
-        //}
-
-        //RenderTwoSidedMiddleWalls(renderInfo);
         GL.ColorMask(true, true, true, true);
 
         if (m_planeClipFrameBuffer != null)
@@ -394,7 +369,9 @@ public class LegacyWorldRenderer : WorldRenderer
             GL.ActiveTexture(TextureUnit.Texture0);
             SetStaticUniforms(m_staticWallClipProgram, renderInfo);
             m_geometryRenderer.RenderStaticOneSidedCoverWalls();
+            GL.Disable(EnableCap.CullFace);
             m_geometryRenderer.RenderStaticCoverWalls();
+            GL.Enable(EnableCap.CullFace);
             m_staticWallClipProgram.Unbind();
 
             m_staticPlaneClipProgram.Bind();

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -315,7 +315,6 @@ public class LegacyWorldRenderer : WorldRenderer
             }
 
             RenderTwoSidedMiddleWalls(renderInfo);
-            m_entityRenderer.RenderHealthBars(renderInfo);
             m_entityRenderer.RenderOpaque(renderInfo);
             RenderTransparent(renderInfo, framebuffer, false);
             m_primitiveRenderer.Render(renderInfo);
@@ -351,8 +350,7 @@ public class LegacyWorldRenderer : WorldRenderer
 
         if (m_planeClipFrameBuffer != null)
             WritePlaneClipData(m_planeClipFrameBuffer, renderInfo, framebuffer);        
-
-        m_entityRenderer.RenderHealthBars(renderInfo);
+        
         m_entityRenderer.RenderOpaque(renderInfo);
         RenderTransparent(renderInfo, framebuffer, true);
         m_primitiveRenderer.Render(renderInfo);

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -296,7 +296,7 @@ public class LegacyWorldRenderer : WorldRenderer
         if (!m_vanillaRender)
         {
             m_interpolationProgram.Bind();
-            GL.ActiveTexture(TextureUnit.Texture0);
+            GL.ActiveTexture(BindTextures.BoundTexture);
             SetInterpolationUniforms(m_interpolationProgram, renderInfo, false);
             m_interpolationProgram.VertexGapClampUV(m_pixelGapCorrection);
             m_worldDataManager.RenderWalls();
@@ -306,7 +306,7 @@ public class LegacyWorldRenderer : WorldRenderer
             if (m_renderStatic)
             {
                 m_staticProgram.Bind();
-                GL.ActiveTexture(TextureUnit.Texture0);
+                GL.ActiveTexture(BindTextures.BoundTexture);
                 SetStaticUniforms(m_staticProgram, renderInfo);
                 m_staticProgram.VertexGapClampUV(m_pixelGapCorrection);
                 m_geometryRenderer.RenderStaticGeometryWalls();
@@ -322,7 +322,7 @@ public class LegacyWorldRenderer : WorldRenderer
         }
 
         m_interpolationProgram.Bind();
-        GL.ActiveTexture(TextureUnit.Texture0);
+        GL.ActiveTexture(BindTextures.BoundTexture);
         SetInterpolationUniforms(m_interpolationProgram, renderInfo, false);
         m_interpolationProgram.VertexGapClampUV(m_pixelGapCorrection);
         m_worldDataManager.RenderWalls();
@@ -332,7 +332,7 @@ public class LegacyWorldRenderer : WorldRenderer
         if (m_renderStatic)
         {
             m_staticProgram.Bind();
-            GL.ActiveTexture(TextureUnit.Texture0);
+            GL.ActiveTexture(BindTextures.BoundTexture);
             SetStaticUniforms(m_staticProgram, renderInfo);
             m_staticProgram.VertexGapClampUV(m_pixelGapCorrection);
             m_geometryRenderer.RenderStaticGeometryWalls();
@@ -392,7 +392,7 @@ public class LegacyWorldRenderer : WorldRenderer
             if (walls)
             {
                 m_staticWallClipProgram.Bind();
-                GL.ActiveTexture(TextureUnit.Texture0);
+                GL.ActiveTexture(BindTextures.BoundTexture);
                 SetStaticUniforms(m_staticWallClipProgram, renderInfo);
                 m_geometryRenderer.RenderStaticOneSidedCoverWalls();
                 GL.Disable(EnableCap.CullFace);
@@ -403,7 +403,7 @@ public class LegacyWorldRenderer : WorldRenderer
             else
             {
                 m_staticPlaneClipProgram.Bind();
-                GL.ActiveTexture(TextureUnit.Texture0);
+                GL.ActiveTexture(BindTextures.BoundTexture);
                 SetStaticUniforms(m_staticPlaneClipProgram, renderInfo);
                 m_geometryRenderer.RenderStaticGeometryFloors();
                 m_staticPlaneClipProgram.Unbind();
@@ -413,7 +413,7 @@ public class LegacyWorldRenderer : WorldRenderer
         if (walls)
         {
             m_interpolationWallClipShader.Bind();
-            GL.ActiveTexture(TextureUnit.Texture0);
+            GL.ActiveTexture(BindTextures.BoundTexture);
             SetInterpolationUniforms(m_interpolationWallClipShader, renderInfo, false);
             GL.Disable(EnableCap.CullFace);
             m_worldDataManager.RenderCoverWalls();
@@ -423,7 +423,7 @@ public class LegacyWorldRenderer : WorldRenderer
         else
         {
             m_interpolationPlaneClipShader.Bind();
-            GL.ActiveTexture(TextureUnit.Texture0);
+            GL.ActiveTexture(BindTextures.BoundTexture);
             SetInterpolationUniforms(m_interpolationPlaneClipShader, renderInfo, false);
             m_worldDataManager.RenderFloors();
             m_interpolationPlaneClipShader.Unbind();
@@ -447,7 +447,7 @@ public class LegacyWorldRenderer : WorldRenderer
         GL.DepthMask(false);
         m_entityRenderer.RenderOitTransparentPass(renderInfo);
 
-        m_oitFrameBuffer.BindTextures(TextureUnit.Texture4, TextureUnit.Texture5, TextureUnit.Texture6, TextureUnit.Texture7, framebuffer);
+        m_oitFrameBuffer.BindTextures(BindTextures.AccumTexture, BindTextures.AccumCountTexture, BindTextures.FuzzTexture, BindTextures.OpaqueTexture, framebuffer);
 
         if (fuzzData)
         {
@@ -469,7 +469,7 @@ public class LegacyWorldRenderer : WorldRenderer
         // Alpha walls are the exception to pixel gap correction. Only required for opaque walls.
         m_interpolationTransparentProgram.VertexGapClampUV(false);
         SetInterpolationUniforms(m_interpolationTransparentProgram, renderInfo, true);
-        GL.ActiveTexture(TextureUnit.Texture0);
+        GL.ActiveTexture(BindTextures.BoundTexture);
         m_worldDataManager.RenderAlphaWalls();
 
         ResetBlendEquations();
@@ -482,7 +482,7 @@ public class LegacyWorldRenderer : WorldRenderer
             m_interpolationCompositeProgram.Bind();
             m_interpolationCompositeProgram.VertexGapClampUV(false);
             SetInterpolationUniforms(m_interpolationCompositeProgram, renderInfo, true);
-            GL.ActiveTexture(TextureUnit.Texture0);
+            GL.ActiveTexture(BindTextures.BoundTexture);
             m_worldDataManager.RenderAlphaWalls();
         }
 
@@ -503,14 +503,14 @@ public class LegacyWorldRenderer : WorldRenderer
     private void RenderTwoSidedMiddleWalls(RenderInfo renderInfo)
     {
         m_interpolationProgram.Bind();
-        GL.ActiveTexture(TextureUnit.Texture0);
+        GL.ActiveTexture(BindTextures.BoundTexture);
         m_interpolationProgram.VertexGapClampUV(m_pixelGapCorrection);
         m_worldDataManager.RenderTwoSidedMiddleWalls();
 
         if (m_renderStatic)
         {
             m_staticProgram.Bind();
-            GL.ActiveTexture(TextureUnit.Texture0);
+            GL.ActiveTexture(BindTextures.BoundTexture);
             SetStaticUniforms(m_staticProgram, renderInfo);
             m_staticProgram.VertexGapClampUV(m_pixelGapCorrection);
             m_geometryRenderer.RenderStaticTwoSidedWalls();
@@ -585,10 +585,10 @@ public class LegacyWorldRenderer : WorldRenderer
     private static void SetInterpolationUniforms(InterpolationShader program, RenderInfo renderInfo, bool checkPlaneClip)
     {
         program.Bind();
-        program.BoundTexture(TextureUnit.Texture0);
-        program.SectorLightTexture(TextureUnit.Texture1);
-        program.ColormapTexture(TextureUnit.Texture2);
-        program.SectorColormapTexture(TextureUnit.Texture3);
+        program.BoundTexture(BindTextures.BoundTexture);
+        program.SectorLightTexture(BindTextures.SectorLight);
+        program.ColormapTexture(BindTextures.Colormap);
+        program.SectorColormapTexture(BindTextures.SectorColormap);
         program.PlaneClipTexture(BindTextures.PlaneClipTexture);
         program.WallClipTexture(BindTextures.WallClipTexture);
         program.HasInvulnerability(renderInfo.Uniforms.DrawInvulnerability);
@@ -607,17 +607,17 @@ public class LegacyWorldRenderer : WorldRenderer
 
         if (program is InterpolationCompositeShader)
         {
-            program.AccumTexture(TextureUnit.Texture4);
-            program.AccumCountTextre(TextureUnit.Texture5);
+            program.AccumTexture(BindTextures.AccumTexture);
+            program.AccumCountTextre(BindTextures.AccumCountTexture);
         }
     }
 
     private static void SetStaticUniforms(StaticShader program, RenderInfo renderInfo)
     {
-        program.BoundTexture(TextureUnit.Texture0);
-        program.SectorLightTexture(TextureUnit.Texture1);
-        program.ColormapTexture(TextureUnit.Texture2);
-        program.SectorColormapTexture(TextureUnit.Texture3);
+        program.BoundTexture(BindTextures.BoundTexture);
+        program.SectorLightTexture(BindTextures.SectorLight);
+        program.ColormapTexture(BindTextures.Colormap);
+        program.SectorColormapTexture(BindTextures.SectorColormap);
         program.HasInvulnerability(renderInfo.Uniforms.DrawInvulnerability);
         program.Mvp(renderInfo.Uniforms.Mvp);
         program.MvpNoPitch(renderInfo.Uniforms.MvpNoPitch);

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -34,6 +34,7 @@ public class LegacyWorldRenderer : WorldRenderer
     private readonly InterpolationTransparentShader m_interpolationTransparentProgram = new();
     private readonly InterpolationCompositeShader m_interpolationCompositeProgram = new();
     private readonly InterpolationPlaneClipShader m_interpolationPlaneClipShader = new();
+    private readonly InterpolationWallClipShader m_interpolationWallClipShader = new();
     private readonly StaticShader m_staticProgram = new("Main");
     private readonly StaticPlaneClipShader m_staticPlaneClipProgram = new();
     private readonly StaticWallClipShader m_staticWallClipProgram = new();
@@ -344,7 +345,11 @@ public class LegacyWorldRenderer : WorldRenderer
 
         GL.Clear(ClearBufferMask.DepthBufferBit);
         GL.ColorMask(false, false, false, false);
-        GL.Disable(EnableCap.CullFace);
+
+        // Write two-sided middle walls to depth as these generally look better with normal discard handling
+        RenderTwoSidedMiddleWalls(renderInfo);
+
+        //GL.Disable(EnableCap.CullFace);
 
         //if (m_renderStatic)
         //{
@@ -357,7 +362,7 @@ public class LegacyWorldRenderer : WorldRenderer
         //m_worldDataManager.RenderCoverWalls();
         //// Need to render flood fill again. Sprites need to be blocked by flood filling if visible.
         //m_geometryRenderer.Portals.Render(renderInfo);
-        GL.Enable(EnableCap.CullFace);
+        //GL.Enable(EnableCap.CullFace);
 
         //if (m_renderStatic)
         //{
@@ -370,7 +375,7 @@ public class LegacyWorldRenderer : WorldRenderer
         GL.ColorMask(true, true, true, true);
 
         if (m_planeClipFrameBuffer != null)
-            WritePlaneData(m_planeClipFrameBuffer, renderInfo, framebuffer);        
+            WritePlaneClipData(m_planeClipFrameBuffer, renderInfo, framebuffer);        
 
         m_entityRenderer.RenderHealthBars(renderInfo);
         m_entityRenderer.RenderOpaque(renderInfo);
@@ -378,25 +383,32 @@ public class LegacyWorldRenderer : WorldRenderer
         m_primitiveRenderer.Render(renderInfo);
     }
 
-    private void WritePlaneData(PlaneClipFrameBuffer planeClipFrameBuffer, RenderInfo renderInfo, GLFramebuffer framebuffer)
+    private void WritePlaneClipData(PlaneClipFrameBuffer planeClipFrameBuffer, RenderInfo renderInfo, GLFramebuffer framebuffer)
     {
         planeClipFrameBuffer.BindFrameBuffer();
         planeClipFrameBuffer.StartRender();
 
         if (m_renderStatic)
         {
+            m_staticWallClipProgram.Bind();
+            GL.ActiveTexture(TextureUnit.Texture0);
+            SetStaticUniforms(m_staticWallClipProgram, renderInfo);
+            m_geometryRenderer.RenderStaticOneSidedCoverWalls();
+            m_geometryRenderer.RenderStaticCoverWalls();
+            m_staticWallClipProgram.Unbind();
+
             m_staticPlaneClipProgram.Bind();
             GL.ActiveTexture(TextureUnit.Texture0);
             SetStaticUniforms(m_staticPlaneClipProgram, renderInfo);
             m_geometryRenderer.RenderStaticGeometryFloors();
             m_staticPlaneClipProgram.Unbind();
-
-            m_staticWallClipProgram.Bind();
-            GL.ActiveTexture(TextureUnit.Texture0);
-            SetStaticUniforms(m_staticWallClipProgram, renderInfo);
-            m_geometryRenderer.RenderStaticOneSidedCoverWalls();
-            m_staticWallClipProgram.Unbind();
         }
+
+        m_interpolationWallClipShader.Bind();
+        GL.ActiveTexture(TextureUnit.Texture0);
+        SetInterpolationUniforms(m_interpolationWallClipShader, renderInfo);
+        m_worldDataManager.RenderCoverWalls();
+        m_interpolationWallClipShader.Unbind();
 
         m_interpolationPlaneClipShader.Bind();
         GL.ActiveTexture(TextureUnit.Texture0);
@@ -412,7 +424,7 @@ public class LegacyWorldRenderer : WorldRenderer
 
     private unsafe void RenderTransparent(RenderInfo renderInfo, GLFramebuffer framebuffer, bool vanillaRender)
     {
-        bool fuzzData = m_entityRenderer.HasFuzz();
+        bool fuzzData = m_entityRenderer.HasFuzz(); 
         bool alphaData = m_entityRenderer.HasAlpha();
         bool alphaWalls = m_worldDataManager.HasAlphaWalls();
         if (!fuzzData && !alphaData && !alphaWalls)

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -316,7 +316,7 @@ public class LegacyWorldRenderer : WorldRenderer
 
             RenderTwoSidedMiddleWalls(renderInfo);
             m_entityRenderer.RenderOpaque(renderInfo);
-            RenderTransparent(renderInfo, framebuffer, false);
+            RenderTransparent(renderInfo, framebuffer);
             m_primitiveRenderer.Render(renderInfo);
             return;
         }
@@ -355,7 +355,7 @@ public class LegacyWorldRenderer : WorldRenderer
             WritePlaneClipData(m_planeClipFrameBuffer, renderInfo, framebuffer, false);
 
         m_entityRenderer.RenderOpaque(renderInfo);
-        RenderTransparent(renderInfo, framebuffer, true);
+        RenderTransparent(renderInfo, framebuffer);
         m_primitiveRenderer.Render(renderInfo);
     }
 
@@ -422,6 +422,7 @@ public class LegacyWorldRenderer : WorldRenderer
             SetInterpolationUniforms(m_interpolationWallClipShader, renderInfo, false);
             GL.Disable(EnableCap.CullFace);
             m_worldDataManager.RenderCoverWalls();
+            m_geometryRenderer.RenderWallClipPortals(renderInfo);
             GL.Enable(EnableCap.CullFace);
             m_interpolationWallClipShader.Unbind();
         }
@@ -440,7 +441,7 @@ public class LegacyWorldRenderer : WorldRenderer
         ResetBlendEquations();
     }
 
-    private unsafe void RenderTransparent(RenderInfo renderInfo, GLFramebuffer framebuffer, bool vanillaRender)
+    private unsafe void RenderTransparent(RenderInfo renderInfo, GLFramebuffer framebuffer)
     {
         bool fuzzData = m_entityRenderer.HasFuzz(); 
         bool alphaData = m_entityRenderer.HasAlpha();

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -364,7 +364,7 @@ public class LegacyWorldRenderer : WorldRenderer
         bool bind = false;
         if (m_planeClipFrameBuffer != null)
         {
-            m_planeClipFrameBuffer.CreateOrUpdate(dimension);
+            m_planeClipFrameBuffer.CreateOrUpdate("PlaneClip", dimension);
             m_planeClipFrameBuffer.BindFrameBuffer();
             m_planeClipFrameBuffer.Clear();
             bind = true;
@@ -372,7 +372,7 @@ public class LegacyWorldRenderer : WorldRenderer
 
         if (m_wallClipFrameBuffer != null)
         {
-            m_wallClipFrameBuffer.CreateOrUpdate(dimension);
+            m_wallClipFrameBuffer.CreateOrUpdate("WallClip", dimension);
             m_wallClipFrameBuffer.BindFrameBuffer();
             m_wallClipFrameBuffer.Clear();
             bind = true;
@@ -405,7 +405,12 @@ public class LegacyWorldRenderer : WorldRenderer
                 m_staticPlaneClipProgram.Bind();
                 GL.ActiveTexture(BindTextures.BoundTexture);
                 SetStaticUniforms(m_staticPlaneClipProgram, renderInfo);
+                m_staticPlaneClipProgram.PlaneType(0);
                 m_geometryRenderer.RenderStaticGeometryFloors();
+
+                m_staticPlaneClipProgram.PlaneType(1);
+                m_geometryRenderer.RenderStaticGeometryCeilings();
+
                 m_staticPlaneClipProgram.Unbind();
             }
         }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -469,7 +469,7 @@ public class LegacyWorldRenderer : WorldRenderer
         m_interpolationTransparentProgram.Bind();
         // Alpha walls are the exception to pixel gap correction. Only required for opaque walls.
         m_interpolationTransparentProgram.VertexGapClampUV(false);
-        SetInterpolationUniforms(m_interpolationTransparentProgram, renderInfo, true);
+        SetInterpolationUniforms(m_interpolationTransparentProgram, renderInfo, m_vanillaRender);
         GL.ActiveTexture(BindTextures.BoundTexture);
         m_worldDataManager.RenderAlphaWalls();
 
@@ -482,7 +482,7 @@ public class LegacyWorldRenderer : WorldRenderer
         {
             m_interpolationCompositeProgram.Bind();
             m_interpolationCompositeProgram.VertexGapClampUV(false);
-            SetInterpolationUniforms(m_interpolationCompositeProgram, renderInfo, true);
+            SetInterpolationUniforms(m_interpolationCompositeProgram, renderInfo, m_vanillaRender);
             GL.ActiveTexture(BindTextures.BoundTexture);
             m_worldDataManager.RenderAlphaWalls();
         }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -351,6 +351,9 @@ public class LegacyWorldRenderer : WorldRenderer
         if (m_wallClipFrameBuffer != null)
             WritePlaneClipData(m_wallClipFrameBuffer, renderInfo, framebuffer, true);
 
+        if (m_planeClipFrameBuffer != null)
+            WritePlaneClipData(m_planeClipFrameBuffer, renderInfo, framebuffer, false);
+
         m_entityRenderer.RenderOpaque(renderInfo);
         RenderTransparent(renderInfo, framebuffer, true);
         m_primitiveRenderer.Render(renderInfo);
@@ -428,7 +431,7 @@ public class LegacyWorldRenderer : WorldRenderer
 
         planeClipFrameBuffer.UnbindFrameBuffer();
         framebuffer.Bind();
-        planeClipFrameBuffer.BindPlaneTexture(BindTextures.WallClipTexture);
+        planeClipFrameBuffer.BindPlaneTexture(walls ? BindTextures.WallClipTexture : BindTextures.PlaneClipTexture);
         ResetBlendEquations();
     }
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -384,7 +384,9 @@ public class LegacyWorldRenderer : WorldRenderer
         m_interpolationWallClipShader.Bind();
         GL.ActiveTexture(TextureUnit.Texture0);
         SetInterpolationUniforms(m_interpolationWallClipShader, renderInfo, false);
+        GL.Disable(EnableCap.CullFace);
         m_worldDataManager.RenderCoverWalls();
+        GL.Enable(EnableCap.CullFace);
         m_interpolationWallClipShader.Unbind();
 
         m_interpolationPlaneClipShader.Bind();

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -297,7 +297,7 @@ public class LegacyWorldRenderer : WorldRenderer
         {
             m_interpolationProgram.Bind();
             GL.ActiveTexture(TextureUnit.Texture0);
-            SetInterpolationUniforms(m_interpolationProgram, renderInfo);
+            SetInterpolationUniforms(m_interpolationProgram, renderInfo, false);
             m_interpolationProgram.VertexGapClampUV(m_pixelGapCorrection);
             m_worldDataManager.RenderWalls();
             m_interpolationProgram.VertexGapClampUV(false);
@@ -324,7 +324,7 @@ public class LegacyWorldRenderer : WorldRenderer
 
         m_interpolationProgram.Bind();
         GL.ActiveTexture(TextureUnit.Texture0);
-        SetInterpolationUniforms(m_interpolationProgram, renderInfo);
+        SetInterpolationUniforms(m_interpolationProgram, renderInfo, false);
         m_interpolationProgram.VertexGapClampUV(m_pixelGapCorrection);
         m_worldDataManager.RenderWalls();
         m_interpolationProgram.VertexGapClampUV(false);
@@ -383,13 +383,13 @@ public class LegacyWorldRenderer : WorldRenderer
 
         m_interpolationWallClipShader.Bind();
         GL.ActiveTexture(TextureUnit.Texture0);
-        SetInterpolationUniforms(m_interpolationWallClipShader, renderInfo);
+        SetInterpolationUniforms(m_interpolationWallClipShader, renderInfo, false);
         m_worldDataManager.RenderCoverWalls();
         m_interpolationWallClipShader.Unbind();
 
         m_interpolationPlaneClipShader.Bind();
         GL.ActiveTexture(TextureUnit.Texture0);
-        SetInterpolationUniforms(m_interpolationPlaneClipShader, renderInfo);
+        SetInterpolationUniforms(m_interpolationPlaneClipShader, renderInfo, false);
         m_worldDataManager.RenderFloors();
         m_interpolationPlaneClipShader.Unbind();
 
@@ -429,13 +429,10 @@ public class LegacyWorldRenderer : WorldRenderer
             m_entityRenderer.RenderOitTransparentFuzzPass(renderInfo);
         }
 
-        if (vanillaRender && alphaWalls)
-            RenderFlatsToDepth(renderInfo);
-
         m_interpolationTransparentProgram.Bind();
         // Alpha walls are the exception to pixel gap correction. Only required for opaque walls.
         m_interpolationTransparentProgram.VertexGapClampUV(false);
-        SetInterpolationUniforms(m_interpolationTransparentProgram, renderInfo);
+        SetInterpolationUniforms(m_interpolationTransparentProgram, renderInfo, true);
         GL.ActiveTexture(TextureUnit.Texture0);
         m_worldDataManager.RenderAlphaWalls();
 
@@ -446,12 +443,9 @@ public class LegacyWorldRenderer : WorldRenderer
 
         if (alphaWalls)
         {
-            if (vanillaRender)
-                RenderFlatsToDepth(renderInfo);
-
             m_interpolationCompositeProgram.Bind();
             m_interpolationCompositeProgram.VertexGapClampUV(false);
-            SetInterpolationUniforms(m_interpolationCompositeProgram, renderInfo);
+            SetInterpolationUniforms(m_interpolationCompositeProgram, renderInfo, true);
             GL.ActiveTexture(TextureUnit.Texture0);
             m_worldDataManager.RenderAlphaWalls();
         }
@@ -468,26 +462,6 @@ public class LegacyWorldRenderer : WorldRenderer
         GL.BlendEquation(BlendEquationMode.FuncAdd);
         GL.Enable(EnableCap.Blend);
         GL.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
-    }
-
-    private void RenderFlatsToDepth(RenderInfo renderInfo)
-    {
-        // Render flats so two-sided middle alpha walls are clipped to flats
-        GL.DepthMask(true);
-        GL.ColorMask(false, false, false, false);
-
-        m_staticProgram.Bind();
-        GL.ActiveTexture(TextureUnit.Texture0);
-        SetStaticUniforms(m_staticProgram, renderInfo);
-        m_geometryRenderer.RenderStaticGeometryFlats();
-
-        m_interpolationProgram.Bind();
-        GL.ActiveTexture(TextureUnit.Texture0);
-        SetInterpolationUniforms(m_interpolationProgram, renderInfo);
-        m_worldDataManager.RenderFlats();
-
-        GL.DepthMask(false);
-        GL.ColorMask(true, true, true, true);
     }
 
     private void RenderTwoSidedMiddleWalls(RenderInfo renderInfo)
@@ -572,13 +546,14 @@ public class LegacyWorldRenderer : WorldRenderer
         m_primitiveRenderer.AddSegment(seg, color, alpha, type);
     }
 
-    private static void SetInterpolationUniforms(InterpolationShader program, RenderInfo renderInfo)
+    private static void SetInterpolationUniforms(InterpolationShader program, RenderInfo renderInfo, bool checkPlaneClip)
     {
         program.Bind();
         program.BoundTexture(TextureUnit.Texture0);
         program.SectorLightTexture(TextureUnit.Texture1);
         program.ColormapTexture(TextureUnit.Texture2);
         program.SectorColormapTexture(TextureUnit.Texture3);
+        program.PlaneClipTexture(TextureUnit.Texture8);
         program.HasInvulnerability(renderInfo.Uniforms.DrawInvulnerability);
         program.Mvp(renderInfo.Uniforms.Mvp);
         program.MvpNoPitch(renderInfo.Uniforms.MvpNoPitch);
@@ -591,6 +566,7 @@ public class LegacyWorldRenderer : WorldRenderer
         program.ColorMapIndex(renderInfo.Uniforms.ColorMapUniforms.GlobalIndex);
         program.LightMode(renderInfo.Uniforms.LightMode);
         program.GammaCorrection(renderInfo.Uniforms.GammaCorrection);
+        program.CheckPlaneClip(checkPlaneClip);
 
         if (program is InterpolationCompositeShader)
         {

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -36,6 +36,7 @@ public class LegacyWorldRenderer : WorldRenderer
     private readonly InterpolationPlaneClipShader m_interpolationPlaneClipShader = new();
     private readonly StaticShader m_staticProgram = new("Main");
     private readonly StaticPlaneClipShader m_staticPlaneClipProgram = new();
+    private readonly StaticWallClipShader m_staticWallClipProgram = new();
     private readonly RenderWorldDataManager m_worldDataManager = new();
     private readonly ArchiveCollection m_archiveCollection;
     private readonly LegacyGLTextureManager m_textureManager;
@@ -268,7 +269,14 @@ public class LegacyWorldRenderer : WorldRenderer
 
         var dimension = new Dimension(renderInfo.Viewport.Width, renderInfo.Viewport.Height);
         m_oitFrameBuffer.CreateOrUpdate(dimension, framebuffer.DepthTexture);
-        m_planeClipFrameBuffer?.CreateOrUpdate(dimension);
+
+        if (m_planeClipFrameBuffer != null)
+        {
+            m_planeClipFrameBuffer.CreateOrUpdate(dimension);
+            m_planeClipFrameBuffer.BindFrameBuffer();
+            m_planeClipFrameBuffer.Clear();
+            framebuffer.Bind();
+        }
 
         if (m_lastTicker != world.GameTicker)
             m_entityRenderer.Start(renderInfo);
@@ -338,27 +346,27 @@ public class LegacyWorldRenderer : WorldRenderer
         GL.ColorMask(false, false, false, false);
         GL.Disable(EnableCap.CullFace);
 
-        if (m_renderStatic)
-        {
-            m_staticProgram.Bind();
-            GL.ActiveTexture(TextureUnit.Texture0);
-            m_geometryRenderer.RenderStaticCoverWalls();
-        }
+        //if (m_renderStatic)
+        //{
+        //    m_staticProgram.Bind();
+        //    GL.ActiveTexture(TextureUnit.Texture0);
+        //    m_geometryRenderer.RenderStaticCoverWalls();
+        //}
 
-        m_interpolationProgram.Bind();
-        m_worldDataManager.RenderCoverWalls();
-        // Need to render flood fill again. Sprites need to be blocked by flood filling if visible.
-        m_geometryRenderer.Portals.Render(renderInfo);
+        //m_interpolationProgram.Bind();
+        //m_worldDataManager.RenderCoverWalls();
+        //// Need to render flood fill again. Sprites need to be blocked by flood filling if visible.
+        //m_geometryRenderer.Portals.Render(renderInfo);
         GL.Enable(EnableCap.CullFace);
 
-        if (m_renderStatic)
-        {
-            m_staticProgram.Bind();
-            GL.ActiveTexture(TextureUnit.Texture0);
-            m_geometryRenderer.RenderStaticOneSidedCoverWalls();
-        }
+        //if (m_renderStatic)
+        //{
+        //    m_staticProgram.Bind();
+        //    GL.ActiveTexture(TextureUnit.Texture0);
+        //    m_geometryRenderer.RenderStaticOneSidedCoverWalls();
+        //}
 
-        RenderTwoSidedMiddleWalls(renderInfo);
+        //RenderTwoSidedMiddleWalls(renderInfo);
         GL.ColorMask(true, true, true, true);
 
         if (m_planeClipFrameBuffer != null)
@@ -372,8 +380,8 @@ public class LegacyWorldRenderer : WorldRenderer
 
     private void WritePlaneData(PlaneClipFrameBuffer planeClipFrameBuffer, RenderInfo renderInfo, GLFramebuffer framebuffer)
     {
-        planeClipFrameBuffer.StartRender();
         planeClipFrameBuffer.BindFrameBuffer();
+        planeClipFrameBuffer.StartRender();
 
         if (m_renderStatic)
         {
@@ -382,6 +390,12 @@ public class LegacyWorldRenderer : WorldRenderer
             SetStaticUniforms(m_staticPlaneClipProgram, renderInfo);
             m_geometryRenderer.RenderStaticGeometryFloors();
             m_staticPlaneClipProgram.Unbind();
+
+            m_staticWallClipProgram.Bind();
+            GL.ActiveTexture(TextureUnit.Texture0);
+            SetStaticUniforms(m_staticWallClipProgram, renderInfo);
+            m_geometryRenderer.RenderStaticOneSidedCoverWalls();
+            m_staticWallClipProgram.Unbind();
         }
 
         m_interpolationPlaneClipShader.Bind();
@@ -392,7 +406,7 @@ public class LegacyWorldRenderer : WorldRenderer
 
         planeClipFrameBuffer.UnbindFrameBuffer();
         framebuffer.Bind();
-        planeClipFrameBuffer.BindPlaneZTexture(TextureUnit.Texture8);
+        planeClipFrameBuffer.BindPlaneTexture(TextureUnit.Texture8);
         ResetBlendEquations();
     }
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -405,12 +405,7 @@ public class LegacyWorldRenderer : WorldRenderer
                 m_staticPlaneClipProgram.Bind();
                 GL.ActiveTexture(BindTextures.BoundTexture);
                 SetStaticUniforms(m_staticPlaneClipProgram, renderInfo);
-                m_staticPlaneClipProgram.PlaneType(0);
-                m_geometryRenderer.RenderStaticGeometryFloors();
-
-                m_staticPlaneClipProgram.PlaneType(1);
-                m_geometryRenderer.RenderStaticGeometryCeilings();
-
+                m_geometryRenderer.RenderStaticGeometryFlats();
                 m_staticPlaneClipProgram.Unbind();
             }
         }
@@ -431,7 +426,7 @@ public class LegacyWorldRenderer : WorldRenderer
             m_interpolationPlaneClipShader.Bind();
             GL.ActiveTexture(BindTextures.BoundTexture);
             SetInterpolationUniforms(m_interpolationPlaneClipShader, renderInfo, false);
-            m_worldDataManager.RenderFloors();
+            m_worldDataManager.RenderFlats();
             m_interpolationPlaneClipShader.Unbind();
         }
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -53,6 +53,7 @@ public class LegacyWorldRenderer : WorldRenderer
     private IWorld? m_previousWorld;
     private RenderBlockMapData m_renderData;
     private PlaneClipFrameBuffer? m_planeClipFrameBuffer;
+    private PlaneClipFrameBuffer? m_wallClipFrameBuffer;
 
     public LegacyWorldRenderer(IConfig config, ArchiveCollection archiveCollection, LegacyGLTextureManager textureManager)
     {
@@ -86,6 +87,11 @@ public class LegacyWorldRenderer : WorldRenderer
             m_planeClipFrameBuffer = new();
         else
             m_planeClipFrameBuffer?.Dispose();
+
+        if (m_vanillaRender && m_wallClipFrameBuffer == null)
+            m_wallClipFrameBuffer = new();
+        else
+            m_wallClipFrameBuffer?.Dispose();
 
         if (m_previousWorld != null)
             m_previousWorld.OnResetInterpolation -= World_OnResetInterpolation;
@@ -259,7 +265,7 @@ public class LegacyWorldRenderer : WorldRenderer
     }
 
     protected override void PerformRender(IWorld world, RenderInfo renderInfo, GLFramebuffer framebuffer)
-    {   
+    {
         // If the transfer height view is not the middle then the cached static geometry cannot be used.
         // Render all sectors dynamically instead.
         m_renderStatic = renderInfo.TransferHeightView == TransferHeightView.Middle;
@@ -271,13 +277,7 @@ public class LegacyWorldRenderer : WorldRenderer
         var dimension = new Dimension(renderInfo.Viewport.Width, renderInfo.Viewport.Height);
         m_oitFrameBuffer.CreateOrUpdate(dimension, framebuffer.DepthTexture);
 
-        if (m_planeClipFrameBuffer != null)
-        {
-            m_planeClipFrameBuffer.CreateOrUpdate(dimension);
-            m_planeClipFrameBuffer.BindFrameBuffer();
-            m_planeClipFrameBuffer.Clear();
-            framebuffer.Bind();
-        }
+        SetupClipBuffers(framebuffer, dimension);
 
         if (m_lastTicker != world.GameTicker)
             m_entityRenderer.Start(renderInfo);
@@ -348,54 +348,87 @@ public class LegacyWorldRenderer : WorldRenderer
         RenderTwoSidedMiddleWalls(renderInfo);
         GL.ColorMask(true, true, true, true);
 
-        if (m_planeClipFrameBuffer != null)
-            WritePlaneClipData(m_planeClipFrameBuffer, renderInfo, framebuffer);        
-        
+        if (m_wallClipFrameBuffer != null)
+            WritePlaneClipData(m_wallClipFrameBuffer, renderInfo, framebuffer, true);
+
         m_entityRenderer.RenderOpaque(renderInfo);
         RenderTransparent(renderInfo, framebuffer, true);
         m_primitiveRenderer.Render(renderInfo);
     }
 
-    private void WritePlaneClipData(PlaneClipFrameBuffer planeClipFrameBuffer, RenderInfo renderInfo, GLFramebuffer framebuffer)
+    private void SetupClipBuffers(GLFramebuffer framebuffer, Dimension dimension)
+    {
+        bool bind = false;
+        if (m_planeClipFrameBuffer != null)
+        {
+            m_planeClipFrameBuffer.CreateOrUpdate(dimension);
+            m_planeClipFrameBuffer.BindFrameBuffer();
+            m_planeClipFrameBuffer.Clear();
+            bind = true;
+        }
+
+        if (m_wallClipFrameBuffer != null)
+        {
+            m_wallClipFrameBuffer.CreateOrUpdate(dimension);
+            m_wallClipFrameBuffer.BindFrameBuffer();
+            m_wallClipFrameBuffer.Clear();
+            bind = true;
+        }
+
+        if (bind)
+            framebuffer.Bind();
+    }
+
+    private void WritePlaneClipData(PlaneClipFrameBuffer planeClipFrameBuffer, RenderInfo renderInfo, GLFramebuffer framebuffer, bool walls)
     {
         planeClipFrameBuffer.BindFrameBuffer();
         planeClipFrameBuffer.StartRender();
 
         if (m_renderStatic)
         {
-            m_staticWallClipProgram.Bind();
-            GL.ActiveTexture(TextureUnit.Texture0);
-            SetStaticUniforms(m_staticWallClipProgram, renderInfo);
-            m_geometryRenderer.RenderStaticOneSidedCoverWalls();
-            GL.Disable(EnableCap.CullFace);
-            m_geometryRenderer.RenderStaticCoverWalls();
-            GL.Enable(EnableCap.CullFace);
-            m_staticWallClipProgram.Unbind();
-
-            m_staticPlaneClipProgram.Bind();
-            GL.ActiveTexture(TextureUnit.Texture0);
-            SetStaticUniforms(m_staticPlaneClipProgram, renderInfo);
-            m_geometryRenderer.RenderStaticGeometryFloors();
-            m_staticPlaneClipProgram.Unbind();
+            if (walls)
+            {
+                m_staticWallClipProgram.Bind();
+                GL.ActiveTexture(TextureUnit.Texture0);
+                SetStaticUniforms(m_staticWallClipProgram, renderInfo);
+                m_geometryRenderer.RenderStaticOneSidedCoverWalls();
+                GL.Disable(EnableCap.CullFace);
+                m_geometryRenderer.RenderStaticCoverWalls();
+                GL.Enable(EnableCap.CullFace);
+                m_staticWallClipProgram.Unbind();
+            }
+            else
+            {
+                m_staticPlaneClipProgram.Bind();
+                GL.ActiveTexture(TextureUnit.Texture0);
+                SetStaticUniforms(m_staticPlaneClipProgram, renderInfo);
+                m_geometryRenderer.RenderStaticGeometryFloors();
+                m_staticPlaneClipProgram.Unbind();
+            }
         }
 
-        m_interpolationWallClipShader.Bind();
-        GL.ActiveTexture(TextureUnit.Texture0);
-        SetInterpolationUniforms(m_interpolationWallClipShader, renderInfo, false);
-        GL.Disable(EnableCap.CullFace);
-        m_worldDataManager.RenderCoverWalls();
-        GL.Enable(EnableCap.CullFace);
-        m_interpolationWallClipShader.Unbind();
-
-        m_interpolationPlaneClipShader.Bind();
-        GL.ActiveTexture(TextureUnit.Texture0);
-        SetInterpolationUniforms(m_interpolationPlaneClipShader, renderInfo, false);
-        m_worldDataManager.RenderFloors();
-        m_interpolationPlaneClipShader.Unbind();
+        if (walls)
+        {
+            m_interpolationWallClipShader.Bind();
+            GL.ActiveTexture(TextureUnit.Texture0);
+            SetInterpolationUniforms(m_interpolationWallClipShader, renderInfo, false);
+            GL.Disable(EnableCap.CullFace);
+            m_worldDataManager.RenderCoverWalls();
+            GL.Enable(EnableCap.CullFace);
+            m_interpolationWallClipShader.Unbind();
+        }
+        else
+        {
+            m_interpolationPlaneClipShader.Bind();
+            GL.ActiveTexture(TextureUnit.Texture0);
+            SetInterpolationUniforms(m_interpolationPlaneClipShader, renderInfo, false);
+            m_worldDataManager.RenderFloors();
+            m_interpolationPlaneClipShader.Unbind();
+        }
 
         planeClipFrameBuffer.UnbindFrameBuffer();
         framebuffer.Bind();
-        planeClipFrameBuffer.BindPlaneTexture(TextureUnit.Texture8);
+        planeClipFrameBuffer.BindPlaneTexture(BindTextures.WallClipTexture);
         ResetBlendEquations();
     }
 
@@ -553,7 +586,8 @@ public class LegacyWorldRenderer : WorldRenderer
         program.SectorLightTexture(TextureUnit.Texture1);
         program.ColormapTexture(TextureUnit.Texture2);
         program.SectorColormapTexture(TextureUnit.Texture3);
-        program.PlaneClipTexture(TextureUnit.Texture8);
+        program.PlaneClipTexture(BindTextures.PlaneClipTexture);
+        program.WallClipTexture(BindTextures.WallClipTexture);
         program.HasInvulnerability(renderInfo.Uniforms.DrawInvulnerability);
         program.Mvp(renderInfo.Uniforms.Mvp);
         program.MvpNoPitch(renderInfo.Uniforms.MvpNoPitch);

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/LightLevel.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/LightLevel.cs
@@ -22,7 +22,7 @@ public static class LightLevel
     public static string VertexLightBuffer(VertexLightBufferOptions options) =>
 @"int texBufferIndex = int(lightLevelBufferIndex);
 float lightLevelBufferValue = texelFetch(sectorLightTexture, texBufferIndex).r;
-lightLevelFrag = clamp(lightLevelBufferValue" + ((options & VertexLightBufferOptions.LightLevelAdd) != 0 ? " + lightLevelAdd + vertexLightLevelFrag" : " + vertexLightLevelFrag") + ", 0.0, 256.0);";
+lightLevelFrag = clamp(lightLevelBufferValue" + ((options & VertexLightBufferOptions.LightLevelAdd) != 0 ? " + lightLevelAddValue + vertexLightLevelFrag" : " + vertexLightLevelFrag") + ", 0.0, 256.0);";
 
     public static string VertexDist(string posVariable) => $"dist = (mvpNoPitch * {posVariable}).{ShaderVars.Depth};";
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/PlaneClip.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/PlaneClip.cs
@@ -29,6 +29,10 @@ public static class PlaneClip
             layout (location = 0) out vec3 outPlane;
 
             void main() {
+                // This is required for flood fill rendering that doesn't separate planes(floor/ceiling) from walls
+                // Planes are written with -1 and need to be discarded
+                if (mapIdFrag < 0)
+                    discard;
                 outPlane = vec3(mapIdFrag, depthFrag, lowerFrag + (upperFrag * 2));
             }";
 }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/PlaneClip.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/PlaneClip.cs
@@ -6,15 +6,15 @@ public static class PlaneClip
          @"
             #version 330
 
-            uniform int planeType;
-
             flat in float zPos;
+            flat in float upperFrag;
+            flat in float lowerFrag;
             in float depthFrag;
 
             layout (location = 0) out vec3 outPlane;
 
             void main() {
-                outPlane = vec3(zPos, depthFrag, planeType);
+                outPlane = vec3(zPos, depthFrag, lowerFrag + (upperFrag * 2));
             }";
 
     public static string WriteWallFragFunction() =>

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/PlaneClip.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/PlaneClip.cs
@@ -6,18 +6,22 @@ public static class PlaneClip
          @"
             #version 330
 
+            uniform int planeType;
+
             flat in float zPos;
             in float depthFrag;
 
             layout (location = 0) out vec3 outPlane;
 
             void main() {
-                outPlane = vec3(zPos, depthFrag, 0);
+                outPlane = vec3(zPos, depthFrag, planeType);
             }";
 
     public static string WriteWallFragFunction() =>
          @"
             #version 330
+
+            uniform int planeType;
 
             flat in float mapIdFrag;
             in float depthFrag;
@@ -25,6 +29,6 @@ public static class PlaneClip
             layout (location = 0) out vec3 outPlane;
 
             void main() {
-                outPlane = vec3(mapIdFrag, depthFrag, 1);
+                outPlane = vec3(mapIdFrag, depthFrag, 0);
             }";
 }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/PlaneClip.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/PlaneClip.cs
@@ -21,8 +21,6 @@ public static class PlaneClip
          @"
             #version 330
 
-            uniform int planeType;
-
             flat in float mapIdFrag;
             flat in float upperFrag;
             flat in float lowerFrag;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/PlaneClip.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/PlaneClip.cs
@@ -9,10 +9,10 @@ public static class PlaneClip
             flat in float zPos;
             in float depthFrag;
 
-            layout (location = 0) out vec3 outPlaneZ;
+            layout (location = 0) out vec3 outPlane;
 
             void main() {
-                outPlaneZ = vec3(zPos, depthFrag, 0);
+                outPlane = vec3(zPos, depthFrag, 0);
             }";
 
     public static string WriteWallFragFunction() =>
@@ -22,9 +22,9 @@ public static class PlaneClip
             flat in float mapIdFrag;
             in float depthFrag;
 
-            layout (location = 0) out vec3 outPlaneZ;
+            layout (location = 0) out vec3 outPlane;
 
             void main() {
-                outPlaneZ = vec3(mapIdFrag, depthFrag, 1);
+                outPlane = vec3(mapIdFrag, depthFrag, 1);
             }";
 }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/PlaneClip.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/PlaneClip.cs
@@ -9,9 +9,22 @@ public static class PlaneClip
             flat in float zPos;
             in float depthFrag;
 
-            layout (location = 0) out vec2 outPlaneZ;
+            layout (location = 0) out vec3 outPlaneZ;
 
             void main() {
-                outPlaneZ = vec2(zPos, depthFrag);
+                outPlaneZ = vec3(zPos, depthFrag, 0);
+            }";
+
+    public static string WriteWallFragFunction() =>
+         @"
+            #version 330
+
+            flat in float mapIdFrag;
+            in float depthFrag;
+
+            layout (location = 0) out vec3 outPlaneZ;
+
+            void main() {
+                outPlaneZ = vec3(mapIdFrag, depthFrag, 1);
             }";
 }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/PlaneClip.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/PlaneClip.cs
@@ -24,11 +24,13 @@ public static class PlaneClip
             uniform int planeType;
 
             flat in float mapIdFrag;
+            flat in float upperFrag;
+            flat in float lowerFrag;
             in float depthFrag;
 
             layout (location = 0) out vec3 outPlane;
 
             void main() {
-                outPlane = vec3(mapIdFrag, depthFrag, 0);
+                outPlane = vec3(mapIdFrag, depthFrag, lowerFrag + (upperFrag * 2));
             }";
 }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/VertexFunction.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/VertexFunction.cs
@@ -36,7 +36,7 @@ public static class VertexFunction
             upperFrag = trunc(splitOptions / 16);
             splitOptions -= (upperFrag * 16);
             lowerFrag = trunc(splitOptions / 8);
-            splitOptions -= (upperFrag - 8);
+            splitOptions -= (lowerFrag * 8);
             addAlphaFrag = trunc(splitOptions / 4);
             splitOptions -= (addAlphaFrag * 4);
             float topLeft = trunc(splitOptions / 2);

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/VertexFunction.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/VertexFunction.cs
@@ -26,13 +26,17 @@ public static class VertexFunction
                 uvClampMaxFrag.x = mix(uvClampMaxFrag.x, uvFrag.x - uvGap.x, topLeft == 0);
                 uvClampMaxFrag.y = mix(uvClampMaxFrag.y, uvFrag.y - uvGap.y, topLeft == 0);
             }
-";
+    ";
 
     public static string VertexOptionsSet =>
         @"  
             float splitOptions = options;
-            float lightLevelBufferIndex = trunc(splitOptions / 8);
-            splitOptions -= (lightLevelBufferIndex * 8);
+            float lightLevelBufferIndex = trunc(splitOptions / 32);
+            splitOptions -= (lightLevelBufferIndex * 32);
+            upperFrag = trunc(splitOptions / 16);
+            splitOptions -= (upperFrag * 16);
+            lowerFrag = trunc(splitOptions / 8);
+            splitOptions -= (upperFrag - 8);
             addAlphaFrag = trunc(splitOptions / 4);
             splitOptions -= (addAlphaFrag * 4);
             float topLeft = trunc(splitOptions / 2);

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/VertexFunction.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/VertexFunction.cs
@@ -19,12 +19,16 @@ public static class VertexFunction
                 const float VertexGapY = 0.9;
                 ivec2 texSize = textureSize(boundTexture, 0);
                 vec2 uvGap = vec2(VertexGapX / texSize.x, VertexGapY / texSize.y);
+
+                // Account for when z is in between pixel values
+                float minOffsetV = (1 - fract(mixPos.z)) / texSize.y;
+                float maxOffsetV = fract(mixPos.z) / texSize.y;
                 
                 uvClampMinFrag.x = mix(uvClampMinFrag.x, uvFrag.x + uvGap.x, topLeft == 1);
-                uvClampMinFrag.y = mix(uvClampMinFrag.y, uvFrag.y + uvGap.y, topLeft == 1);
+                uvClampMinFrag.y = mix(uvClampMinFrag.y, uvFrag.y + uvGap.y - minOffsetV, topLeft == 1);
 
                 uvClampMaxFrag.x = mix(uvClampMaxFrag.x, uvFrag.x - uvGap.x, topLeft == 0);
-                uvClampMaxFrag.y = mix(uvClampMaxFrag.y, uvFrag.y - uvGap.y, topLeft == 0);
+                uvClampMaxFrag.y = mix(uvClampMaxFrag.y, uvFrag.y - uvGap.y + maxOffsetV, topLeft == 0);
             }
     ";
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Sky/Sphere/SkySphereRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Sky/Sphere/SkySphereRenderer.cs
@@ -53,7 +53,7 @@ public class SkySphereRenderer : IDisposable
     public void Render(RenderInfo renderInfo, SkyOptions options, Vec2F offset)
     {
         m_mode = renderInfo.Config.SkyMode.Value;
-        GL.ActiveTexture(TextureUnit.Texture0);
+        GL.ActiveTexture(BindTextures.BoundTexture);
 
         var skyTexture = m_texture.GetSkyTexture(out var skyTransform);
         skyTransform.Sky.Offset.X += offset.X;
@@ -78,7 +78,7 @@ public class SkySphereRenderer : IDisposable
             return;
 
         m_foregroundProgram.Bind();
-        GL.ActiveTexture(TextureUnit.Texture0);
+        GL.ActiveTexture(BindTextures.BoundTexture);
 
         var foregroundTexture = m_texture.GetForegroundTexture(skyTransform.Foreground);
         if (skyTransform.Foreground.Type == SkyTransformType.Fire)
@@ -195,8 +195,8 @@ public class SkySphereRenderer : IDisposable
         var offset = SkySphereTexture.CalcOffset(skyTexture, skyTransform, m_mode, scaleUV, options);
         var skyHeight = SkySphereTexture.CalcSkyHeight(texture.Dimension.Height, m_mode);
 
-        m_skyProgram.BoundTexture(TextureUnit.Texture0);
-        m_skyProgram.ColormapTexture(TextureUnit.Texture2);
+        m_skyProgram.BoundTexture(BindTextures.BoundTexture);
+        m_skyProgram.ColormapTexture(BindTextures.Colormap);
         m_skyProgram.Mvp(CalculateMvp(renderInfo));
         m_skyProgram.Scale(scaleUV);
         m_skyProgram.FlipU((options & SkyOptions.Flip) != 0);
@@ -234,8 +234,8 @@ public class SkySphereRenderer : IDisposable
         var offset = SkySphereTexture.CalcOffset(foregroundTexture, foregroundTransform, m_mode, scaleUV);
         var textureHeight = SkySphereTexture.CalcSkyHeight(foregroundTexture.GlTexture.Dimension.Height, m_mode);
 
-        m_foregroundProgram.BoundTexture(TextureUnit.Texture0);
-        m_foregroundProgram.ColormapTexture(TextureUnit.Texture2);
+        m_foregroundProgram.BoundTexture(BindTextures.BoundTexture);
+        m_foregroundProgram.ColormapTexture(BindTextures.Colormap);
         m_foregroundProgram.Mvp(CalculateMvp(renderInfo));
         m_foregroundProgram.Scale(scaleUV);
         m_foregroundProgram.FlipU(flipSkyHorizontal);
@@ -276,8 +276,8 @@ public class SkySphereRenderer : IDisposable
         var offset = SkySphereTexture.CalcFireOffset(foregroundTexture, foregroundTransform);
         var textureHeight = SkySphereTexture.CalcSkyHeight(foregroundTexture.GlTexture.Dimension.Height, m_mode);
 
-        m_foregroundProgram.BoundTexture(TextureUnit.Texture0);
-        m_foregroundProgram.ColormapTexture(TextureUnit.Texture2);
+        m_foregroundProgram.BoundTexture(BindTextures.BoundTexture);
+        m_foregroundProgram.ColormapTexture(BindTextures.Colormap);
         m_foregroundProgram.Mvp(CalculateMvp(renderInfo));
         m_foregroundProgram.Scale(scaleUV);
         m_foregroundProgram.FlipU(flipSkyHorizontal);

--- a/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
@@ -25,6 +25,7 @@ public class StaticShader : RenderProgram
     private readonly int m_lightModeLocation;
     private readonly int m_gammaCorrectionLocation;
     private readonly int m_vertexGapClampUV;
+    private readonly int m_planeTypeLocation;
 
     public StaticShader(string name) : base($"WorldStatic - {name}")
     {
@@ -44,6 +45,7 @@ public class StaticShader : RenderProgram
         m_lightModeLocation = Uniforms.GetLocation("lightMode");
         m_gammaCorrectionLocation = Uniforms.GetLocation("gammaCorrection");
         m_vertexGapClampUV = Uniforms.GetLocation("vertexGapClampUV");
+        m_planeTypeLocation = Uniforms.GetLocation("planeType");
     }
 
     public void BoundTexture(TextureUnit unit) => Uniforms.Set(unit, m_boundTextureLocation);
@@ -63,6 +65,7 @@ public class StaticShader : RenderProgram
     public void LightMode(RenderLightMode mode) => Uniforms.Set((int)mode, m_lightModeLocation);
     public void GammaCorrection(float value) => Uniforms.Set(value, m_gammaCorrectionLocation);
     public void VertexGapClampUV(bool value) => Uniforms.Set(value, m_vertexGapClampUV);
+    public void PlaneType(int value) => Uniforms.Set(value, m_planeTypeLocation);
 
     protected override string VertexShader() => @"
         #version 330

--- a/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
@@ -107,9 +107,9 @@ public class StaticShader : RenderProgram
             float lightLevelAddValue = lightLevelAdd - (mapIdFrag * 256);
             mapIdFrag = abs(mapIdFrag);
             
+            vec4 mixPos = vec4(pos, 1.0);
             ${VertexGapSet}
             
-            vec4 mixPos = vec4(pos, 1.0);
             ${VertexLightBuffer}
             ${LightLevelVertexDist}
             ${SectorColorMapVertexFunction}

--- a/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
@@ -83,6 +83,8 @@ public class StaticShader : RenderProgram
         flat out float vertexLightLevelFrag;
         flat out float zPos;
         flat out float mapIdFrag;
+        flat out float upperFrag;
+        flat out float lowerFrag;
         out float depthFrag;
         ${VertexGapVariables}
 
@@ -148,6 +150,8 @@ public class StaticShader : RenderProgram
             flat in float zPos;
             flat in float distFrag;
             flat in float mapIdFrag;
+            flat in float upperFrag;
+            flat in float lowerFrag;
             ${VertexGapVariables}
 
             out vec4 fragColor;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
@@ -25,7 +25,6 @@ public class StaticShader : RenderProgram
     private readonly int m_lightModeLocation;
     private readonly int m_gammaCorrectionLocation;
     private readonly int m_vertexGapClampUV;
-    private readonly int m_planeTypeLocation;
 
     public StaticShader(string name) : base($"WorldStatic - {name}")
     {
@@ -45,7 +44,6 @@ public class StaticShader : RenderProgram
         m_lightModeLocation = Uniforms.GetLocation("lightMode");
         m_gammaCorrectionLocation = Uniforms.GetLocation("gammaCorrection");
         m_vertexGapClampUV = Uniforms.GetLocation("vertexGapClampUV");
-        m_planeTypeLocation = Uniforms.GetLocation("planeType");
     }
 
     public void BoundTexture(TextureUnit unit) => Uniforms.Set(unit, m_boundTextureLocation);
@@ -65,7 +63,6 @@ public class StaticShader : RenderProgram
     public void LightMode(RenderLightMode mode) => Uniforms.Set((int)mode, m_lightModeLocation);
     public void GammaCorrection(float value) => Uniforms.Set(value, m_gammaCorrectionLocation);
     public void VertexGapClampUV(bool value) => Uniforms.Set(value, m_vertexGapClampUV);
-    public void PlaneType(int value) => Uniforms.Set(value, m_planeTypeLocation);
 
     protected override string VertexShader() => @"
         #version 330

--- a/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
@@ -131,6 +131,9 @@ public class StaticShader : RenderProgram
         if (this is StaticPlaneClipShader)
             return PlaneClip.WritePlaneFragFunction();
 
+        if (this is StaticWallClipShader)
+            return PlaneClip.WriteWallFragFunction();
+
         return @"
             #version 330
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
@@ -72,6 +72,7 @@ public class StaticShader : RenderProgram
         layout(location = 2) in float lightLevelAdd;
         layout(location = 3) in float options;
         layout(location = 4) in float colorMapIndex;
+        layout(location = 5) in float mapId;
 
         out vec2 uvFrag;
         flat out float alphaFrag;
@@ -79,6 +80,7 @@ public class StaticShader : RenderProgram
         flat out float colorMapIndexFrag;
         flat out float vertexLightLevelFrag;
         flat out float zPos;
+        flat out float mapIdFrag;
         out float depthFrag;
         ${VertexGapVariables}
 
@@ -94,6 +96,7 @@ public class StaticShader : RenderProgram
 
         void main() {
             uvFrag = uv;
+            mapIdFrag = mapId;
 
             ${VertexOptionsSet}
 
@@ -136,6 +139,7 @@ public class StaticShader : RenderProgram
             flat in float addAlphaFrag;
             flat in float zPos;
             flat in float distFrag;
+            flat in float mapIdFrag;
             ${VertexGapVariables}
 
             out vec4 fragColor;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
@@ -72,7 +72,6 @@ public class StaticShader : RenderProgram
         layout(location = 2) in float lightLevelAdd;
         layout(location = 3) in float options;
         layout(location = 4) in float colorMapIndex;
-        layout(location = 5) in float mapId;
 
         out vec2 uvFrag;
         flat out float alphaFrag;
@@ -96,12 +95,15 @@ public class StaticShader : RenderProgram
 
         void main() {
             uvFrag = uv;
-            mapIdFrag = mapId;
 
             ${VertexOptionsSet}
 
             colorMapIndexFrag = trunc(colorMapIndex / 256);
             vertexLightLevelFrag = colorMapIndex - (colorMapIndexFrag * 256);
+
+            mapIdFrag = trunc(lightLevelAdd / 256);
+            float lightLevelAddValue = lightLevelAdd - (mapIdFrag * 256);
+            mapIdFrag = abs(mapIdFrag);
             
             ${VertexGapSet}
             

--- a/Core/Render/OpenGL/Renderers/Legacy/World/StaticVertex.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/StaticVertex.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 namespace Helion.Render.OpenGL.Renderers.Legacy.World;
 
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public struct StaticVertex(float x, float y, float z, float u, float v, float options, float lightLevelAdd, float colorMapIndex, float mapId)
+public struct StaticVertex(float x, float y, float z, float u, float v, float options, float lightLevelAdd, float colorMapIndex)
 {
     [VertexAttribute("pos", size: 3)]
     public float X = x;
@@ -22,8 +22,5 @@ public struct StaticVertex(float x, float y, float z, float u, float v, float op
     public float Options = options;
 
     [VertexAttribute(required: false)]
-    public float ColoMapIndex = colorMapIndex;
-
-    [VertexAttribute(required: false)]
-    public float MapId = mapId;
+    public float ColorMapIndex = colorMapIndex;
 }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/StaticVertex.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/StaticVertex.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 namespace Helion.Render.OpenGL.Renderers.Legacy.World;
 
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public struct StaticVertex(float x, float y, float z, float u, float v, float options, float lightLevelAdd, float colorMapIndex)
+public struct StaticVertex(float x, float y, float z, float u, float v, float options, float lightLevelAdd, float colorMapIndex, float mapId)
 {
     [VertexAttribute("pos", size: 3)]
     public float X = x;
@@ -23,4 +23,7 @@ public struct StaticVertex(float x, float y, float z, float u, float v, float op
 
     [VertexAttribute(required: false)]
     public float ColoMapIndex = colorMapIndex;
+
+    [VertexAttribute(required: false)]
+    public float MapId = mapId;
 }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/StaticWallClipShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/StaticWallClipShader.cs
@@ -1,0 +1,9 @@
+﻿namespace Helion.Render.OpenGL.Renderers.Legacy.World;
+
+public class StaticWallClipShader : StaticShader
+{
+    public StaticWallClipShader() : base("WallClip")
+    {
+
+    }
+}

--- a/Core/Render/OpenGL/Renderers/Legacy/World/VertexOptions.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/VertexOptions.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System;
+using System.Runtime.CompilerServices;
 
 namespace Helion.Render.OpenGL.Renderers.Legacy.World;
 
@@ -17,6 +18,16 @@ public static class VertexOptions
         // Packs the vertexLightLevel used for UDMF with the colormap index.
         // The static vertex is on the edge of the optimal size for performance so this prevents adding another float prop.
         return vertexLightLevel + 256 * colorMapIndex;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static float LightLevelAdd(int mapId, float lightLevelAdd)
+    {
+        // Packs LightLevelAdd with MapId
+        if (lightLevelAdd < 0)
+            return -(Math.Abs(lightLevelAdd) + 256 * mapId);
+
+        return lightLevelAdd + 256 * mapId;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Core/Render/OpenGL/Renderers/Legacy/World/VertexOptions.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/VertexOptions.cs
@@ -6,10 +6,10 @@ namespace Helion.Render.OpenGL.Renderers.Legacy.World;
 public static class VertexOptions
 {
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static float World(float topLeft, float alpha, float addAlpha, int lightLevelBufferIndex)
+    public static float World(float topLeft, float alpha, float addAlpha, int upper, int lower, int lightLevelBufferIndex)
     {
         // Alpha must be first since it's < 1
-        return alpha + (topLeft * 2) + (addAlpha * 4) + (lightLevelBufferIndex * 8);
+        return alpha + (topLeft * 2) + (addAlpha * 4) + (lower * 8) + (upper * 16) + (lightLevelBufferIndex * 32);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Core/Render/OpenGL/Renderers/TransitionRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/TransitionRenderer.cs
@@ -96,19 +96,19 @@ public class TransitionRenderer : IDisposable
         GL.Viewport(0, 0, targetBuffer.Dimension.Width, targetBuffer.Dimension.Height);
         m_program.Bind();
 
-        GL.ActiveTexture(TextureUnit.Texture0);
+        GL.ActiveTexture(BindTextures.BoundTexture);
         m_startBuffer.ColorAttachment0.Bind();
         if (m_program is MeltTransitionProgram meltProgram)
         {
             // the melt shader uses ticks, so convert [0,1] to [0,42] ticks
             float loopElapsedTicks = progress * 42;
             // TODO: would be nice here to align strips with the virtual res
-            meltProgram.SetUniforms(TextureUnit.Texture0, mat4.Identity, loopElapsedTicks, targetBuffer.Dimension.Width / 4);
+            meltProgram.SetUniforms(BindTextures.BoundTexture, mat4.Identity, loopElapsedTicks, targetBuffer.Dimension.Width / 4);
         }
         else if (m_program is FadeTransitionProgram fadeProgram)
-            fadeProgram.SetUniforms(TextureUnit.Texture0, mat4.Identity, progress);
+            fadeProgram.SetUniforms(BindTextures.BoundTexture, mat4.Identity, progress);
         else
-            m_program.SetUniforms(TextureUnit.Texture0, mat4.Identity);
+            m_program.SetUniforms(BindTextures.BoundTexture, mat4.Identity);
 
         m_vao.Bind();
         m_vbo.DrawArrays();

--- a/Core/Render/Renderer.World.cs
+++ b/Core/Render/Renderer.World.cs
@@ -93,7 +93,7 @@ public partial class Renderer
         {
             const int FloatSize = 4;
             m_lightBufferData = new float[world.Sectors.Count * LightBuffer.BufferSize * FloatSize + (LightBuffer.SectorIndexStart * FloatSize)];
-            m_mapBufferData = new float[world.Sides.Count * FloatSize];
+            m_mapBufferData = new float[world.Lines.Count * FloatSize];
             SetMapDataBuffer(world);
         }
 
@@ -195,21 +195,11 @@ public partial class Renderer
         m_mapDataBuffer.Map(data =>
         {
             float* buffer = (float*)data.ToPointer();
-            for (int i = 0; i < world.Sides.Count; i++)
+            for (int i = 0; i < world.Lines.Count; i++)
             {
-                var side = world.Sides[i];
-                var line = side.Line;
-
-                if (line.Front == side)
-                {
-                    *(Vec2F*)&buffer[i * 4] = side.Line.Segment.Start.Float;
-                    *(Vec2F*)&buffer[i * 4 + 2] = (side.Line.Segment.End - side.Line.Segment.Start).Float;
-                }
-                else
-                {
-                    *(Vec2F*)&buffer[i * 4] = side.Line.Segment.End.Float;
-                    *(Vec2F*)&buffer[i * 4 + 2] = (side.Line.Segment.Start - side.Line.Segment.End).Float;
-                }
+                var line = world.Lines[i];
+                *(Vec2F*)&buffer[i * 4] = line.Segment.Start.Float;
+                *(Vec2F*)&buffer[i * 4 + 2] = line.Segment.Delta.Float;
             }
         });
     }

--- a/Core/Render/Renderer.World.cs
+++ b/Core/Render/Renderer.World.cs
@@ -91,9 +91,7 @@ public partial class Renderer
 
         if (!m_world.SameAsPreviousMap)
         {
-            const int FloatSize = 4;
-            m_lightBufferData = new float[world.Sectors.Count * LightBuffer.BufferSize * FloatSize + (LightBuffer.SectorIndexStart * FloatSize)];
-            m_mapBufferData = new float[world.Lines.Count * FloatSize];
+            m_lightBufferData = new float[world.Sectors.Count * LightBuffer.BufferSize + LightBuffer.SectorIndexStart];
             SetMapDataBuffer(world);
         }
 
@@ -105,11 +103,10 @@ public partial class Renderer
     {
         bool usePalette = ShaderVars.PaletteColorMode;
         // First index will always map to default colormap
-        const int FloatSize = 4;
-        int sectorBufferCount = world.Sectors.Count + 1 * Constants.LightBuffer.BufferSize;
+        int sectorBufferCount = (world.Sectors.Count + 1) * LightBuffer.BufferSize;
         // PaletteColorMode is index to colormap, true color will be RGB mix
         int size = usePalette ? 1 : 3;
-        var sectorBuffer = new float[sectorBufferCount * FloatSize * size];
+        var sectorBuffer = new float[sectorBufferCount * size];
 
         m_sectorColorMapsBuffer?.Dispose();
         m_sectorColorMapsBuffer = new("Sector colormaps", sectorBuffer, usePalette ? SizedInternalFormat.R32f : SizedInternalFormat.Rgb32f, GLInfo.MapPersistentBitSupported);
@@ -172,7 +169,7 @@ public partial class Renderer
             lightBuffer[LightBuffer.DarkIndex] = 0;
             lightBuffer[LightBuffer.FullBrightIndex] = 255;
 
-            for (int i = 0; i < Constants.LightBuffer.ColorMapCount; i++)
+            for (int i = 0; i < LightBuffer.ColorMapCount; i++)
                 lightBuffer[LightBuffer.ColorMapStartIndex + i] =
                     256 - ((LightBuffer.ColorMapCount - i) * 256 / LightBuffer.ColorMapCount);
 
@@ -190,16 +187,20 @@ public partial class Renderer
     public unsafe void SetMapDataBuffer(IWorld world)
     {
         m_mapDataBuffer?.Dispose();
-        m_mapDataBuffer = new("Map data buffer", m_mapBufferData, SizedInternalFormat.Rgba32f, GLInfo.MapPersistentBitSupported);
+        m_mapBufferData = new float[world.Lines.Count * 4];
+        m_mapDataBuffer = new("Map data buffer", m_mapBufferData, SizedInternalFormat.Rgba32f, false);
 
         m_mapDataBuffer.Map(data =>
         {
             float* buffer = (float*)data.ToPointer();
-            for (int i = 0; i < world.Lines.Count; i++)
+            for (int i = 0; i < world.StructLines.Length; i++)
             {
-                var line = world.Lines[i];
-                *(Vec2F*)&buffer[i * 4] = line.Segment.Start.Float;
-                *(Vec2F*)&buffer[i * 4 + 2] = line.Segment.End.Float;
+                ref var line = ref world.StructLines.Data[i];
+                int index = i * 4;
+                buffer[index] = (float)line.Segment.Start.X;
+                buffer[index + 1] = (float)line.Segment.Start.Y;
+                buffer[index + 2] = (float)line.Segment.End.X;
+                buffer[index + 3] = (float)line.Segment.End.Y;
             }
         });
     }

--- a/Core/Render/Renderer.World.cs
+++ b/Core/Render/Renderer.World.cs
@@ -12,6 +12,7 @@ using Helion.Geometry.Vectors;
 using static Helion.Util.Constants;
 using Helion.World.Geometry.Sides;
 using Helion.World.Geometry.Walls;
+using System;
 
 namespace Helion.Render;
 
@@ -24,6 +25,7 @@ public partial class Renderer
     private GLBufferTextureStorage? m_sectorColorMapsBuffer;
 
     private float[] m_lightBufferData = [];
+    private float[] m_mapBufferData = [];
 
     public static int GetLightBufferIndex(Side side, Wall wall, Sector sector)
     {
@@ -92,6 +94,8 @@ public partial class Renderer
         {
             const int FloatSize = 4;
             m_lightBufferData = new float[world.Sectors.Count * LightBuffer.BufferSize * FloatSize + (LightBuffer.SectorIndexStart * FloatSize)];
+            m_mapBufferData = new float[world.Sides.Count * FloatSize * 2];
+            SetMapDataBuffer(world);
         }
 
         SetSectorLightBuffer(world);
@@ -184,6 +188,28 @@ public partial class Renderer
         });
     }
 
+    public unsafe void SetMapDataBuffer(IWorld world)
+    {
+        m_mapDataBuffer?.Dispose();
+        m_mapDataBuffer = new("Map data buffer", m_mapBufferData, SizedInternalFormat.Rg32f, false);
+
+        m_mapDataBuffer.Map(data =>
+        {
+            float* buffer = (float*)data.ToPointer();
+            for (int i = 0; i < world.StructLines.Length; i++)
+            {
+                ref var line = ref world.StructLines.Data[i];
+                var normal = new Vec2F((float)line.Segment.Delta.X, (float)-line.Segment.Delta.Y);
+
+                var length = (float)Math.Sqrt(normal.X * normal.X + normal.Y * normal.Y);
+                normal.X /= length;
+                normal.Y /= length;
+
+                *(Vec2F*)&buffer[i * 2] = normal;
+            }
+        });
+    }
+
     private void World_SectorLightChanged(object? sender, Sector sector)
     {
         m_updateLightSectors.Add(sector);
@@ -214,10 +240,10 @@ public partial class Renderer
         {
             Sector sector = m_updateLightSectors.UpdateSectors[i];
             float level = sector.LightLevel;
-            int index = sector.Id * Constants.LightBuffer.BufferSize + Constants.LightBuffer.SectorIndexStart;
-            lightData[index + Constants.LightBuffer.FloorOffset] = level;
-            lightData[index + Constants.LightBuffer.CeilingOffset] = level;
-            lightData[index + Constants.LightBuffer.WallOffset] = level;
+            int index = sector.Id * LightBuffer.BufferSize + LightBuffer.SectorIndexStart;
+            lightData[index + LightBuffer.FloorOffset] = level;
+            lightData[index + LightBuffer.CeilingOffset] = level;
+            lightData[index + LightBuffer.WallOffset] = level;
         }
 
         m_lightBufferStorage.Unbind();

--- a/Core/Render/Renderer.World.cs
+++ b/Core/Render/Renderer.World.cs
@@ -212,7 +212,7 @@ public partial class Renderer
 
         m_lineHeightsBuffer?.Dispose();
         m_lineHeightsBufferData = new float[world.Lines.Count * 2];
-        m_lineHeightsBuffer = new("Plane data buffer", m_lineHeightsBufferData, SizedInternalFormat.Rg32f, true);
+        m_lineHeightsBuffer = new("Line heights data buffer", m_lineHeightsBufferData, SizedInternalFormat.Rg32f, true);
         m_lineHeightsBuffer.Map(data =>
         {
             float* buffer = (float*)data.ToPointer();
@@ -253,8 +253,10 @@ public partial class Renderer
     {
         UpdateLights();
         UpdateColorMaps();
+        UpdateLineHeights();
         m_updateLightSectors.Clear();
         m_updateColorMapSectors.Clear();
+        m_updateLineHeights.Clear();
     }
 
     private unsafe void UpdateLights()
@@ -317,7 +319,7 @@ public partial class Renderer
                     ceilingZ = Math.Min(ceilingZ, (float)line.Back.Sector.Ceiling.Z);
                 }
 
-                int index = i * 2;
+                int index = line.Id * 2;
                 buffer[index] = floorZ;
                 buffer[index + 1] = ceilingZ;
             }

--- a/Core/Render/Renderer.World.cs
+++ b/Core/Render/Renderer.World.cs
@@ -213,7 +213,7 @@ public partial class Renderer
 
         m_lineHeightsBuffer?.Dispose();
         m_lineHeightsBufferData = new float[world.Lines.Count * 2];
-        m_lineHeightsBuffer = new("Line heights data buffer", m_lineHeightsBufferData, SizedInternalFormat.R32f, true);
+        m_lineHeightsBuffer = new("Line heights data buffer", m_lineHeightsBufferData, SizedInternalFormat.R32f, GLInfo.MapPersistentBitSupported);
         m_lineHeightsBuffer.Map(data =>
         {
             float* buffer = (float*)data.ToPointer();

--- a/Core/Render/Renderer.World.cs
+++ b/Core/Render/Renderer.World.cs
@@ -199,7 +199,7 @@ public partial class Renderer
             {
                 var line = world.Lines[i];
                 *(Vec2F*)&buffer[i * 4] = line.Segment.Start.Float;
-                *(Vec2F*)&buffer[i * 4 + 2] = line.Segment.Delta.Float;
+                *(Vec2F*)&buffer[i * 4 + 2] = line.Segment.End.Float;
             }
         });
     }

--- a/Core/Render/Renderer.World.cs
+++ b/Core/Render/Renderer.World.cs
@@ -4,7 +4,6 @@ using Helion.World.Geometry.Sectors;
 using Helion.World;
 using OpenTK.Graphics.OpenGL;
 using Helion.Render.OpenGL.Textures;
-using Helion.Util;
 using Helion.Render.OpenGL.Util;
 using Helion.Render.OpenGL.Renderers.Legacy.World.Geometry.Static;
 using Helion.Graphics.Palettes;
@@ -12,6 +11,7 @@ using Helion.Geometry.Vectors;
 using static Helion.Util.Constants;
 using Helion.World.Geometry.Sides;
 using Helion.World.Geometry.Walls;
+using System;
 
 namespace Helion.Render;
 
@@ -19,12 +19,14 @@ public partial class Renderer
 {
     private readonly SectorUpdates m_updateLightSectors = new();
     private readonly SectorUpdates m_updateColorMapSectors = new();
+    private readonly SectorUpdates m_updateLineHeights = new();
 
     private GLBufferTextureStorage? m_lightBufferStorage;
     private GLBufferTextureStorage? m_sectorColorMapsBuffer;
 
     private float[] m_lightBufferData = [];
     private float[] m_mapBufferData = [];
+    private float[] m_lineHeightsBufferData = [];
 
     public static int GetLightBufferIndex(Side side, Wall wall, Sector sector)
     {
@@ -73,8 +75,10 @@ public partial class Renderer
     {
         m_updateLightSectors.ClearAndReset();
         m_updateColorMapSectors.ClearAndReset();
+        m_updateLineHeights.ClearAndReset();
         m_updateLightSectors.EnsureCapacity(world.Sectors.Count);
         m_updateColorMapSectors.EnsureCapacity(world.Sectors.Count);
+        m_updateLineHeights.EnsureCapacity(world.Sectors.Count);
 
         m_worldRenderer.UpdateToNewWorld(world);
         m_automapRenderer.UpdateTo(world);
@@ -83,11 +87,13 @@ public partial class Renderer
         {
             m_world.SectorLightChanged -= World_SectorLightChanged;
             m_world.SectorColorMapChanged -= World_SectorColorMapChanged;
+            m_world.SectorMove -= World_SectorMove;
         }
 
         m_world = world;
         m_world.SectorLightChanged += World_SectorLightChanged;
         m_world.SectorColorMapChanged += World_SectorColorMapChanged;
+        m_world.SectorMove += World_SectorMove;
 
         if (!m_world.SameAsPreviousMap)
         {
@@ -187,7 +193,7 @@ public partial class Renderer
     public unsafe void SetMapDataBuffer(IWorld world)
     {
         m_mapDataBuffer?.Dispose();
-        m_mapBufferData = new float[world.Lines.Count * 4];
+        m_mapBufferData = new float[world.Lines.Count * 6];
         m_mapDataBuffer = new("Map data buffer", m_mapBufferData, SizedInternalFormat.Rgba32f, false);
 
         m_mapDataBuffer.Map(data =>
@@ -203,6 +209,29 @@ public partial class Renderer
                 buffer[index + 3] = (float)line.Segment.End.Y;
             }
         });
+
+        m_lineHeightsBuffer?.Dispose();
+        m_lineHeightsBufferData = new float[world.Lines.Count * 2];
+        m_lineHeightsBuffer = new("Plane data buffer", m_lineHeightsBufferData, SizedInternalFormat.Rg32f, true);
+        m_lineHeightsBuffer.Map(data =>
+        {
+            float* buffer = (float*)data.ToPointer();
+            for (int i = 0; i < world.StructLines.Length; i++)
+            {
+                ref var line = ref world.StructLines.Data[i];
+                float floorZ = (float)line.FrontFloorPlane.Z;
+                if (line.BackFloorPlane != null)
+                    floorZ = Math.Max(floorZ, (float)line.BackFloorPlane.Z);
+
+                float ceilingZ = (float)line.FrontCeilingPlane.Z;
+                if (line.BackCeilingPlane != null)
+                    ceilingZ = Math.Min(ceilingZ, (float)line.BackCeilingPlane.Z);
+
+                int index = i * 2;
+                buffer[index] = floorZ;
+                buffer[index + 1] = ceilingZ;
+            }
+        });
     }
 
     private void World_SectorLightChanged(object? sender, Sector sector)
@@ -213,6 +242,11 @@ public partial class Renderer
     private void World_SectorColorMapChanged(object? sender, Sector sector)
     {
         m_updateColorMapSectors.Add(sector);
+    }
+
+    private void World_SectorMove(object? sender, SectorPlane e)
+    {
+        m_updateLineHeights.Add(e.Sector);
     }
 
     private void UpdateBuffers()
@@ -228,12 +262,12 @@ public partial class Renderer
         if (m_updateLightSectors.UpdateSectors.Length == 0 || m_lightBufferStorage == null)
             return;
 
-        GLMappedBuffer<float> lightBuffer = m_lightBufferStorage.GetMappedBufferAndBind();
+        var lightBuffer = m_lightBufferStorage.GetMappedBufferAndBind();
         float* lightData = lightBuffer.MappedMemoryPtr;
 
         for (int i = 0; i < m_updateLightSectors.UpdateSectors.Length; i++)
         {
-            Sector sector = m_updateLightSectors.UpdateSectors[i];
+            var sector = m_updateLightSectors.UpdateSectors[i];
             float level = sector.LightLevel;
             int index = sector.Id * LightBuffer.BufferSize + LightBuffer.SectorIndexStart;
             lightData[index + LightBuffer.FloorOffset] = level;
@@ -249,15 +283,46 @@ public partial class Renderer
         if (m_updateColorMapSectors.UpdateSectors.Length == 0 || m_sectorColorMapsBuffer == null)
             return;
 
-        GLMappedBuffer<float> mappedBuffer = m_sectorColorMapsBuffer.GetMappedBufferAndBind();
+        var mappedBuffer = m_sectorColorMapsBuffer.GetMappedBufferAndBind();
         float* colorMapBuffer = mappedBuffer.MappedMemoryPtr;
 
         for (int i = 0; i < m_updateColorMapSectors.UpdateSectors.Length; i++)
         {
-            Sector sector = m_updateColorMapSectors.UpdateSectors[i];
+            var sector = m_updateColorMapSectors.UpdateSectors[i];
             SetSectorColorMap(colorMapBuffer, sector, sector.Colormap);
         }
 
         m_sectorColorMapsBuffer.Unbind();
+    }
+
+    private unsafe void UpdateLineHeights()
+    {
+        if (m_updateLineHeights.UpdateSectors.Length == 0 || m_lineHeightsBuffer == null)
+            return;
+
+        var mappedBuffer = m_lineHeightsBuffer.GetMappedBufferAndBind();
+        float* buffer = mappedBuffer.MappedMemoryPtr;
+
+        for (int i = 0; i < m_updateLineHeights.UpdateSectors.Length; i++)
+        {
+            var sector = m_updateLineHeights.UpdateSectors[i];
+            for (int j = 0; j < sector.Lines.Count; j++)
+            {
+                var line = sector.Lines[j];
+                float floorZ = (float)line.Front.Sector.Floor.Z;
+                float ceilingZ = (float)line.Front.Sector.Ceiling.Z;
+                if (line.Back != null)
+                {
+                    floorZ = Math.Max(floorZ, (float)line.Back.Sector.Floor.Z);
+                    ceilingZ = Math.Min(ceilingZ, (float)line.Back.Sector.Ceiling.Z);
+                }
+
+                int index = i * 2;
+                buffer[index] = floorZ;
+                buffer[index + 1] = ceilingZ;
+            }
+        }
+
+        m_lineHeightsBuffer.Unbind();
     }
 }

--- a/Core/Render/Renderer.World.cs
+++ b/Core/Render/Renderer.World.cs
@@ -12,6 +12,7 @@ using static Helion.Util.Constants;
 using Helion.World.Geometry.Sides;
 using Helion.World.Geometry.Walls;
 using System;
+using Helion.World.Geometry.Lines;
 
 namespace Helion.Render;
 
@@ -212,26 +213,25 @@ public partial class Renderer
 
         m_lineHeightsBuffer?.Dispose();
         m_lineHeightsBufferData = new float[world.Lines.Count * 2];
-        m_lineHeightsBuffer = new("Line heights data buffer", m_lineHeightsBufferData, SizedInternalFormat.Rg32f, true);
+        m_lineHeightsBuffer = new("Line heights data buffer", m_lineHeightsBufferData, SizedInternalFormat.R32f, true);
         m_lineHeightsBuffer.Map(data =>
         {
             float* buffer = (float*)data.ToPointer();
             for (int i = 0; i < world.StructLines.Length; i++)
             {
                 ref var line = ref world.StructLines.Data[i];
-                float floorZ = (float)line.FrontFloorPlane.Z;
-                if (line.BackFloorPlane != null)
-                    floorZ = Math.Max(floorZ, (float)line.BackFloorPlane.Z);
-
-                float ceilingZ = (float)line.FrontCeilingPlane.Z;
-                if (line.BackCeilingPlane != null)
-                    ceilingZ = Math.Min(ceilingZ, (float)line.BackCeilingPlane.Z);
-
-                int index = i * 2;
-                buffer[index] = floorZ;
-                buffer[index + 1] = ceilingZ;
+                SetLineHeightBuffer(buffer, i, ref line);
             }
         });
+    }
+
+    private static unsafe void SetLineHeightBuffer(float* buffer, int index, ref StructLine line)
+    {
+        var floorZ = (float)line.FrontFloorPlane.Z;
+        if (line.BackFloorPlane != null)
+            floorZ = Math.Max(floorZ, (float)line.BackFloorPlane.Z);
+
+        buffer[index] = floorZ;
     }
 
     private void World_SectorLightChanged(object? sender, Sector sector)
@@ -299,29 +299,26 @@ public partial class Renderer
 
     private unsafe void UpdateLineHeights()
     {
-        if (m_updateLineHeights.UpdateSectors.Length == 0 || m_lineHeightsBuffer == null)
+        if (m_updateLineHeights.UpdateSectors.Length == 0 || m_lineHeightsBuffer == null || m_world == null)
             return;
 
+        var checkCounter = ++WorldStatic.CheckCounter;
         var mappedBuffer = m_lineHeightsBuffer.GetMappedBufferAndBind();
+        var lineArray = m_world.StructLines.Data;
         float* buffer = mappedBuffer.MappedMemoryPtr;
 
         for (int i = 0; i < m_updateLineHeights.UpdateSectors.Length; i++)
         {
             var sector = m_updateLineHeights.UpdateSectors[i];
-            for (int j = 0; j < sector.Lines.Count; j++)
+            for (int j = 0; j < sector.LineIds.Length; j++)
             {
-                var line = sector.Lines[j];
-                float floorZ = (float)line.Front.Sector.Floor.Z;
-                float ceilingZ = (float)line.Front.Sector.Ceiling.Z;
-                if (line.Back != null)
-                {
-                    floorZ = Math.Max(floorZ, (float)line.Back.Sector.Floor.Z);
-                    ceilingZ = Math.Min(ceilingZ, (float)line.Back.Sector.Ceiling.Z);
-                }
+                var lineId = sector.LineIds[j];
+                if (WorldStatic.CheckedLines[lineId] == checkCounter)
+                    continue;
 
-                int index = line.Id * 2;
-                buffer[index] = floorZ;
-                buffer[index + 1] = ceilingZ;
+                ref var line = ref lineArray[lineId];
+                WorldStatic.CheckedLines[lineId] = checkCounter;
+                SetLineHeightBuffer(buffer, lineId, ref line);
             }
         }
 

--- a/Core/Render/Renderer.World.cs
+++ b/Core/Render/Renderer.World.cs
@@ -12,7 +12,6 @@ using Helion.Geometry.Vectors;
 using static Helion.Util.Constants;
 using Helion.World.Geometry.Sides;
 using Helion.World.Geometry.Walls;
-using System;
 
 namespace Helion.Render;
 
@@ -94,7 +93,7 @@ public partial class Renderer
         {
             const int FloatSize = 4;
             m_lightBufferData = new float[world.Sectors.Count * LightBuffer.BufferSize * FloatSize + (LightBuffer.SectorIndexStart * FloatSize)];
-            m_mapBufferData = new float[world.Sides.Count * FloatSize * 2];
+            m_mapBufferData = new float[world.Sides.Count * FloatSize];
             SetMapDataBuffer(world);
         }
 
@@ -191,21 +190,26 @@ public partial class Renderer
     public unsafe void SetMapDataBuffer(IWorld world)
     {
         m_mapDataBuffer?.Dispose();
-        m_mapDataBuffer = new("Map data buffer", m_mapBufferData, SizedInternalFormat.Rg32f, false);
+        m_mapDataBuffer = new("Map data buffer", m_mapBufferData, SizedInternalFormat.Rgba32f, GLInfo.MapPersistentBitSupported);
 
         m_mapDataBuffer.Map(data =>
         {
             float* buffer = (float*)data.ToPointer();
-            for (int i = 0; i < world.StructLines.Length; i++)
+            for (int i = 0; i < world.Sides.Count; i++)
             {
-                ref var line = ref world.StructLines.Data[i];
-                var normal = new Vec2F((float)line.Segment.Delta.X, (float)-line.Segment.Delta.Y);
+                var side = world.Sides[i];
+                var line = side.Line;
 
-                var length = (float)Math.Sqrt(normal.X * normal.X + normal.Y * normal.Y);
-                normal.X /= length;
-                normal.Y /= length;
-
-                *(Vec2F*)&buffer[i * 2] = normal;
+                if (line.Front == side)
+                {
+                    *(Vec2F*)&buffer[i * 4] = side.Line.Segment.Start.Float;
+                    *(Vec2F*)&buffer[i * 4 + 2] = (side.Line.Segment.End - side.Line.Segment.Start).Float;
+                }
+                else
+                {
+                    *(Vec2F*)&buffer[i * 4] = side.Line.Segment.End.Float;
+                    *(Vec2F*)&buffer[i * 4 + 2] = (side.Line.Segment.Start - side.Line.Segment.End).Float;
+                }
             }
         });
     }

--- a/Core/Render/Renderer.cs
+++ b/Core/Render/Renderer.cs
@@ -435,7 +435,7 @@ public partial class Renderer : IDisposable
 
     private void BindMapDataBuffer()
     {
-        m_mapDataBuffer?.BindTexture(TextureUnit.Texture9);
+        m_mapDataBuffer?.BindTexture(BindTextures.MapLineData);
     }
 
     public void PerformThrowableErrorChecks()

--- a/Core/Render/Renderer.cs
+++ b/Core/Render/Renderer.cs
@@ -72,6 +72,7 @@ public partial class Renderer : IDisposable
     private IWorld? m_world;
     private GLBufferTextureStorage? m_colorMapBuffer;
     private GLBufferTextureStorage? m_mapDataBuffer;
+    private GLBufferTextureStorage? m_lineHeightsBuffer;
     private Rectangle m_viewport = new(0, 0, 800, 600);
     private uint[] m_frameBufferPixelData = [];
     private bool m_disposed;
@@ -356,6 +357,7 @@ public partial class Renderer : IDisposable
         BindSectorColorMapBuffer();
         BindLightBuffer();
         BindMapDataBuffer();
+        BindLineHeightsBuffer();
 
         // This has to be tracked beyond just the rendering command, and it
         // also prevents something from going terribly wrong if there is no
@@ -436,6 +438,11 @@ public partial class Renderer : IDisposable
     private void BindMapDataBuffer()
     {
         m_mapDataBuffer?.BindTexture(BindTextures.MapLineData);
+    }
+
+    private void BindLineHeightsBuffer()
+    {
+        m_lineHeightsBuffer?.BindTexture(BindTextures.LineHeights);
     }
 
     public void PerformThrowableErrorChecks()
@@ -753,6 +760,7 @@ public partial class Renderer : IDisposable
         m_sectorColorMapsBuffer?.Dispose();
         m_transitionRenderer?.Dispose();
         m_mapDataBuffer?.Dispose();
+        m_lineHeightsBuffer?.Dispose();
 
         m_disposed = true;
     }

--- a/Core/Render/Renderer.cs
+++ b/Core/Render/Renderer.cs
@@ -71,6 +71,7 @@ public partial class Renderer : IDisposable
 
     private IWorld? m_world;
     private GLBufferTextureStorage? m_colorMapBuffer;
+    private GLBufferTextureStorage? m_mapDataBuffer;
     private Rectangle m_viewport = new(0, 0, 800, 600);
     private uint[] m_frameBufferPixelData = [];
     private bool m_disposed;
@@ -354,6 +355,7 @@ public partial class Renderer : IDisposable
         BindColorMapBuffer();
         BindSectorColorMapBuffer();
         BindLightBuffer();
+        BindMapDataBuffer();
 
         // This has to be tracked beyond just the rendering command, and it
         // also prevents something from going terribly wrong if there is no
@@ -429,6 +431,11 @@ public partial class Renderer : IDisposable
     private void BindLightBuffer()
     {
         m_lightBufferStorage?.BindTexture(TextureUnit.Texture1);
+    }
+
+    private void BindMapDataBuffer()
+    {
+        m_mapDataBuffer?.BindTexture(TextureUnit.Texture9);
     }
 
     public void PerformThrowableErrorChecks()
@@ -745,6 +752,7 @@ public partial class Renderer : IDisposable
         m_lightBufferStorage?.Dispose();
         m_sectorColorMapsBuffer?.Dispose();
         m_transitionRenderer?.Dispose();
+        m_mapDataBuffer?.Dispose();
 
         m_disposed = true;
     }

--- a/Core/Render/Renderer.cs
+++ b/Core/Render/Renderer.cs
@@ -420,17 +420,17 @@ public partial class Renderer : IDisposable
 
     private void BindColorMapBuffer()
     {
-        m_colorMapBuffer?.BindTexture(TextureUnit.Texture2);
+        m_colorMapBuffer?.BindTexture(BindTextures.Colormap);
     }
 
     private void BindSectorColorMapBuffer()
     {
-        m_sectorColorMapsBuffer?.BindTexture(TextureUnit.Texture3);
+        m_sectorColorMapsBuffer?.BindTexture(BindTextures.SectorColormap);
     }
 
     private void BindLightBuffer()
     {
-        m_lightBufferStorage?.BindTexture(TextureUnit.Texture1);
+        m_lightBufferStorage?.BindTexture(BindTextures.SectorLight);
     }
 
     private void BindMapDataBuffer()
@@ -676,7 +676,7 @@ public partial class Renderer : IDisposable
     private void DrawHudImagesIfAnyQueued(Rectangle viewport, ShaderUniforms uniforms)
     {
         // Bind main buffer for fuzz refraction sampling when player has partial invisibility
-        GL.ActiveTexture(TextureUnit.Texture7);
+        GL.ActiveTexture(BindTextures.OpaqueTexture);
         GL.BindTexture(TextureTarget.Texture2D, m_mainFramebuffer.ColorAttachment0.Name);
         m_hudRenderer.Render(viewport, m_mainFramebuffer.Dimension, uniforms);
         m_hudRenderer.Clear();

--- a/Core/World/IWorld.cs
+++ b/Core/World/IWorld.cs
@@ -50,6 +50,7 @@ public interface IWorld : IDisposable
     event EventHandler? OnResetInterpolation;
     event EventHandler<SectorPlane>? SectorMoveStart;
     event EventHandler<SectorPlane>? SectorMoveComplete;
+    event EventHandler<SectorPlane>? SectorMove;
     event EventHandler<SideTextureEvent>? SideTextureChanged;
     event EventHandler<PlaneTextureEvent>? PlaneTextureChanged;
     event EventHandler<Sector>? SectorLightChanged;

--- a/Core/World/WorldBase.cs
+++ b/Core/World/WorldBase.cs
@@ -89,7 +89,7 @@ public abstract partial class WorldBase : IWorld
     public event EventHandler? ClearConsole;
     public event EventHandler? OnResetInterpolation;
     public event EventHandler<SectorPlane>? SectorMoveStart;
-    public event EventHandler<SectorPlane>? SectorMoveComplete;
+    public event EventHandler<SectorPlane>? SectorMoveComplete;    public event EventHandler<SectorPlane>? SectorMove;
     public event EventHandler<SideTextureEvent>? SideTextureChanged;
     public event EventHandler<PlaneTextureEvent>? PlaneTextureChanged;
     public event EventHandler<Sector>? SectorLightChanged;
@@ -2260,6 +2260,8 @@ public abstract partial class WorldBase : IWorld
     {
         if (moveSpecial.IsInitialMove)
             SectorMoveStart?.Invoke(this, moveSpecial.SectorPlane);
+
+        SectorMove?.Invoke(this, moveSpecial.SectorPlane);
 
         return PhysicsManager.MoveSectorZ(speed, destZ, moveSpecial);
     }

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -12,6 +12,7 @@
 - Added fix for sprites clipping through lower floors with emulate vanilla rendering (issue #907)
 - Replaced HUD horizontal margin with HUD width option
 - Added optional health bars to render above shootable things
+- Upgraded vanilla rendering emulation to draw sprites over walls similar to vanilla
 
 ## Bug fixes:
 - Correct missile blocking checks to match original behavior (fixes radsuits blocking rockets etc)


### PR DESCRIPTION
Allows sprites to render over walls in certain scenarios like vanilla.

Tests for when to clip sprites vertically against wall lines are exact to the original.

Rendering sprites over lower textures is emulated but not exact and limited to checking distances to the line. This is limited since the line sampling can only get the closest line to depth. The original engine checked against all segs during BSP traversal, some of which are discarded to depth in the wall clip texture.

Rendering sprites over upper textures is not emulated here because of the previous limitation.