### PR TITLE
Use TargetFramework property from props file rather than in projects

### DIFF
--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -9,8 +9,6 @@
     <ApplicationIcon>helion.ico</ApplicationIcon>
 
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-
-    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(SelfContainedRelease)' == 'true'">

--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -9,7 +9,6 @@
 
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>CS1591;CS8714;CS8500</NoWarn>
-    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <AssemblyVersion>0.9.6.1</AssemblyVersion>
     <FileVersion>0.9.6.1</FileVersion>
     

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -4,7 +4,6 @@
     <IsPackable>false</IsPackable>
     <RootNamespace>Helion.Tests</RootNamespace>
     <AssemblyName>Tests</AssemblyName>
-    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is just housekeeping; shouldn't have any immediate effect.