### PR TITLE
Add basic Discord integration

### DIFF
--- a/Client/Client.Commands.cs
+++ b/Client/Client.Commands.cs
@@ -400,29 +400,13 @@ public partial class Client
     [ConsoleCommand("printmap", "Prints the current map")]
     private void PrintMap(ConsoleCommandEventArgs args)
     {
-        var map = m_layerManager.WorldLayer?.CurrentMap;
-        if (map != null)
-            HelionLog.Info(map.GetDisplayNameWithPrefix(m_archiveCollection.Language));
-        else
-            HelionLog.Info("No map loaded");
+        HelionLog.Info(GetMapName() ?? "No map loaded");
     }
 
     [ConsoleCommand("printgame", "Prints the current game title (or WAD filename)")]
     private void PrintGame(ConsoleCommandEventArgs args)
     {
-        // try gameconf (rare)
-        string? title = m_archiveCollection.Definitions.GameConfDefinition.Data?.Title;
-        // then gameinfo (uncommon)
-        title ??= m_archiveCollection.Definitions.GameInfoDefinition.StartupTitle;
-        // fall back to WAD title
-        if (title == null)
-        {
-            var map = m_layerManager.WorldLayer?.CurrentMap;
-            if (map != null)
-                title = Path.GetFileName(m_archiveCollection.FindMap(map.MapName)?.ArchivePath);
-        }
-        if (title != null)
-            HelionLog.Info(title);
+        HelionLog.Info(GetGameName() ?? "No map loaded");
     }
 
     [ConsoleCommand("startGame", "Starts a new game")]

--- a/Client/Client.Initialize.cs
+++ b/Client/Client.Initialize.cs
@@ -80,7 +80,11 @@ public partial class Client
                 ClearStatsFile();
 
             m_discord.SetEnabled(m_config.Game.DiscordIntegration);
-            m_config.Game.DiscordIntegration.OnChanged += (s, e) => m_discord.SetEnabled(e);
+            m_config.Game.DiscordIntegration.OnChanged += (s, e) =>
+            {
+                m_discord.SetEnabled(e);
+                m_discord.UpdateRichPresence(GetGameName(), GetMapName());
+            };
 
             if (m_commandLineArgs.LoadGame != null)
             {

--- a/Client/Client.Initialize.cs
+++ b/Client/Client.Initialize.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using DiscordRPC;
 using Helion.Layer.Consoles;
 using Helion.Layer.Images;
 using Helion.Layer.IwadSelection;
@@ -14,7 +13,6 @@ using Helion.Resources.IWad;
 using Helion.Util;
 using Helion.Util.CommandLine;
 using Helion.Util.Configs.Components;
-using Helion.Util.Configs.Impl;
 using Helion.Util.Consoles;
 using Helion.World;
 using Helion.World.Util;
@@ -81,9 +79,8 @@ public partial class Client
             if (m_commandLineArgs.LevelStat)
                 ClearStatsFile();
 
-            InitializeDiscordClient();
-            UpdateDiscordRichPresence();
-            m_config.Game.DiscordIntegration.OnChanged += DiscordIntegration_OnChanged;
+            m_discord.SetEnabled(m_config.Game.DiscordIntegration);
+            m_config.Game.DiscordIntegration.OnChanged += (s, e) => m_discord.SetEnabled(e);
 
             if (m_commandLineArgs.LoadGame != null)
             {
@@ -311,25 +308,5 @@ public partial class Client
             world.Player.PitchRadians = MathHelper.ToRadians(args.SetPitch.Value);
             world.Player.ResetInterpolation();
         }
-    }
-
-    private void InitializeDiscordClient()
-    {
-        if (!m_config.Game.DiscordIntegration)
-            return;
-        m_discordClient ??= new DiscordRpcClient("1367261916359299102");
-        // discordRpcClientclient.Logger = new ConsoleLogger() { Level = DiscordRPC.Logging.LogLevel.Warning };
-        m_discordClient.Initialize();
-    }
-
-    private void DiscordIntegration_OnChanged(object? sender, bool enabled)
-    {
-        if (enabled)
-        {
-            InitializeDiscordClient();
-            UpdateDiscordRichPresence();
-        }
-        else
-            DisableDiscord();
     }
 }

