### PR TITLE
Add option to emulate invulnerability colormaps

### DIFF
--- a/Core/Layer/Options/Sections/ListedConfigSection.cs
+++ b/Core/Layer/Options/Sections/ListedConfigSection.cs
@@ -83,6 +83,7 @@ public class ListedConfigSection : IOptionSection
         m_config.Render.Anisotropy.OptionDisabled = paletteMode;
         m_config.Render.LightMode.OptionDisabled = paletteMode;
         m_config.Render.Brightmaps.OptionDisabled = paletteMode;
+        m_config.Render.EmulateInvulnerabilityColorMap.OptionDisabled = paletteMode;
 
         m_config.Mouse.ForwardBackwardSpeed.OptionDisabled = m_config.Mouse.Look.Value == true;
 

--- a/Core/Render/OpenGL/Renderers/Legacy/Hud/LegacyHudRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/Hud/LegacyHudRenderer.cs
@@ -137,6 +137,7 @@ public class LegacyHudRenderer : HudRenderer
         m_program.PaletteIndex((int)uniforms.PaletteIndex);
         m_program.ColorMapIndex(uniforms.ColorMapUniforms.SectorIndex == 0 ? uniforms.ColorMapUniforms.GlobalIndex : uniforms.ColorMapUniforms.SectorIndex);
         m_program.HasInvulnerability(uniforms.DrawInvulnerability);
+        m_program.EmulateInvulnerabilityColorMap(uniforms.EmulateInvulnerabilityColorMap);
         m_program.GammaCorrection(uniforms.GammaCorrection);
         m_program.ScreenBounds((framebufferDimension.Width, framebufferDimension.Height));
         m_program.UseBrightmaps(uniforms.UseBrightmaps);

--- a/Core/Render/OpenGL/Renderers/Legacy/Hud/LegacyHudShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/Hud/LegacyHudShader.cs
@@ -92,11 +92,12 @@ public class LegacyHudShader : RenderProgram
     .Replace("${ColorMapFragSet}", ShaderVars.PaletteColorMode ? "drawPaletteFrag = drawPalette; hudColorMapIndexFrag = hudColorMapIndex;" : "");
 
     private static readonly string TrueColorInvul =
