### PR TITLE
Vanilla chex quest

### DIFF
--- a/Core/Layer/IwadSelection/IwadSelectionLayer.cs
+++ b/Core/Layer/IwadSelection/IwadSelectionLayer.cs
@@ -65,7 +65,7 @@ public class IwadSelectionLayer : IGameLayer
         int fontSize = m_config.Window.GetMenuLargeFontSize();
         int spacer = m_config.Window.GetMenuScaled(8);
 
-        hud.RenderFullscreenImage("background");
+        hud.RenderFullscreenImage(Constants.DefaultBackgroundImage);
         hud.FillBox(new(new Vec2I(0, 0), new Vec2I(hud.Dimension.Width, hud.Dimension.Height)), Color.Black, alpha: 0.8f);
 
         Dimension dim;

--- a/Core/Layer/Options/OptionsLayer.cs
+++ b/Core/Layer/Options/OptionsLayer.cs
@@ -34,7 +34,6 @@ public class OptionsLayer : IGameLayer, IAnimationLayer
     public long LastClosedNanos;
     public bool CurrentlyBindingKey => m_sections[m_currentSectionIndex] is KeyBindingSection x && x.CurrentlyBinding;
 
-    private const string TiledBackgroundFlat = "FLOOR5_1";
     private const int BackIndex = 0;
     private const int ForwardIndex = 1;
     private const string Font = Fonts.SmallGray;
@@ -359,17 +358,11 @@ public class OptionsLayer : IGameLayer, IAnimationLayer
         }
     }
 
-    private static void FillBackgroundRepeatingImages(IRenderableSurfaceContext ctx, IHudRenderContext hud)
+    private static void RenderBackground(IRenderableSurfaceContext ctx, IHudRenderContext hud)
     {
-        if (!hud.Textures.HasImage(TiledBackgroundFlat))
-            return;
-
         (int w, int h) = ctx.Surface.Dimension;
-        for (int y = 0; y < (h / 64) + 1; y++)
-            for (int x = 0; x < (w / 64) + 1; x++)
-                hud.Image(TiledBackgroundFlat, (x * 64, y * 64));
-
-        hud.FillBox((0, 0, w, h), Color.Black, alpha: 0.8f);
+        hud.RenderFullscreenImage(DefaultBackgroundImage);
+        hud.FillBox((0, 0, w, h), Color.Black, alpha: 0.85f);
     }
 
     public void Render(IRenderableSurfaceContext ctx, IHudRenderContext hud)
@@ -382,7 +375,7 @@ public class OptionsLayer : IGameLayer, IAnimationLayer
 
         SetMouseFromRender(hud);
 
-        FillBackgroundRepeatingImages(ctx, hud);
+        RenderBackground(ctx, hud);
 
         int fontSize = m_config.Window.GetMenuMediumFontSize();
         int largeFontSize = m_config.Window.GetMenuLargeFontSize();

--- a/Core/Resources/Definitions/MapInfo/EpisodeDef.cs
+++ b/Core/Resources/Definitions/MapInfo/EpisodeDef.cs
@@ -22,4 +22,9 @@ public class EpisodeDef
     {
         return StartMap.GetHashCode();
     }
+
+    public override string ToString()
+    {
+        return $"{StartMap} - {Name}";
+    }
 }

--- a/Core/Resources/Definitions/MapInfo/UniversalMapInfo.cs
+++ b/Core/Resources/Definitions/MapInfo/UniversalMapInfo.cs
@@ -162,7 +162,7 @@ public partial class MapInfoDefinition
     {
         if (parser.ConsumeIf("clear"))
         {
-            MapInfo.RemoveEpisodeByMapName(mapDef.MapName);
+            MapInfo.ClearEpisodes();
             return;
         }
 

--- a/Core/Util/Constants.cs
+++ b/Core/Util/Constants.cs
@@ -85,6 +85,8 @@ public static class Constants
 
     public const string DefaultSkyTextureName = "SKY1";
 
+    public const string DefaultBackgroundImage = "background";
+
     public static class MenuSounds
     {
         public const string Activate = "menu/activate";

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -58,3 +58,5 @@
 - Fix active switch change specials not being serialized to saves
 - Fix issue with sky textures not loading from a patch name if last archive had no pnames lump
 - Fix namespace with pk3 entries and nested folders
+- Fix UMAPINFO clear episode
+- Fix default background for options menu

--- a/Tests/Resources/UMAPINFO1.TXT
+++ b/Tests/Resources/UMAPINFO1.TXT
@@ -6,6 +6,7 @@ map e1m1
 	music = "D_E1M0"
 	next = "E1M2"
 	levelpic = "WILV00"
+	episode = clear
 	episode = "M_EPI1", "1"
 	author = "the author"
 	partime = 420
@@ -101,7 +102,6 @@ map e3m1
 {
 	levelname = "The lone map"
 	unknownitem = "test"
-	episode = clear
 }
 
 map e3m2


### PR DESCRIPTION
Fix clear episode for UMAPINFO. Fixes Chex Quest Vanilla Edition episode list order.

Use default background from assets for options menu. Simplifies and fixes case where an iwad does not have the flat image used for the tiled background.