### PR TITLE
Sky align fix

### DIFF
--- a/Core/Render/OpenGL/Renderers/Legacy/World/Sky/Sphere/SkySphereComponent.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Sky/Sphere/SkySphereComponent.cs
@@ -21,9 +21,12 @@ public class SkySphereComponent : ISkyComponent
     public bool HasGeometry => !m_geometryVbo.Empty;
     public VertexBufferObject<SkyGeometryVertex> Vbo => m_geometryVbo;
 
+    public readonly string Name;
+
     public SkySphereComponent(ArchiveCollection archiveCollection, LegacyGLTextureManager textureManager, int textureHandle,
         SkyOptions options, Vec2F offset)
     {
+        Name = textureManager.GetTexture(textureHandle).Name;
         m_skySphereRenderer = new(archiveCollection, textureManager, textureHandle);
         m_geometryVao = new("Sky geometry");
         m_geometryVbo = new("Sky geometry");
@@ -84,4 +87,6 @@ public class SkySphereComponent : ISkyComponent
 
         m_skySphereRenderer.Dispose();
     }
+
+    public override string ToString() => Name;
 }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Sky/Sphere/SkySphereForegroundShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Sky/Sphere/SkySphereForegroundShader.cs
@@ -1,72 +1,13 @@
-﻿using GlmSharp;
-using Helion.Geometry.Vectors;
-using Helion.Render.OpenGL.Renderers.Legacy.World.Shader;
-using Helion.Render.OpenGL.Shader;
-using OpenTK.Graphics.OpenGL;
+﻿using Helion.Render.OpenGL.Renderers.Legacy.World.Shader;
 
 namespace Helion.Render.OpenGL.Renderers.Legacy.World.Sky.Sphere;
 
-internal class SkySphereForegroundShader : RenderProgram
+internal class SkySphereForegroundShader : SkySphereShader
 {
-    private readonly int m_boundTextureLocation;
-    private readonly int m_colormapTextureLocation;
-    private readonly int m_mvpLocation;
-    private readonly int m_hasInvulnerabilityLocation;
-    private readonly int m_scaleLocation;
-    private readonly int m_flipULocation;
-    private readonly int m_paletteIndexLocation;
-    private readonly int m_colorMapIndexLocation;
-    private readonly int m_scrollOffsetLocation;
-    private readonly int m_textureHeightLocation;
-    private readonly int m_textureStartLocation;
-    private readonly int m_topColorLocation;
-    private readonly int m_bottomColorLocation;
-    private readonly int m_skyHeight;
-    private readonly int m_skyMin;
-    private readonly int m_skyMax;
-    private readonly int m_colorMixLocation;
-    private readonly int m_gammaCorrectionLocation;
-
     public SkySphereForegroundShader() : base("Sky foreground texture")
     {
-        m_boundTextureLocation = Uniforms.GetLocation("boundTexture");
-        m_colormapTextureLocation = Uniforms.GetLocation("colormapTexture");
-        m_mvpLocation = Uniforms.GetLocation("mvp");
-        m_hasInvulnerabilityLocation = Uniforms.GetLocation("hasInvulnerability");
-        m_scaleLocation = Uniforms.GetLocation("scale");
-        m_flipULocation = Uniforms.GetLocation("flipU");
-        m_paletteIndexLocation = Uniforms.GetLocation("paletteIndex");
-        m_colorMapIndexLocation = Uniforms.GetLocation("colormapIndex");
-        m_scrollOffsetLocation = Uniforms.GetLocation("scrollOffset");
-        m_textureHeightLocation = Uniforms.GetLocation("textureHeight");
-        m_textureStartLocation = Uniforms.GetLocation("textureStart");
-        m_topColorLocation = Uniforms.GetLocation("topColor");
-        m_bottomColorLocation = Uniforms.GetLocation("bottomColor");
-        m_skyHeight = Uniforms.GetLocation("skyHeight");
-        m_skyMin = Uniforms.GetLocation("skyMin");
-        m_skyMax = Uniforms.GetLocation("skyMax");
-        m_colorMixLocation = Uniforms.GetLocation("colorMix");
-        m_gammaCorrectionLocation = Uniforms.GetLocation("gammaCorrection");
-    }
 
-    public void BoundTexture(TextureUnit unit) => Uniforms.Set(unit, m_boundTextureLocation);
-    public void ColormapTexture(TextureUnit unit) => Uniforms.Set(unit, m_colormapTextureLocation);
-    public void HasInvulnerability(bool invul) => Uniforms.Set(invul, m_hasInvulnerabilityLocation);
-    public void Mvp(mat4 mat) => Uniforms.Set(mat, m_mvpLocation);
-    public void Scale(Vec2F v) => Uniforms.Set(v, m_scaleLocation);
-    public void FlipU(bool flip) => Uniforms.Set(flip, m_flipULocation);
-    public void PaletteIndex(int index) => Uniforms.Set(index, m_paletteIndexLocation);
-    public void ColorMapIndex(int index) => Uniforms.Set(index, m_colorMapIndexLocation);
-    public void ScrollOffset(Vec2F offset) => Uniforms.Set(offset, m_scrollOffsetLocation);
-    public void TextureHeight(float height) => Uniforms.Set(height, m_textureHeightLocation);
-    public void TextureStart(float start) => Uniforms.Set(start, m_textureStartLocation);
-    public void TopColor(Vec4F topColor) => Uniforms.Set(topColor, m_topColorLocation);
-    public void BottomColor(Vec4F bottomColor) => Uniforms.Set(bottomColor, m_bottomColorLocation);
-    public void SkyHeight(float value) => Uniforms.Set(value, m_skyHeight);
-    public void SkyMin(float value) => Uniforms.Set(value, m_skyMin);
-    public void SkyMax(float value) => Uniforms.Set(value, m_skyMax);
-    public void ColorMix(Vec3F value) => Uniforms.Set(value, m_colorMixLocation);
-    public void GammaCorrection(float value) => Uniforms.Set(value, m_gammaCorrectionLocation);
+    }
 
     protected override string VertexShader() => @"
         #version 330
