### PR TITLE
Window resize QoL improvements

### DIFF
--- a/Client/Window.cs
+++ b/Client/Window.cs
@@ -294,7 +294,7 @@ public class Window : GameWindow, IWindow
 
     private void Window_MouseMove(MouseMoveEventArgs args)
     {
-        m_inputManager.SetMousePosition(((int)args.Position.X, (int)args.Position.Y));
+        m_inputManager.SetMousePosition(((int)(args.Position.X * m_clientScaling.X), (int)(args.Position.Y * m_clientScaling.Y)));
         if (!m_inputManagement.ShouldHandleMouseMovement())
             return;
 

--- a/Client/Window.cs
+++ b/Client/Window.cs
@@ -17,6 +17,7 @@ using NLog;
 using OpenTK.Mathematics;
 using OpenTK.Windowing.Common;
 using OpenTK.Windowing.Desktop;
+using OpenTK.Windowing.GraphicsLibraryFramework;
 using static Helion.Util.Assertion.Assert;
 
 namespace Helion.Client;
@@ -31,15 +32,22 @@ public class Window : GameWindow, IWindow
 {
     private static readonly Logger Log = LogManager.GetCurrentClassLogger();
 
-    public IInputManager InputManager => m_inputManager;
     public Renderer Renderer { get; }
-    public Dimension ClientDimension => new(ClientSize.X, ClientSize.Y);
     private readonly IConfig m_config;
+    
+    public IInputManager InputManager => m_inputManager;
     private readonly IInputManagement m_inputManagement;
     private readonly InputManager m_inputManager = new();
     private readonly SpanString m_textInput = new();
-    private bool m_disposed;
     public readonly ControllerAdapter JoystickAdapter;
+
+    public Dimension ClientDimension => new((int)(ClientSize.X * m_clientScaling.X), (int)(ClientSize.Y * m_clientScaling.Y));
+    private bool m_firstResizeEvent = true;
+    private bool m_updatingWindowState;
+    private bool m_isLinuxWayland = OperatingSystem.IsLinux() && GLFW.GetPlatform() == Platform.Wayland;
+    private Vec2F m_clientScaling = new(1, 1);
+
+    private bool m_disposed;
 
     public Window(string title, IConfig config, ArchiveCollection archiveCollection, FpsTracker tracker, IInputManagement inputManagement,
         int glMajor, int glMinor, GLContextFlags flags, Action onCreate) :
@@ -162,11 +170,53 @@ public class Window : GameWindow, IWindow
         };
     }
 
