### PR TITLE
implement ColorAddExplosion render style

### DIFF
--- a/Core/Render/OpenGL/Renderers/Legacy/World/Data/RenderDataManager.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Data/RenderDataManager.cs
@@ -18,6 +18,7 @@ public class RenderDataManager<[DynamicallyAccessedMembers(DynamicallyAccessedMe
         RenderDataStyle.Translucent,
         RenderDataStyle.Add,
         RenderDataStyle.ColorAdd,
+        RenderDataStyle.ColorAdd,
         RenderDataStyle.ColorAdd
     ];
 
@@ -40,8 +41,8 @@ public class RenderDataManager<[DynamicallyAccessedMembers(DynamicallyAccessedMe
         Dispose(false);
     }
 
-    public bool HasDataToRenderByStyle(RenderStyle style) =>
-        m_renderDataStyles[(int)RenderStyleLookup[(int)style]].HasDataToRender();
+    public bool HasDataToRenderByStyle(RenderDataStyle style) =>
+        m_renderDataStyles[(int)style].HasDataToRender();
 
     public void Clear()
     {
@@ -58,8 +59,8 @@ public class RenderDataManager<[DynamicallyAccessedMembers(DynamicallyAccessedMe
     public RenderData<TVertex> GetByRenderStyle(RenderStyle style, GLLegacyTexture texture, GLLegacyTexture? brightmapTexture = null) =>
          m_renderDataStyles[(int)RenderStyleLookup[(int)style]].Get(texture, brightmapTexture);
 
-    public void RenderByRenderStyle(RenderStyle style, PrimitiveType primitive) =>
-        m_renderDataStyles[(int)RenderStyleLookup[(int)style]].Render(primitive);
+    public void RenderByRenderStyle(RenderDataStyle style, PrimitiveType primitive) =>
+        m_renderDataStyles[(int)style].Render(primitive);
 
     protected virtual void Dispose(bool disposing)
     {

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
@@ -75,7 +75,7 @@ public class EntityRenderer : IDisposable
         PerformDispose();
     }
 
-    public bool HasDataToRenderByStyle(RenderStyle style) => m_dataManager.HasDataToRenderByStyle(style);
+    public bool HasDataToRenderByStyle(RenderDataStyle style) => m_dataManager.HasDataToRenderByStyle(style);
 
     public void HealthBarMode(bool set) => m_program.HealthBarMode(set);
 
@@ -242,8 +242,13 @@ public class EntityRenderer : IDisposable
 
         // If fullbright and modified through dehacked then change render style to ColorAdd for better color rendering.
         var entityAlpha = entity.Alpha;
-        if (m_spriteAlpha && entity.RenderStyle == RenderStyle.ColorAddFullBright)
-            renderStyle = isFullBright ? RenderStyle.ColorAdd : RenderStyle.Translucent;
+        if (m_spriteAlpha)
+        {
+            if (entity.RenderStyle == RenderStyle.ColorAddFullBright)
+                renderStyle = isFullBright ? RenderStyle.ColorAdd : RenderStyle.Translucent;
+            else if (entity.RenderStyle == RenderStyle.ColorAddExplosion)
+                renderStyle = entity.Flags.Missile ? RenderStyle.Normal : RenderStyle.ColorAdd;
+        }
 
         if (renderStyle == RenderStyle.ColorAdd)
             entityAlpha = 1.0f;
@@ -397,7 +402,7 @@ public class EntityRenderer : IDisposable
         GL.ActiveTexture(BindTextures.BoundTexture);
         SetUniforms(m_program, renderInfo);
         m_program.HealthBarMode(false);
-        m_dataManager.RenderByRenderStyle(RenderStyle.Normal, PrimitiveType.Points);
+        m_dataManager.RenderByRenderStyle(RenderDataStyle.Normal, PrimitiveType.Points);
 
         if (m_healthBars)
         {
@@ -414,11 +419,11 @@ public class EntityRenderer : IDisposable
         m_programTransparent.RenderFuzz(false);
         GL.ActiveTexture(BindTextures.BoundTexture);
         SetUniforms(m_programTransparent, renderInfo);
-        m_dataManager.RenderByRenderStyle(RenderStyle.Translucent, PrimitiveType.Points);
-        m_dataManager.RenderByRenderStyle(RenderStyle.Add, PrimitiveType.Points);
-        m_dataManager.RenderByRenderStyle(RenderStyle.Fuzzy, PrimitiveType.Points);
+        m_dataManager.RenderByRenderStyle(RenderDataStyle.Translucent, PrimitiveType.Points);
+        m_dataManager.RenderByRenderStyle(RenderDataStyle.Add, PrimitiveType.Points);
+        m_dataManager.RenderByRenderStyle(RenderDataStyle.Fuzzy, PrimitiveType.Points);
         m_programTransparent.ColorClamp(0.9f);
-        m_dataManager.RenderByRenderStyle(RenderStyle.ColorAdd, PrimitiveType.Points);
+        m_dataManager.RenderByRenderStyle(RenderDataStyle.ColorAdd, PrimitiveType.Points);
         m_programTransparent.Unbind();
     }
 
@@ -428,7 +433,7 @@ public class EntityRenderer : IDisposable
         m_programTransparent.RenderFuzz(true);
         GL.ActiveTexture(BindTextures.BoundTexture);
         SetUniforms(m_programTransparent, renderInfo);
-        m_dataManager.RenderByRenderStyle(RenderStyle.Fuzzy, PrimitiveType.Points);
+        m_dataManager.RenderByRenderStyle(RenderDataStyle.Fuzzy, PrimitiveType.Points);
         m_programTransparent.Unbind();
     }
 
@@ -437,18 +442,18 @@ public class EntityRenderer : IDisposable
         m_programComposite.Bind();
         GL.ActiveTexture(BindTextures.BoundTexture);
         SetUniforms(m_programComposite, renderInfo);
-        m_dataManager.RenderByRenderStyle(RenderStyle.Translucent, PrimitiveType.Points);
+        m_dataManager.RenderByRenderStyle(RenderDataStyle.Translucent, PrimitiveType.Points);
 
-        if (m_dataManager.HasDataToRenderByStyle(RenderStyle.Add))
+        if (m_dataManager.HasDataToRenderByStyle(RenderDataStyle.Add))
         {
             GL.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.One);
-            m_dataManager.RenderByRenderStyle(RenderStyle.Add, PrimitiveType.Points);
+            m_dataManager.RenderByRenderStyle(RenderDataStyle.Add, PrimitiveType.Points);
         }
 
-        if (m_dataManager.HasDataToRenderByStyle(RenderStyle.ColorAdd))
+        if (m_dataManager.HasDataToRenderByStyle(RenderDataStyle.ColorAdd))
         {
             GL.BlendFunc(BlendingFactor.SrcColor, BlendingFactor.One);
-            m_dataManager.RenderByRenderStyle(RenderStyle.ColorAdd, PrimitiveType.Points);
+            m_dataManager.RenderByRenderStyle(RenderDataStyle.ColorAdd, PrimitiveType.Points);
         }
 
         GL.BlendEquation(BlendEquationMode.FuncAdd);
@@ -463,7 +468,7 @@ public class EntityRenderer : IDisposable
         GL.ActiveTexture(BindTextures.BoundTexture);
         m_programFuzzRefraction.RenderFuzzRefractionColor(renderColor);
         SetUniforms(m_programFuzzRefraction, renderInfo);
-        m_dataManager.RenderByRenderStyle(RenderStyle.Fuzzy, PrimitiveType.Points);
+        m_dataManager.RenderByRenderStyle(RenderDataStyle.Fuzzy, PrimitiveType.Points);
         m_programFuzzRefraction.Unbind();
     }
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -466,9 +466,9 @@ public class LegacyWorldRenderer : WorldRenderer
 
     private unsafe void RenderTransparent(RenderInfo renderInfo, GLFramebuffer framebuffer)
     {
-        var fuzzData = m_entityRenderer.HasDataToRenderByStyle(RenderStyle.Fuzzy); 
-        var alphaData = m_entityRenderer.HasDataToRenderByStyle(RenderStyle.Translucent) || m_entityRenderer.HasDataToRenderByStyle(RenderStyle.Add) || 
-            m_entityRenderer.HasDataToRenderByStyle(RenderStyle.ColorAdd);
+        var fuzzData = m_entityRenderer.HasDataToRenderByStyle(RenderDataStyle.Fuzzy); 
+        var alphaData = m_entityRenderer.HasDataToRenderByStyle(RenderDataStyle.Translucent) || m_entityRenderer.HasDataToRenderByStyle(RenderDataStyle.Add) || 
+            m_entityRenderer.HasDataToRenderByStyle(RenderDataStyle.ColorAdd);
         var alphaWalls = m_worldDataManager.HasAlphaWalls();
         if (!fuzzData && !alphaData && !alphaWalls)
             return;

--- a/Core/Resources/Definitions/Decorate/Properties/Enums/RenderStyle.cs
+++ b/Core/Resources/Definitions/Decorate/Properties/Enums/RenderStyle.cs
@@ -10,5 +10,7 @@ public enum RenderStyle
     ColorAdd,
     // Use ColorAdd when FullBright, otherwise Translucent
     ColorAddFullBright,
+    // Use ColorAdd after death, otherwise Normal (Currently set from +DEHEXPLOSION)
+    ColorAddExplosion,
     Count
 }

--- a/Core/World/Entities/Definition/Composer/DefinitionFlagApplier.cs
+++ b/Core/World/Entities/Definition/Composer/DefinitionFlagApplier.cs
@@ -1,5 +1,6 @@
 using Helion.Resources.Definitions.Decorate.Flags;
 using Helion.Resources.Definitions.Decorate.Properties;
+using Helion.Resources.Definitions.Decorate.Properties.Enums;
 
 namespace Helion.World.Entities.Definition.Composer;
 
@@ -181,5 +182,7 @@ public static class DefinitionFlagApplier
             definition.Flags.CanPass = flags.CanPass.Value;
         if (flags.Shadow != null)
             definition.Flags.Shadow = flags.Shadow.Value;
+        if (flags.DehExplosion != null)
+            definition.Properties.RenderStyle = RenderStyle.ColorAddExplosion;
     }
 }

--- a/Core/World/Entities/Definition/Composer/EntityDefinitionComposer.cs
+++ b/Core/World/Entities/Definition/Composer/EntityDefinitionComposer.cs
@@ -159,8 +159,8 @@ public class EntityDefinitionComposer
 
     private static void ApplyActorFlagsAndProperties(EntityDefinition definition, ActorDefinition actorDefinition)
     {
-        DefinitionFlagApplier.Apply(definition, actorDefinition.Flags, actorDefinition.FlagProperties);
         DefinitionPropertyApplier.Apply(definition, actorDefinition.Properties);
+        DefinitionFlagApplier.Apply(definition, actorDefinition.Flags, actorDefinition.FlagProperties);
     }
 
     private bool CreateInheritanceOrderedList(ActorDefinition actorDef, out IList<ActorDefinition> actorDefinitions)


### PR DESCRIPTION
Adds the behavior from GZDoom where the rocket sprite changes to the color additive render style on explosion through +DEHEXPLOSION flag.

GZDoom will use either translucent or color add depending on the addrocketexplosion (defaulted to false). I'm not bringing over another render config variable. Helion will use color additive since it's rendered at fullbright and looks preferable.