@@ -104,8 +45,6 @@ internal class SkySphereForegroundShader : RenderProgram
         uniform int hasInvulnerability;
         uniform int paletteIndex;
         uniform int colormapIndex;
-        uniform float textureHeight;
-        uniform float textureStart;
         uniform float skyHeight;
         uniform float skyMin;
         uniform float skyMax;
@@ -114,6 +53,9 @@ internal class SkySphereForegroundShader : RenderProgram
         
         uniform vec4 topColor;
         uniform vec4 bottomColor;
+
+        float textureHeight = skyHeight;
+        float textureStart = 0.5;
 
         vec4 blendSky(vec4 fragColor, vec4 topBlendColor, vec4 bottomBlendColor) {
             float blendAmount = skyHeight / 4.6;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Sky/Sphere/SkySphereRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Sky/Sphere/SkySphereRenderer.cs
@@ -229,9 +229,9 @@ public class SkySphereRenderer : IDisposable
         if (renderInfo.ViewerEntity.PlayerObj != null)
             invulnerability = renderInfo.ViewerEntity.PlayerObj.DrawInvulnerableColorMap();
 
-        var scaleUV = SkySphereTexture.CalcScale(foregroundTexture, foregroundTransform);
-        var offset = SkySphereTexture.CalcOffset(foregroundTexture, foregroundTransform, m_mode, scaleUV);
-        var textureHeight = SkySphereTexture.CalcSkyHeight(foregroundTexture.GlTexture.Dimension.Height, m_mode);
+        var scaleUV = SkySphereTexture.CalcScale(skyTexture, foregroundTransform);
+        var offset = SkySphereTexture.CalcOffset(skyTexture, foregroundTransform, m_mode, scaleUV);
+        var textureHeight = SkySphereTexture.CalcSkyHeight(skyTexture.GlTexture.Dimension.Height, m_mode);
 
         m_foregroundProgram.BoundTexture(BindTextures.BoundTexture);
         m_foregroundProgram.ColormapTexture(BindTextures.Colormap);

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Sky/Sphere/SkySphereRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Sky/Sphere/SkySphereRenderer.cs
@@ -59,19 +59,10 @@ public class SkySphereRenderer : IDisposable
         skyTransform.Sky.Offset.X += offset.X;
         skyTransform.Sky.Offset.Y += offset.Y;
 
-        if (skyTransform.Sky.Type == SkyTransformType.Fire)
-        {
-            m_foregroundProgram.Bind();
-            RenderFire(renderInfo, skyTexture, skyTransform.Sky);
-            m_foregroundProgram.Unbind();
-        }
-        else
-        {
-            m_skyProgram.Bind();
-            SetSkyUniforms(renderInfo, options, skyTexture, skyTransform.Sky);
-            DrawSphere(skyTexture.GlTexture);
-            m_skyProgram.Unbind();
-        }
+        m_skyProgram.Bind();
+        SetSkyUniforms(renderInfo, options, skyTexture, skyTransform.Sky);
+        DrawSphere(skyTexture.GlTexture);
+        m_skyProgram.Unbind();
 
         if (skyTransform.Foreground == null)
             return;
@@ -80,25 +71,10 @@ public class SkySphereRenderer : IDisposable
         GL.ActiveTexture(BindTextures.BoundTexture);
 
         var foregroundTexture = m_texture.GetForegroundTexture(skyTransform.Foreground);
-        if (skyTransform.Foreground.Type == SkyTransformType.Fire)
-        {
-            RenderFire(renderInfo, foregroundTexture, skyTransform.Foreground);
-        }
-        else
-        {
-            SetForegroundUniforms(renderInfo, true, skyTexture, foregroundTexture, skyTransform.Foreground);
-            DrawSphere(foregroundTexture.GlTexture);
-        }
+        SetForegroundUniforms(renderInfo, true, skyTexture, foregroundTexture, skyTransform.Foreground);
+        DrawSphere(foregroundTexture.GlTexture);
 
         m_foregroundProgram.Unbind();
-    }
-
-    private void RenderFire(RenderInfo renderInfo, in SkyTexture foregroundTexture, SkyTransformTexture foregroundTransform)
-    {
-        SetForegroundFireUniforms(renderInfo, true, foregroundTexture, foregroundTransform, topFire: true);
-        DrawSphere(foregroundTexture.GlTexture);
-        SetForegroundFireUniforms(renderInfo, true, foregroundTexture, foregroundTransform, topFire: false);
-        DrawSphere(foregroundTexture.GlTexture);
     }
 
     public void Dispose()
@@ -190,8 +166,8 @@ public class SkySphereRenderer : IDisposable
             invulnerability = renderInfo.ViewerEntity.PlayerObj.DrawInvulnerableColorMap();
 
         var texture = skyTexture.GlTexture;
-        var scaleUV = SkySphereTexture.CalcScale(skyTexture, skyTransform);
-        var offset = SkySphereTexture.CalcOffset(skyTexture, skyTransform, m_mode, scaleUV, options);
+        var scaleUV = SkySphereTexture.CalcScale(skyTexture.GlTexture.Dimension, skyTransform);
+        var offset = SkySphereTexture.CalcOffset(skyTexture.GlTexture.Dimension, skyTransform, m_mode, scaleUV, options);
         var skyHeight = SkySphereTexture.CalcSkyHeight(texture.Dimension.Height, m_mode);
 
         m_skyProgram.BoundTexture(BindTextures.BoundTexture);