+
+    private void UpdateScaling()
+    {
+        if (!m_isLinuxWayland)
+        {
+            return;
+        }
+
+        unsafe
+        {
+            // This mainly applies to Wayland on Linux, which uses some odd "virtual resolution" logic for window size.
+            GLFW.GetWindowContentScale(WindowPtr, out float xScale, out float yScale);
+            m_clientScaling = new(xScale, yScale);
+        }
+    }
+
+
+    protected override void OnResize(ResizeEventArgs e)
+    {
+        if (m_firstResizeEvent)
+        {
+            // OpenTK fires a dummy window-resize event on startup.  Ignore whatever size the window is then.
+            m_firstResizeEvent = false;
+        }
+
+        UpdateScaling();
+
+        if (!m_updatingWindowState && m_config.Window.State.Value == RenderWindowState.Normal)
+        {
+            // If the user resizes the window manually by dragging the handles, update the config file.
+            // This allows the user to persist their window resize.
+            Dimension scaledDimension = ((int)(m_clientScaling.X * e.Width), (int)(m_clientScaling.Y * e.Height));
+
+            string resolutionString = $"{scaledDimension.Width}x{scaledDimension.Height}";
+            m_config.Window.Dimension.Set(resolutionString, fireChangeEvents: false);
+        }
+
+        base.OnResize(e);
+    }
+
     /// <summary>
     /// Update the window, ensuring that all of the border/dimension/screen state parameters remain logically consistent
     /// </summary>
     public void UpdateWindow()
     {
+        UpdateScaling();
+
         // Apply fullscreen / window / borderless fullscreen window mode, ensure size and borders
         switch (m_config.Window.State.Value)
         {
@@ -177,7 +227,7 @@ public class Window : GameWindow, IWindow
                 WindowState oldWindowState = WindowState;
                 WindowState = WindowState.Normal;
                 Dimension dimension = m_config.Window.Dimension.Value;
-                ClientSize = (dimension.Width, dimension.Height);
+                ClientSize = ((int)(dimension.Width / m_clientScaling.X), (int)(dimension.Height / m_clientScaling.Y));
                 //Size
                 if (WindowState != oldWindowState)
                 {
@@ -190,7 +240,8 @@ public class Window : GameWindow, IWindow
                 WindowState = WindowState.Normal;
                 WindowBorder = WindowBorder.Hidden;
                 MonitorInfo monitorInfo = Monitors.GetMonitorFromWindow(this);
-                ClientSize = (monitorInfo.HorizontalResolution, monitorInfo.VerticalResolution);
+                ClientSize = ((int)(monitorInfo.HorizontalResolution / m_clientScaling.X),
+                    (int)(monitorInfo.VerticalResolution / m_clientScaling.Y));
                 break;
         }
 

--- a/Client/Window.cs
+++ b/Client/Window.cs
@@ -34,7 +34,7 @@ public class Window : GameWindow, IWindow
 
     public Renderer Renderer { get; }
     private readonly IConfig m_config;
-    
+
     public IInputManager InputManager => m_inputManager;
     private readonly IInputManagement m_inputManagement;
     private readonly InputManager m_inputManager = new();
@@ -197,7 +197,7 @@ public class Window : GameWindow, IWindow
 
         UpdateScaling();
 
-        if (!m_updatingWindowState && m_config.Window.State.Value == RenderWindowState.Normal)
+        if (!m_updatingWindowState && m_config.Window.State.Value == RenderWindowState.Normal && WindowBorder == WindowBorder.Resizable)
         {
             // If the user resizes the window manually by dragging the handles, update the config file.
             // This allows the user to persist their window resize.

--- a/Core/Util/Configs/Values/ConfigValue.cs
+++ b/Core/Util/Configs/Values/ConfigValue.cs
@@ -90,17 +90,17 @@ public class ConfigValue<T> : IConfigValue where T : notnull
 
     public static implicit operator T(ConfigValue<T> val) => val.Value;
 
-    public ConfigSetResult Set(object newValue, bool writeToConfig = true)
+    public ConfigSetResult Set(object newValue, bool writeToConfig = true, bool fireChangeEvents = true)
     {
         return TryConvertInternal(newValue, out var convertedValue)
-            ? Set(convertedValue, writeToConfig)
+            ? Set(convertedValue, writeToConfig, fireChangeEvents)
             : ConfigSetResult.NotSetByBadConversion;
     }
 
-    public ConfigSetResult Set(T newValue, bool writeToConfig = true)
+    public ConfigSetResult Set(T newValue, bool writeToConfig = true, bool fireChangeEvents = true)
     {
         WriteToConfig = writeToConfig;
-        var result = SetValue(newValue, false);
+        var result = SetValue(newValue, false, fireChangeEvents);
         if (WriteToConfig)
         {
             UserValue = Value;
@@ -165,7 +165,7 @@ public class ConfigValue<T> : IConfigValue where T : notnull
         HasTemporaryValue = false;
     }
 
-    private ConfigSetResult SetValue(T newValue, bool ignoreSetFlags)
+    private ConfigSetResult SetValue(T newValue, bool ignoreSetFlags, bool fireChangeEvents = true)
     {
         if (Equals(newValue, Value))
             return ConfigSetResult.Unchanged;
@@ -186,8 +186,11 @@ public class ConfigValue<T> : IConfigValue where T : notnull
         T oldValue = Value;
         Value = newValue;
         Changed = true;
-        OnChanged?.Invoke(this, newValue);
-        OnChangedBeforeAfter?.Invoke(this, (oldValue, newValue));
+        if (fireChangeEvents)
+        {
+            OnChanged?.Invoke(this, newValue);
+            OnChangedBeforeAfter?.Invoke(this, (oldValue, newValue));
+        }
 
         m_queuedChange = default(T);
         m_hasQueuedChange = false;

--- a/Core/Util/Configs/Values/IConfigValue.cs
+++ b/Core/Util/Configs/Values/IConfigValue.cs
@@ -54,8 +54,10 @@ public interface IConfigValue
     ///     string   -> numeric:  attempts a TryParse
     /// </remarks>
     /// <param name="newValue">The new value.</param>
+    /// <param name="writeToConfig">Whether this change should write to the config file</param>
+    /// <param name="fireChangeEvents">Whether event handlers subscribed to this value should fire on this change</param>
     /// <returns>The set result.</returns>
-    ConfigSetResult Set(object newValue, bool writeToConfig = true);
+    ConfigSetResult Set(object newValue, bool writeToConfig = true, bool fireChangeEvents = true);
 
     /// <summary>
     /// Attempts to parse a new value without setting it.


### PR DESCRIPTION
1.  Include Linux Wayland-specific scaling factors in window scaling and mouse move scaling calculations; this is necessary because Wayland does some odd "virtual resolution" stuff, so setting a window dimension directly based on resolution may produce a window that is _not_ the expected size.
2.  If the window is _interactively_ resized, then persist that to the config file.