### PR TITLE
Add "grace period" on window resize event, platform-specific tweaks for Windows and X11

### DIFF
--- a/Client/Window.cs
+++ b/Client/Window.cs
@@ -47,7 +47,7 @@ public class Window : GameWindow, IWindow
     private bool m_firstResizeEvent = true;
     private DateTime m_windowStateUpdateTimestamp;
     private readonly bool m_isLinuxWayland = OperatingSystem.IsLinux() && GLFW.GetPlatform() == Platform.Wayland;
-    private readonly bool m_isX11 = OperatingSystem.IsLinux() && GLFW.GetPlatform() == Platform.X11;
+    private readonly bool m_isLinuxX11 = OperatingSystem.IsLinux() && GLFW.GetPlatform() == Platform.X11;
     private readonly bool m_isWindows = OperatingSystem.IsWindows();
     private Vec2F m_clientScaling = new(1, 1);
     private bool m_disposed;
@@ -281,23 +281,17 @@ public class Window : GameWindow, IWindow
                         GLFW.RestoreWindow(WindowPtr);
                     }
 
-                    if (m_isX11)
+                    if (m_isLinuxX11 && oldWindowState == RenderWindowState.BorderlessFullscreenWindow)
                     {
-                        switch (oldWindowState)
-                        {
-                            case RenderWindowState.Fullscreen:
-                                // Must ensure window isn't maximized
-                                GLFW.RestoreWindow(WindowPtr);
-                                break;
-                            case RenderWindowState.BorderlessFullscreenWindow:
-                                // Need to quickly bounce through full-screen for...reasons?
-                                GLFW.SetWindowMonitor(WindowPtr, monitor, 0, 0, modePtr->Width, modePtr->Height, modePtr->RefreshRate);
-                                break;
-                            default:
-                                break;
-                        }
+                        // Note:  There seems to be a weird bug here where if the application is started in borderless, 
+                        // and then the user goes to Windowed _without ever moving their mouse_, the mouse cursor gets "stuck"
+                        // in a narrow range and cannot be moved.
+
+                        // Need to quickly bounce through full-screen for...reasons?
+                        GLFW.SetWindowMonitor(WindowPtr, monitor, 0, 0, modePtr->Width, modePtr->Height, modePtr->RefreshRate);
                     }
 
+                    // Note: Wayland (at least on Gnome, Ubuntu 24.04) seems to ignore window decor settings.
                     WindowBorder = m_config.Window.Border;
                     GLFW.SetWindowMonitor(WindowPtr, null, windowX, windowY, (int)(windowDimension.Width / m_clientScaling.X), (int)(windowDimension.Height / m_clientScaling.Y), GLFW.DontCare);
 

--- a/Client/Window.cs
+++ b/Client/Window.cs
@@ -60,7 +60,6 @@ public class Window : GameWindow, IWindow
         onCreate();
         m_config = config;
         m_renderWindowState = config.Window.State;
-        UpdateWindow();
         m_inputManagement = inputManagement;
         CursorState = config.Mouse.Focus ? CursorState.Grabbed : CursorState.Hidden;
         Renderer = new(this, config, archiveCollection, tracker);
@@ -89,8 +88,18 @@ public class Window : GameWindow, IWindow
         m_config.Render.VSync.OnChanged += OnVSyncChanged;
     }
 
+    public override void Run()
+    {
+        UpdateWindow();
+        base.Run();
+    }
+
     public void SetMousePosition(Vec2I pos)
     {
+        // Wayland does not support setting mouse position
+        if (m_isLinuxWayland)
+            return;
+
         MousePosition = (pos.X, pos.Y);
         InputManager.MousePosition = pos;
     }