--- a/Client/Client.Initialize.cs
+++ b/Client/Client.Initialize.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using DiscordRPC;
 using Helion.Layer.Consoles;
 using Helion.Layer.Images;
 using Helion.Layer.IwadSelection;
@@ -13,6 +14,7 @@ using Helion.Resources.IWad;
 using Helion.Util;
 using Helion.Util.CommandLine;
 using Helion.Util.Configs.Components;
+using Helion.Util.Configs.Impl;
 using Helion.Util.Consoles;
 using Helion.World;
 using Helion.World.Util;
@@ -78,6 +80,10 @@ public partial class Client
 
             if (m_commandLineArgs.LevelStat)
                 ClearStatsFile();
+
+            InitializeDiscordClient();
+            UpdateDiscordRichPresence();
+            m_config.Game.DiscordIntegration.OnChanged += DiscordIntegration_OnChanged;
 
             if (m_commandLineArgs.LoadGame != null)
             {
@@ -305,5 +311,25 @@ public partial class Client
             world.Player.PitchRadians = MathHelper.ToRadians(args.SetPitch.Value);
             world.Player.ResetInterpolation();
         }
+    }
+
+    private void InitializeDiscordClient()
+    {
+        if (!m_config.Game.DiscordIntegration)
+            return;
+        m_discordClient ??= new DiscordRpcClient("1367261916359299102");
+        // discordRpcClientclient.Logger = new ConsoleLogger() { Level = DiscordRPC.Logging.LogLevel.Warning };
+        m_discordClient.Initialize();
+    }
+
+    private void DiscordIntegration_OnChanged(object? sender, bool enabled)
+    {
+        if (enabled)
+        {
+            InitializeDiscordClient();
+            UpdateDiscordRichPresence();
+        }
+        else
+            DisableDiscord();
     }
 }

--- a/Client/Client.cs
+++ b/Client/Client.cs
@@ -385,10 +385,11 @@ public partial class Client : IDisposable, IInputManagement
         m_levelChangeEvent = LevelChangeEvent.Default;
         PlayTransition();
         UpdateVolume();
-        m_discord.UpdateRichPresence(GetGameName(), GetMapName());
 
         m_onLoadMapComplete?.OnComplete(m_onLoadMapComplete.CompleteParam);
         m_onLoadMapComplete = null;
+
+        m_discord.UpdateRichPresence(GetGameName(), GetMapName());
 
         GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, false);
         GCUtil.SetGameplayLatencyMode();

--- a/Client/Client.cs
+++ b/Client/Client.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
+using DiscordRPC;
 using Helion.Audio;
 using Helion.Audio.Impl;
 using Helion.Audio.Sounds;
@@ -71,6 +72,7 @@ public partial class Client : IDisposable, IInputManagement
     private OnLoadMapComplete? m_onLoadMapComplete;
     private LoadMapResult? m_loadMapResult;
     private QueueLoadMapParams? m_queueMapLoad;
+    private DiscordRpcClient? m_discordClient;
 
     record struct VersionTest(int Major, int Minor);
     private static readonly VersionTest[] Versions =
@@ -384,6 +386,7 @@ public partial class Client : IDisposable, IInputManagement
         m_levelChangeEvent = LevelChangeEvent.Default;
         PlayTransition();
         UpdateVolume();
+        UpdateDiscordRichPresence();
 
         m_onLoadMapComplete?.OnComplete(m_onLoadMapComplete.CompleteParam);
         m_onLoadMapComplete = null;
