### PR TITLE
map render data styles

### DIFF
--- a/Core/Render/OpenGL/Renderers/Legacy/World/Data/RenderDataManager.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Data/RenderDataManager.cs
@@ -1,6 +1,7 @@
 ﻿using Helion.Render.OpenGL.Shader;
 using Helion.Render.OpenGL.Texture.Legacy;
 using Helion.Resources.Definitions.Decorate.Properties.Enums;
+using Helion.Util.Assertion;
 using OpenTK.Graphics.OpenGL;
 using System;
 using System.Diagnostics.CodeAnalysis;
@@ -9,14 +10,25 @@ namespace Helion.Render.OpenGL.Renderers.Legacy.World.Data;
 
 public class RenderDataManager<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TVertex> : IDisposable where TVertex : struct
 {
-    private readonly RenderDataCollection<TVertex>[] m_renderDataStyles;
+    private static readonly RenderDataStyle[] RenderStyleLookup =
+    [
+        RenderDataStyle.Normal,
+        RenderDataStyle.Normal,
+        RenderDataStyle.Fuzzy,
+        RenderDataStyle.Translucent,
+        RenderDataStyle.Add,
+        RenderDataStyle.ColorAdd,
+        RenderDataStyle.ColorAdd
+    ];
 
+    private readonly RenderDataCollection<TVertex>[] m_renderDataStyles;
     private readonly RenderData<TVertex> m_healthBarData;
     private bool m_disposed;
 
     public RenderDataManager(RenderProgram program, GLLegacyTexture healthBarTexture)
     {
-        m_renderDataStyles = new RenderDataCollection<TVertex>[(int)RenderStyle.Count];
+        Assert.Precondition(RenderStyleLookup.Length == (int)RenderStyle.Count, "Render style lookup size mismatch");
+        m_renderDataStyles = new RenderDataCollection<TVertex>[(int)RenderDataStyle.Count];
         for (int i = 0; i < m_renderDataStyles.Length; i++)
             m_renderDataStyles[i] = new(program);
 
@@ -29,7 +41,7 @@ public class RenderDataManager<[DynamicallyAccessedMembers(DynamicallyAccessedMe
     }
 
     public bool HasDataToRenderByStyle(RenderStyle style) =>
-        m_renderDataStyles[(int)style].HasDataToRender();
+        m_renderDataStyles[(int)RenderStyleLookup[(int)style]].HasDataToRender();
 
     public void Clear()
     {
@@ -44,10 +56,10 @@ public class RenderDataManager<[DynamicallyAccessedMembers(DynamicallyAccessedMe
         m_healthBarData.Draw(PrimitiveType.Points);
 
     public RenderData<TVertex> GetByRenderStyle(RenderStyle style, GLLegacyTexture texture, GLLegacyTexture? brightmapTexture = null) =>
-         m_renderDataStyles[(int)style].Get(texture, brightmapTexture);
+         m_renderDataStyles[(int)RenderStyleLookup[(int)style]].Get(texture, brightmapTexture);
 
     public void RenderByRenderStyle(RenderStyle style, PrimitiveType primitive) =>
-        m_renderDataStyles[(int)style].Render(primitive);
+        m_renderDataStyles[(int)RenderStyleLookup[(int)style]].Render(primitive);
 
     protected virtual void Dispose(bool disposing)
     {

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Data/RenderDataStyle.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Data/RenderDataStyle.cs
@@ -1,0 +1,11 @@
+﻿namespace Helion.Render.OpenGL.Renderers.Legacy.World.Data;
+
+public enum RenderDataStyle
+{
+    Normal = 0,
+    Fuzzy,
+    Translucent,
+    Add,
+    ColorAdd,
+    Count
+}


### PR DESCRIPTION
map RenderStyle to RenderDataStyle to not allocate buckets for multiple types that map to the same underlying bucket