### PR TITLE
Downscale sprite clip buffer

### DIFF
--- a/Core/Layer/Options/Sections/ListedConfigSection.cs
+++ b/Core/Layer/Options/Sections/ListedConfigSection.cs
@@ -85,6 +85,7 @@ public class ListedConfigSection : IOptionSection
         m_config.Render.LightMode.OptionDisabled = paletteMode;
         m_config.Render.Brightmaps.OptionDisabled = paletteMode;
         m_config.Render.EmulateInvulnerabilityColorMap.OptionDisabled = paletteMode;
+        m_config.Render.DownScaleVanillaRenderSampleBuffer.OptionDisabled = m_config.Render.VanillaRender.Value == false;
 
         m_config.Mouse.ForwardBackwardSpeed.OptionDisabled = m_config.Mouse.Look.Value == true;
 

--- a/Core/Render/OpenGL/Framebuffer/PlaneClipFrameBuffer.cs
+++ b/Core/Render/OpenGL/Framebuffer/PlaneClipFrameBuffer.cs
@@ -27,12 +27,12 @@ public class PlaneClipFrameBuffer : IDisposable
         m_texture = GL.GenTexture();
         GL.BindTexture(TextureTarget.Texture2D, m_texture);
         GLHelper.ObjectLabel(ObjectLabelIdentifier.Texture, m_texture, $"{name} Texture");
-        GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgb32f, width, height, 0, PixelFormat.Rgb, PixelType.Float, IntPtr.Zero);
+        GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgba32f, width, height, 0, PixelFormat.Rgba, PixelType.Float, IntPtr.Zero);
         GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int)TextureMinFilter.Linear);
         GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int)TextureMagFilter.Linear);
         GL.BindTexture(TextureTarget.Texture2D, 0);
 
-        m_depthTexture = new GLTexture2D($"{name} Depth Stencil Attachment", dimension);
+        m_depthTexture = new GLTexture2D($"{name} Depth Stencil Attachment", m_dimension);
         m_depthTexture.Bind();
         GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Depth32fStencil8, width, height, 0, PixelFormat.DepthStencil, PixelType.Float32UnsignedInt248Rev, IntPtr.Zero);
         m_depthTexture.Unbind();

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
@@ -47,6 +47,7 @@ public class EntityProgram : RenderProgram
     private readonly int m_lineHeightsTextureLocation;
     private readonly int m_useBrightmapsLocation;
     private readonly int m_downScaleAmountLocation;
+    private readonly int m_downScaleSampleFactorLocation;
 
     public EntityProgram(string name) : base($"Entity - {name}")
     {
@@ -88,6 +89,7 @@ public class EntityProgram : RenderProgram
         m_lineHeightsTextureLocation = Uniforms.GetLocation("lineHeightsTexture");
         m_useBrightmapsLocation = Uniforms.GetLocation("useBrightmaps");
         m_downScaleAmountLocation = Uniforms.GetLocation("downScaleAmount");
+        m_downScaleSampleFactorLocation = Uniforms.GetLocation("downScaleSampleFactor");
     }
     
     public void BoundTexture(TextureUnit unit) => ProgramUniforms.Set(unit, m_boundTextureLocation);
@@ -128,7 +130,8 @@ public class EntityProgram : RenderProgram
     public void CheckPlaneClip(bool value) => ProgramUniforms.Set(value, m_checkPlaneClipLocation);
     public void HealthBarMode(bool value) => ProgramUniforms.Set(value, m_healthBarModeLocation);
     public void UseBrightmaps(bool value) => ProgramUniforms.Set(value, m_useBrightmapsLocation);
-    public void SetDownScaleAmount(int value) => ProgramUniforms.Set(value, m_downScaleAmountLocation);
+    public void SetSpriteClipDownScaleAmount(int value) => ProgramUniforms.Set(value, m_downScaleAmountLocation);
+    public void SetSpriteClipDownScaleSampleFactor(Vec2F value) => ProgramUniforms.Set(value, m_downScaleSampleFactorLocation);
 
     private const string BoxDefines = @"
         const float BoxWidth = 20;
@@ -357,6 +360,7 @@ public class EntityProgram : RenderProgram
         uniform vec3 viewPos;
         uniform float timeFrac;
         uniform int downScaleAmount;
