### PR TITLE
true color overlay option for palette color mode

### DIFF
--- a/Core/Graphics/Palettes/PaletteUtil.cs
+++ b/Core/Graphics/Palettes/PaletteUtil.cs
@@ -36,12 +36,18 @@ public static class PaletteUtil
 
         if (damageCount > 0)
         {
+            float damageIntensity;
             if (damageCount == player.DamageCount)
-                damageCount = (int)(player.DamageCount * config.Game.PainIntensity);
+            {
+                damageIntensity = (float)config.Game.PainIntensity;
+                damageCount = player.DamageCount;
+            }
             else
-                damageCount = (int)(damageCount * config.Game.BerserkIntensity);
+            {
+                damageIntensity = (float)config.Game.BerserkIntensity;
+            }
 
-            palette = GetDamagePalette(damageCount);
+            palette = GetDamagePalette(damageCount, damageIntensity);
         }
         else if (player.BonusCount > 0)
         {
@@ -68,11 +74,12 @@ public static class PaletteUtil
         return (PaletteIndex)palette;
     }
 
-    private static PaletteIndex GetDamagePalette(int damageCount)
+    private static PaletteIndex GetDamagePalette(int damageCount, float damgeIntensity)
     {
         const int RedPals = 8;
         const int StartRedPals = 1;
         int palette = (damageCount + 7) >> 3;
+        palette = (int)(palette * damgeIntensity);
         if (palette >= RedPals)
             palette = RedPals - 1;
         palette += StartRedPals;

--- a/Core/Layer/Options/Sections/ListedConfigSection.cs
+++ b/Core/Layer/Options/Sections/ListedConfigSection.cs
@@ -78,6 +78,7 @@ public class ListedConfigSection : IOptionSection
         m_config.Game.QuickSaveConfirm.OptionDisabled = m_config.Game.RotatingQuickSaves > 0;
 
         m_config.Window.Dimension.OptionDisabled = m_config.Window.State != RenderWindowState.Normal;
+        m_config.Window.PaletteTrueColorOverlay.OptionDisabled = m_config.Window.ColorMode.Value != RenderColorMode.Palette;
 
         bool paletteMode = m_config.Window.ColorMode.Value == RenderColorMode.Palette;
         m_config.Render.Filter.Texture.OptionDisabled = paletteMode;

--- a/Core/Layer/Worlds/WorldLayer.Render.Hud.cs
+++ b/Core/Layer/Worlds/WorldLayer.Render.Hud.cs
@@ -3,6 +3,7 @@ using Helion.Geometry.Boxes;
 using Helion.Geometry.Vectors;
 using Helion.Graphics;
 using Helion.Graphics.Fonts;
+using Helion.Graphics.Palettes;
 using Helion.Render;
 using Helion.Render.Common;
 using Helion.Render.Common.Context;
@@ -268,7 +269,7 @@ public partial class WorldLayer
 
     private void DrawHudEffects(IHudRenderContext hud)
     {
-        if (!WorldStatic.World.DrawHud || ShaderVars.PaletteColorMode)
+        if (!WorldStatic.World.DrawHud || (ShaderVars.PaletteColorMode && !m_config.Window.PaletteTrueColorOverlay))
             return;
 
         IPowerup? powerup = Player.Inventory.PowerupEffectColor;
@@ -282,10 +283,20 @@ public partial class WorldLayer
         }
 
         if (Player.BonusCount > 0)
-            hud.Clear(PickupColor, 0.2f);
+        {
+            const float PickupScaleAmount = 3f;
+            var pickupScale = (Player.BonusCount + 7) / PickupScaleAmount;
+            pickupScale *= 1 / PickupScaleAmount;
+            hud.Clear(PickupColor, Math.Min(pickupScale, 0.2f));
+        }
 
         if (Player.DamageCount > 0)
-            hud.Clear(DamageColor, Player.DamageCount * 0.01f * (float)m_config.Game.PainIntensity);
+        {
+            const float DamageScaleAmount = 8f;
+            var damageScale = Math.Min(Player.DamageCount + 7, 100) / DamageScaleAmount;
+            damageScale *= 1 / DamageScaleAmount;
+            hud.Clear(DamageColor, Math.Min(damageScale, 0.89f) * (float)m_config.Game.PainIntensity);
+        }
     }
 
     private void DrawFPS(IHudRenderContext hud, ref int topRightY)