@@ -632,5 +635,47 @@ public partial class Client : IDisposable, IInputManagement
     {
         if (e.Success)
             m_lastWorldModel = e.WorldModel;
+    }
+
+    private string? GetGameName()
+    {
+        // try gameconf (rare)
+        string? title = m_archiveCollection.Definitions.GameConfDefinition.Data?.Title;
+        // then gameinfo (uncommon)
+        if (string.IsNullOrWhiteSpace(title))
+            title = m_archiveCollection.Definitions.GameInfoDefinition.StartupTitle;
+        // fall back to WAD title
+        if (string.IsNullOrWhiteSpace(title))
+        {
+            var map = m_layerManager.WorldLayer?.CurrentMap;
+            if (map != null)
+                title = Path.GetFileName(m_archiveCollection.FindMap(map.MapName)?.ArchivePath);
+        }
+        return title;
+    }
+
+    private string? GetMapName()
+    {
+        var map = m_layerManager.WorldLayer?.CurrentMap;
+        if (map != null)
+            return map.GetDisplayNameWithPrefix(m_archiveCollection.Language);
+        return null;
+    }
+
+    private void UpdateDiscordRichPresence()
+    {
+        if (m_discordClient == null)
+            InitializeDiscordClient();
+
+        m_discordClient?.SetPresence(new RichPresence()
+        {
+            Details = GetGameName(),
+            State = GetMapName(),
+        });
+    }
+
+    private void DisableDiscord()
+    {
+        m_discordClient?.Deinitialize();
     }
 }

--- a/Client/Client.cs
+++ b/Client/Client.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
-using DiscordRPC;
 using Helion.Audio;
 using Helion.Audio.Impl;
 using Helion.Audio.Sounds;
@@ -64,6 +63,7 @@ public partial class Client : IDisposable, IInputManagement
     private readonly Profiler m_profiler = new();
     private readonly Ticker m_ticker = new(Constants.TicksPerSecond);
     private readonly SaveGameScreenshotGenerator m_screenshotGenerator;
+    private readonly DiscordHandler m_discord = new();
     private bool m_disposed;
     private bool m_takeScreenshot;
     private bool m_loadComplete;
@@ -72,7 +72,6 @@ public partial class Client : IDisposable, IInputManagement
     private OnLoadMapComplete? m_onLoadMapComplete;
     private LoadMapResult? m_loadMapResult;
     private QueueLoadMapParams? m_queueMapLoad;
-    private DiscordRpcClient? m_discordClient;
 
     record struct VersionTest(int Major, int Minor);
     private static readonly VersionTest[] Versions =
@@ -386,7 +385,7 @@ public partial class Client : IDisposable, IInputManagement
         m_levelChangeEvent = LevelChangeEvent.Default;
         PlayTransition();
         UpdateVolume();
-        UpdateDiscordRichPresence();
+        m_discord.UpdateRichPresence(GetGameName(), GetMapName());
 
         m_onLoadMapComplete?.OnComplete(m_onLoadMapComplete.CompleteParam);
         m_onLoadMapComplete = null;
@@ -660,22 +659,5 @@ public partial class Client : IDisposable, IInputManagement
         if (map != null)
             return map.GetDisplayNameWithPrefix(m_archiveCollection.Language);
         return null;
-    }
-
-    private void UpdateDiscordRichPresence()
-    {
-        if (m_discordClient == null)
-            InitializeDiscordClient();
-
-        m_discordClient?.SetPresence(new RichPresence()
-        {
-            Details = GetGameName(),
-            State = GetMapName(),
-        });
-    }
-
-    private void DisableDiscord()
-    {
-        m_discordClient?.Deinitialize();
     }
 }

--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -67,6 +67,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="DiscordRichPresence" Version="1.2.1.24" />
     <PackageReference Include="OpenTK" Version="4.7.4" />
     <PackageReference Include="Helion.NFluidsynth" Version="1.0.0.1" />
     <PackageReference Include="Helion.SDLControllerWrapper" Version="1.2.0.1" />

--- a/Client/DiscordHandler.cs
+++ b/Client/DiscordHandler.cs
@@ -1,0 +1,48 @@
+using DiscordRPC;
+using DiscordRPC.Logging;
+
+namespace Helion.Client;
+
+public class DiscordHandler
+{
+    private const string AppId = "1367261916359299102";
+    private DiscordRpcClient? m_client;
+
+    private void Initialize()
+    {
+        if (m_client != null)
+            return;
+        m_client = new DiscordRpcClient(AppId);
+        m_client.Logger = new ConsoleLogger() { Level = LogLevel.Warning };
+        m_client.Initialize();
+        UpdateRichPresence();
+    }
+
+    private void Deinitialize()
+    {
+        m_client?.Dispose();
+        m_client = null;
+    }
+
+    public void SetEnabled(bool enabled)
+    {
+        if (enabled)
+            Initialize();
+        else
+            Deinitialize();
+    }
+
+    public void UpdateRichPresence(string? gameName = null, string? mapName = null)
+    {
+        if (m_client == null || !m_client.IsInitialized)
+            return;
+
+        m_client.SetPresence(new RichPresence()
+        {
+            Details = gameName,
+            State = mapName,
+        });
+    }
+
+    ~DiscordHandler() => Deinitialize();
+}

