### PR TITLE
Fix A_AddFlags/A_RemoveFlags not updating sprite transparency when changing TRANSLUCENT flag

### DIFF
--- a/Core/World/Entities/Definition/States/EntityActionFunctions.cs
+++ b/Core/World/Entities/Definition/States/EntityActionFunctions.cs
@@ -3371,6 +3371,7 @@ public static class EntityActionFunctions
 
         DehackedApplier.SetEntityFlags(entity.Properties, ref entity.Flags, flags1, false);
         DehackedApplier.SetEntityFlagsMbf21(entity.Properties, ref entity.Flags, flags2, false);
+        entity.Alpha = (float)entity.Properties.Alpha;
     }
 
     private static void A_RemoveFlags(Entity entity)
@@ -3380,6 +3381,7 @@ public static class EntityActionFunctions
 
         DehackedApplier.SetEntityFlags(entity.Properties, ref entity.Flags, flags1, true);
         DehackedApplier.SetEntityFlagsMbf21(entity.Properties, ref entity.Flags, flags2, true);
+        entity.Alpha = (float)entity.Properties.Alpha;
     }
 
     public static void A_ClosetLook(Entity entity)

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -17,5 +17,6 @@
 - Fix incorrect warnings for sounds and invalid bex string memonic with custom sounds prefixed with USER_.
 - Fix UMAPINFO/MAPINFO EnterText/ExitText/SecretExitText/ExitText with escaped double quotes.
 - Fix setting vanilla sky render mode with skydefs when only flatmapping is defined with no skies.
-- Fix alignment with id24 skies
-- Fix sky fire foregrounds not rendering when used on two different sky backings
+- Fix alignment with id24 skies.
+- Fix sky fire foregrounds not rendering when used on two different sky backings.
+- Fix A_AddFlags/A_RemoveFlags not updating sprite transparency when changing TRANSLUCENT flag.


### PR DESCRIPTION
carry over potential alpha change to entity when flags are changed since it's not read from the properties in the renderer

fixes #1184 