### PR TITLE
Lemming104/z music reverb

### DIFF
--- a/Client/Music/MusicPlayer.cs
+++ b/Client/Music/MusicPlayer.cs
@@ -184,8 +184,6 @@ public class MusicPlayer : IMusicPlayer
             options |= FluidMidiOptions.Reverb;
 
         m_zMusicPlayer.SetFluidMidiOptions(options);
-        if (m_zMusicPlayer.IsPlaying)
-            RestartZMusicPlayer();
     }
 
     private void PlayQueueTask()

--- a/Client/Music/MusicPlayer.cs
+++ b/Client/Music/MusicPlayer.cs
@@ -56,12 +56,19 @@ public class MusicPlayer : IMusicPlayer
 
     private ZMusicPlayer CreateZMusicPlayer(ConfigAudio configAudio, AudioStreamFactory streamFactory, string soundFontPath)
     {
+        FluidMidiOptions midiOptions = FluidMidiOptions.None;
+        if (configAudio.EnableChorus)
+            midiOptions |= FluidMidiOptions.Chorus;
+        if (configAudio.EnableReverb)
+            midiOptions |= FluidMidiOptions.Reverb;
+
         var player = new ZMusicPlayer(
             streamFactory,
             configAudio.Synthesizer == Synth.OPL3 ? MidiDevice.OPL3 : MidiDevice.FluidSynth,
             soundFontPath,
             null,
-            (float)configAudio.MusicVolume.Value);
+            (float)configAudio.MusicVolume.Value,
+            fluidMidiOptions: midiOptions);
         SetSynthesizer(player);
         return player;
     }

--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="GlmSharp-netstandard" Version="0.9.8.1" />
     <PackageReference Include="Helion.TextCopyLite" Version="1.0.0" />
-    <PackageReference Include="Helion.ZMusic" Version="2.0.1.1" />
+    <PackageReference Include="Helion.ZMusic" Version="2.0.1.2" />
     <PackageReference Include="NAudio.Core" Version="2.2.1" />
     <PackageReference Include="NLog" Version="6.0.0" />
     <PackageReference Include="OpenTK" Version="4.9.4" />

--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="GlmSharp-netstandard" Version="0.9.8.1" />
     <PackageReference Include="Helion.TextCopyLite" Version="1.0.0" />
-    <PackageReference Include="Helion.ZMusic" Version="2.0.1" />
+    <PackageReference Include="Helion.ZMusic" Version="2.0.1.1" />
     <PackageReference Include="NAudio.Core" Version="2.2.1" />
     <PackageReference Include="NLog" Version="6.0.0" />
     <PackageReference Include="OpenTK" Version="4.9.4" />


### PR DESCRIPTION
1.  (ZMusicWrapper) value for "reverb" is 0 or 2, not 0 or 1, and the "settings" methods in ZMusic reject it, see [this change](https://github.com/Helion-Engine/ZMusicWrapper/commit/1c3d6756d35fe7395a649fa25563a23c60244066)
2. (Partially in ZMusicWrapper) We should be able to change reverb/chorus without a restart, see [this change](https://github.com/Helion-Engine/ZMusicWrapper/commit/908eb6743d0c4fc92d67091356d35835f43aa381)
3.  Values for reverb and chorus are not applied when the player is created, only when the settings are changed.

I am not entirely convinced that this solves the reported problems with chorus and reverb settings not being honored, but I believe this closes out the managed code side of things and anything left over _should_ be on the native side.