### PR TITLE
line heights interpolation fix

### DIFF
--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
@@ -344,6 +344,7 @@ public class EntityProgram : RenderProgram
         uniform int checkPlaneClip;
         uniform int healthBarMode;
         uniform vec3 viewPos;
+        uniform float timeFrac;
 
         uniform sampler2D planeClipTexture;
         uniform sampler2D wallClipTexture;
@@ -383,7 +384,8 @@ public class EntityProgram : RenderProgram
             
             if (wallClip.r >= 0) {
                 vec4 linePoints = texelFetch(mapDataTexture, int(wallClip.r));
-                float floorHeight = texelFetch(lineHeightsTexture, int(wallClip.r)).r;
+                vec2 floorHeights = texelFetch(lineHeightsTexture, int(wallClip.r)).rg;
+                float floorHeight = mix(floorHeights.r, floorHeights.g, timeFrac);
                 vec2 lineStart = linePoints.rg;
                 vec2 lineEnd = linePoints.ba;
                 vec2 lineDelta = lineEnd - lineStart;

--- a/Core/Render/Renderer.World.cs
+++ b/Core/Render/Renderer.World.cs
@@ -12,7 +12,6 @@ using Helion.World.Geometry.Sides;
 using Helion.World.Geometry.Walls;
 using System;
 using Helion.World.Geometry.Lines;
-using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace Helion.Render;
 
@@ -148,11 +147,19 @@ public partial class Renderer
 
     private unsafe void SetLineHeights(IWorld world, bool alloc)
     {
+        if (!world.Config.Render.VanillaRender)
+        {
+            m_lineHeightsBufferData = [];
+            m_lineHeightsBuffer?.Dispose();
+            m_lineHeightsBuffer = null;
+            return;
+        }
+
         if (alloc || m_lineHeightsBuffer == null)
         {
             m_lineHeightsBuffer?.Dispose();
             m_lineHeightsBufferData = new float[world.Lines.Count * 2];
-            m_lineHeightsBuffer = new("Line heights data buffer", m_lineHeightsBufferData, SizedInternalFormat.R32f, GLInfo.MapPersistentBitSupported);
+            m_lineHeightsBuffer = new("Line heights data buffer", m_lineHeightsBufferData, SizedInternalFormat.Rg32f, GLInfo.MapPersistentBitSupported);
 
             m_lineHeightsBuffer.Map(data =>
             {
@@ -268,10 +275,15 @@ public partial class Renderer
 
     private static unsafe void SetLineHeightBuffer(float* buffer, int index, ref StructLine line)
     {
+        var prevFloorZ = (float)line.FrontFloorPlane.PrevZ;
         var floorZ = (float)line.FrontFloorPlane.Z;
         if (line.BackFloorPlane != null)
+        {
+            prevFloorZ = Math.Max(prevFloorZ, (float)line.BackFloorPlane.PrevZ);
             floorZ = Math.Max(floorZ, (float)line.BackFloorPlane.Z);
+        }
 
+        buffer[index] = prevFloorZ;
         buffer[index] = floorZ;
     }
 


### PR DESCRIPTION
interpolate floor height in shader to fix sprites on the edge of moving floors being clipped incorrectly