### PR TITLE
Transfer heights transition fix

### DIFF
--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
@@ -592,12 +592,13 @@ public class GeometryRenderer : IDisposable
             var visibility = GetSideVisibility(side, otherSide, facingSector, otherSector);
             if ((visibility & SideTexture.Upper) == 0 || (visibility & SideTexture.Lower) == 0)
             {
+                var bufferCoverWall = m_worldDataManager.BufferCoverWalls;
                 SetBufferCoverWall(true);
                 // Need to copy since the vertices may be part of member variable cache
                 for (int i = 0; i < midTexVertices.Length; i++) 
                     m_coverWallVertices[i] = midTexVertices[i];
                 RenderMidTexCoverWalls(side, facingSector, otherSector, m_coverWallVertices, visibility, m_renderCoverWallAction);
-                SetBufferCoverWall(false);
+                SetBufferCoverWall(bufferCoverWall);
             }
         }
     }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
@@ -1355,6 +1355,7 @@ public class GeometryRenderer : IDisposable
             m_ceilingVertexLookupInvalidated.SetAll(true);
         }
         Portals.SetTransferHeightView(view);
+        SetBufferCoverWall(true);
     }
 
     public void SetBuffer(bool set) => m_buffer = set;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -47,6 +47,7 @@ public class LegacyWorldRenderer : WorldRenderer
     private bool m_occlude;
     private bool m_vanillaRender;
     private bool m_renderStatic;
+    private bool m_lastRenderStatic;
     private bool m_pixelGapCorrection;
     private int m_lastTicker = -1;
     private Entity? m_viewerEntity;
@@ -125,7 +126,7 @@ public class LegacyWorldRenderer : WorldRenderer
 
     private void IterateBlockmap(IWorld world, RenderInfo renderInfo)
     {
-        bool shouldRender = m_lastTicker != world.GameTicker;
+        bool shouldRender = m_lastTicker != world.GameTicker || m_renderStatic != m_lastRenderStatic;
         if (!shouldRender)
             return;
 
@@ -268,6 +269,7 @@ public class LegacyWorldRenderer : WorldRenderer
     {
         // If the transfer height view is not the middle then the cached static geometry cannot be used.
         // Render all sectors dynamically instead.
+        m_lastRenderStatic = m_renderStatic;
         m_renderStatic = renderInfo.TransferHeightView == TransferHeightView.Middle;
         Clear(world, renderInfo);
 


### PR DESCRIPTION
recalculate rendering when switching transfer heights positions between game ticks

restore buffer cover wall to original value since it can be true for transfer heights dynamic rendering