@@ -229,9 +205,11 @@ public class SkySphereRenderer : IDisposable
         if (renderInfo.ViewerEntity.PlayerObj != null)
             invulnerability = renderInfo.ViewerEntity.PlayerObj.DrawInvulnerableColorMap();
 
-        var scaleUV = SkySphereTexture.CalcScale(skyTexture, foregroundTransform);
-        var offset = SkySphereTexture.CalcOffset(skyTexture, foregroundTransform, m_mode, scaleUV);
-        var textureHeight = SkySphereTexture.CalcSkyHeight(skyTexture.GlTexture.Dimension.Height, m_mode);
+        // The sky fire is a special case where it's rendered at the standard dimenion but it's actual dimension differs.
+        var dimension = foregroundTexture.IsFire ? SkySphereTexture.StandardDimension : foregroundTexture.GlTexture.Dimension;
+        var scaleUV = SkySphereTexture.CalcScale(dimension, foregroundTransform);
+        var offset = SkySphereTexture.CalcOffset(dimension, foregroundTransform, m_mode, scaleUV);
+        var textureHeight = SkySphereTexture.CalcSkyHeight(dimension.Height, m_mode);
 
         m_foregroundProgram.BoundTexture(BindTextures.BoundTexture);
         m_foregroundProgram.ColormapTexture(BindTextures.Colormap);
@@ -262,48 +240,6 @@ public class SkySphereRenderer : IDisposable
         m_foregroundProgram.SkyMin(0.5f - textureHeight);
         m_foregroundProgram.SkyMax(0.5f + textureHeight);
         m_foregroundProgram.TextureStart(0.5f);
-    }
-
-    private void SetForegroundFireUniforms(RenderInfo renderInfo, bool flipSkyHorizontal,
-        in SkyTexture foregroundTexture, SkyTransformTexture foregroundTransform, bool topFire)
-    {
-        bool invulnerability = false;
-        if (renderInfo.ViewerEntity.PlayerObj != null)
-            invulnerability = renderInfo.ViewerEntity.PlayerObj.DrawInvulnerableColorMap();
-
-        var scaleUV = SkySphereTexture.CalcScale(foregroundTexture, foregroundTransform);
-        var offset = SkySphereTexture.CalcFireOffset(foregroundTexture, foregroundTransform);
-        var textureHeight = SkySphereTexture.CalcSkyHeight(foregroundTexture.GlTexture.Dimension.Height, m_mode);
-
-        m_foregroundProgram.BoundTexture(BindTextures.BoundTexture);
-        m_foregroundProgram.ColormapTexture(BindTextures.Colormap);
-        m_foregroundProgram.Mvp(CalculateMvp(renderInfo));
-        m_foregroundProgram.Scale(scaleUV);
-        m_foregroundProgram.FlipU(flipSkyHorizontal);
-        m_foregroundProgram.ColorMix(renderInfo.Uniforms.ColorMix.Sky);
-        m_foregroundProgram.TopColor(Vec4F.Zero);
-        m_foregroundProgram.BottomColor(Vec4F.Zero);
-        m_foregroundProgram.HasInvulnerability(invulnerability);
-        m_foregroundProgram.PaletteIndex((int)renderInfo.Uniforms.PaletteIndex);
-        m_foregroundProgram.ColorMapIndex(renderInfo.Uniforms.ColorMapUniforms.SkyIndex);
-        m_foregroundProgram.ScrollOffset(offset);
-
-        m_foregroundProgram.TextureHeight(textureHeight);
-
-        if (topFire)
-        {
-            m_foregroundProgram.TextureHeight(textureHeight);
-            m_foregroundProgram.SkyHeight(textureHeight);
-            m_foregroundProgram.SkyMin(0.5f - textureHeight);
-            m_foregroundProgram.SkyMax(0.5f + textureHeight);
-            m_foregroundProgram.TextureStart(0.5f);
-        }
-        else
-        {
-            m_foregroundProgram.SkyMin(textureHeight);
-            m_foregroundProgram.SkyMax(0.5f);
-            m_foregroundProgram.TextureStart(0.5f);
-        }
     }
 
     private void ReleaseUnmanagedResources()

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Sky/Sphere/SkySphereRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Sky/Sphere/SkySphereRenderer.cs
@@ -1,5 +1,6 @@
 using System;
 using GlmSharp;
+using Helion.Geometry;
 using Helion.Geometry.Vectors;
 using Helion.Render.OpenGL.Buffer.Array.Vertex;
 using Helion.Render.OpenGL.Renderers.Legacy.World.Shader;
@@ -60,7 +61,7 @@ public class SkySphereRenderer : IDisposable
         skyTransform.Sky.Offset.Y += offset.Y;
 
         m_skyProgram.Bind();
-        SetSkyUniforms(renderInfo, options, skyTexture, skyTransform.Sky);
+        SetSkyUniforms(m_skyProgram, renderInfo, options, m_mode, skyTexture, skyTexture, skyTransform.Sky);
         DrawSphere(skyTexture.GlTexture);
         m_skyProgram.Unbind();
 
@@ -71,7 +72,7 @@ public class SkySphereRenderer : IDisposable
         GL.ActiveTexture(BindTextures.BoundTexture);
 
         var foregroundTexture = m_texture.GetForegroundTexture(skyTransform.Foreground);
-        SetForegroundUniforms(renderInfo, true, skyTexture, foregroundTexture, skyTransform.Foreground);
+        SetSkyUniforms(m_foregroundProgram, renderInfo, SkyOptions.Flip, m_mode, foregroundTexture, skyTexture, skyTransform.Foreground);
         DrawSphere(foregroundTexture.GlTexture);
 
         m_foregroundProgram.Unbind();
