### PR TITLE
Parse doubles in locale-agnostic way (in UDMF map loading)

### DIFF
--- a/Core/Maps/Udmf/UdmfMap.cs
+++ b/Core/Maps/Udmf/UdmfMap.cs
@@ -145,11 +145,11 @@ public class UdmfMap : IMap
         {
             var prop = ParseProperty(parser);
             if (prop.Name.EqualsIgnoreCase("x"))
-                x = double.Parse(prop.Value);
+                x = parser.ParseDouble(prop.Value);
             else if (prop.Name.EqualsIgnoreCase("y"))
-                y = double.Parse(prop.Value);
+                y = parser.ParseDouble(prop.Value);
             else if (prop.Name.EqualsIgnoreCase("height"))
-                z = double.Parse(prop.Value);
+                z = parser.ParseDouble(prop.Value);
             else if (prop.Name.EqualsIgnoreCase("angle"))
                 thing.Angle = (ushort)parser.ParseInt(prop.Value);
             else if (prop.Name.EqualsIgnoreCase("type"))
@@ -488,9 +488,9 @@ public class UdmfMap : IMap
         {
             var prop = ParseProperty(parser);
             if (prop.Name.EqualsIgnoreCase("x"))
-                x = double.Parse(prop.Value);
+                x = parser.ParseDouble(prop.Value);
             else if (prop.Name.EqualsIgnoreCase("y"))
-                y = double.Parse(prop.Value);
+                y = parser.ParseDouble(prop.Value);
         }
 
         vertices.Add(new(vertices.Count, new(x, y)));


### PR DESCRIPTION
Hello,
I tried to load an UDMF map in Helion and it failed because I live in a country where comma is used as decimal separator and `double.Parse` without culture argument uses system default culture. It looks that your `parser.ParseDouble` already parses numbers in locale-agnostic way so the fix was very simple. UDMF always uses a dot as decimal separator.
After applying this fix I can load UDMF maps in Helion on my PC, so I thought I will make a PR :)
Thanks
Jacek