### PR TITLE
underwater transferheights noblockmap fix

### DIFF
--- a/Core/World/Special/Specials/ScrollSpecial.cs
+++ b/Core/World/Special/Specials/ScrollSpecial.cs
@@ -271,7 +271,7 @@ public class ScrollSpecial : ISpecial
 
     private void ScrollPlane(SectorPlane sectorPlane, double x, double y)
     {
-        ref RenderOffsets scroll = ref sectorPlane.RenderOffsets;
+        ref var scroll = ref sectorPlane.RenderOffsets;
         if (m_type == ScrollType.Scroll)
         {
             if (x == 0 && y == 0)
@@ -291,22 +291,23 @@ public class ScrollSpecial : ISpecial
         }
         else if (m_type == ScrollType.Carry && sectorPlane == sectorPlane.Sector.Floor)
         {
-            LinkableNode<Entity>? node = sectorPlane.Sector.Entities.Head;
+            var node = sectorPlane.Sector.Entities.Head;
             while (node != null)
             {
-                Entity entity = node.Value;
+                var entity = node.Value;
                 node = node.Next;
-                
-                // Boom would carry anything that was considered 'underwater'
-                double waterHeight = double.MinValue;
-                if (sectorPlane.Sector.TransferHeights != null)
-                    waterHeight = sectorPlane.Sector.TransferHeights.ControlSector.Floor.Z > sectorPlane.Sector.Floor.Z ?
-                        sectorPlane.Sector.TransferHeights.ControlSector.Floor.Z : double.MinValue;
 
-                if (entity.Flags.NoClip)
+                if (entity.Flags.NoClip || entity.Flags.NoBlockmap)
                     continue;
+
+                // Boom would carry anything that was considered 'underwater'
+                var waterHeight = double.MinValue;
+                var transfer = sectorPlane.Sector.TransferHeights;
+                if (transfer != null)
+                    waterHeight = transfer.ControlSector.Floor.Z > sectorPlane.Sector.Floor.Z ?
+                        transfer.ControlSector.Floor.Z : double.MinValue;
                 
-                if (entity.Position.Z >= waterHeight && (entity.Flags.NoBlockmap || entity.Flags.NoGravity || !entity.OnGround || !entity.OnSectorFloorZ(sectorPlane.Sector)))
+                if (entity.Position.Z >= waterHeight && (entity.Flags.NoGravity || !entity.OnGround || !entity.OnSectorFloorZ(sectorPlane.Sector)))
                     continue;
 
                 entity.Velocity.X += x;

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -52,3 +52,4 @@
 - Automatically line wrap custom quit messages
 - Fix issue with texture buffers not being uploaded on resize that could causing issues with rendering after sector movement
 - Fix custom sndinfo definitions not removing random flag from base sndinfo
+- Fix things with no blockmap flag (teleport destinations) being moved in transfer heights sectors considered underwater

--- a/Tests/Unit/GameAction/Boom/BoomActions_ScrollingFloorPhysics.cs
+++ b/Tests/Unit/GameAction/Boom/BoomActions_ScrollingFloorPhysics.cs
@@ -57,16 +57,16 @@ public partial class BoomActions
         World.EntityManager.Destroy(rocket);
     }
 
-    [Fact(DisplayName = "Rocket that is considered underwater should move with scrolling floor")]
+    [Fact(DisplayName = "Thing that is considered underwater should move with scrolling floor")]
     public void ScrollingFloorUnderwater()
     {
         var scrollSector = GameActions.GetSectorByTag(World, 10);
-        var rocket = GameActions.CreateEntity(World, "Rocket", (-192, 736, 0));
+        var rocket = GameActions.CreateEntity(World, "LostSoul", (-192, 736, 0));
         rocket.Sector.Should().Be(scrollSector);
 
         GameActions.TickWorld(World, 1);
 
-        rocket.Velocity.Should().Be(Vec3D.Zero);
+        rocket.Velocity.XY.Should().Be(Vec2D.Zero);
 
         rocket.UnlinkFromWorld();
         rocket.Position = (-192, 736, -48);
@@ -75,9 +75,33 @@ public partial class BoomActions
         GameActions.TickWorld(World, 1);
 
         rocket.OnGround.Should().BeFalse();
-        rocket.Velocity.Should().NotBe(Vec3D.Zero);
+        rocket.Velocity.XY.Should().NotBe(Vec2D.Zero);
 
         World.EntityManager.Destroy(rocket);
+    }
+
+    [Fact(DisplayName = "NoBlockmap thing that is considered underwater should not move with scrolling floor")]
+    public void ScrollingFloorUnderwaterNoBlockmap()
+    {
+        var scrollSector = GameActions.GetSectorByTag(World, 10);
+        var teleport = GameActions.CreateEntity(World, "Rocket", (-192, 736, 0));
+        teleport.Flags.NoBlockmap.Should().BeTrue();
+        teleport.Sector.Should().Be(scrollSector);
+
+        GameActions.TickWorld(World, 1);
+
+        teleport.Velocity.XY.Should().Be(Vec2D.Zero);
+
+        teleport.UnlinkFromWorld();
+        teleport.Position = (-192, 736, -48);
+        World.Link(teleport);
+
+        GameActions.TickWorld(World, 1);
+
+        teleport.OnGround.Should().BeFalse();
+        teleport.Velocity.XY.Should().Be(Vec2D.Zero);
+
+        World.EntityManager.Destroy(teleport);
     }
 
     [Fact(DisplayName = "Scrolling floor that pushes the velocity past MaxMoveXY")]


### PR DESCRIPTION
correct to not scroll things with no blockmap flag when considered underwater in transfer heights

fixes #1127 