@@ -159,87 +160,50 @@ public class SkySphereRenderer : IDisposable
         }
     }
 
-    private void SetSkyUniforms(RenderInfo renderInfo, SkyOptions options, in SkyTexture skyTexture, SkyTransformTexture skyTransform)
+    private static void SetSkyUniforms(SkySphereShader skyProgram, RenderInfo renderInfo, SkyOptions options, SkyRenderMode skyRenderMode,
+        in SkyTexture skyTexture, in SkyTexture blendSkyTexture, SkyTransformTexture skyTransform)
     {
         bool invulnerability = false;
         if (renderInfo.ViewerEntity.PlayerObj != null)
             invulnerability = renderInfo.ViewerEntity.PlayerObj.DrawInvulnerableColorMap();
 
-        var texture = skyTexture.GlTexture;
-        var scaleUV = SkySphereTexture.CalcScale(skyTexture.GlTexture.Dimension, skyTransform);
-        var offset = SkySphereTexture.CalcOffset(skyTexture.GlTexture.Dimension, skyTransform, m_mode, scaleUV, options);
-        var skyHeight = SkySphereTexture.CalcSkyHeight(texture.Dimension.Height, m_mode);
+        var dimension = GetSkyTextureDimension(skyTexture);
+        var scaleUV = SkySphereTexture.CalcScale(dimension, skyTransform);
+        var offset = SkySphereTexture.CalcOffset(dimension, skyTransform, skyRenderMode, scaleUV, options);
+        var skyHeight = SkySphereTexture.CalcSkyHeight(dimension.Height, skyRenderMode);
 
-        m_skyProgram.BoundTexture(BindTextures.BoundTexture);
-        m_skyProgram.ColormapTexture(BindTextures.Colormap);
-        m_skyProgram.Mvp(CalculateMvp(renderInfo));
-        m_skyProgram.Scale(scaleUV);
-        m_skyProgram.FlipU((options & SkyOptions.Flip) != 0);
-        m_skyProgram.ColorMix(renderInfo.Uniforms.ColorMix.Sky);
-        m_skyProgram.GammaCorrection(renderInfo.Uniforms.GammaCorrection);
+        skyProgram.BoundTexture(BindTextures.BoundTexture);
+        skyProgram.ColormapTexture(BindTextures.Colormap);
+        skyProgram.Mvp(CalculateMvp(renderInfo));
+        skyProgram.Scale(scaleUV);
+        skyProgram.FlipU((options & SkyOptions.Flip) != 0);
+        skyProgram.ColorMix(renderInfo.Uniforms.ColorMix.Sky);
+        skyProgram.GammaCorrection(renderInfo.Uniforms.GammaCorrection);
 
         if (ShaderVars.PaletteColorMode)
         {
-            m_skyProgram.TopColor(new Vec4F(skyTexture.TopColorIndex / 255f, 0, 0, 0));
-            m_skyProgram.BottomColor(new Vec4F(skyTexture.BottomColorIndex / 255f, 0, 0, 0));
+            skyProgram.TopColor(new Vec4F(blendSkyTexture.TopColorIndex / 255f, 0, 0, 0));
+            skyProgram.BottomColor(new Vec4F(blendSkyTexture.BottomColorIndex / 255f, 0, 0, 0));
         }
         else
         {
-            m_skyProgram.TopColor(skyTexture.TopColor);
-            m_skyProgram.BottomColor(skyTexture.BottomColor);
+            skyProgram.TopColor(blendSkyTexture.TopColor);
+            skyProgram.BottomColor(blendSkyTexture.BottomColor);
         }
 
-        m_skyProgram.HasInvulnerability(invulnerability);
-        m_skyProgram.PaletteIndex((int)renderInfo.Uniforms.PaletteIndex);
-        m_skyProgram.ColorMapIndex(renderInfo.Uniforms.ColorMapUniforms.SkyIndex);
-        m_skyProgram.ScrollOffset(offset);
-        m_skyProgram.SkyHeight(skyHeight);
-        m_skyProgram.SkyMin(0.5f - skyHeight);
-        m_skyProgram.SkyMax(0.5f + skyHeight);
+        skyProgram.HasInvulnerability(invulnerability);
+        skyProgram.PaletteIndex((int)renderInfo.Uniforms.PaletteIndex);
+        skyProgram.ColorMapIndex(renderInfo.Uniforms.ColorMapUniforms.SkyIndex);
+        skyProgram.ScrollOffset(offset);
+        skyProgram.SkyHeight(skyHeight);
+        skyProgram.SkyMin(0.5f - skyHeight);
+        skyProgram.SkyMax(0.5f + skyHeight);
     }
 