@@ -233,17 +242,19 @@ public class Window : GameWindow, IWindow
         {
             Monitor* monitor = CurrentMonitor.Handle.ToUnsafePtr<Monitor>();
             VideoMode* modePtr = GLFW.GetVideoMode(monitor);
-            GLFW.GetWindowPos(WindowPtr, out int windowX, out int windowY);
+            int windowX = 0, windowY = 0;
+
+            // Wayland does not support querying window position
+            if (!m_isLinuxWayland)
+            {
+                GLFW.GetWindowPos(WindowPtr, out windowX, out windowY);
+            }
 
             // Keep a "known good" coordinate for transitions into Normal (windowed) mode, based on the last time we were in
             // Normal mode.
-            if (oldWindowState == RenderWindowState.Normal)
+            if (oldWindowState == RenderWindowState.Normal || m_knownGoodWindowPos == null)
             {
                 m_knownGoodWindowPos = new(windowX, windowY);
-            }
-            else
-            {
-                m_knownGoodWindowPos ??= new(windowX, windowY);
             }
 
             GLFW.RestoreWindow(WindowPtr);

--- a/Client/Window.cs
+++ b/Client/Window.cs
@@ -47,6 +47,7 @@ public class Window : GameWindow, IWindow
     private bool m_firstResizeEvent = true;
     private DateTime m_windowStateUpdateTimestamp;
     private readonly bool m_isLinuxWayland = OperatingSystem.IsLinux() && GLFW.GetPlatform() == Platform.Wayland;
+    private readonly bool m_isX11 = OperatingSystem.IsLinux() && GLFW.GetPlatform() == Platform.X11;
     private Vec2F m_clientScaling = new(1, 1);
     private bool m_disposed;
     private RenderWindowState m_renderWindowState;
@@ -257,8 +258,6 @@ public class Window : GameWindow, IWindow
                 m_knownGoodWindowPos = new(windowX, windowY);
             }
 
-            GLFW.RestoreWindow(WindowPtr);
-
             switch (m_renderWindowState)
             {
                 case RenderWindowState.Fullscreen:
@@ -277,12 +276,25 @@ public class Window : GameWindow, IWindow
                     {
                         windowX = m_knownGoodWindowPos.Value.X;
                         windowY = m_knownGoodWindowPos.Value.Y;
+
+                        GLFW.RestoreWindow(WindowPtr);
                     }
 
-                    if (oldWindowState == RenderWindowState.BorderlessFullscreenWindow)
+                    if (m_isX11)
                     {
-                        // This seems to mess up something on X11 unless we cycle through true fullscreen first
-                        GLFW.SetWindowMonitor(WindowPtr, monitor, 0, 0, modePtr->Width, modePtr->Height, modePtr->RefreshRate);
+                        switch (oldWindowState)
+                        {
+                            case RenderWindowState.Fullscreen:
+                                // Must ensure window isn't maximized
+                                GLFW.RestoreWindow(WindowPtr);
+                                break;
+                            case RenderWindowState.BorderlessFullscreenWindow:
+                                // Need to quickly bounce through full-screen for...reasons?
+                                GLFW.SetWindowMonitor(WindowPtr, monitor, 0, 0, modePtr->Width, modePtr->Height, modePtr->RefreshRate);
+                                break;
+                            default:
+                                break;
+                        }
                     }
 
                     WindowBorder = m_config.Window.Border;

--- a/Client/Window.cs
+++ b/Client/Window.cs
@@ -48,6 +48,7 @@ public class Window : GameWindow, IWindow
     private DateTime m_windowStateUpdateTimestamp;
     private readonly bool m_isLinuxWayland = OperatingSystem.IsLinux() && GLFW.GetPlatform() == Platform.Wayland;
     private readonly bool m_isX11 = OperatingSystem.IsLinux() && GLFW.GetPlatform() == Platform.X11;
+    private readonly bool m_isWindows = OperatingSystem.IsWindows();
     private Vec2F m_clientScaling = new(1, 1);
     private bool m_disposed;
     private RenderWindowState m_renderWindowState;
@@ -299,6 +300,12 @@ public class Window : GameWindow, IWindow
 
                     WindowBorder = m_config.Window.Border;
                     GLFW.SetWindowMonitor(WindowPtr, null, windowX, windowY, (int)(windowDimension.Width / m_clientScaling.X), (int)(windowDimension.Height / m_clientScaling.Y), GLFW.DontCare);
+
+                    if (m_isWindows && (oldWindowState != RenderWindowState.Normal))
+                    {
+                        // Titlebar tends to get stuck off-screen; just center the window to ensure that doesn't happen
+                        CenterWindow();
+                    }
                     break;
             }
         }

