### PR TITLE
Add support for ee_compat flag (to load maps compatible with Eternity Engine)

### DIFF
--- a/Core/Maps/Udmf/UdmfMap.cs
+++ b/Core/Maps/Udmf/UdmfMap.cs
@@ -110,6 +110,15 @@ public class UdmfMap : IMap
         while (!parser.IsDone())
         {
             var type = parser.ConsumeStringSpan();
+
+            if (type.EqualsIgnoreCase("ee_compat")) // flag indicating that map is compatible with Eternity Engine
+            {
+                parser.Consume('=');
+                parser.ConsumeStringSpan(); // this will normally be "true" but we don't care about the value
+                parser.Consume(';');
+                continue;
+            }
+            
             parser.Consume('{');
 
             if (type.EqualsIgnoreCase("vertex"))

--- a/Core/Maps/Udmf/UdmfMap.cs
+++ b/Core/Maps/Udmf/UdmfMap.cs
@@ -110,31 +110,38 @@ public class UdmfMap : IMap
         while (!parser.IsDone())
         {
             var type = parser.ConsumeStringSpan();
-
-            if (type.EqualsIgnoreCase("ee_compat")) // flag indicating that map is compatible with Eternity Engine
-            {
-                parser.Consume('=');
-                parser.ConsumeStringSpan(); // this will normally be "true" but we don't care about the value
-                parser.Consume(';');
-                continue;
-            }
-            
-            parser.Consume('{');
-
             if (type.EqualsIgnoreCase("vertex"))
+            {
+                parser.Consume('{');
                 ParseVertex(parser, vertices);
+                parser.Consume('}');
+            }
             else if (type.EqualsIgnoreCase("linedef"))
+            {
+                parser.Consume('{');
                 ParseLine(parser, lines);
+                parser.Consume('}');
+            }
             else if (type.EqualsIgnoreCase("sidedef"))
+            {
+                parser.Consume('{');
                 ParseSide(parser, sides);
+                parser.Consume('}');
+            }
             else if (type.EqualsIgnoreCase("sector"))
+            {
+                parser.Consume('{');
                 ParseSector(parser, sectors);
+                parser.Consume('}');
+            }
             else if (type.EqualsIgnoreCase("thing"))
+            {
+                parser.Consume('{');
                 ParseThing(parser, things);
+                parser.Consume('}');
+            }
             else
-                ConsumeBlock(parser);
-
-            parser.Consume('}');
+                ConsumeUnknownBlockOrProperty(parser);
         }
 
         foreach (var side in sides)
@@ -144,6 +151,32 @@ public class UdmfMap : IMap
         }
 
         MapLines(lines, vertices, sides);
+    }
+
+    private static void ConsumeUnknownBlockOrProperty(SimpleParser parser)
+    {
+        if (parser.Peek("="))
+            ConsumeUnknownProperty(parser);
+        else if (parser.Peek("{"))
+            ConsumeUnknownBlock(parser);
+        else
+            throw new Exception("Malformed UDMF TEXTMAP. Expected '=' or '{' but found: " + parser.PeekString());
+    }
+
+    private static void ConsumeUnknownProperty(SimpleParser parser)
+    {
+        parser.Consume('=');
+        parser.ConsumeStringSpan();
+        parser.Consume(';');
+    }
+
+    private static void ConsumeUnknownBlock(SimpleParser parser)
+    {
+        parser.Consume('{');
+        while (!parser.Peek('}'))
+            parser.ConsumeStringSpan();
+
+        parser.Consume('}');
     }
 
     private static void ParseThing(SimpleParser parser, List<UdmfThing> things)
@@ -503,12 +536,6 @@ public class UdmfMap : IMap
         }
 
         vertices.Add(new(vertices.Count, new(x, y)));
-    }
-
-    private static void ConsumeBlock(SimpleParser parser)
-    {
-        while (parser.PeekStringSpan() != "}")
-            parser.ConsumeLineSpan();
     }
 
     private static Property ParseProperty(SimpleParser parser)


### PR DESCRIPTION
Hello,
Thanks for merging my previous PR :)

I'm working on a map in UDMF format and it currently works in DSDA-Doom, GZDoom and Eternity Engine.
I noticed that Helion recently introduced UDMF support so I wanted to see if there is a chance to get my map to work in Helion.

I'm using "dsda" namespace and it's supported by recent versions of both DSDA-Doom and GZDoom.
Eternity Engine does not support "dsda" namespace directly but it supports almost all features from that namespace - in order for Eternity Engine to load a map from any namespace different than "eternity" you need to add a flag "ee_compat = true;" to your TEXTMAP.
See: https://eternity.youfailit.net/wiki/UDMF

So a TEXTMAP looks like that:
```
namespace = "dsda";
ee_compat = true;
thing
{
```

That's also how you make maps that are compatible with both GZDoom and Eternity Engine - you just use a subset of the "zdoom" namespace that is supported by both engines, set namespace to "zdoom" and add "ee_compat = true" flag.

My solution is a bit hacky, ideally the parser would support any `property = value;` statements outside of the blocks but I'm not aware of any other flag you can set in this way. And supporting it would be great as it will make it possible to make a map compatible with FOUR engines - DSDA_Doom, GZDoom, Eternity Engine and Helion! :)

I can see that UDMF support is work in progress and not all features are working yet (for example flat rotation works but translation doesn't) but I think it's getting very close. I was thrilled to see midtex3d working!

There is one more problem with the fix - it needs to be applied BOTH to Helion and zdbspSharp as they are both loading the map and have the same problem with ee_compat flag. I did an identical fix to zdbspSharp. I referenced this project directly for testing and it works fine but of course the proper way would be to make a new nuget of zdbspSharp with the fix and update it here. This is the PR to zdbspSharp repo: https://github.com/nstlaurent/zdbspSharp/pull/3

Thanks

Jacek