### PR TITLE
Id24 pickup message fix

### DIFF
--- a/Core/Dehacked/DehackedApplier.cs
+++ b/Core/Dehacked/DehackedApplier.cs
@@ -752,6 +752,9 @@ public class DehackedApplier
             if (thing.BloodColor.HasValue)
                 properties.BloodPaletteColor = (PaletteColor)thing.BloodColor.Value;
 
+            // id24 pickup types override dehacked vanilla sprite lookup
+            definition.IgnoreVanillaSpriteLookup = thing.PickupItemType.HasValue || thing.PickupWeaponType.HasValue || thing.PickupAmmoType.HasValue;
+
             properties.TranslationEntry = thing.TranslationLump;
         }
     }

--- a/Core/Layer/Menus/MenuLayer.Render.cs
+++ b/Core/Layer/Menus/MenuLayer.Render.cs
@@ -10,11 +10,11 @@ using Helion.Render.Common;
 using Helion.Render.Common.Enums;
 using Helion.Render.Common.Renderers;
 using Helion.Render.Common.Textures;
+using Helion.Strings;
 using Helion.Util;
 using Helion.Util.Extensions;
 using System;
 using System.Collections.Generic;
-using System.Text;
 using static Helion.Render.Common.RenderDimensions;
 
 namespace Helion.Layer.Menus;
@@ -25,10 +25,7 @@ public partial class MenuLayer
     private const int SelectedOffsetX = -32;
     private const int SelectedOffsetY = 5;
 
-    private readonly List<string> m_mapNameLines = [];
-    private readonly StringBuilder m_mapNameStringBuilder = new();
-    private readonly static StringBuilder m_lineWrapStringBuilder = new();
-    private readonly static List<string> m_lineWrapLines = new();
+    private readonly static List<StringSlice> m_lineWrapLines = [];
 
     private IMenuComponent? m_previousSelectedComponent;
     private IRenderableTextureHandle? m_saveGameTexture;
@@ -108,11 +105,11 @@ public partial class MenuLayer
         {
             int rowHeight = 0;
             var height = hud.MeasureText("0", text.FontName, text.Size).Height;
-            hud.LineWrap(text.Text, text.FontName, text.Size, hud.Dimension.Width, m_lineWrapLines, m_lineWrapStringBuilder, out addHeight);
+            hud.LineWrap(text.Text, text.FontName, text.Size, hud.Dimension.Width, m_lineWrapLines, out addHeight);
 
             foreach (var line in m_lineWrapLines)
             {
-                hud.Text(line, text.FontName, text.Size, (0, offsetY + rowHeight), out _, both: align);
+                hud.Text(line.AsSpan(), text.FontName, text.Size, (0, offsetY + rowHeight), out _, both: align);
                 rowHeight += height;
             }
         }
@@ -271,7 +268,7 @@ public partial class MenuLayer
         int boxHeight = thumbnailHeight + 5 * textSize + 3;
 
         var centerOffset = GetSaveMenuOffset(hud);
