### PR TITLE
remove duplicate MusicChanger definition

### DIFF
--- a/Assets/Assets/Actors/Doom/Misc.txt
+++ b/Assets/Assets/Actors/Doom/Misc.txt
@@ -33,5 +33,3 @@ ACTOR PointPuller 5002
   +INVISIBLE
   +NOCLIP
 }
-
-ACTOR MusicChanger 14165 {}

--- a/Assets/Assets/Actors/MusicChanger.txt
+++ b/Assets/Assets/Actors/MusicChanger.txt
@@ -4,4 +4,5 @@ actor MusicChanger 14100
     +INVISIBLE
     +NOBLOCKMAP
     +NOGRAVITY
+    +NOSECTOR
 }

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -36,4 +36,5 @@
 - Fix issue where players view can be unintentionally changed from mouse input during melt transition
 - Fix UMAPINFO default mapping for secret exit text levels
 - Fix Doom1 y offset patch fixes for BIGDOOR7 and SKY1 to apply to wads with custom textures
-- Fix crash when setting enum config value from console as a number and it's out of range 
+- Fix crash when setting enum config value from console as a number and it's out of range
+- Fix duplicate MusicChanger definition in assets that was clearing it's flags that allowed it to interact with map scrollers and activate line specials


### PR DESCRIPTION
remove duplicate MusicChanger definition that was overwriting the flags of the correct one, add NOSECTOR