### PR TITLE
Use final Nlog 6.x release

### DIFF
--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="GlmSharp-netstandard" Version="0.9.8.1" />
     <PackageReference Include="Helion.TextCopyLite" Version="1.0.0" />
     <PackageReference Include="NAudio.Core" Version="2.2.1" />
-    <PackageReference Include="NLog" Version="6.0.0-preview1" />
+    <PackageReference Include="NLog" Version="6.0.0" />
     <PackageReference Include="OpenTK" Version="4.9.4" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.4" />
     <PackageReference Include="ini-parser-net8" Version="2.6.2.1" />


### PR DESCRIPTION
I previously moved to a preview release of NLog 6.0 because prior versions had trim warnings that were noticeably bloating the size of trimmed and AOT executables.  The final release is now available, so it makes sense to use that rather than a prerelease version.