-        hud.LineWrap(m_saveGameSummary.MapName, Font, textSize, boxWidth - 4, m_mapNameLines, m_mapNameStringBuilder, 
+        hud.LineWrap(m_saveGameSummary.MapName, Font, textSize, boxWidth - 4, m_lineWrapLines, 
             out var requiredHeight);
         boxHeight += requiredHeight;
 
@@ -301,9 +298,9 @@ public partial class MenuLayer
 
         Vec2I offset = boxUpperLeft + (2, thumbnailHeight + 2);
 
-        for (int i = 0; i < m_mapNameLines.Count; i++)
+        for (int i = 0; i < m_lineWrapLines.Count; i++)
         {
-            hud.Text(m_mapNameLines[i], Font, textSize, offset, out var drawArea);
+            hud.Text(m_lineWrapLines[i].AsSpan(), Font, textSize, offset, out var drawArea);
             offset += (0, drawArea.Height);
         }
 

--- a/Core/Layer/Options/Dialogs/DialogBase.cs
+++ b/Core/Layer/Options/Dialogs/DialogBase.cs
@@ -5,6 +5,7 @@ using Helion.Graphics;
 using Helion.Render.Common;
 using Helion.Render.Common.Enums;
 using Helion.Render.Common.Renderers;
+using Helion.Strings;
 using Helion.Util;
 using Helion.Util.Configs.Components;
 using Helion.Util.Configs.Extensions;
@@ -14,7 +15,6 @@ using Helion.Window;
 using Helion.Window.Input;
 using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Helion.Layer.Options.Dialogs;
 
@@ -37,10 +37,9 @@ internal abstract class DialogBase(ConfigWindow config, string? acceptButton, st
     protected Dimension m_box;
     protected Box2I m_dialogBox;
     protected Vec2I m_dialogOffset;
-    private BoxList m_buttonPosList = new();
-    private List<Action> m_buttonActionList = new();
+    private readonly BoxList m_buttonPosList = new();
+    private readonly List<Action> m_buttonActionList = [];
     private int m_buttonIndex = 0;
-    private StringBuilder m_textWrapBuilder = new();
 
     public void Dispose()
     {
@@ -158,6 +157,24 @@ internal abstract class DialogBase(ConfigWindow config, string? acceptButton, st
         hud.AddOffset((0, m_rowHeight + m_padding));
     }
 
+    protected void RenderDialogText(
+        IHudRenderContext hud,
+        ReadOnlySpan<char> message,
+        Color? color = null,
+        TextAlign textAlign = TextAlign.Left,
+        Align windowAlign = Align.TopLeft,
+        Align anchorAlign = Align.TopLeft)
+    {
+        if (!(message.Length > 0))
+        {
+            hud.AddOffset((0, m_rowHeight));
+            return;
+        }
+
+        hud.Text(message, Font, m_fontSize, (0, 0), color: color, textAlign: textAlign, window: windowAlign, anchor: anchorAlign, maxWidth: m_box.Width);
+        hud.AddOffset((0, m_rowHeight + m_padding));
+    }
+
     protected void RenderDialogImage(
         IHudRenderContext hud,
         string imageName,
@@ -174,9 +191,9 @@ internal abstract class DialogBase(ConfigWindow config, string? acceptButton, st
         return hud.TruncateText(text, Font, m_fontSize, m_box.Width).ToString();
     }
 
-    protected void WrapTextToDialogWidth(string text, IHudRenderContext hud, List<string> wrappedLines)
+    protected void WrapTextToDialogWidth(string text, IHudRenderContext hud, List<StringSlice> wrappedLines)
     {
-        hud.LineWrap(text, Font, m_fontSize, m_box.Width, wrappedLines, m_textWrapBuilder, out _);
+        hud.LineWrap(text, Font, m_fontSize, m_box.Width, wrappedLines, out _);
     }
 
     public virtual void RunLogic(TickerInfo tickerInfo)

--- a/Core/Layer/Options/Dialogs/MessageDialog.cs
+++ b/Core/Layer/Options/Dialogs/MessageDialog.cs
@@ -1,5 +1,6 @@
 ﻿using Helion.Graphics;
 using Helion.Render.Common.Renderers;
+using Helion.Strings;
 using Helion.Util.Configs.Components;
 using System.Collections.Generic;
 
@@ -10,8 +11,8 @@ internal class MessageDialog(ConfigWindow config, string title, IList<string> me
 {
     private readonly string m_title = title;
     private readonly IList<string> m_message = message;
-    private readonly List<string> m_messageFormatted = [];
-    private readonly List<string> m_lines = [];
+    private readonly List<StringSlice> m_messageFormatted = [];
+    private readonly List<StringSlice> m_lines = [];
 
     protected override void RenderDialogContents(IRenderableSurfaceContext ctx, IHudRenderContext hud, bool sizeChanged)
     {
@@ -24,11 +25,11 @@ internal class MessageDialog(ConfigWindow config, string title, IList<string> me
             m_messageFormatted.Clear();
             m_lines.Clear();
 
-            foreach (string str in m_message)
+            foreach (var str in m_message)
             {
                 if (str.Length == 0)
                 {
-                    m_messageFormatted.Add(str);
+                    m_messageFormatted.Add(StringSlice.Empty);
                     continue;
                 }
 
@@ -38,8 +39,6 @@ internal class MessageDialog(ConfigWindow config, string title, IList<string> me
         }
 
         foreach (var message in m_messageFormatted)
-        {
-            RenderDialogText(hud, message);
-        }
+            RenderDialogText(hud, message.AsSpan());
     }
 }

--- a/Core/Layer/Options/OptionsLayer.cs
+++ b/Core/Layer/Options/OptionsLayer.cs
@@ -8,6 +8,7 @@ using Helion.Layer.Options.Sections;
 using Helion.Render.Common.Enums;
 using Helion.Render.Common.Renderers;
 using Helion.Resources;
+using Helion.Strings;
 using Helion.Util;
 using Helion.Util.Configs;
 using Helion.Util.Configs.Components;
@@ -21,7 +22,6 @@ using Helion.Window;
 using Helion.Window.Input;
 using System;
 using System.Collections.Generic;
-using System.Text;
 using static Helion.Util.Constants;
 
 namespace Helion.Layer.Options;
@@ -47,8 +47,7 @@ public class OptionsLayer : IGameLayer, IAnimationLayer
     private readonly IWindow m_window;
     private readonly List<IOptionSection> m_sections;
     private readonly BoxList m_backForwardPos = new();
-    private readonly List<string> m_footerLines = [];
-    private readonly StringBuilder m_footerStringBuilder = new();
+    private readonly List<StringSlice> m_footerLines = [];
     private Dimension m_windowSize;
     private Vec2I m_cursorPos;
     private int m_currentSectionIndex;
@@ -406,7 +405,7 @@ public class OptionsLayer : IGameLayer, IAnimationLayer
 
         m_headerHeight += pageInstrArea.Height + m_config.Window.GetMenuScaled(16);
         if (m_lastSelectedRowDescription != m_selectedRowDescription)
-            GenerateFooterLines(m_selectedRowDescription, FooterFont, fontSize, hud, m_footerLines, m_footerStringBuilder, out m_footerHeight);
+            GenerateFooterLines(m_selectedRowDescription, FooterFont, fontSize, hud, m_footerLines, out m_footerHeight);
         m_lastSelectedRowDescription = m_selectedRowDescription;
 
         y += m_headerHeight;
@@ -457,21 +456,21 @@ public class OptionsLayer : IGameLayer, IAnimationLayer
         }
     }
 
-    private void GenerateFooterLines(string inputText, string font, int fontSize, IHudRenderContext hud, List<string> lines, StringBuilder builder,
+    private void GenerateFooterLines(string inputText, string font, int fontSize, IHudRenderContext hud, List<StringSlice> lines,
         out int requiredHeight)
     {
         // Setting descriptions may be verbose, and may need multiple lines to render.  This method precomputes 
         // the dimensions we'll need for a footer, so we can reserve room when doing rendering and scroll offset
         // calculations.  It also returns the split text, since we need to figure that out anyway and are going to
         // need it later when we actually render the footer.
-        hud.LineWrap(inputText, font, fontSize, hud.Width, lines, builder, out requiredHeight);
+        hud.LineWrap(inputText, font, fontSize, hud.Width, lines, out requiredHeight);
 
         // Calculate how much room we need for the footer, with padding both above and below the text
         int padding = m_config.Window.GetMenuScaled(8);
         requiredHeight += padding * 2;
     }
 
-    private void RenderFooter(List<string> lines, int startY, string font, int fontSize, IHudRenderContext hud)
+    private void RenderFooter(List<StringSlice> lines, int startY, string font, int fontSize, IHudRenderContext hud)
     {
         int padding = m_config.Window.GetMenuScaled(8);
 
@@ -483,10 +482,11 @@ public class OptionsLayer : IGameLayer, IAnimationLayer
 
         int y = hud.Height - m_footerHeight + padding;
 
-        foreach (string line in lines)
+        foreach (var line in lines)
         {
-            Dimension tokenSize = hud.MeasureText(line, font, fontSize);
-            hud.Text(line, font, fontSize, (0, y), out Dimension drawArea, both: Align.TopMiddle, color: Color.White);
+            var span = line.AsSpan();
+            Dimension tokenSize = hud.MeasureText(span, font, fontSize);
+            hud.Text(span, font, fontSize, (0, y), out Dimension drawArea, both: Align.TopMiddle, color: Color.White);
             y += drawArea.Height;
         }
     }

--- a/Core/Layer/Worlds/WorldLayer.Render.Hud.cs
+++ b/Core/Layer/Worlds/WorldLayer.Render.Hud.cs
@@ -11,7 +11,6 @@ using Helion.Render.Common.Renderers;
 using Helion.Render.Common.Textures;
 using Helion.Render.OpenGL.Renderers.Legacy.World.Shader;
 using Helion.Render.OpenGL.Texture.Fonts;
-using Helion.Render.OpenGL.Texture.Legacy;
 using Helion.Render.OpenGL.Util;
 using Helion.Resources;
 using Helion.Resources.Definitions.Decorate.States;
@@ -105,6 +104,7 @@ public partial class WorldLayer
     private readonly RenderableString[] RenderableStatLabels;
     private readonly RenderableString[] RenderableStatValues;
     private readonly Font m_largeHudFont;
+    private readonly List<StringSlice> m_lineWrapStrings = [];
 
     private readonly record struct HudDrawWeapon(IHudRenderContext Hud, FrameState FrameState, int yOffset, bool Flash);
 
@@ -1077,11 +1077,23 @@ public partial class WorldLayer
 
             int fontSize = (int)(1.25 * hud.GetFontMaxHeight(SmallHudFont));
             int slideOffsetY = m_messages.Count <= 1 ? 0 : CalculateSlide(hud, lastMessageTime);
+            var scale = GetDoomScale(hud, out _);
+            var width = m_config.Hud.Width.Value * 320.0 * scale.X / m_scale;
+
+            if (m_config.Hud.Width.Value == 0)
+                width = hud.Dimension.Width / m_scale;
+
             for (int i = m_messages.Count - 1; i >= 0; i--)
             {
-                hud.Text(m_messages[i].message, SmallHudFont, fontSize, (LeftOffset + m_hudPaddingX, offsetY + slideOffsetY),
-                    out Dimension drawArea, window: Align.TopLeft, scale: m_scale, alpha: m_messages[i].alpha * m_hudAlpha);
-                offsetY += drawArea.Height + MessageSpacing;
+                (var message, var alpha) = m_messages[i];
+                hud.LineWrap(message, SmallHudFont, fontSize, (int)width, m_lineWrapStrings, out var drawHeight);
+
+                foreach (var line in m_lineWrapStrings)
+                {
+                    hud.Text(line.Source.AsSpan(line.Start, line.Length), SmallHudFont, fontSize, (LeftOffset + m_hudPaddingX, offsetY + slideOffsetY),
+                        out Dimension drawArea, window: Align.TopLeft, scale: m_scale, alpha: alpha * m_hudAlpha);
+                    offsetY += drawArea.Height + MessageSpacing;
+                }
             }
 
             m_lastMessageCount = m_messages.Count;

--- a/Core/Strings/StringSlice.cs
+++ b/Core/Strings/StringSlice.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace Helion.Strings;
+
+public struct StringSlice(string source, int start, int length)
+{
+    public string Source = source;
+    public int Start = start;
+    public int Length = length;
+
+    public static readonly StringSlice Empty = new(string.Empty, 0, 0);
+
+    public readonly ReadOnlySpan<char> AsSpan() =>
+        Source.AsSpan(Start, Length);
+
+    public override readonly string ToString() => 
+        AsSpan().ToString();
+}

--- a/Core/Util/Extensions/HudExtensions.cs
+++ b/Core/Util/Extensions/HudExtensions.cs
@@ -3,9 +3,9 @@ using Helion.Render.Common.Enums;
 using Helion.Render.Common.Renderers;
 using Helion.Render.Common.Textures;
 using Helion.Resources;
+using Helion.Strings;
 using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Helion.Util.Extensions;
 
@@ -115,11 +115,10 @@ public static class HudExtensions
         return inputText;
     }
 
-    public static void LineWrap(this IHudRenderContext hud, string inputText, string font, int fontSize, int maxWidth, List<string> lines, StringBuilder builder,
+    public static void LineWrap(this IHudRenderContext hud, string inputText, string font, int fontSize, int maxWidth, List<StringSlice> lines,
         out int requiredHeight)
     {
         lines.Clear();
-        builder.Clear();
         if (string.IsNullOrEmpty(inputText))
         {
             requiredHeight = 0;
@@ -128,9 +127,13 @@ public static class HudExtensions
 
         int maxTokenHeight = 0;
         int widthCounter = 0;
-
         int splitStart;
         int splitEnd = 0;
+        int sliceStart = 0;
+        int sliceLength = 0;
+
+        var spaceWidth = hud.MeasureText(" ", font, fontSize).Width;
+
         for (int i = 0; i < inputText.Length; i++)
         {
             if (inputText[i] == ' ' || i == inputText.Length - 1)
@@ -144,24 +147,28 @@ public static class HudExtensions
             }
 
             splitEnd++;
-            var token = inputText.AsSpan(splitStart, splitEnd - splitStart);
+            var token = inputText.AsSpan(splitStart, splitEnd - splitStart - 1);
             var tokenSize = hud.MeasureText(token, font, fontSize);
             maxTokenHeight = Math.Max(maxTokenHeight, tokenSize.Height);
 
             if (widthCounter + tokenSize.Width > maxWidth)
             {
-                lines.Add(builder.ToString());
-                builder.Clear();
+                lines.Add(new(inputText, sliceStart, sliceLength));
+                sliceLength = splitEnd - splitStart;
+                sliceStart = splitStart;
                 widthCounter = 0;
             }
+            else
+            {
+                sliceLength += token.Length + 1;
+            }
 
-            builder.Append(token);
-            widthCounter += tokenSize.Width;
+            widthCounter += tokenSize.Width + spaceWidth;
         }
 
-        // Flush the last line out of the StringBuilder
-        if (builder.Length > 0)
-            lines.Add(builder.ToString());
+        // Flush the last line out
+        if (sliceLength > 0)
+            lines.Add(new(inputText, sliceStart, sliceLength));
 
         requiredHeight = lines.Count * maxTokenHeight;
     }

--- a/Core/World/Entities/Definition/EntityDefinition.cs
+++ b/Core/World/Entities/Definition/EntityDefinition.cs
@@ -34,6 +34,7 @@ public class EntityDefinition
     public string? BaseInventoryName;
     public string DehackedName = string.Empty;
     public bool DefinitionSet;
+    public bool IgnoreVanillaSpriteLookup;
 
     public EntityFrame? HealFrame;
 

--- a/Core/World/WorldBase.cs
+++ b/Core/World/WorldBase.cs
@@ -1858,7 +1858,9 @@ public abstract partial class WorldBase : IWorld
 
     public virtual bool GiveItem(Player player, Entity item, EntityFlags? flags, out EntityDefinition definition, bool pickupFlash = true)
     {
-        if (ArchiveCollection.Definitions.DehackedDefinition != null && GetDehackedPickup(ArchiveCollection.Definitions.DehackedDefinition, item, out var vanillaDef))
+        if (!item.Definition.IgnoreVanillaSpriteLookup &&
+            ArchiveCollection.Definitions.DehackedDefinition != null &&
+            GetDehackedPickup(ArchiveCollection.Definitions.DehackedDefinition, item, out var vanillaDef))
         {
             definition = vanillaDef;
             flags = GetCombinedPickupFlags(vanillaDef.Flags, flags);

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -5,7 +5,9 @@
 - Dehacked blood color support for both palette and true color images.
 - Blood color is passed to children through A_SpawnObject so Smooth Doom MBF21 blood spawners with blood color match parent blood.
 - UDMF midtex3d and midtex3dimpassible line flags support. Includes physics for monsters to walk on without dropping off.
+- HUD message text will wrap to HUD width.
 
 ## Bug Fixes:
 - Fix spawn ceiling sprite offsets for vanilla sprite rendering.
 - Ignore GL nodes in archive and always build nodes internally to fix maps with bad GL nodes.
+- Fix id24 pickups to skip using the sprite name for lookup.

--- a/Tests/Unit/GameAction/Id24/Pickups.cs
+++ b/Tests/Unit/GameAction/Id24/Pickups.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using Helion.Geometry.Vectors;
+using Helion.Resources.Definitions;
 using Helion.Resources.IWad;
 using Helion.Tests.Unit.GameAction.Util;
 using Helion.World;
@@ -7,6 +8,7 @@ using Helion.World.Entities.Inventories.Powerups;
 using Helion.World.Entities.Players;
 using Helion.World.Impl.SinglePlayer;
 using Xunit;
+using static Helion.Dehacked.DehackedDefinition;
 
 namespace Helion.Tests.Unit.GameAction.Id24;
 
@@ -109,10 +111,13 @@ public class Pickups
 
     [Fact(DisplayName = "Pickup message")]
     public void PickupMessage()
-    {
+    {        
         PlayerMessageEvent? messageEvent = null;
         World.PlayerMessage += World_PlayerMessage;
         var item = GameActions.CreateEntity(World, "*deh/entity42068", ItemPos);
+        // Use megasphere frame index to test that vanilla lookup by sprite is ignored for id24
+        var frameIndex = World.ArchiveCollection.Definitions.EntityFrameTable.VanillaFrameMap[(int)ThingState.MEGA].MasterFrameIndex;
+        item.FrameState.Frame = World.ArchiveCollection.Definitions.EntityFrameTable.Frames[frameIndex];
         item.Definition.Properties.Inventory.PickupMessage.Should().Be("$*deh/USER_PICKUPITEM1");
         World.PerformItemPickup(Player, item);
         messageEvent.HasValue.Should().BeTrue();
@@ -245,6 +250,7 @@ public class Pickups
 
     private static readonly string Dehacked =
 @"Thing 42069 (PickupThing)
+Initial frame = 2772
 Bits = SPECIAL
 Pickup item type = 0
 Pickup bonus count = 20


### PR DESCRIPTION
Force ignore dehacked sprite lookup for pickups when id24 pickup properties are set

Wrap messages to HUD width and remove allocations in line wrap function