-    private void SetForegroundUniforms(RenderInfo renderInfo, bool flipSkyHorizontal, 
-        in SkyTexture skyTexture, in SkyTexture foregroundTexture, SkyTransformTexture foregroundTransform)
+    private static Dimension GetSkyTextureDimension(SkyTexture skyTexture)
     {
-        bool invulnerability = false;
-        if (renderInfo.ViewerEntity.PlayerObj != null)
-            invulnerability = renderInfo.ViewerEntity.PlayerObj.DrawInvulnerableColorMap();
-
         // The sky fire is a special case where it's rendered at the standard dimenion but it's actual dimension differs.
-        var dimension = foregroundTexture.IsFire ? SkySphereTexture.StandardDimension : foregroundTexture.GlTexture.Dimension;
-        var scaleUV = SkySphereTexture.CalcScale(dimension, foregroundTransform);
-        var offset = SkySphereTexture.CalcOffset(dimension, foregroundTransform, m_mode, scaleUV);
-        var textureHeight = SkySphereTexture.CalcSkyHeight(dimension.Height, m_mode);
-
-        m_foregroundProgram.BoundTexture(BindTextures.BoundTexture);
-        m_foregroundProgram.ColormapTexture(BindTextures.Colormap);
-        m_foregroundProgram.Mvp(CalculateMvp(renderInfo));
-        m_foregroundProgram.Scale(scaleUV);
-        m_foregroundProgram.FlipU(flipSkyHorizontal);
-        m_foregroundProgram.ColorMix(renderInfo.Uniforms.ColorMix.Sky);
-        m_foregroundProgram.GammaCorrection(renderInfo.Uniforms.GammaCorrection);
-
-        if (ShaderVars.PaletteColorMode)
-        {
-            m_foregroundProgram.TopColor(new Vec4F(skyTexture.TopColorIndex / 255f, 0, 0, 0));
-            m_foregroundProgram.BottomColor(new Vec4F(skyTexture.BottomColorIndex / 255f, 0, 0, 0));
-        }
-        else
-        {
-            m_foregroundProgram.TopColor(skyTexture.TopColor);
-            m_foregroundProgram.BottomColor(skyTexture.BottomColor);
-        }
-
-        m_foregroundProgram.HasInvulnerability(invulnerability);
-        m_foregroundProgram.PaletteIndex((int)renderInfo.Uniforms.PaletteIndex);
-        m_foregroundProgram.ColorMapIndex(renderInfo.Uniforms.ColorMapUniforms.SkyIndex);
-        m_foregroundProgram.ScrollOffset(offset);
-
-        m_foregroundProgram.TextureHeight(textureHeight);
-        m_foregroundProgram.SkyHeight(textureHeight);
-        m_foregroundProgram.SkyMin(0.5f - textureHeight);
-        m_foregroundProgram.SkyMax(0.5f + textureHeight);
-        m_foregroundProgram.TextureStart(0.5f);
+        return skyTexture.IsFire ? SkySphereTexture.StandardDimension : skyTexture.GlTexture.Dimension;
     }
 
     private void ReleaseUnmanagedResources()

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Sky/Sphere/SkySphereShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Sky/Sphere/SkySphereShader.cs
@@ -25,7 +25,7 @@ public class SkySphereShader : RenderProgram
     private readonly int m_colorMixLocation;
     private readonly int m_gammaCorrectionLocation;
 