-        @"if (drawColorMapFrag != 0) {
-            float maxColor = max(max(fragColor.x, fragColor.y), fragColor.z);
-            maxColor *= 1.5;
-            fragColor.xyz = vec3(maxColor, maxColor, maxColor);
-        }";
+        """
+        if (drawColorMapFrag != 0)
+        {
+            {InvulnerabilityFragColorInner}
+        }
+        """.Replace("{InvulnerabilityFragColorInner}", FragFunction.InvulnerabilityFragColorInner);
 
     private static string GetBrightmapColorBlend()
     {

--- a/Core/Render/OpenGL/Renderers/Legacy/Hud/LegacyHudShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/Hud/LegacyHudShader.cs
@@ -16,6 +16,7 @@ public class LegacyHudShader : RenderProgram
     private readonly int m_paletteIndexLocation;
     private readonly int m_colorMapIndexLocation;
     private readonly int m_hasInvulnerabilityLocation;
+    private readonly int m_emulateInvulnerabilityColorMapLocation;
     private readonly int m_gammaCorrectionLocation;
     private readonly int m_opaqueTextureLocation;
     private readonly int m_screenBoundsLocation;
@@ -32,6 +33,7 @@ public class LegacyHudShader : RenderProgram
         m_paletteIndexLocation = Uniforms.GetLocation("paletteIndex");
         m_colorMapIndexLocation = Uniforms.GetLocation("colormapIndex");
         m_hasInvulnerabilityLocation = Uniforms.GetLocation("hasInvulnerability");
+        m_emulateInvulnerabilityColorMapLocation = Uniforms.GetLocation("emulateInvulnerabilityColorMap");
         m_gammaCorrectionLocation = Uniforms.GetLocation("gammaCorrection");
         m_opaqueTextureLocation = Uniforms.GetLocation("opaqueTexture");
         m_screenBoundsLocation = Uniforms.GetLocation("screenBounds");
@@ -48,6 +50,7 @@ public class LegacyHudShader : RenderProgram
     public void FuzzDiv(float div) => Uniforms.Set(div, m_fuzzDivLocation);
     public void PaletteIndex(int index) => Uniforms.Set(index, m_paletteIndexLocation);
     public void HasInvulnerability(bool invul) => Uniforms.Set(invul, m_hasInvulnerabilityLocation);
+    public void EmulateInvulnerabilityColorMap(bool value) => Uniforms.Set(value, m_emulateInvulnerabilityColorMapLocation);
     public void ColorMapIndex(int index) => Uniforms.Set(index, m_colorMapIndexLocation);
     public void GammaCorrection(float value) => Uniforms.Set(value, m_gammaCorrectionLocation);
     public void ScreenBounds(Vec2I value) => Uniforms.Set(value, m_screenBoundsLocation);
@@ -128,6 +131,7 @@ public class LegacyHudShader : RenderProgram
         uniform int paletteIndex;
         uniform int colormapIndex;
         uniform int hasInvulnerability;
+        uniform int emulateInvulnerabilityColorMap;
         uniform int useBrightmaps;
         uniform float gammaCorrection;
         uniform ivec2 screenBounds;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
@@ -16,6 +16,7 @@ public class EntityProgram : RenderProgram
     private readonly int m_mvpLocation;
     private readonly int m_timeFracLocation;
     private readonly int m_hasInvulnerabilityLocation;
+    private readonly int m_emulateInvulnerabilityColorMapLocation;
     private readonly int m_mvpNoPitchLocation;
     private readonly int m_fuzzFracLocation;
     private readonly int m_lightLevelMixLocation;
@@ -56,6 +57,7 @@ public class EntityProgram : RenderProgram
         m_mvpLocation = Uniforms.GetLocation("mvp");
         m_timeFracLocation = Uniforms.GetLocation("timeFrac");
         m_hasInvulnerabilityLocation = Uniforms.GetLocation("hasInvulnerability");
+        m_emulateInvulnerabilityColorMapLocation = Uniforms.GetLocation("emulateInvulnerabilityColorMap");
         m_mvpNoPitchLocation = Uniforms.GetLocation("mvpNoPitch");
         m_fuzzFracLocation = Uniforms.GetLocation("fuzzFrac");
         m_lightLevelMixLocation = Uniforms.GetLocation("lightLevelMix");
@@ -103,6 +105,7 @@ public class EntityProgram : RenderProgram
 
     public void ExtraLight(int extraLight) => Uniforms.Set(extraLight, m_extraLightLocation);
     public void HasInvulnerability(bool invul) => Uniforms.Set(invul, m_hasInvulnerabilityLocation);
+    public void EmulateInvulnerabilityColorMap(bool value) => Uniforms.Set(value, m_emulateInvulnerabilityColorMapLocation);
     public void LightLevelMix(float lightLevelMix) => Uniforms.Set(lightLevelMix, m_lightLevelMixLocation);
     public void Mvp(mat4 mvp) => Uniforms.Set(mvp, m_mvpLocation);
     public void MvpNoPitch(mat4 mvpNoPitch) => Uniforms.Set(mvpNoPitch, m_mvpNoPitchLocation);
@@ -330,6 +333,7 @@ public class EntityProgram : RenderProgram
         ${OutFragColor}
 
         uniform int hasInvulnerability;
+        uniform int emulateInvulnerabilityColorMap;
         uniform float fuzzFrac;
         uniform sampler2D boundTexture;
         uniform sampler2D brightmapTexture;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
@@ -328,6 +328,7 @@ public class EntityRenderer : IDisposable
         program.SectorColormapTexture(BindTextures.SectorColormap);
         program.ExtraLight(renderInfo.Uniforms.ExtraLight);
         program.HasInvulnerability(renderInfo.Uniforms.DrawInvulnerability);
+        program.EmulateInvulnerabilityColorMap(renderInfo.Uniforms.EmulateInvulnerabilityColorMap);
         program.LightLevelMix(renderInfo.Uniforms.Mix);
         program.Mvp(renderInfo.Uniforms.Mvp);
         program.MvpNoPitch(renderInfo.Uniforms.MvpNoPitch);

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillProgram.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillProgram.cs
@@ -17,6 +17,7 @@ public class FloodFillProgram : RenderProgram
     private readonly int m_mvpLocation;
     private readonly int m_timeFracLocation;
     private readonly int m_hasInvulnerabilityLocation;
+    private readonly int m_emulateInvulnerabilityColorMapLocation;
     private readonly int m_mvpNoPitchLocation;
     private readonly int m_lightLevelMixLocation;
     private readonly int m_extraLightLocation;
@@ -38,6 +39,7 @@ public class FloodFillProgram : RenderProgram
         m_mvpLocation = Uniforms.GetLocation("mvp");
         m_timeFracLocation = Uniforms.GetLocation("timeFrac");
         m_hasInvulnerabilityLocation = Uniforms.GetLocation("hasInvulnerability");
+        m_emulateInvulnerabilityColorMapLocation = Uniforms.GetLocation("emulateInvulnerabilityColorMap");
         m_mvpNoPitchLocation = Uniforms.GetLocation("mvpNoPitch");
         m_lightLevelMixLocation = Uniforms.GetLocation("lightLevelMix");
         m_extraLightLocation = Uniforms.GetLocation("extraLight");
@@ -59,6 +61,7 @@ public class FloodFillProgram : RenderProgram
     public void Mvp(mat4 mvp) => Uniforms.Set(mvp, m_mvpLocation);
     public void TimeFrac(float frac) => Uniforms.Set(frac, m_timeFracLocation);
     public void HasInvulnerability(bool invul) => Uniforms.Set(invul, m_hasInvulnerabilityLocation);
+    public void EmulateInvulnerabilityColorMap(bool value) => Uniforms.Set(value, m_emulateInvulnerabilityColorMapLocation);
     public void MvpNoPitch(mat4 mvpNoPitch) => Uniforms.Set(mvpNoPitch, m_mvpNoPitchLocation);
     public void LightLevelMix(float lightLevelMix) => Uniforms.Set(lightLevelMix, m_lightLevelMixLocation);
     public void ExtraLight(int extraLight) => Uniforms.Set(extraLight, m_extraLightLocation);
@@ -157,6 +160,7 @@ public class FloodFillProgram : RenderProgram
             uniform vec3 camera;
             uniform mat4 mvpNoPitch;
             uniform int hasInvulnerability;
+            uniform int emulateInvulnerabilityColorMap;
             uniform vec3 colorMix;
             uniform int paletteIndex;
             uniform int colormapIndex;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillRenderer.cs
@@ -344,6 +344,7 @@ public class FloodFillRenderer(LegacyGLTextureManager glTextureManager, FloodFil
         program.Mvp(renderInfo.Uniforms.Mvp);
         program.TimeFrac(renderInfo.TickFraction);
         program.HasInvulnerability(renderInfo.Uniforms.DrawInvulnerability);
+        program.EmulateInvulnerabilityColorMap(renderInfo.Uniforms.EmulateInvulnerabilityColorMap);
         program.MvpNoPitch(renderInfo.Uniforms.MvpNoPitch);
         program.TimeFrac(renderInfo.TickFraction);
         program.LightLevelMix(renderInfo.Uniforms.Mix);

--- a/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
@@ -16,6 +16,7 @@ public class InterpolationShader : RenderProgram
     private readonly int m_mvpLocation;
     private readonly int m_timeFracLocation;
     private readonly int m_hasInvulnerabilityLocation;
+    private readonly int m_emulateInvulnerabilityColorMapLocation;
     private readonly int m_mvpNoPitchLocation;
     private readonly int m_lightLevelMixLocation;
     private readonly int m_extraLightLocation;
@@ -42,6 +43,7 @@ public class InterpolationShader : RenderProgram
         m_mvpLocation = Uniforms.GetLocation("mvp");
         m_timeFracLocation = Uniforms.GetLocation("timeFrac");
         m_hasInvulnerabilityLocation = Uniforms.GetLocation("hasInvulnerability");
+        m_emulateInvulnerabilityColorMapLocation = Uniforms.GetLocation("emulateInvulnerabilityColorMap");
         m_mvpNoPitchLocation = Uniforms.GetLocation("mvpNoPitch");
         m_lightLevelMixLocation = Uniforms.GetLocation("lightLevelMix");
         m_extraLightLocation = Uniforms.GetLocation("extraLight");
@@ -70,6 +72,7 @@ public class InterpolationShader : RenderProgram
     public void WallClipTexture(TextureUnit unit) => Uniforms.Set(unit, m_wallClipTextureLocation);
 
     public void HasInvulnerability(bool invul) => Uniforms.Set(invul, m_hasInvulnerabilityLocation);
+    public void EmulateInvulnerabilityColorMap(bool value) => Uniforms.Set(value, m_emulateInvulnerabilityColorMapLocation);
     public void Mvp(mat4 mvp) => Uniforms.Set(mvp, m_mvpLocation);
     public void MvpNoPitch(mat4 mvpNoPitch) => Uniforms.Set(mvpNoPitch, m_mvpNoPitchLocation);
     public void TimeFrac(float frac) => Uniforms.Set(frac, m_timeFracLocation);
@@ -177,6 +180,7 @@ public class InterpolationShader : RenderProgram
             ${OutFragColor}
 
             uniform int hasInvulnerability;
+            uniform int emulateInvulnerabilityColorMap;
             uniform sampler2D boundTexture;
             uniform sampler2D brightmapTexture;
             uniform vec3 colorMix;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -595,6 +595,7 @@ public class LegacyWorldRenderer : WorldRenderer
         program.PlaneClipTexture(BindTextures.PlaneClipTexture);
         program.WallClipTexture(BindTextures.WallClipTexture);
         program.HasInvulnerability(renderInfo.Uniforms.DrawInvulnerability);
+        program.EmulateInvulnerabilityColorMap(renderInfo.Uniforms.EmulateInvulnerabilityColorMap);
         program.Mvp(renderInfo.Uniforms.Mvp);
         program.MvpNoPitch(renderInfo.Uniforms.MvpNoPitch);
         program.TimeFrac(renderInfo.TickFraction);
@@ -623,6 +624,7 @@ public class LegacyWorldRenderer : WorldRenderer
         program.SectorColormapTexture(BindTextures.SectorColormap);
         program.BrightmapTexture(BindTextures.BrightmapTexture);
         program.HasInvulnerability(renderInfo.Uniforms.DrawInvulnerability);
+        program.EmulateInvulnerabilityColorMap(renderInfo.Uniforms.EmulateInvulnerabilityColorMap);
         program.Mvp(renderInfo.Uniforms.Mvp);
         program.MvpNoPitch(renderInfo.Uniforms.MvpNoPitch);
         program.LightLevelMix(renderInfo.Uniforms.Mix);

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/FragFunction.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/FragFunction.cs
@@ -352,11 +352,16 @@ public class FragFunction
 
     public static string GammaCorrection() => "fragColor.rgb = pow(fragColor.rgb, vec3(1.0/gammaCorrection));";
 
-    public static string InvulnerabilityFragColor =>
-        ShaderVars.PaletteColorMode ? "" :
-    @"
-    if (hasInvulnerability != 0)
-    {
+    public static string InvulnerabilityFragColor => ShaderVars.PaletteColorMode ? "" :
+        """
+        if (hasInvulnerability != 0)
+        {
+            {InvulnerabilityFragColorInner}
+        }
+        """.Replace("{InvulnerabilityFragColorInner}", InvulnerabilityFragColorInner);
+
+    public static string InvulnerabilityFragColorInner => ShaderVars.PaletteColorMode ? "" :
+        """
         float gray = fragColor.x * 0.299 + fragColor.y * 0.587 + fragColor.z * 0.144;
         gray = 1 - gray;
         if (emulateInvulnerabilityColorMap == 0)
@@ -365,23 +370,26 @@ public class FragFunction
         }
         else
         {
-            // Map brightness to black + black + gray ramp (32x) + white + white
+            // Map brightness to white + white + gray ramp (32x) + low grays (3x) + black
             // in invuln color map, to emulate palette mode's invuln effect.
             // Since this only covers the colormap's grays, the degree to which
             // the original effect is matched can vary.
-            float maxIndex = 36 - 1;
+            float maxIndex = 38 - 1;
             int indexA = int(gray * maxIndex);
             int indexB = indexA + 1;
             float localPos = (gray - float(indexA) / maxIndex) * maxIndex;
 
             // [ 0,  1] => [ 4,   4]
             // [ 2, 33] => [80, 111]
-            // [34, 35] => [ 0,   0]
+            // [34, 36] => [ 5,   7]
+            // [37, 37] => [ 0,   0]
             if (indexA <= 1) { indexA = 4; }
             else if (indexA <= 33) { indexA += 78; }
+            else if (indexA <= 36) { indexA -= 29; }
             else { indexA = 0; }
             if (indexB <= 1) { indexB = 4; }
             else if (indexB <= 33) { indexB += 78; }
+            else if (indexB <= 36) { indexB -= 29; }
             else { indexB = 0; }
 
             int colorMapOffset = 256 * 32; // invuln colormap start
@@ -389,8 +397,7 @@ public class FragFunction
             vec3 blendB = texelFetch(colormapTexture, colorMapOffset + indexB).rgb;
             fragColor.rgb = mix(blendA, blendB, localPos);
         }
-    }
-";
+        """;
 
     public static string VertexGapVariables => "flat in vec2 uvClampMinFrag; flat in vec2 uvClampMaxFrag;";
 }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/FragFunction.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/FragFunction.cs
@@ -359,7 +359,36 @@ public class FragFunction
     {
         float gray = fragColor.x * 0.299 + fragColor.y * 0.587 + fragColor.z * 0.144;
         gray = 1 - gray;
-        fragColor.xyz = vec3(gray, gray, gray);
+        if (emulateInvulnerabilityColorMap == 0)
+        {
+            fragColor.xyz = vec3(gray, gray, gray);
+        }
+        else
+        {
+            // Map brightness to black + black + gray ramp (32x) + white + white
+            // in invuln color map, to emulate palette mode's invuln effect.
+            // Since this only covers the colormap's grays, the degree to which
+            // the original effect is matched can vary.
+            float maxIndex = 36 - 1;
+            int indexA = int(gray * maxIndex);
+            int indexB = indexA + 1;
+            float localPos = (gray - float(indexA) / maxIndex) * maxIndex;
+
+            // [ 0,  1] => [ 4,   4]
+            // [ 2, 33] => [80, 111]
+            // [34, 35] => [ 0,   0]
+            if (indexA <= 1) { indexA = 4; }
+            else if (indexA <= 33) { indexA += 78; }
+            else { indexA = 0; }
+            if (indexB <= 1) { indexB = 4; }
+            else if (indexB <= 33) { indexB += 78; }
+            else { indexB = 0; }
+
+            int colorMapOffset = 256 * 32; // invuln colormap start
+            vec3 blendA = texelFetch(colormapTexture, colorMapOffset + indexA).rgb;
+            vec3 blendB = texelFetch(colormapTexture, colorMapOffset + indexB).rgb;
+            fragColor.rgb = mix(blendA, blendB, localPos);
+        }
     }
 ";
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/FragFunction.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/FragFunction.cs
@@ -374,7 +374,7 @@ public class FragFunction
             // in invuln color map, to emulate palette mode's invuln effect.
             // Since this only covers the colormap's grays, the degree to which
             // the original effect is matched can vary.
-            float maxIndex = 38 - 1;
+            const float maxIndex = 38 - 1;
             int indexA = int(gray * maxIndex);
             int indexB = indexA + 1;
             float localPos = (gray - float(indexA) / maxIndex) * maxIndex;
@@ -392,7 +392,7 @@ public class FragFunction
             else if (indexB <= 36) { indexB -= 29; }
             else { indexB = 0; }
 
-            int colorMapOffset = 256 * 32; // invuln colormap start
+            const int colorMapOffset = 256 * 32; // invuln colormap start
             vec3 blendA = texelFetch(colormapTexture, colorMapOffset + indexA).rgb;
             vec3 blendB = texelFetch(colormapTexture, colorMapOffset + indexB).rgb;
             fragColor.rgb = mix(blendA, blendB, localPos);

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/FragFunction.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/FragFunction.cs
@@ -372,8 +372,11 @@ public class FragFunction
         {
             // Map brightness to white + white + gray ramp (32x) + low grays (3x) + black
             // in invuln color map, to emulate palette mode's invuln effect.
-            // Since this only covers the colormap's grays, the degree to which
-            // the original effect is matched can vary.
+            // These grays are not completely evenly spaced (most are 8 apart,
+            // some are 4), but it's even enough to work.
+            // Since some colormaps customize non-gray colors instead of just
+            // mapping to brightness, the degree to which the original effect
+            // is matched can vary by WAD.
             const float maxIndex = 38 - 1;
             int indexA = int(gray * maxIndex);
             int indexB = indexA + 1;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/ShaderUniforms.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/ShaderUniforms.cs
@@ -8,9 +8,23 @@ namespace Helion.Render.OpenGL.Renderers.Legacy.World;
 public record struct ColorMapUniforms(int GlobalIndex, int SkyIndex, int SectorIndex);
 public record struct ColorMixUniforms(Vec3F Global, Vec3F Sky, Vec3F Sector);
 
-public struct ShaderUniforms(mat4 mvp, mat4 mvpNoPitch, float timeFrac, bool drawInvulnerability, float mix, int extraLight, float distanceOffset,
-    ColorMixUniforms colorMix, float fuzzDiv, ColorMapUniforms colorMapUniforms, PaletteIndex paletteIndex, RenderLightMode lightMode, float gammaCorrection,
-    int maxDistance, bool useBrightmaps)
+public struct ShaderUniforms(
+    mat4 mvp,
+    mat4 mvpNoPitch,
+    float timeFrac,
+    bool drawInvulnerability,
+    float mix,
+    int extraLight,
+    float distanceOffset,
+    ColorMixUniforms colorMix,
+    float fuzzDiv,
+    ColorMapUniforms colorMapUniforms,
+    PaletteIndex paletteIndex,
+    RenderLightMode lightMode,
+    float gammaCorrection,
+    int maxDistance,
+    bool useBrightmaps,
+    bool emulateInvulnerabilityColorMap)
 {
     public mat4 Mvp = mvp;
     public mat4 MvpNoPitch = mvpNoPitch;
@@ -27,4 +41,5 @@ public struct ShaderUniforms(mat4 mvp, mat4 mvpNoPitch, float timeFrac, bool dra
     public float GammaCorrection = gammaCorrection;
     public int MaxDistance = maxDistance;
     public bool UseBrightmaps = useBrightmaps;
+    public bool EmulateInvulnerabilityColorMap = emulateInvulnerabilityColorMap;
 }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Sky/Sphere/SkySphereForegroundShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Sky/Sphere/SkySphereForegroundShader.cs
@@ -12,6 +12,7 @@ internal class SkySphereForegroundShader : RenderProgram
     private readonly int m_colormapTextureLocation;
     private readonly int m_mvpLocation;
     private readonly int m_hasInvulnerabilityLocation;
+    private readonly int m_emulateInvulnerabilityColorMapLocation;
     private readonly int m_scaleLocation;
     private readonly int m_flipULocation;
     private readonly int m_paletteIndexLocation;
@@ -33,6 +34,7 @@ internal class SkySphereForegroundShader : RenderProgram
         m_colormapTextureLocation = Uniforms.GetLocation("colormapTexture");
         m_mvpLocation = Uniforms.GetLocation("mvp");
         m_hasInvulnerabilityLocation = Uniforms.GetLocation("hasInvulnerability");
+        m_emulateInvulnerabilityColorMapLocation = Uniforms.GetLocation("emulateInvulnerabilityColorMap");
         m_scaleLocation = Uniforms.GetLocation("scale");
         m_flipULocation = Uniforms.GetLocation("flipU");
         m_paletteIndexLocation = Uniforms.GetLocation("paletteIndex");
@@ -52,6 +54,7 @@ internal class SkySphereForegroundShader : RenderProgram
     public void BoundTexture(TextureUnit unit) => Uniforms.Set(unit, m_boundTextureLocation);
     public void ColormapTexture(TextureUnit unit) => Uniforms.Set(unit, m_colormapTextureLocation);
     public void HasInvulnerability(bool invul) => Uniforms.Set(invul, m_hasInvulnerabilityLocation);
+    public void EmulateInvulnerabilityColorMap(bool value) => Uniforms.Set(value, m_emulateInvulnerabilityColorMapLocation);
     public void Mvp(mat4 mat) => Uniforms.Set(mat, m_mvpLocation);
     public void Scale(Vec2F v) => Uniforms.Set(v, m_scaleLocation);
     public void FlipU(bool flip) => Uniforms.Set(flip, m_flipULocation);
@@ -102,6 +105,7 @@ internal class SkySphereForegroundShader : RenderProgram
         uniform sampler2D boundTexture;
         uniform samplerBuffer colormapTexture;
         uniform int hasInvulnerability;
+        uniform int emulateInvulnerabilityColorMap;
         uniform int paletteIndex;
         uniform int colormapIndex;
         uniform float textureHeight;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Sky/Sphere/SkySphereRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Sky/Sphere/SkySphereRenderer.cs
@@ -215,6 +215,7 @@ public class SkySphereRenderer : IDisposable
         }
 
         m_skyProgram.HasInvulnerability(invulnerability);
+        m_skyProgram.EmulateInvulnerabilityColorMap(renderInfo.Uniforms.EmulateInvulnerabilityColorMap);
         m_skyProgram.PaletteIndex((int)renderInfo.Uniforms.PaletteIndex);
         m_skyProgram.ColorMapIndex(renderInfo.Uniforms.ColorMapUniforms.SkyIndex);
         m_skyProgram.ScrollOffset(offset);
@@ -254,6 +255,7 @@ public class SkySphereRenderer : IDisposable
         }
 
         m_foregroundProgram.HasInvulnerability(invulnerability);
+        m_foregroundProgram.EmulateInvulnerabilityColorMap(renderInfo.Uniforms.EmulateInvulnerabilityColorMap);
         m_foregroundProgram.PaletteIndex((int)renderInfo.Uniforms.PaletteIndex);
         m_foregroundProgram.ColorMapIndex(renderInfo.Uniforms.ColorMapUniforms.SkyIndex);
         m_foregroundProgram.ScrollOffset(offset);
@@ -285,6 +287,7 @@ public class SkySphereRenderer : IDisposable
         m_foregroundProgram.TopColor(Vec4F.Zero);
         m_foregroundProgram.BottomColor(Vec4F.Zero);
         m_foregroundProgram.HasInvulnerability(invulnerability);
+        m_foregroundProgram.EmulateInvulnerabilityColorMap(renderInfo.Uniforms.EmulateInvulnerabilityColorMap);
         m_foregroundProgram.PaletteIndex((int)renderInfo.Uniforms.PaletteIndex);
         m_foregroundProgram.ColorMapIndex(renderInfo.Uniforms.ColorMapUniforms.SkyIndex);
         m_foregroundProgram.ScrollOffset(offset);

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Sky/Sphere/SkySphereShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Sky/Sphere/SkySphereShader.cs
@@ -12,6 +12,7 @@ public class SkySphereShader : RenderProgram
     private readonly int m_colormapTextureLocation;
     private readonly int m_mvpLocation;
     private readonly int m_hasInvulnerabilityLocation;
+    private readonly int m_emulateInvulnerabilityColorMapLocation;
     private readonly int m_scaleLocation;
     private readonly int m_flipULocation;
     private readonly int m_paletteIndexLocation;
@@ -31,6 +32,7 @@ public class SkySphereShader : RenderProgram
         m_colormapTextureLocation = Uniforms.GetLocation("colormapTexture");
         m_mvpLocation = Uniforms.GetLocation("mvp");
         m_hasInvulnerabilityLocation = Uniforms.GetLocation("hasInvulnerability");
+        m_emulateInvulnerabilityColorMapLocation = Uniforms.GetLocation("emulateInvulnerabilityColorMap");
         m_scaleLocation = Uniforms.GetLocation("scale");
         m_flipULocation = Uniforms.GetLocation("flipU");
         m_paletteIndexLocation = Uniforms.GetLocation("paletteIndex");
@@ -48,6 +50,7 @@ public class SkySphereShader : RenderProgram
     public void BoundTexture(TextureUnit unit) => Uniforms.Set(unit, m_boundTextureLocation);
     public void ColormapTexture(TextureUnit unit) => Uniforms.Set(unit, m_colormapTextureLocation);
     public void HasInvulnerability(bool invul) => Uniforms.Set(invul, m_hasInvulnerabilityLocation);
+    public void EmulateInvulnerabilityColorMap(bool value) => Uniforms.Set(value, m_emulateInvulnerabilityColorMapLocation);
     public void Mvp(mat4 mat) => Uniforms.Set(mat, m_mvpLocation);
     public void Scale(Vec2F v) => Uniforms.Set(v, m_scaleLocation);
     public void FlipU(bool flip) => Uniforms.Set(flip, m_flipULocation);
@@ -109,6 +112,7 @@ vec4 bottomFetchColor = bottomColor;
         uniform sampler2D boundTexture;
         uniform samplerBuffer colormapTexture;
         uniform int hasInvulnerability;
+        uniform int emulateInvulnerabilityColorMap;
         uniform int paletteIndex;
         uniform int colormapIndex;
         uniform float skyHeight;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
@@ -16,6 +16,7 @@ public class StaticShader : RenderProgram
     private readonly int m_brightmapTextureLocation;
     private readonly int m_mvpLocation;
     private readonly int m_hasInvulnerabilityLocation;
+    private readonly int m_emulateInvulnerabilityColorMapLocation;
     private readonly int m_mvpNoPitchLocation;
     private readonly int m_lightLevelMixLocation;
     private readonly int m_extraLightLocation;
@@ -37,6 +38,7 @@ public class StaticShader : RenderProgram
         m_brightmapTextureLocation = Uniforms.GetLocation("brightmapTexture");
         m_mvpLocation = Uniforms.GetLocation("mvp");
         m_hasInvulnerabilityLocation = Uniforms.GetLocation("hasInvulnerability");
+        m_emulateInvulnerabilityColorMapLocation = Uniforms.GetLocation("emulateInvulnerabilityColorMap");
         m_mvpNoPitchLocation = Uniforms.GetLocation("mvpNoPitch");
         m_lightLevelMixLocation = Uniforms.GetLocation("lightLevelMix");
         m_extraLightLocation = Uniforms.GetLocation("extraLight");
@@ -57,6 +59,7 @@ public class StaticShader : RenderProgram
     public void BrightmapTexture(TextureUnit unit) => Uniforms.Set(unit, m_brightmapTextureLocation);
 
     public void HasInvulnerability(bool invul) => Uniforms.Set(invul, m_hasInvulnerabilityLocation);
+    public void EmulateInvulnerabilityColorMap(bool value) => Uniforms.Set(value, m_emulateInvulnerabilityColorMapLocation);
     public void Mvp(mat4 mvp) => Uniforms.Set(mvp, m_mvpLocation);
     public void MvpNoPitch(mat4 mvpNoPitch) => Uniforms.Set(mvpNoPitch, m_mvpNoPitchLocation);
     public void LightLevelMix(float lightLevelMix) => Uniforms.Set(lightLevelMix, m_lightLevelMixLocation);
@@ -160,6 +163,7 @@ public class StaticShader : RenderProgram
             out vec4 fragColor;
 
             uniform int hasInvulnerability;
+            uniform int emulateInvulnerabilityColorMap;
             uniform sampler2D boundTexture;
             uniform sampler2D brightmapTexture;
             uniform vec3 colorMix;

--- a/Core/Render/Renderer.cs
+++ b/Core/Render/Renderer.cs
@@ -130,9 +130,6 @@ public partial class Renderer : IDisposable
 
     public unsafe void UploadColorMap()
     {
-        if (!ShaderVars.PaletteColorMode)
-            return;
-
         var colorMapData = ColorMapBuffer.Create(m_archiveCollection.Palette, m_archiveCollection.Definitions.Colormaps);
         m_colorMapBuffer = new("Colormap buffer", colorMapData, SizedInternalFormat.Rgb32f, GLInfo.MapPersistentBitSupported);
 
@@ -219,11 +216,23 @@ public partial class Renderer : IDisposable
         if (maxDistance <= 0)
             maxDistance = Constants.DefaultMaxDistance;
 
-        return new ShaderUniforms(CalculateMvpMatrix(renderInfo),
+        return new ShaderUniforms(
+            CalculateMvpMatrix(renderInfo),
             CalculateMvpMatrix(renderInfo, true),
-            GetTimeFrac(), drawInvulnerability, mix, extraLight, GetDistanceOffset(renderInfo),
-            colorMix, GetFuzzDiv(renderInfo.Config, renderInfo.Viewport), colorMapUniforms, paletteIndex, config.Render.LightMode, 
-            (float)config.Render.GammaCorrection, maxDistance, config.Render.Brightmaps);
+            GetTimeFrac(),
+            drawInvulnerability,
+            mix,
+            extraLight,
+            GetDistanceOffset(renderInfo),
+            colorMix,
+            GetFuzzDiv(renderInfo.Config, renderInfo.Viewport),
+            colorMapUniforms,
+            paletteIndex,
+            config.Render.LightMode, 
+            (float)config.Render.GammaCorrection,
+            maxDistance,
+            config.Render.Brightmaps,
+            config.Render.EmulateInvulnerabilityColorMap);
     }
 
     private static ColorMapUniforms GetColorMapUniforms(Entity viewer, OldCamera camera)

--- a/Core/Util/Configs/Components/ConfigRender.cs
+++ b/Core/Util/Configs/Components/ConfigRender.cs
@@ -156,6 +156,10 @@ public class ConfigRender: ConfigElement<ConfigRender>
     [OptionMenu(OptionSectionType.Render, "Emulate Vanilla Rendering", spacer: true)]
     public readonly ConfigValue<bool> VanillaRender = new(false);
 
+    [ConfigInfo("Emulates custom invulnerability palettes in true color mode. May not work well with all WADs.")]
+    [OptionMenu(OptionSectionType.Render, "Emulate Invulnerability Colormap")]
+    public readonly ConfigValue<bool> EmulateInvulnerabilityColorMap = new(false);
+
     [ConfigInfo("Line contrast mode.", mapRestartRequired: true)]
     [OptionMenu(OptionSectionType.Render, "Line contrast mode")]
     public readonly ConfigValue<RenderContrastMode> ContrastMode = new(RenderContrastMode.Vanilla);

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -10,6 +10,7 @@
 - Line contrast mode (off, vanilla, smooth)
 - Calculate locked key door color by using key icon image
 - Added pixel gap correction to rendering that is on by default. Prevents most pixel gap problems caused by floating point precision
+- Added partial emulation of custom invulnerability colormaps in true color mode
 - Added MAPINFO and md5 to have correct level names and progression for nerve.wad (No Rest for the Living)
 - Added fix for sprites clipping through lower floors with emulate vanilla rendering (issue #907)
 - Replaced HUD horizontal margin with HUD width option


### PR DESCRIPTION
Implements #1137
Enabled by a new option, defaults to disabled since it's a partial emulation of the real thing. This also makes the weapon invulnerability color calculation match the world's, regardless of whether the option is enabled.

Comparisons in roughly descending quality:

|Emulated|Original|
|----------|---------|
|![helion_20250603_17 31 51 1984](https://github.com/user-attachments/assets/29fcb63b-16a2-4993-ae1e-04731eb99405)|![helion_20250603_17 36 30 5533](https://github.com/user-attachments/assets/41871f39-e81a-4bc1-9e51-46f5502a5bbb)|
|![helion_20250603_17 34 50 916](https://github.com/user-attachments/assets/1e263e43-7227-464f-943f-7639a6f021aa)|![helion_20250603_17 35 17 3084](https://github.com/user-attachments/assets/7e41152c-90a9-4b3c-a2bb-b58e1af56004)|
|![helion_20250603_17 32 26 2524](https://github.com/user-attachments/assets/1692c4f4-ac51-4e63-ac24-d7e6e5d94bf3)|![helion_20250603_17 36 15 8562](https://github.com/user-attachments/assets/498983fe-b8dc-4182-a0e7-4d59ce02cdc6)|
|![helion_20250603_17 32 58 5384](https://github.com/user-attachments/assets/778f491c-32f9-4ef9-9940-c9794da74ea1)|![helion_20250603_17 35 59 6877](https://github.com/user-attachments/assets/03a1c9b3-77c1-4e55-a944-1ec70155b852)|
|![helion_20250603_17 34 15 3057](https://github.com/user-attachments/assets/510bd9d3-572a-48ca-9a4b-91854392acf5)|![helion_20250603_17 35 27 9916](https://github.com/user-attachments/assets/f2e24364-b022-4b07-893a-5d0b126ec3ea)|
|![helion_20250603_17 33 26 6031](https://github.com/user-attachments/assets/3423c5ee-51b1-4af7-b0a4-52d8f485e793)|![helion_20250603_17 35 43 6497](https://github.com/user-attachments/assets/e7527b79-efb5-4510-ba91-2cdcd298d2b8)|
