### PR TITLE
Make Helion's icon work on Wayland

### DIFF
--- a/Assets/Misc/Helion.desktop
+++ b/Assets/Misc/Helion.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Name=Helion
+Comment=Doom source port focused on performance
+Icon=Helion
+TryExec=Helion
+Exec=Helion %f
+Categories=Game;ActionGame;
+MimeType=application/x-doom-wad
+Keywords=first;person;shooter;doom;boom;mbf;

--- a/Client/Client.cs
+++ b/Client/Client.cs
@@ -108,10 +108,10 @@ public partial class Client : IDisposable, IInputManagement
         else
         {
             SetOpenGLVersion(config);
-            GLFWProvider.EnsureInitialized();
-            GLFW.WindowHint(WindowHintString.WaylandAppID, "Helion");
         }
 
+        GLFWProvider.EnsureInitialized();
+        GLFW.WindowHint(WindowHintString.WaylandAppID, "Helion");
         m_window = new Window(AppInfo.ApplicationName, config, archiveCollection, m_fpsTracker, this, GlVersion.Major, GlVersion.Minor, GlVersion.Flags, CheckOpenGLSupport);
         m_screenshotGenerator = new(m_window.Renderer);
         m_soundManager.SoundCreated += m_window.JoystickAdapter.RumbleForSoundCreated;

--- a/Client/Client.cs
+++ b/Client/Client.cs
@@ -108,6 +108,8 @@ public partial class Client : IDisposable, IInputManagement
         else
         {
             SetOpenGLVersion(config);
+            GLFWProvider.EnsureInitialized();
+            GLFW.WindowHint(WindowHintString.WaylandAppID, "Helion");
         }
 
         m_window = new Window(AppInfo.ApplicationName, config, archiveCollection, m_fpsTracker, this, GlVersion.Major, GlVersion.Minor, GlVersion.Flags, CheckOpenGLSupport);

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,13 @@
+build:
+	dotnet publish -c Release -r linux-x64 --self-contained=true -p:AOT=true
+install-system-wide: build
+	ln -s Publish/linux-x64_AOT/Helion /usr/local/bin
+	cp Assets/Misc/helion.svg /usr/share/icons/hicolor/scalable/apps/Helion.svg
+	cp Assets/Misc/Helion.desktop /usr/share/applications/Helion.desktop
+	gtk-update-icon-cache /usr/share/icons/hicolor
+install-single-user: build
+	ln -s Publish/linux-x64_AOT/Helion ~/.local/bin
+	mkdir -p ~/.local/share/icons/hicolor/scalable/apps/
+	cp Assets/Misc/helion.svg ~/.local/share/icons/hicolor/scalable/apps/Helion.svg
+	cp Assets/Misc/Helion.desktop ~/.local/share/applications/Helion.desktop
+	gtk-update-icon-cache /usr/share/icons/hicolor

--- a/Justfile
+++ b/Justfile
@@ -1,5 +1,5 @@
 build:
-	dotnet publish -c Release -r linux-x64 --self-contained=true -p:AOT=true
+	dotnet publish -c Release -r linux-x64 -p:AOT=true
 install-system-wide: build
 	ln -s Publish/linux-x64_AOT/Helion /usr/local/bin
 	cp Assets/Misc/helion.svg /usr/share/icons/hicolor/scalable/apps/Helion.svg


### PR DESCRIPTION
This adds some assets designed to get Helion working on Wayland.  This includes:

* An install script that can target both system-wide installation (for potential packagers) and single-user installation (for developers).  This installs both Helion and it's icon.
* A .desktop file designed to ensure Helion will show its icon on a taskbar like KDE's.  This is installed in an appropriate location.

This script requires the use of the [```just```](https://github.com/casey/just) command, which is available from most popular Linux distributions.  If it's not in yours, but you can get Rust installed, ```cargo install just``` will install it.