--- a/Client/Window.cs
+++ b/Client/Window.cs
@@ -30,6 +30,8 @@ namespace Helion.Client;
 /// </remarks>
 public class Window : GameWindow, IWindow
 {
+    const int WINDOW_RESIZE_GRACE_MS = 2000;
+
     private static readonly Logger Log = LogManager.GetCurrentClassLogger();
 
     public Renderer Renderer { get; }
@@ -43,7 +45,7 @@ public class Window : GameWindow, IWindow
 
     public Dimension ClientDimension => new((int)(ClientSize.X * m_clientScaling.X), (int)(ClientSize.Y * m_clientScaling.Y));
     private bool m_firstResizeEvent = true;
-    private bool m_updatingWindowState;
+    private DateTime m_windowStateUpdateTimestamp;
     private readonly bool m_isLinuxWayland = OperatingSystem.IsLinux() && GLFW.GetPlatform() == Platform.Wayland;
     private Vec2F m_clientScaling = new(1, 1);
     private bool m_disposed;
@@ -198,7 +200,9 @@ public class Window : GameWindow, IWindow
 
         UpdateScaling();
 
-        if (!m_updatingWindowState && m_config.Window.State.Value == RenderWindowState.Normal && WindowBorder == WindowBorder.Resizable)
+        if ((DateTime.Now - m_windowStateUpdateTimestamp).TotalMilliseconds > WINDOW_RESIZE_GRACE_MS
+            && m_config.Window.State.Value == RenderWindowState.Normal
+            && WindowBorder == WindowBorder.Resizable)
         {
             // If the user resizes the window manually by dragging the handles, update the config file.
             // This allows the user to persist their window resize.
@@ -216,7 +220,7 @@ public class Window : GameWindow, IWindow
     /// </summary>
     public void UpdateWindow()
     {
-        m_updatingWindowState = true;
+        m_windowStateUpdateTimestamp = DateTime.Now;
         UpdateScaling();
 
         RenderWindowState oldWindowState = m_renderWindowState;
@@ -277,7 +281,6 @@ public class Window : GameWindow, IWindow
         }
 
         SetSyncMode(m_config.Render.MaxFPS.Value, m_config.Render.VSync.Value);
-        m_updatingWindowState = false;
     }
 
     private static void SetDisplay(int display, NativeWindowSettings settings)


### PR DESCRIPTION
1. Add a "grace period" after changing video mode so that any stray animations from the window manager don't trigger spurious window resize events that we'd then persist in the window size config value.  This mainly impacts Wayland.
2. On Windows, center the window on the screen when transitioning from Fullscreen/Borderless to Windowed.  This is necessary because Windows can sometimes plop the window titlebar offscreen, making it very difficult to move the window.
3. Only bounce to fullscreen and back again when recovering to regular windowed mode on X11.  This is unnecessary on Windows.

At present, Windows 11 and X11 (Cinnamon UI on Linux Mint 22.1) can successfully start in any of the three supported window modes, and can change to any of the _other_ window modes once started, regardless of which mode they were started in.  I _did_ notice a bug in X11 where, if the user starts in Borderless Fullscreen Window mode and _does not move the mouse at any time_ before switching to Windowed mode, the mouse cursor gets weirdly "stuck" in the window.

Known bugs on Wayland (Gnome on Ubuntu 24.04), which still need to be investigated and fixed:
1. Cannot properly start in Borderless Fullscreen mode (taskbar doesn't get hidden)
2. If user is in Windowed mode and transitions to Borderless Fullscreen, that works.  However, if they go from Windowed->Full Screen Exclusive->Borderless Fullscreen, the user gets a regular window instead.
3. Window decor (titlebar, etc.) are not shown and cannot be shown.  This _may_ be specific to Gnome.