### PR TITLE
fix dehacked string block to ignore bad data

### DIFF
--- a/Core/Dehacked/DehackedDefinition.cs
+++ b/Core/Dehacked/DehackedDefinition.cs
@@ -789,14 +789,17 @@ public partial class DehackedDefinition
         while (!IsBlockComplete(parser, isBex: true))
         {
             BexString bexString = new();
-            bexString.Mnemonic = ConsumeBexStringMnemonic(parser);
-            parser.ConsumeString("=");
-            bexString.Value = ConsumeBexTextValue(parser);
-            BexStrings.Add(bexString);
+            if (ConsumeBexStringMnemonic(parser, out var mnemonic))
+            {
+                bexString.Mnemonic = mnemonic;
+                parser.ConsumeString("=");
+                bexString.Value = ConsumeBexTextValue(parser);
+                BexStrings.Add(bexString);
+            }
         }
     }
 
-    private string ConsumeBexStringMnemonic(SimpleParser parser)
+    private bool ConsumeBexStringMnemonic(SimpleParser parser, [NotNullWhen(true)] out string? mnemonic)
     {
         var startLine = parser.GetCurrentLine();
         var line = parser.PeekLine();
@@ -808,10 +811,18 @@ public partial class DehackedDefinition
                 parser.ConsumeString();
 
             if (startLine == parser.GetCurrentLine())
-                return value;
+            {
+                mnemonic = value;
+                return true;
+            }
+        }
+        else
+        {
+            parser.ConsumeLineSpan();
         }
 
-        throw new ParserException(parser.GetCurrentLine(), parser.GetCurrentCharOffset(), 0, "Expected '='");
+        mnemonic = null;
+        return false;
     }
 
     private string ConsumeBexTextValue(SimpleParser parser)

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -39,3 +39,4 @@
 - Fix crash when cycling weapons while in chasecam mode.
 - Fix crash when parsing files with a multiline comment that starts and terminates on same line.
 - Fix save/load menu max rows not filling the box.
+- Fix dehacked parsing issue with [STRINGS] block that would stop parsing when it encountered bad data (fixes Sunder 2407 dehacked).

--- a/Tests/Unit/Dehacked/DehackedComment.cs
+++ b/Tests/Unit/Dehacked/DehackedComment.cs
@@ -1,0 +1,52 @@
+﻿using FluentAssertions;
+using Helion.Dehacked;
+using Xunit;
+
+namespace Helion.Tests.Unit.Dehacked;
+
+public class DehackedComment
+{
+    [Fact(DisplayName = "Dehacked comments")]
+    public void DehackedComments()
+    {
+        // Dehacked doesn't actually have // comments but users can mistakenly add them like in sunder which broke the bex string parsing.
+        string data = @"
+# this is a normal dehacked comment
+
+[STRINGS]
+HUSTR_1 = MAP01: The First Map // Hello
+
+// also should be ignored
+
+Thing 25 (Something) // This is a thing
+Action sound = 102
+Width = 3932160
+Death frame = 757
+Far attack frame = 730
+Bits = SOLID+SHOOTABLE+COUNTKILL
+Height = 7208960
+Initial frame = 45
+Hit points = 2000
+Injury frame = 742
+First moving frame = 142
+Alert sound = 101
+Speed = 18
+Mass = 5000
+Pain chance = 10
+
+# another dehacked comment
+// slash comment
+#// mixing it up
+//# mix
+
+Thing 41 (Another thing)
+Initial frame = 144
+// ending with a comment";
+
+        var def = new DehackedDefinition();
+        def.Parse(data);
+        def.BexStrings.Count.Should().Be(1);
+        def.BexStrings[0].Value.Should().Be("MAP01: The First Map // Hello");
+        def.Things.Count.Should().Be(2);
+    }
+}

--- a/Tests/Unit/Dehacked/DehackedStrings.cs
+++ b/Tests/Unit/Dehacked/DehackedStrings.cs
@@ -23,6 +23,8 @@ E1TEXT = This is the\n\
 E2TEXT = This is the\n\
          e2text
 
+// not a comment but ignored
+
 Frame 185
 Sprite subnumber = 32773
 ";


### PR DESCRIPTION
fix strings block to not throw on bad data to match functionality of other dehacked parsers (fixes sunder 2047)