+        uniform vec2 downScaleSampleFactor;
 
         uniform sampler2D planeClipTexture;
         uniform sampler2D wallClipTexture;
@@ -385,7 +389,8 @@ public class EntityProgram : RenderProgram
         }
 
         bool discardPlaneClip() {
-            ivec2 getCoords = ivec2(gl_FragCoord.xy) / downScaleAmount;
+            vec2 maxBounds = vec2(screenBounds.x / downScaleAmount - 1, screenBounds.y / downScaleAmount - 1);
+            ivec2 getCoords = ivec2(clamp(gl_FragCoord.xy / downScaleSampleFactor, vec2(0.0), maxBounds));
             vec3 wallClip = texelFetch(wallClipTexture, getCoords, 0).rgb;
             vec3 planeClip = texelFetch(planeClipTexture, getCoords, 0).rgb;
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
@@ -46,6 +46,7 @@ public class EntityProgram : RenderProgram
     private readonly int m_wallClipTextureLocation;
     private readonly int m_lineHeightsTextureLocation;
     private readonly int m_useBrightmapsLocation;
+    private readonly int m_downScaleAmountLocation;
 
     public EntityProgram(string name) : base($"Entity - {name}")
     {
@@ -86,6 +87,7 @@ public class EntityProgram : RenderProgram
         m_wallClipTextureLocation = Uniforms.GetLocation("wallClipTexture");
         m_lineHeightsTextureLocation = Uniforms.GetLocation("lineHeightsTexture");
         m_useBrightmapsLocation = Uniforms.GetLocation("useBrightmaps");
+        m_downScaleAmountLocation = Uniforms.GetLocation("downScaleAmount");
     }
     
     public void BoundTexture(TextureUnit unit) => ProgramUniforms.Set(unit, m_boundTextureLocation);
@@ -126,6 +128,7 @@ public class EntityProgram : RenderProgram
     public void CheckPlaneClip(bool value) => ProgramUniforms.Set(value, m_checkPlaneClipLocation);
     public void HealthBarMode(bool value) => ProgramUniforms.Set(value, m_healthBarModeLocation);
     public void UseBrightmaps(bool value) => ProgramUniforms.Set(value, m_useBrightmapsLocation);
+    public void SetDownScaleAmount(int value) => ProgramUniforms.Set(value, m_downScaleAmountLocation);
 
     private const string BoxDefines = @"
         const float BoxWidth = 20;
@@ -353,6 +356,7 @@ public class EntityProgram : RenderProgram
         uniform int useBrightmaps;
         uniform vec3 viewPos;
         uniform float timeFrac;
+        uniform int downScaleAmount;
 
         uniform sampler2D planeClipTexture;
         uniform sampler2D wallClipTexture;
@@ -381,7 +385,7 @@ public class EntityProgram : RenderProgram
         }
 
         bool discardPlaneClip() {
-            ivec2 getCoords = ivec2(gl_FragCoord.xy);
+            ivec2 getCoords = ivec2(gl_FragCoord.xy) / downScaleAmount;
             vec3 wallClip = texelFetch(wallClipTexture, getCoords, 0).rgb;
             vec3 planeClip = texelFetch(planeClipTexture, getCoords, 0).rgb;
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
@@ -361,7 +361,22 @@ public class EntityRenderer : IDisposable
         program.ScreenBounds((renderInfo.Viewport.Width, renderInfo.Viewport.Height));
         program.CheckPlaneClip(m_vanillaRender);
         program.UseBrightmaps(renderInfo.Uniforms.UseBrightmaps);
-        program.SetDownScaleAmount(renderInfo.Uniforms.DownScaleAmount);
+
+        if (renderInfo.Uniforms.DownScaleAmount > 1)
+        {
+            // Decrease the scale factor slightly so the sampling overdraws pixels at the edges to fix underdraw gaps against walls.
+            const float ScaleFactor = 0.997f;
+            var downScale = renderInfo.Uniforms.DownScaleAmount;
+            var scaleX = ScaleFactor - ((downScale - 2) * 0.002f);
+            var scaleY = ScaleFactor - ((downScale - 2) * 0.002f);
+            program.SetSpriteClipDownScaleAmount(downScale);
+            program.SetSpriteClipDownScaleSampleFactor(new(downScale * scaleX, downScale * scaleY));
+        }
+        else
+        {
+            program.SetSpriteClipDownScaleAmount(1);
+            program.SetSpriteClipDownScaleSampleFactor(Vec2F.One);
+        }
 
         // The fade distance calculations work using squared distances
         float maxDistanceSquared = renderInfo.Uniforms.MaxDistance * renderInfo.Uniforms.MaxDistance;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
@@ -361,6 +361,7 @@ public class EntityRenderer : IDisposable
         program.ScreenBounds((renderInfo.Viewport.Width, renderInfo.Viewport.Height));
         program.CheckPlaneClip(m_vanillaRender);
         program.UseBrightmaps(renderInfo.Uniforms.UseBrightmaps);
+        program.SetDownScaleAmount(renderInfo.Uniforms.DownScaleAmount);
 
         // The fade distance calculations work using squared distances
         float maxDistanceSquared = renderInfo.Uniforms.MaxDistance * renderInfo.Uniforms.MaxDistance;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
@@ -33,6 +33,7 @@ public class InterpolationShader : RenderProgram
     private readonly int m_wallClipTextureLocation;
     private readonly int m_useBrightmapsLocation;
     private readonly int m_brightmapTextureLocation;
+    private readonly int m_downScaleAmountLocation;
 
     public InterpolationShader(string name) : base($"World Interpolation - {name}")
     {
@@ -60,6 +61,7 @@ public class InterpolationShader : RenderProgram
         m_checkPlaneClipLocation = Uniforms.GetLocation("checkPlaneClip");
         m_wallClipTextureLocation = Uniforms.GetLocation("wallClipTexture");
         m_useBrightmapsLocation = Uniforms.GetLocation("useBrightmaps");
+        m_downScaleAmountLocation = Uniforms.GetLocation("downScaleAmount");
     }
 
     public void BoundTexture(TextureUnit unit) => ProgramUniforms.Set(unit, m_boundTextureLocation);
@@ -87,6 +89,7 @@ public class InterpolationShader : RenderProgram
     public void VertexGapClampUV(bool value) => ProgramUniforms.Set(value, m_vertexGapClampUV);
     public void CheckPlaneClip(bool value) => ProgramUniforms.Set(value, m_checkPlaneClipLocation);
     public void UseBrightmaps(bool value) => ProgramUniforms.Set(value, m_useBrightmapsLocation);
+    public void SetDownScaleAmount(int value) => ProgramUniforms.Set(value, m_downScaleAmountLocation);
 
     protected override string VertexShader() => @"
         #version 330
@@ -189,6 +192,7 @@ public class InterpolationShader : RenderProgram
             uniform sampler2D wallClipTexture;
             uniform int checkPlaneClip;
             uniform int useBrightmaps;
+            uniform int downScaleAmount;
 
             ${LightLevelFragVariables}
             ${SectorColorMapFragVariables}
@@ -196,7 +200,7 @@ public class InterpolationShader : RenderProgram
 
             void main() {
                 if (checkPlaneClip == 1) {
-                    ivec2 getCoords = ivec2(gl_FragCoord.xy);
+                    ivec2 getCoords = ivec2(gl_FragCoord.xy) / downScaleAmount;
                     float wallClipDepth = texelFetch(wallClipTexture, getCoords, 0).g;
                     float planeClipDepth = texelFetch(planeClipTexture, getCoords, 0).g;
                     // This is for alpha walls and vanilla rendering

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -353,34 +353,37 @@ public class LegacyWorldRenderer : WorldRenderer
         GL.ColorMask(true, true, true, true);
 
         if (m_wallClipFrameBuffer != null || m_planeClipFrameBuffer != null)
-        {
-            var useRenderInfo = renderInfo;
-            if (renderInfo.Uniforms.DownScaleAmount != 1)
-            {
-                var downScaleAmount = renderInfo.Uniforms.DownScaleAmount;
-                useRenderInfo = m_downSizedRenderInfo;
-                var viewport = renderInfo.Viewport;
-                viewport = new Rectangle(viewport.X / downScaleAmount, viewport.Y / downScaleAmount, viewport.Width / downScaleAmount, viewport.Height / downScaleAmount);
-                m_downSizedRenderInfo.Set(renderInfo.Camera, renderInfo.TickFraction, viewport, renderInfo.ViewerEntity,
-                    renderInfo.DrawAutomap, renderInfo.AutomapOffset, renderInfo.AutomapScale,
-                    renderInfo.Config, renderInfo.ViewSector, renderInfo.TransferHeightView);
-                m_downSizedRenderInfo.Uniforms = Renderer.GetShaderUniforms(m_config, world, m_downSizedRenderInfo);
-
-                GL.Viewport(viewport.X, viewport.Y, viewport.Width, viewport.Height);
-            }
-
-            if (m_wallClipFrameBuffer != null)
-                WritePlaneClipData(m_wallClipFrameBuffer, useRenderInfo, framebuffer, true);
-
-            if (m_planeClipFrameBuffer != null)
-                WritePlaneClipData(m_planeClipFrameBuffer, useRenderInfo, framebuffer, false);
-
-            if (renderInfo.Uniforms.DownScaleAmount != 1)
-                GL.Viewport(renderInfo.Viewport.X, renderInfo.Viewport.Y, renderInfo.Viewport.Width, renderInfo.Viewport.Height);
-        }
+            WriteSpriteClipBuffers(world, renderInfo, framebuffer);
 
         m_entityRenderer.RenderOpaque(renderInfo);
         RenderTransparent(renderInfo, framebuffer);
+    }
+
+    private void WriteSpriteClipBuffers(IWorld world, RenderInfo renderInfo, GLFramebuffer framebuffer)
+    {
+        var useRenderInfo = renderInfo;
+        if (renderInfo.Uniforms.DownScaleAmount > 1)
+        {
+            var downScaleAmount = renderInfo.Uniforms.DownScaleAmount;
+            useRenderInfo = m_downSizedRenderInfo;
+            var viewport = renderInfo.Viewport;
+            viewport = new Rectangle(viewport.X / downScaleAmount, viewport.Y / downScaleAmount, viewport.Width / downScaleAmount, viewport.Height / downScaleAmount);
+            m_downSizedRenderInfo.Set(renderInfo.Camera, renderInfo.TickFraction, viewport, renderInfo.ViewerEntity,
+                renderInfo.DrawAutomap, renderInfo.AutomapOffset, renderInfo.AutomapScale,
+                renderInfo.Config, renderInfo.ViewSector, renderInfo.TransferHeightView);
+            m_downSizedRenderInfo.Uniforms = Renderer.GetShaderUniforms(m_config, world, m_downSizedRenderInfo);
+
+            GL.Viewport(viewport.X, viewport.Y, viewport.Width, viewport.Height);
+        }
+
+        if (m_wallClipFrameBuffer != null)
+            WritePlaneClipData(m_wallClipFrameBuffer, useRenderInfo, framebuffer, true);
+
+        if (m_planeClipFrameBuffer != null)
+            WritePlaneClipData(m_planeClipFrameBuffer, useRenderInfo, framebuffer, false);
+
+        if (renderInfo.Uniforms.DownScaleAmount > 1)
+            GL.Viewport(renderInfo.Viewport.X, renderInfo.Viewport.Y, renderInfo.Viewport.Width, renderInfo.Viewport.Height);
     }
 
     private void SetupClipBuffers(GLFramebuffer framebuffer, Dimension dimension)

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -43,6 +43,7 @@ public class LegacyWorldRenderer : WorldRenderer
     private readonly LegacyGLTextureManager m_textureManager;
     private readonly Stopwatch m_stopwatch = new();
     private readonly OitFrameBuffer m_oitFrameBuffer = new();
+    private readonly RenderInfo m_downSizedRenderInfo = new();
     private Vec2D m_occludeViewPos;
     private bool m_occlude;
     private bool m_vanillaRender;
@@ -351,11 +352,32 @@ public class LegacyWorldRenderer : WorldRenderer
         RenderTwoSidedMiddleWalls(renderInfo);
         GL.ColorMask(true, true, true, true);
 
-        if (m_wallClipFrameBuffer != null)
-            WritePlaneClipData(m_wallClipFrameBuffer, renderInfo, framebuffer, true);
+        if (m_wallClipFrameBuffer != null || m_planeClipFrameBuffer != null)
+        {
+            var useRenderInfo = renderInfo;
+            if (renderInfo.Uniforms.DownScaleAmount != 1)
+            {
+                var downScaleAmount = renderInfo.Uniforms.DownScaleAmount;
+                useRenderInfo = m_downSizedRenderInfo;
+                var viewport = renderInfo.Viewport;
+                viewport = new Rectangle(viewport.X / downScaleAmount, viewport.Y / downScaleAmount, viewport.Width / downScaleAmount, viewport.Height / downScaleAmount);
+                m_downSizedRenderInfo.Set(renderInfo.Camera, renderInfo.TickFraction, viewport, renderInfo.ViewerEntity,
+                    renderInfo.DrawAutomap, renderInfo.AutomapOffset, renderInfo.AutomapScale,
+                    renderInfo.Config, renderInfo.ViewSector, renderInfo.TransferHeightView);
+                m_downSizedRenderInfo.Uniforms = Renderer.GetShaderUniforms(m_config, world, m_downSizedRenderInfo);
 
-        if (m_planeClipFrameBuffer != null)
-            WritePlaneClipData(m_planeClipFrameBuffer, renderInfo, framebuffer, false);
+                GL.Viewport(viewport.X, viewport.Y, viewport.Width, viewport.Height);
+            }
+
+            if (m_wallClipFrameBuffer != null)
+                WritePlaneClipData(m_wallClipFrameBuffer, useRenderInfo, framebuffer, true);
+
+            if (m_planeClipFrameBuffer != null)
+                WritePlaneClipData(m_planeClipFrameBuffer, useRenderInfo, framebuffer, false);
+
+            if (renderInfo.Uniforms.DownScaleAmount != 1)
+                GL.Viewport(renderInfo.Viewport.X, renderInfo.Viewport.Y, renderInfo.Viewport.Width, renderInfo.Viewport.Height);
+        }
 
         m_entityRenderer.RenderOpaque(renderInfo);
         RenderTransparent(renderInfo, framebuffer);
@@ -609,6 +631,7 @@ public class LegacyWorldRenderer : WorldRenderer
         program.GammaCorrection(renderInfo.Uniforms.GammaCorrection);
         program.CheckPlaneClip(checkPlaneClip);
         program.UseBrightmaps(renderInfo.Uniforms.UseBrightmaps);
+        program.SetDownScaleAmount(renderInfo.Uniforms.DownScaleAmount);
 
         if (program is InterpolationCompositeShader)
         {

--- a/Core/Render/OpenGL/Renderers/Legacy/World/ShaderUniforms.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/ShaderUniforms.cs
@@ -23,7 +23,8 @@ public struct ShaderUniforms(
     RenderLightMode lightMode,
     float gammaCorrection,
     int maxDistance,
-    bool useBrightmaps)
+    bool useBrightmaps,
+    int downScaleAmount)
 {
     public mat4 Mvp = mvp;
     public mat4 MvpNoPitch = mvpNoPitch;
@@ -40,4 +41,5 @@ public struct ShaderUniforms(
     public float GammaCorrection = gammaCorrection;
     public int MaxDistance = maxDistance;
     public bool UseBrightmaps = useBrightmaps;
+    public int DownScaleAmount = downScaleAmount;
 }

--- a/Core/Render/Renderer.cs
+++ b/Core/Render/Renderer.cs
@@ -57,7 +57,7 @@ public partial class Renderer : IDisposable
     /// Framebuffer used to draw the world.
     /// </summary>
     private GLFramebuffer m_virtualFramebuffer;
-    private GLFramebuffer m_screenshotFramebuffer;
+    private readonly GLFramebuffer m_screenshotFramebuffer;
     public readonly LegacyGLTextureManager Textures;
     internal readonly IConfig m_config;
     internal readonly FpsTracker m_fpsTracker;
@@ -232,10 +232,19 @@ public partial class Renderer : IDisposable
             GetFuzzDiv(renderInfo.Config, renderInfo.Viewport),
             colorMapUniforms,
             paletteIndex,
-            config.Render.LightMode, 
+            config.Render.LightMode,
             (float)config.Render.GammaCorrection,
             maxDistance,
-            config.Render.Brightmaps);
+            config.Render.Brightmaps,
+            GetDownScaleAmount(config, renderInfo));
+    }
+
+    private static int GetDownScaleAmount(IConfig config, RenderInfo renderInfo)
+    {
+        if (renderInfo.Viewport.Height <= 480)
+            return 1;
+
+        return config.Render.DownScaleVanillaRenderSampleBuffer.Value;
     }
 
     private static ColorMapUniforms GetColorMapUniforms(Entity viewer, OldCamera camera)