-    public SkySphereShader() : base("Sky sphere")
+    public SkySphereShader(string? name = null) : base(name ?? "Sky sphere")
     {
         m_boundTextureLocation = Uniforms.GetLocation("boundTexture");
         m_colormapTextureLocation = Uniforms.GetLocation("colormapTexture");

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Sky/Sphere/SkySphereTexture.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Sky/Sphere/SkySphereTexture.cs
@@ -108,10 +108,8 @@ public class SkySphereTexture(ArchiveCollection archiveCollection, LegacyGLTextu
         {
             var skyFire = skyFireTextures[i];
             var texture = skyFire.Texture;
-            if (!skyFire.RenderUpdate || texture.Image == null || texture.Index != textureIndex)
+            if (skyFire.RenderUpdate != m_archiveCollection.TextureManager.Ticks || texture.Image == null || texture.Index != textureIndex)
                 continue;
-
-            skyFire.RenderUpdate = false;
 
             m_textureManager.ReUpload(skyTexture, texture.Image, texture.Image.m_pixels);
         }
@@ -175,14 +173,17 @@ public class SkySphereTexture(ArchiveCollection archiveCollection, LegacyGLTextu
         // This can't be right. The kex port has some weird offset stuff going on with fire textures specifically.
         var offset = transform.Offset + transform.CurrentScroll;
 
-        const float fireTextureHeight = 200f;
-        offset.Y += fireTextureHeight - StandardHeight;
+        offset.Y += skyTexture.GlTexture.Height - StandardHeight;
 
+        // Calculate the offset so that the midtexel is in the center of the sphere projection
         if (transform.MidTexel.HasValue)
-        {
-            var midOffset = skyTexture.GlTexture.Height * transform.MidTexel.Value / fireTextureHeight;
-            offset.Y += 32 + midOffset;
-        }
+            offset.Y += transform.MidTexel.Value + 28 + 8;
+
+        //if (transform.MidTexel.HasValue)
+        //{
+        //    var midOffset = skyTexture.GlTexture.Height * transform.MidTexel.Value / fireTextureHeight;
+        //    offset.Y += 32 + midOffset;
+        //}
 
         // Offset needs to be in texture coordinates
         offset.X /= skyTexture.GlTexture.Width;
@@ -263,7 +264,7 @@ public class SkySphereTexture(ArchiveCollection archiveCollection, LegacyGLTextu
 
         GetAverageColors(skyImage, out var topColor, out var bottomColor);
         var palette = m_archiveCollection.Palette;
-        var glTexture = CreateTexture(skyImage, $"[SKY][{textureIndex}] {m_archiveCollection.TextureManager.SkyTextureName}");
+        var glTexture = CreateTexture(skyImage, $"[SKY][{textureIndex}]");
         texture = new(glTexture, textureIndex, topColor, bottomColor,
             palette.GetNearestColorIndex(FromRgba(topColor)), palette.GetNearestColorIndex(FromRgba(bottomColor)));
         return true;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Sky/Sphere/SkySphereTexture.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Sky/Sphere/SkySphereTexture.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
+using Helion.Geometry;
 using Helion.Geometry.Vectors;
 using Helion.Graphics;
 using Helion.Render.OpenGL.Texture;
@@ -13,7 +14,7 @@ using OpenTK.Graphics.OpenGL;
 
 namespace Helion.Render.OpenGL.Renderers.Legacy.World.Sky.Sphere;
 
-public record struct SkyTexture(GLLegacyTexture GlTexture, int AnimatedTextureIndex, Vec4F TopColor, Vec4F BottomColor, int TopColorIndex, int BottomColorIndex);
+public record struct SkyTexture(GLLegacyTexture GlTexture, int AnimatedTextureIndex, Vec4F TopColor, Vec4F BottomColor, int TopColorIndex, int BottomColorIndex, bool IsFire);
 
 // The sky texture looks like this (p = padding):
 //
@@ -34,6 +35,7 @@ public record struct SkyTexture(GLLegacyTexture GlTexture, int AnimatedTextureIn
 //
 public class SkySphereTexture(ArchiveCollection archiveCollection, LegacyGLTextureManager textureManager, int textureHandle) : IDisposable
 {
+    public static readonly Dimension StandardDimension = new((int)StandardWidth, (int)StandardHeight);
     private const float StaticSkySize = 0.25f;
     private const float StandardWidth = 256;
     private const float StandardHeight = 128;
@@ -75,43 +77,52 @@ public class SkySphereTexture(ArchiveCollection archiveCollection, LegacyGLTextu
         return GetSkyTextureFromTextureIndex(animationIndex, m_textureHandleIndex);
     }
 
-    private SkyTexture GetSkyTextureFromTextureIndex(int animationIndex, int textureIndex)
+    private unsafe SkyTexture GetSkyTextureFromTextureIndex(int animationIndex, int textureIndex)
     {
-        SkyTexture? findSkyTexture = null;
+        bool foundSkyTexture = false;
+        SkyTexture findSkyTexture = default;
         var skyArray = m_skyTextures.Data;
         for (int i = 0; i < m_skyTextures.Length; i++)
         {
             ref var checkSkyTexture = ref skyArray[i];
             if (checkSkyTexture.AnimatedTextureIndex == animationIndex)
             {
+                foundSkyTexture = true;
                 findSkyTexture = checkSkyTexture;
                 break;
             }
         }
 
-        if (findSkyTexture == null && GenerateSkyTexture(textureIndex, out var skyTexture))
+        if (!foundSkyTexture)
         {
-            m_skyTextures.Add(skyTexture.Value);
-            findSkyTexture = skyTexture;
+            foundSkyTexture = GenerateSkyTexture(textureIndex, out var skyTexture);
+            if (foundSkyTexture)
+            {
+                m_skyTextures.Add(skyTexture);
+                findSkyTexture = skyTexture;
+            }
         }
 
-        if (findSkyTexture != null)
-            CheckSkyFireUpdate(findSkyTexture.Value.GlTexture, textureIndex);
+        var isFire = false;
+        if (foundSkyTexture)
+        {
 
-        return findSkyTexture ?? new SkyTexture(m_textureManager.NullTexture, 0, Vec4F.Zero, Vec4F.Zero, 0, 0);
+            CheckSkyFireUpdate(findSkyTexture.GlTexture, textureIndex, out isFire);
+            findSkyTexture.IsFire = isFire;
+            return findSkyTexture;
+        }
+
+        return new SkyTexture(m_textureManager.NullTexture, 0, Vec4F.Zero, Vec4F.Zero, 0, 0, isFire);
     }
 
-    private void CheckSkyFireUpdate(GLLegacyTexture skyTexture, int textureIndex)
+    private void CheckSkyFireUpdate(GLLegacyTexture skyTexture, int textureIndex, out bool isFire)
     {
-        var skyFireTextures = m_archiveCollection.TextureManager.GetSkyFireTextures();
-        for (int i = 0; i < skyFireTextures.Count; i++)
+        isFire = false;
+        if (m_archiveCollection.TextureManager.SkyFireNeedsUpdate(textureIndex, out var texture, out var needsUpdate))
         {
-            var skyFire = skyFireTextures[i];
-            var texture = skyFire.Texture;
-            if (skyFire.RenderUpdate != m_archiveCollection.TextureManager.Ticks || texture.Image == null || texture.Index != textureIndex)
-                continue;
-
-            m_textureManager.ReUpload(skyTexture, texture.Image, texture.Image.m_pixels);
+            isFire = true;
+            if (needsUpdate && texture.Image != null)
+                m_textureManager.ReUpload(skyTexture, texture.Image, texture.Image.m_pixels);
         }
     }
 
@@ -127,14 +138,14 @@ public class SkySphereTexture(ArchiveCollection archiveCollection, LegacyGLTextu
         GC.SuppressFinalize(this);
     }
 
-    public static Vec2F CalcOffset(in SkyTexture skyTexture, SkyTransformTexture transform, SkyRenderMode mode, Vec2F scaleUV, SkyOptions options = SkyOptions.None)
+    public static Vec2F CalcOffset(Dimension dimension, SkyTransformTexture transform, SkyRenderMode mode, Vec2F scaleUV, SkyOptions options = SkyOptions.None)
     {
         var offset = transform.Offset + transform.CurrentScroll;
 
-        if (mode == SkyRenderMode.Vanilla)
+        if (mode == SkyRenderMode.Vanilla || dimension.Height < 128)
         {
             offset.X += StandardWidth;
-            offset.Y += skyTexture.GlTexture.Height - StandardHeight;
+            offset.Y += dimension.Height - StandardHeight;
 
             // Calculate the offset so that the midtexel is in the center of the sphere projection
             if (transform.MidTexel.HasValue)
@@ -144,17 +155,17 @@ public class SkySphereTexture(ArchiveCollection archiveCollection, LegacyGLTextu
         }
         else
         {
-            var adjustY = skyTexture.GlTexture.Height - StandardHeight;
+            var adjustY = dimension.Height - StandardHeight;
             offset.Y += adjustY / 2;
-            offset.X += GetTextureAdjustmentX(skyTexture.GlTexture.Width, skyTexture.GlTexture.Height);
+            offset.X += GetTextureAdjustmentX(dimension.Width, dimension.Height);
         }
 
         if (transform.Scale.Y != 1)
             offset.Y += (StandardHeight * transform.Scale.Y - StandardHeight) * StandardAspectRatio;
 
         // Offset needs to be in texture coordinates
-        offset.X /= skyTexture.GlTexture.Width;
-        offset.Y /= skyTexture.GlTexture.Height;
+        offset.X /= dimension.Width;
+        offset.Y /= dimension.Height;
         return offset;
     }
 
@@ -168,41 +179,18 @@ public class SkySphereTexture(ArchiveCollection archiveCollection, LegacyGLTextu
         return -offsetX;
     }
 
-    public static Vec2F CalcFireOffset(in SkyTexture skyTexture, SkyTransformTexture transform)
+    public static Vec2F CalcScale(Dimension dimension, SkyTransformTexture skyTransform)
     {
-        // This can't be right. The kex port has some weird offset stuff going on with fire textures specifically.
-        var offset = transform.Offset + transform.CurrentScroll;
-
-        offset.Y += skyTexture.GlTexture.Height - StandardHeight;
-
-        // Calculate the offset so that the midtexel is in the center of the sphere projection
-        if (transform.MidTexel.HasValue)
-            offset.Y += transform.MidTexel.Value + 28 + 8;
-
-        //if (transform.MidTexel.HasValue)
-        //{
-        //    var midOffset = skyTexture.GlTexture.Height * transform.MidTexel.Value / fireTextureHeight;
-        //    offset.Y += 32 + midOffset;
-        //}
-
-        // Offset needs to be in texture coordinates
-        offset.X /= skyTexture.GlTexture.Width;
-        offset.Y /= skyTexture.GlTexture.Height;
-        return offset;
-    }
-
-    public static Vec2F CalcScale(in SkyTexture skyTexture, SkyTransformTexture skyTransform)
-    {
-        double roundedExponent = Math.Round(Math.Log(skyTexture.GlTexture.Dimension.Width, 2));
+        double roundedExponent = Math.Round(Math.Log(dimension.Width, 2));
         float scalingFactor = (float)Math.Pow(2, 10 - roundedExponent);
         float u = 1 / scalingFactor;
-        float v = (skyTexture.GlTexture.Dimension.Height / StandardHeight) * StaticSkySize;
+        float v = (dimension.Height / StandardHeight) * StaticSkySize;
         return (u, v) * skyTransform.Scale;
     }
 
     public static float CalcSkyHeight(float textureHeight, SkyRenderMode mode)
     {
-        if (mode == SkyRenderMode.Vanilla)
+        if (mode == SkyRenderMode.Vanilla || textureHeight < 128)
             return StaticSkySize;
 
         float pad = StandardHeight / textureHeight * StaticSkySize;
@@ -248,17 +236,17 @@ public class SkySphereTexture(ArchiveCollection archiveCollection, LegacyGLTextu
             {
                 int animatedTextureIndex = components[j].TextureIndex;
                 if (GenerateSkyTexture(animatedTextureIndex, out var skyTexture))
-                    m_skyTextures.Add(skyTexture.Value);
+                    m_skyTextures.Add(skyTexture);
             }
         }
     }
 
-    private bool GenerateSkyTexture(int textureIndex, [NotNullWhen(true)] out SkyTexture? texture)
+    private bool GenerateSkyTexture(int textureIndex, out SkyTexture texture)
     {
         Image? skyImage = m_archiveCollection.TextureManager.GetNonAnimatedTexture(textureIndex).Image;
         if (skyImage == null)
         {
-            texture = null;
+            texture = default;
             return false;
         }
 
@@ -266,7 +254,7 @@ public class SkySphereTexture(ArchiveCollection archiveCollection, LegacyGLTextu
         var palette = m_archiveCollection.Palette;
         var glTexture = CreateTexture(skyImage, $"[SKY][{textureIndex}]");
         texture = new(glTexture, textureIndex, topColor, bottomColor,
-            palette.GetNearestColorIndex(FromRgba(topColor)), palette.GetNearestColorIndex(FromRgba(bottomColor)));
+            palette.GetNearestColorIndex(FromRgba(topColor)), palette.GetNearestColorIndex(FromRgba(bottomColor)), false);
         return true;
     }
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Sky/Sphere/SkySphereTexture.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Sky/Sphere/SkySphereTexture.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics.CodeAnalysis;
 using Helion.Geometry;
 using Helion.Geometry.Vectors;
 using Helion.Graphics;

--- a/Core/Resources/TextureManager.cs
+++ b/Core/Resources/TextureManager.cs
@@ -10,7 +10,6 @@ using Helion.Resources.Definitions.Animdefs;
 using Helion.Resources.Definitions.Animdefs.Textures;
 using Helion.Resources.Definitions.MapInfo;
 using Helion.Resources.Definitions.Texture;
-using Helion.Resources.Definitions.Zdoom;
 using Helion.Resources.Images;
 using Helion.Util;
 using Helion.Util.Container;
@@ -43,6 +42,7 @@ public partial class TextureManager : ITickable
     private readonly bool m_unitTest;
     private readonly bool m_cacheAllSprites;
 
+    public int Ticks;
     public DynamicArray<SpriteDefinition> SpriteDefinitions = new();
 
     public List<Animation> GetAnimations() => m_animations;
@@ -98,7 +98,7 @@ public partial class TextureManager : ITickable
     public void MapInit(MapInfoDef mapInfo)
     {
         foreach (var skyFire in m_skyFireTextures)
-            skyFire.RenderUpdate = true;
+            skyFire.RenderUpdate = Ticks;
 
         MapSkyFlat(m_archiveCollection.GameInfo.SkyFlatName, m_skyIndex, mapInfo);
     }
@@ -421,6 +421,7 @@ public partial class TextureManager : ITickable
 
     public void Tick()
     {
+        Ticks++;
         for (int i = 0; i < m_animations.Count; i++)
         {
             Animation anim = m_animations[i];

--- a/Core/Resources/TextureManagerSky.cs
+++ b/Core/Resources/TextureManagerSky.cs
@@ -1,6 +1,4 @@
-﻿using Helion.Geometry.Vectors;
-using Helion.Graphics;
-using Helion.Graphics.Palettes;
+﻿using Helion.Graphics;
 using Helion.Render.OpenGL.Renderers.Legacy.World.Shader;
 using Helion.Resources.Definitions.Id24;
 using Helion.Resources.Definitions.MapInfo;

--- a/Core/Resources/TextureManagerSky.cs
+++ b/Core/Resources/TextureManagerSky.cs
@@ -21,7 +21,7 @@ public class SkyFireAnimation(int[] firePalette, Texture texture, Image fireImag
     public Image FireImage = fireImage;
     public int Ticks = ticks;
     public int CurrentTick;
-    public bool RenderUpdate = true;
+    public int RenderUpdate;
 }
 
 public partial class TextureManager
@@ -52,7 +52,7 @@ public partial class TextureManager
                 continue;
                         
             skyFire.CurrentTick = 0;
-            skyFire.RenderUpdate = true;
+            skyFire.RenderUpdate = Ticks;
             UpdateSkyFire(skyFire);
             var palette = m_archiveCollection.Data.Palette.DefaultLayer;
             WriteSkyFireToTexture(palette, skyFire.FirePalette, skyFire.FireImage, skyFire.Texture.Image);

--- a/Core/Resources/TextureManagerSky.cs
+++ b/Core/Resources/TextureManagerSky.cs
@@ -1,5 +1,6 @@
 ﻿using Helion.Geometry.Vectors;
 using Helion.Graphics;
+using Helion.Graphics.Palettes;
 using Helion.Render.OpenGL.Renderers.Legacy.World.Shader;
 using Helion.Resources.Definitions.Id24;
 using Helion.Resources.Definitions.MapInfo;
@@ -26,8 +27,6 @@ public class SkyFireAnimation(int[] firePalette, Texture texture, Image fireImag
 
 public partial class TextureManager
 {
-    public List<SkyFireAnimation> GetSkyFireTextures() => m_skyFireTextures;
-
     private readonly Dictionary<int, int> m_flatIndexToSkyTextureIndex = [];
     private readonly Dictionary<int, SkyTransform> m_textureIndexToSkyTransform = [];
     private readonly List<SkyTransform> m_skyTransforms = [];
@@ -37,6 +36,26 @@ public partial class TextureManager
     public bool TryGetSkyTransform(int textureIndex, [NotNullWhen(true)] out SkyTransform? skyTransform)
     {
         return m_textureIndexToSkyTransform.TryGetValue(textureIndex, out skyTransform);
+    }
+
+    public bool SkyFireNeedsUpdate(int textureIndex, [NotNullWhen(true)] out Texture? skyFireTexture, out bool needsUpdate)
+    {
+        needsUpdate = false;
+        skyFireTexture = null;
+        for (int i = 0; i < m_skyFireTextures.Count; i++)
+        {
+            var skyFire = m_skyFireTextures[i];
+            var texture = skyFire.Texture;
+
+            if (texture.Index == textureIndex)
+            {
+                skyFireTexture = texture;
+                needsUpdate = skyFire.RenderUpdate == m_archiveCollection.TextureManager.Ticks;
+                return true;
+            }
+        }
+
+        return false;
     }
     
     private void TickSkyFire()
@@ -94,7 +113,7 @@ public partial class TextureManager
         var texturePixels = textureImage.m_pixels;
         var transparentColor = Color.Transparent.Uint;
         int skyFirePaletteLength = skyFirePalette.Length;
-        for (int p = 0; p < fireIndices.Length; p++)
+        for (int p = fireIndices.Length - 1; p >= 0; p--)
         {
             if (fireIndices[p] == 0)
             {
@@ -146,22 +165,6 @@ public partial class TextureManager
 
             var palette = m_archiveCollection.Data.Palette.DefaultLayer;
             WriteSkyFireToTexture(palette, sky.Fire.Palette, fireImage, texture.Image);
-
-            FlagSkyTrasformForegroundAsFire(sky);
-        }
-    }
-
-    private void FlagSkyTrasformForegroundAsFire(Id24SkyDef sky)
-    {
-        foreach (var skyTransform in m_skyTransforms)
-        {
-            if (skyTransform.Foreground == null || !skyTransform.Foreground.TextureName.EqualsIgnoreCase(sky.Name))
-                continue;
-
-            skyTransform.Foreground.Type = SkyTransformType.Fire;
-            skyTransform.Foreground.Scale.Y = 1;
-            skyTransform.Foreground.Scale.X = 1;
-            skyTransform.Foreground.Offset = Vec2F.Zero;
         }
     }
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -17,3 +17,5 @@
 - Fix incorrect warnings for sounds and invalid bex string memonic with custom sounds prefixed with USER_.
 - Fix UMAPINFO/MAPINFO EnterText/ExitText/SecretExitText/ExitText with escaped double quotes.
 - Fix setting vanilla sky render mode with skydefs when only flatmapping is defined with no skies.
+- Fix alignment with id24 skies
+- Fix sky fire foregrounds not rendering when used on two different sky backings


### PR DESCRIPTION
Fixes alignment on id24 sky backing and foreground textures

Fixes sky fire foregrounds not rendering when used on two different sky backings

Fixes alignment on sky textures less 128 pixels high