### PR TITLE
Implement gyro acceleration

### DIFF
--- a/Core/Util/Configs/Components/ConfigController.cs
+++ b/Core/Util/Configs/Components/ConfigController.cs
@@ -70,7 +70,7 @@ public class ConfigController : ConfigElement<ConfigController>
     [OptionMenu(OptionSectionType.Controller, "Lower Gyro Threshold")]
     public readonly ConfigValue<double> LowerGyroThreshold = new(0.0);
 
-    [ConfigInfo("Upper threshold for gyro acceleration. Beyond this point")]
+    [ConfigInfo("Upper threshold for gyro acceleration. Beyond this point, no more acceleration will be applied.")]
     [OptionMenu(OptionSectionType.Controller, "Upper Gyro Threshold")]
     public readonly ConfigValue<double> UpperGyroThreshold = new(75.0);
 

--- a/Core/Util/Configs/Components/ConfigController.cs
+++ b/Core/Util/Configs/Components/ConfigController.cs
@@ -62,6 +62,18 @@ public class ConfigController : ConfigElement<ConfigController>
     [OptionMenu(OptionSectionType.Controller, "Gyro On By Default")]
     public readonly ConfigValue<bool> GyroAimOnByDefault = new(true);
 
+    [ConfigInfo("How much to add to sensitivity at the upper gyro threshold. Set to 0 to disable gyro acceleration")]
+    [OptionMenu(OptionSectionType.Controller, "Gyro Acceleration")]
+    public readonly ConfigValue<double> GyroAcceleration = new(2.0);
+
+    [ConfigInfo("Lower threshold for gyro acceleration. If the speed of the controller falls below this, no acceleration will be applied.")]
+    [OptionMenu(OptionSectionType.Controller, "Lower Gyro Threshold")]
+    public readonly ConfigValue<double> LowerGyroThreshold = new(0.0);
+
+    [ConfigInfo("Upper threshold for gyro acceleration. Beyond this point")]
+    [OptionMenu(OptionSectionType.Controller, "Upper Gyro Threshold")]
+    public readonly ConfigValue<double> UpperGyroThreshold = new(75.0);
+
     [ConfigInfo("Whether gyro smoothing should be enabled to reduce twitchiness.")]
     [OptionMenu(OptionSectionType.Controller, "Gyro Smoothing")]
     public readonly ConfigValue<bool> GyroSmoothingEnabled = new(false);

--- a/Core/World/Impl/SinglePlayer/SinglePlayerWorld.cs
+++ b/Core/World/Impl/SinglePlayer/SinglePlayerWorld.cs
@@ -599,15 +599,33 @@ public class SinglePlayerWorld : WorldBase
 
         if (input.Manager.AnalogAdapter != null)
         {
-            if (input.Manager.AnalogAdapter.TryGetGyroAbsolute((GyroAxis)(int)Config.Controller.GyroAimTurnAxis.Value, out double yaw) == true)
+            double pitch = 0.0;
+            double gyroSpeed;
+            double slowFastFactor = 0.0;
+            bool hasYaw = input.Manager.AnalogAdapter.TryGetGyroAbsolute((GyroAxis)(int)Config.Controller.GyroAimTurnAxis.Value, out double yaw);
+            bool hasPitch = ((Config.Mouse.Look && !MapInfo.HasOption(MapOptions.NoFreelook)) || IsChaseCamMode)
+                && (input.Manager.AnalogAdapter.TryGetGyroAbsolute(GyroAxis.Pitch, out pitch) == true);
+            if (hasYaw)
             {
-                player.AddToYaw((float)(yaw * Config.Controller.GyroAimHorizontalSensitivity), true);
+                if (hasPitch)
+                {
+                    gyroSpeed = Math.Sqrt(yaw * yaw + pitch * pitch) * 365 / Math.Tau;
+                }
+                else
+                {
+                    gyroSpeed = yaw * 365 / Math.Tau;
+                }
+                slowFastFactor = (gyroSpeed - Config.Controller.LowerGyroThreshold) / (Config.Controller.UpperGyroThreshold - Config.Controller.LowerGyroThreshold);
+            }
+            
+            if (hasYaw)
+            {
+                player.AddToYaw((float)(yaw * (Config.Controller.GyroAimHorizontalSensitivity + (Config.Controller.GyroAcceleration * slowFastFactor))), true);
             }
 
-            if (((Config.Mouse.Look && !MapInfo.HasOption(MapOptions.NoFreelook)) || IsChaseCamMode)
-                && (input.Manager.AnalogAdapter.TryGetGyroAbsolute(GyroAxis.Pitch, out double pitch) == true))
+            if (hasPitch)
             {
-                player.AddToPitch((float)(pitch * Config.Controller.GyroAimVerticalSensitivity), true);
+                player.AddToPitch((float)(pitch * (Config.Controller.GyroAimVerticalSensitivity + (Config.Controller.GyroAcceleration * slowFastFactor))), true);
             }
 
             input.Manager.AnalogAdapter.ZeroGyroAbsolute();

--- a/Core/World/Impl/SinglePlayer/SinglePlayerWorld.cs
+++ b/Core/World/Impl/SinglePlayer/SinglePlayerWorld.cs
@@ -607,14 +607,7 @@ public class SinglePlayerWorld : WorldBase
                 && (input.Manager.AnalogAdapter.TryGetGyroAbsolute(GyroAxis.Pitch, out pitch) == true);
             if (hasYaw)
             {
-                if (hasPitch)
-                {
-                    gyroSpeed = Math.Sqrt(yaw * yaw + pitch * pitch) * 365 / Math.Tau;
-                }
-                else
-                {
-                    gyroSpeed = yaw * 365 / Math.Tau;
-                }
+                gyroSpeed = hasPitch ? Math.Sqrt(yaw * yaw + pitch * pitch) * 365 / Math.Tau : gyroSpeed = yaw * 365 / Math.Tau;
                 slowFastFactor = (gyroSpeed - Config.Controller.LowerGyroThreshold) / (Config.Controller.UpperGyroThreshold - Config.Controller.LowerGyroThreshold);
             }
             


### PR DESCRIPTION
Adds gyro acceleration.  This allows for players to have two sensitivities, one for calmly aiming at faraway targets, and one for dealing with enemies up close.

Acceleration is linear, as in Quake 3 Arena, where some top players chose to turn mouse acceleration on.

Closes #903 