--- a/Client/DiscordHandler.cs
+++ b/Client/DiscordHandler.cs
@@ -18,7 +18,7 @@ public class DiscordHandler
         UpdateRichPresence();
     }
 
-    private void Deinitialize()
+    private void Dispose()
     {
         m_client?.Dispose();
         m_client = null;
@@ -29,7 +29,7 @@ public class DiscordHandler
         if (enabled)
             Initialize();
         else
-            Deinitialize();
+            Dispose();
     }
 
     public void UpdateRichPresence(string? gameName = null, string? mapName = null)
@@ -44,5 +44,5 @@ public class DiscordHandler
         });
     }
 
-    ~DiscordHandler() => Deinitialize();
+    ~DiscordHandler() => Dispose();
 }

--- a/Core/Util/Configs/Components/ConfigGame.cs
+++ b/Core/Util/Configs/Components/ConfigGame.cs
@@ -105,6 +105,10 @@ public class ConfigGame : ConfigElement<ConfigGame>
     [OptionMenu(OptionSectionType.General, "RNG Method", spacer: true)]
     public readonly ConfigValue<RngMethod> Rng = new(RngMethod.Boom);
 
+    [ConfigInfo("Shows the currently played WAD/map in Discord.")]
+    [OptionMenu(OptionSectionType.General, "Discord Integration", spacer: true)]
+    public readonly ConfigValue<bool> DiscordIntegration = new(true);
+
     // Non-menu items
     [ConfigInfo("Write stats to levelstat.txt.", save: false)]
     public readonly ConfigValue<bool> LevelStat = new(false);

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -5,6 +5,7 @@
 - UDMF implementation
 - User data folder (config, save games, etc.) now defaults to `(user)/Saved Games/Helion` on Windows. The previous "portable mode" behavior of storing user data in the Helion folder is used if a `config.ini` file exists in the Helion folder, or if `-portable` is passed as a launch parameter.
 - Improvements to initial map load times
+- Added optional Discord rich presence integration
 - Line contrast mode (off, vanilla, smooth)
 - Calculate locked key door color by using key icon image
 - Added pixel gap correction to rendering that is on by default. Prevents most pixel gap problems caused by floating point precision

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -5,7 +5,7 @@
 - UDMF implementation
 - User data folder (config, save games, etc.) now defaults to `(user)/Saved Games/Helion` on Windows. The previous "portable mode" behavior of storing user data in the Helion folder is used if a `config.ini` file exists in the Helion folder, or if `-portable` is passed as a launch parameter.
 - Improvements to initial map load times
-- Added optional Discord rich presence integration
+- Added Discord rich presence integration (can be disabled)
 - Line contrast mode (off, vanilla, smooth)
 - Calculate locked key door color by using key icon image
 - Added pixel gap correction to rendering that is on by default. Prevents most pixel gap problems caused by floating point precision


### PR DESCRIPTION
Adds a Discord rich presence integration, enabled by default. Toggleable in the Game options.

Uses the `printgame` and `printmap` commands to set the status:

![image](https://github.com/user-attachments/assets/3363ac81-bca0-4ffb-aa9b-5ec73c5d3f75)

For most WADs, printgame will only show the filename. For gameconf WADs and any that set the GZDoom startup title, it will show a proper title instead.

Will only send a new status when a map changes (or it's toggled back on), this won't say things like "in a menu".

App creation was simple, I created an app and then added an icon (PNG converted from the bundled .ico, could possibly use a higher res one), no other configuration. I did add it to a team so that other devs can administer the app (joining a team requires enabling 2FA).