### PR TITLE
id24 default skytransform/animation fix

### DIFF
--- a/Core/Render/OpenGL/Renderers/Legacy/World/Sky/Sphere/SkySphereRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Sky/Sphere/SkySphereRenderer.cs
@@ -59,7 +59,6 @@ public class SkySphereRenderer : IDisposable
         skyTransform.Sky.Offset.X += offset.X;
         skyTransform.Sky.Offset.Y += offset.Y;
 
-
         if (skyTransform.Sky.Type == SkyTransformType.Fire)
         {
             m_foregroundProgram.Bind();

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Sky/Sphere/SkySphereTexture.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Sky/Sphere/SkySphereTexture.cs
@@ -70,6 +70,8 @@ public class SkySphereTexture(ArchiveCollection archiveCollection, LegacyGLTextu
         int animationIndex = m_archiveCollection.TextureManager.GetTranslationIndex(m_textureHandleIndex);
         if (m_archiveCollection.TextureManager.TryGetSkyTransform(animationIndex, out var findTransform))
             skyTransform = findTransform;
+        else if (m_archiveCollection.TextureManager.TryGetSkyTransform(m_textureHandleIndex, out findTransform))
+            skyTransform = findTransform;
         return GetSkyTextureFromTextureIndex(animationIndex, m_textureHandleIndex);
     }
 
@@ -134,6 +136,7 @@ public class SkySphereTexture(ArchiveCollection archiveCollection, LegacyGLTextu
         if (mode == SkyRenderMode.Vanilla)
         {
             offset.X += StandardWidth;
+            transform.MidTexel = 0;
             // Set offset to draw from bottom up (only for skytransfer specials or id24 skies with midtexel property)
             if ((options & SkyOptions.SkyTransfer) != 0 || transform.MidTexel.HasValue)
                 offset.Y += skyTexture.GlTexture.Height - StandardHeight;

--- a/Core/Resources/TextureManagerSky.cs
+++ b/Core/Resources/TextureManagerSky.cs
@@ -1,17 +1,16 @@
-﻿using System;
+﻿using Helion.Geometry.Vectors;
+using Helion.Graphics;
+using Helion.Render.OpenGL.Renderers.Legacy.World.Shader;
+using Helion.Resources.Definitions.Id24;
+using Helion.Resources.Definitions.MapInfo;
+using Helion.Resources.Images;
+using Helion.Util;
+using Helion.Util.Extensions;
+using Helion.Util.RandomGenerators;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using Helion.Resources.Archives.Entries;
-using Helion.Resources.Images;
-using Helion.Resources.Definitions.Id24;
 using System.Linq;
-using Helion.Graphics;
-using Helion.Util.RandomGenerators;
-using Helion.Util;
-using Helion.Render.OpenGL.Renderers.Legacy.World.Shader;
-using Helion.Util.Extensions;
-using Helion.Geometry.Vectors;
-using Helion.Resources.Definitions.MapInfo;
 
 namespace Helion.Resources;
 
@@ -240,6 +239,8 @@ public partial class TextureManager
 
         if (skyTransform == null && mapInfo.Sky1.ScrollSpeed != 0)
             skyTransform = SkyTransform.FromMapInfoSky(texture.Index, mapInfo);
+
+        skyTransform ??= SkyTransform.Default;
 
         if (skyTransform != null)
         {

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -12,3 +12,4 @@
 - Ignore GL nodes in archive and always build nodes internally to fix maps with bad GL nodes.
 - Fix id24 pickups to skip using the sprite name for lookup.
 - Fix incorrect warnings for sounds and invalid bex string memonic with custom sounds prefixed with USER_ 
+- Fix id24 skies to have defaults set for when not defined outside of flatmapping and correct lookup for animations


### PR DESCRIPTION
fix id24 skies to have defaults set for when not defined outside of flatmapping and correct lookup for animations