--- a/Core/Render/Renderer.cs
+++ b/Core/Render/Renderer.cs
@@ -207,9 +207,14 @@ public partial class Renderer : IDisposable
 
             if (ShaderVars.PaletteColorMode)
             {
-                mix = 0.0f;
                 colorMapUniforms = GetColorMapUniforms(renderInfo.ViewerEntity, renderInfo.Camera);
-                paletteIndex = PaletteUtil.GetPalette(config, player);
+
+                if (!config.Window.PaletteTrueColorOverlay)
+                {
+                    mix = 0.0f;
+                    paletteIndex = PaletteUtil.GetPalette(config, player);
+                }
+
                 if (!player.DrawInvulnerableColorMap() && player.DrawFullBright())
                     mix = 1.0f;
             }

--- a/Core/Util/Configs/Components/ConfigWindow.cs
+++ b/Core/Util/Configs/Components/ConfigWindow.cs
@@ -71,4 +71,8 @@ public class ConfigWindow: ConfigElement<ConfigWindow>
     [ConfigInfo("Color rendering mode: Palette uses Doom's colormaps and disables texture filtering, producing output that resembles software rendering. True Color interpolates color values. Application restart required.", restartRequired: true)]
     [OptionMenu(OptionSectionType.Video, "Color Mode", allowReset: false)]
     public readonly ConfigValue<RenderColorMode> ColorMode = new(RenderColorMode.TrueColor);
+
+    [ConfigInfo("Use true color overlays instead of Doom's PLAYPAL palettes for damage, item pickups, berserk and radsuit.")]
+    [OptionMenu(OptionSectionType.Video, "True Color Overlay")]
+    public readonly ConfigValue<bool> PaletteTrueColorOverlay = new(true);
 }

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -11,18 +11,19 @@
 - IWAD detection will fallback to reading lumps when MD5/filename checks fail for freedoom.
 - Show IWAD selection screen IWAD fails to load with the -iwad parameter.
 - Support BRGHTMPS from Doom Retro.
-- Use sound decoder from ZMusic to support more sound formats including Ogg and MP3: https://zdoom.org/wiki/Sound_format
-- Separate dependency on Fluidsynth removed, now using built-in version of Fluidsynth in ZMusic
-- Windows AOT builds are statically linked to all dependencies above the Windows API itself
-- Linux AOT builds are statically linked to all dependencies above libsndfile/libmpg123
-- AppImage build support for Linux AOT
-- Ambient sound support from SNDINFO
+- Use sound decoder from ZMusic to support more sound formats including Ogg and MP3: https://zdoom.org/wiki/Sound_format.
+- Separate dependency on Fluidsynth removed, now using built-in version of Fluidsynth in ZMusic.
+- Windows AOT builds are statically linked to all dependencies above the Windows API itself.
+- Linux AOT builds are statically linked to all dependencies above libsndfile/libmpg123.
+- AppImage build support for Linux AOT.
+- Ambient sound support from SNDINFO.
 - Sound more accurately matches Doom's sound curve and cutoff
 - Option to downscale the emulate vanilla sprite render buffer. Increases performance at the expense of pixel accuracy. Allows more GPUs to use emulate vanilla rendering.
 - Support textures in WAD files between TX_START and TX_END markers.
 - Add same sound limit and same sound window similar to parallel same sound limit in dsda-doom, prioritized by distance.
 - Replace ^ with \ in sprite namespace for pk3 and directories.
 - Support Add and Color add render styles from GZDoom with update assets.pk3 to use the supported render styles. Implements custom ColorAddFullbright style that will use ColorAdd when fullbright and translucent otherwise.
+- True color overlay option for palette color mode. Uses true color overlays instead of Doom's PLAYPAL palettes for damage, item pickups, berserk and radsuit.
 
 ## Bug Fixes:
 - Fix spawn ceiling sprite offsets for vanilla sprite rendering.


### PR DESCRIPTION
True color overlay option for palette color mode. Uses true color overlays instead of Doom's PLAYPAL palettes for damage, item pickups, berserk and radsuit.