### PR TITLE
Update Linux AOT build for releases

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -23,6 +23,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Install Linux prereqs
+      run: sudo apt -y install clang zlib1g libsndfile1-dev libmpg123-dev libglib2.0-dev libasound2-dev
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:


### PR DESCRIPTION
The Linux AOT build now does a substantial amount of native linking (bypassing the lazy loading and P/Invoke stuff) and needs some dev packages installed.

I have tested these workflow changes on a fork of this repo, and they seem to work.