--- a/Core/Render/Renderer.cs
+++ b/Core/Render/Renderer.cs
@@ -241,10 +241,10 @@ public partial class Renderer : IDisposable
 
     private static int GetDownScaleAmount(IConfig config, RenderInfo renderInfo)
     {
-        if (renderInfo.Viewport.Height <= 480)
+        if (renderInfo.Viewport.Height <= 480 || !config.Render.DownScaleVanillaRenderSampleBuffer)
             return 1;
 
-        return config.Render.DownScaleVanillaRenderSampleBuffer.Value;
+        return 2;
     }
 
     private static ColorMapUniforms GetColorMapUniforms(Entity viewer, OldCamera camera)

--- a/Core/Util/Configs/Components/ConfigRender.cs
+++ b/Core/Util/Configs/Components/ConfigRender.cs
@@ -156,6 +156,9 @@ public class ConfigRender: ConfigElement<ConfigRender>
     [OptionMenu(OptionSectionType.Render, "Emulate Vanilla Rendering", spacer: true)]
     public readonly ConfigValue<bool> VanillaRender = new(false);
 
+    [ConfigInfo("Amount to downscale the sampling buffer for sprite clipping with emulate vanilla rendering.")]
+    public readonly ConfigValue<int> DownScaleVanillaRenderSampleBuffer = new(2, Clamp(1, 8));
+
     [ConfigInfo("Emulates custom invulnerability palettes in true color mode. May not work well with all WADs. Application restart required.", restartRequired: true)]
     [OptionMenu(OptionSectionType.Render, "Emulate Invulnerability Colormap")]
     public readonly ConfigValue<bool> EmulateInvulnerabilityColorMap = new(false);

