### PR TITLE
Minor dependency cleanup

### DIFF
--- a/Client/Music/MusicPlayer.cs
+++ b/Client/Music/MusicPlayer.cs
@@ -11,6 +11,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -18,14 +19,14 @@ public class MusicPlayer : IMusicPlayer
 {
     private static readonly Logger Log = LogManager.GetCurrentClassLogger();
 
-    private uint m_lastDataHash;
+    private UInt128 m_lastDataHash;
     private bool m_disposed;
 
     private readonly PathsManager m_pathsManager;
     private readonly ConfigAudio m_configAudio;
     private readonly ArchiveCollection m_archiveCollection;
     private readonly ConcurrentQueue<PlayParams> m_playQueue = [];
-    private readonly Dictionary<uint, byte[]> m_convertedMus = [];
+    private readonly Dictionary<UInt128, byte[]> m_convertedMus = [];
     private readonly CancellationTokenSource m_cancelPlayQueue = new();
     private readonly Task m_playQueueTask;
     private Thread? m_playStartThread;
@@ -35,6 +36,7 @@ public class MusicPlayer : IMusicPlayer
     private PlayParams? m_currentTrack;
     private bool m_enabled = true;
     private const string DefaultSoundFont = "SoundFonts/Default.sf2";
+    private MD5 m_md5 = MD5.Create();
 
     public MusicPlayer(PathsManager pathsManager, ConfigAudio configAudio, ArchiveCollection archiveCollection)
     {
@@ -188,7 +190,8 @@ public class MusicPlayer : IMusicPlayer
         m_currentTrack = playParams;
         var data = playParams.Data;
         var options = playParams.Options;
-        uint hash = data.CalculateCrc32();
+        UInt128 hash = BitConverter.ToUInt128(m_md5.ComputeHash(data));
+
         if ((options & MusicPlayerOptions.IgnoreAlreadyPlaying) != 0)
         {
             if (hash == m_lastDataHash)
@@ -290,6 +293,7 @@ public class MusicPlayer : IMusicPlayer
         m_playQueueTask.Wait(1000);
 
         m_zMusicPlayer.Dispose();
+        m_md5.Dispose();
         m_disposed = true;
     }
 

--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -21,16 +21,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Crc32.NET" Version="1.2.0" />
     <PackageReference Include="GlmSharp-netstandard" Version="0.9.8.1" />
-    <PackageReference Include="ini-parser-net8" Version="2.6.2.1" />
+    <PackageReference Include="Helion.TextCopyLite" Version="1.0.0" />
     <PackageReference Include="NAudio.Core" Version="2.2.1" />
     <PackageReference Include="NLog" Version="6.0.0-preview1" />
     <PackageReference Include="OpenTK.Graphics" Version="4.7.4" />
     <PackageReference Include="OpenTK.OpenAL" Version="4.7.4" />
     <PackageReference Include="OpenTK.Windowing.Common" Version="4.7.4" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.4" />
-    <PackageReference Include="TextCopy" Version="6.2.1" />
+    <PackageReference Include="ini-parser-net8" Version="2.6.2.1" />
     <PackageReference Include="xBRZNet" Version="1.2.0" />
     <PackageReference Include="zdbspSharp" Version="1.0.5" />
   </ItemGroup>

--- a/Core/Layer/Consoles/ConsoleLayer.Input.cs
+++ b/Core/Layer/Consoles/ConsoleLayer.Input.cs
@@ -11,14 +11,13 @@ using Helion.World.Cheats;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using TextCopy;
+using TextCopyLite;
 
 namespace Helion.Layer.Consoles;
 
 public partial class ConsoleLayer
 {
     private const int NoInputMessageIndex = -1;
-    private static readonly Clipboard Clipboard = new Clipboard();
 
     private readonly List<string> m_bestOptions = new();
     private DateTime m_lastTabTime = DateTime.Now;

--- a/Core/Util/Extensions/ArrayExtensions.cs
+++ b/Core/Util/Extensions/ArrayExtensions.cs
@@ -1,4 +1,3 @@
-using Force.Crc32;
 using Helion.Util.Container;
 using Helion.Window.Input;
 
@@ -19,16 +18,6 @@ public static class ArrayExtensions
     {
         for (int i = 0; i < array.Length; i++)
             array[i] = element;
-    }
-
-    /// <summary>
-    /// Calculates the CRC32 hash of a bunch of bytes.
-    /// </summary>
-    /// <param name="bytes">The bytes to hash.</param>
-    /// <returns>The hashed uint.</returns>
-    public static uint CalculateCrc32(this byte[] bytes)
-    {
-        return Crc32Algorithm.Compute(bytes);
     }
 
     public static bool Contains(this DynamicArray<Key> keys, Key key)


### PR DESCRIPTION
1.  Use a "lite" version of TextCopy that only implements basic Windows and Linux clipboard support--the original was dragging in DependencyInjection and some other silly stuff
2.  Replace CRC32.NET with built-in hashing function calls