### PR TITLE
cover wall gap fix

### DIFF
--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/CoverWallUtil.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/CoverWallUtil.cs
@@ -1,4 +1,4 @@
-﻿using Helion.Util.Container;
+﻿using Helion.World;
 using Helion.World.Geometry.Sides;
 using Helion.World.Geometry.Walls;
 using Helion.World.Physics;
@@ -7,8 +7,10 @@ namespace Helion.Render.OpenGL.Renderers.Legacy.World.Geometry;
 
 public class CoverWallUtil
 {
-    readonly record struct Heights(int Add, int Sub);
+    readonly record struct Heights(float AddTop, float SubBottom);
     const int ProjectHeight = 8192;
+
+    public static float VertexGap;
 
     public static unsafe void SetCoverWallVertices(Side side, DynamicVertex[] vertices, int index, WallLocation location)
     {
@@ -16,59 +18,28 @@ public class CoverWallUtil
         fixed (DynamicVertex* startVertex = &vertices[index])
         {
             DynamicVertex* v = startVertex;
-            v->Z += heights.Add;
-            v->PrevZ += heights.Add;
+            v->Z += heights.AddTop;
+            v->PrevZ += heights.AddTop;
             v++;
 
-            v->Z -= heights.Sub;
-            v->PrevZ -= heights.Sub;
+            v->Z -= heights.SubBottom;
+            v->PrevZ -= heights.SubBottom;
             v++;
 
-            v->Z += heights.Add;
-            v->PrevZ += heights.Add;
+            v->Z += heights.AddTop;
+            v->PrevZ += heights.AddTop;
             v++;
 
-
-            v->Z -= heights.Sub;
-            v->PrevZ -= heights.Sub;
+            v->Z -= heights.SubBottom;
+            v->PrevZ -= heights.SubBottom;
             v++;
 
-            v->Z += heights.Add;
-            v->PrevZ += heights.Add;
+            v->Z += heights.AddTop;
+            v->PrevZ += heights.AddTop;
             v++;
 
-            v->Z -= heights.Sub;
-            v->PrevZ -= heights.Sub;
-        }
-    }
-
-    public static unsafe void AddCoverWallVertices(Side side, DynamicArray<StaticVertex> staticVertices, DynamicVertex[] vertices, WallLocation location)
-    {
-        var heights = GetProjectHeights(side, location);
-        staticVertices.EnsureCapacity(staticVertices.Length + 6);
-        int staticStartIndex = staticVertices.Length;
-        fixed (DynamicVertex* startVertex = &vertices[0])
-        {
-            DynamicVertex* v = startVertex;
-            staticVertices.Data[staticStartIndex++] = new StaticVertex(v->X, v->Y, v->Z + heights.Add, v->U, v->V,
-                v->Options, v->LightLevelAdd, 0);
-            v++;
-            staticVertices.Data[staticStartIndex++] = new StaticVertex(v->X, v->Y, v->Z - heights.Sub, v->U, v->V,
-                v->Options, v->LightLevelAdd, 0);
-            v++;
-            staticVertices.Data[staticStartIndex++] = new StaticVertex(v->X, v->Y, v->Z + heights.Add, v->U, v->V,
-                v->Options, v->LightLevelAdd, 0);
-            v++;
-            staticVertices.Data[staticStartIndex++] = new StaticVertex(v->X, v->Y, v->Z + heights.Add, v->U, v->V,
-                v->Options, v->LightLevelAdd, 0);
-            v++;
-            staticVertices.Data[staticStartIndex++] = new StaticVertex(v->X, v->Y, v->Z - heights.Sub, v->U, v->V,
-                v->Options, v->LightLevelAdd, 0);
-            v++;
-            staticVertices.Data[staticStartIndex++] = new StaticVertex(v->X, v->Y, v->Z - heights.Sub, v->U, v->V,
-                v->Options, v->LightLevelAdd, 0);
-
-            staticVertices.SetLength(staticVertices.Length + 6);
+            v->Z -= heights.SubBottom;
+            v->PrevZ -= heights.SubBottom;
         }
     }
 
@@ -78,22 +49,22 @@ public class CoverWallUtil
         fixed (DynamicVertex* startVertex = &vertices[0])
         {
             DynamicVertex* v = startVertex;
-            staticVertices[index++] = new StaticVertex(v->X, v->Y, v->Z + heights.Add, v->U, v->V,
+            staticVertices[index++] = new StaticVertex(v->X, v->Y, v->Z + heights.AddTop, v->U, v->V,
                 v->Options, v->LightLevelAdd, 0);
             v++;
-            staticVertices[index++] = new StaticVertex(v->X, v->Y, v->Z - heights.Sub, v->U, v->V,
+            staticVertices[index++] = new StaticVertex(v->X, v->Y, v->Z - heights.SubBottom, v->U, v->V,
                 v->Options, v->LightLevelAdd, 0);
             v++;
-            staticVertices[index++] = new StaticVertex(v->X, v->Y, v->Z + heights.Add, v->U, v->V,
+            staticVertices[index++] = new StaticVertex(v->X, v->Y, v->Z + heights.AddTop, v->U, v->V,
                 v->Options, v->LightLevelAdd, 0);
             v++;
-            staticVertices[index++] = new StaticVertex(v->X, v->Y, v->Z - heights.Sub, v->U, v->V,
+            staticVertices[index++] = new StaticVertex(v->X, v->Y, v->Z - heights.SubBottom, v->U, v->V,
                 v->Options, v->LightLevelAdd, 0);
             v++;
-            staticVertices[index++] = new StaticVertex(v->X, v->Y, v->Z + heights.Add, v->U, v->V,
+            staticVertices[index++] = new StaticVertex(v->X, v->Y, v->Z + heights.AddTop, v->U, v->V,
                 v->Options, v->LightLevelAdd, 0);
             v++;
-            staticVertices[index++] = new StaticVertex(v->X, v->Y, v->Z - heights.Sub, v->U, v->V,
+            staticVertices[index++] = new StaticVertex(v->X, v->Y, v->Z - heights.SubBottom, v->U, v->V,
                 v->Options, v->LightLevelAdd, 0);
         }
     }
@@ -105,10 +76,11 @@ public class CoverWallUtil
             return new Heights(ProjectHeight, ProjectHeight);
 
         // Do not add to upper portion of lower textures, or upper portion of lower textures
+        // Adjust cover wall offsets to not block extra pixels from the the backside
         return new Heights
         (
-            location == WallLocation.Lower ? 0 : ProjectHeight,
-            location == WallLocation.Upper ? 0 : ProjectHeight
+            location == WallLocation.Lower ? WorldStatic.CoverWallOffset : ProjectHeight,
+            location == WallLocation.Upper ? WorldStatic.CoverWallOffset : ProjectHeight
         );
     }
 }

--- a/Core/Render/Renderer.cs
+++ b/Core/Render/Renderer.cs
@@ -118,11 +118,13 @@ public partial class Renderer : IDisposable
         {
             WorldStatic.LineVertexGap = Constants.VertexGapPush;
             WorldStatic.LineVertexOffset = -(float)Constants.VertexGapPush;
+            WorldStatic.CoverWallOffset = -(float)Constants.VertexGapPush * 2;
         }
         else
         {
             WorldStatic.LineVertexGap = 0;
             WorldStatic.LineVertexOffset = 0;
+            WorldStatic.CoverWallOffset = 0;
         }
     }
 

--- a/Core/World/WorldStatic.cs
+++ b/Core/World/WorldStatic.cs
@@ -49,6 +49,7 @@ public static class WorldStatic
     public static int[] CheckedLines = [];
     public static double LineVertexGap = 0;
     public static float LineVertexOffset = 0;
+    public static float CoverWallOffset = 0;
 
     public static EntityDefinition DoomImpBall = EntityDefinition.Default;
     public static EntityDefinition ArachnotronPlasma = EntityDefinition.Default;


### PR DESCRIPTION
adjust cover walls back for gap so sprites behind lower/upper walls don't have pixel rows discarded when they shouldn't