### PR TITLE
Update ZMusicWrapper to 2.0.0

### DIFF
--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="GlmSharp-netstandard" Version="0.9.8.1" />
     <PackageReference Include="Helion.TextCopyLite" Version="1.0.0" />
-    <PackageReference Include="Helion.ZMusic" Version="1.1.0" />
+    <PackageReference Include="Helion.ZMusic" Version="2.0.0" />
     <PackageReference Include="NAudio.Core" Version="2.2.1" />
     <PackageReference Include="NLog" Version="6.0.0" />
     <PackageReference Include="OpenTK" Version="4.9.4" />


### PR DESCRIPTION
This includes some requested additions, but also removes most of the visible P/Invoke methods.