--- a/Core/Util/Configs/Components/ConfigRender.cs
+++ b/Core/Util/Configs/Components/ConfigRender.cs
@@ -151,13 +151,14 @@ public class ConfigRender: ConfigElement<ConfigRender>
     [ConfigInfo("Enable sprite transparency.")]
     [OptionMenu(OptionSectionType.Render, "Sprite Transparency")]
     public readonly ConfigValue<bool> SpriteTransparency = new(true);
-
-    [ConfigInfo("Render sprites over floors/ceilings. Sprites always clipped to walls. May slow down rendering.", mapRestartRequired: true)]
+     
+    [ConfigInfo("Render sprites emulating software sprite clipping. May slow down rendering.", mapRestartRequired: true)]
     [OptionMenu(OptionSectionType.Render, "Emulate Vanilla Rendering", spacer: true)]
     public readonly ConfigValue<bool> VanillaRender = new(false);
 
-    [ConfigInfo("Amount to downscale the sampling buffer for sprite clipping with emulate vanilla rendering.")]
-    public readonly ConfigValue<int> DownScaleVanillaRenderSampleBuffer = new(2, Clamp(1, 8));
+    [ConfigInfo("Downscales the sprite clipping buffer with emulate vanilla rendering. Increases performance at the expense of pixel accuracy.")]
+    [OptionMenu(OptionSectionType.Render, "Downscale Vanilla Buffer")]
+    public readonly ConfigValue<bool> DownScaleVanillaRenderSampleBuffer = new(true);
 
     [ConfigInfo("Emulates custom invulnerability palettes in true color mode. May not work well with all WADs. Application restart required.", restartRequired: true)]
     [OptionMenu(OptionSectionType.Render, "Emulate Invulnerability Colormap")]


### PR DESCRIPTION
Option to downscale the emulate vanilla sprite render buffer. Increases performance at the expense of pixel accuracy. Allows more GPUs to use emulate vanilla rendering.

On means the sampling buffer is scaled in half. Because of the decrease in size the sampling is very slightly upscaled to over sample. This means pixels at wall edges will be overdrawn slightly to prevent pixel gaps from underdraw.