### PR TITLE
Add .a file for OpenAL, add Direct P/Invoke for OpenAL on Linux

### DIFF
--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -38,7 +38,7 @@
     <DirectPInvoke Include="fluidsynth-3" />
     <DirectPInvoke Include="glfw3" />
     <DirectPInvoke Include="sdl2" />
-    <DirectPInvoke Condition="'$(RuntimeIdentifier)'=='win-x64'" Include="AL" />
+    <DirectPInvoke Include="AL" />
 
     <NativeLibrary Condition="'$(RuntimeIdentifier)'=='win-x64'" Include="Unmanaged\lib\win-x64\*.lib" />
     <NativeLibrary Condition="'$(RuntimeIdentifier)'=='linux-x64'" Include="Unmanaged\lib\linux-x64\*.a" />
@@ -57,6 +57,10 @@
     <LinkerArg Include="Imm32.lib" />
     <LinkerArg Include="Shlwapi.lib" />
     <LinkerArg Include="Setupapi.lib" />
+  </ItemGroup>
+
+  <ItemGroup Condition="('$(AOT)' == 'true') AND ('$(RuntimeIdentifier)'=='linux-x64')">
+    <LinkerArg Include="-lstdc++" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
@@ -79,6 +83,7 @@
     <Content Include="$(ProjectDir)Unmanaged\binary\**\*" Link="runtimes\%(RecursiveDir)\native\%(Filename)%(Extension)" Condition="'$(RuntimeIdentifier)' == ''" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="$(ProjectDir)Unmanaged\binary\$(RuntimeIdentifier)\*.dll" Link="%(Filename)%(Extension)" Condition="('$(RuntimeIdentifier)' == 'win-x64') AND ('$(AOT)' != 'true')" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="$(ProjectDir)Unmanaged\binary\$(RuntimeIdentifier)\*.so*" Link="%(Filename)%(Extension)" Condition="'$(RuntimeIdentifier)' == 'linux-x64'" CopyToOutputDirectory="PreserveNewest" />
+    <Content Remove="$(ProjectDir)Unmanaged\binary\$(RuntimeIdentifier)\libopenal.so.1" Condition="('$(RuntimeIdentifier)' == 'linux-x64') AND ('$(AOT)' == 'true')" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
1. Compile static library for OpenAL from official 1.24.3 sources 
2. Revise .csproj file to use the OpenAL static lib for Direct P/Invoke
3. Remove libopenal.so.1 from output directory in AOT builds (it seems like we're getting static linking here according to observed behavior in `lsof`; `ldd` doesn't seem helpful for these AOT executables on Linux)

Environment: Ubuntu 22.04 LTS (WSL)
clang 14.0.0-1ubuntu1.1
CMake 4.0.3

args:  cmake -DBUILD_SHARED_LIBS=OFF -DLIBTYPE=STATIC -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE -DCMAKE_CXX_COMPILER=clang -DCMAKE_C_COMPILER=clang ..


