### PR TITLE
fix middle textures not rendering correctly when part of a transfer heights sector that is moving

### DIFF
--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
@@ -1232,11 +1232,15 @@ public class GeometryRenderer : IDisposable
 
             var opening = GetMidTexOpening(TextureManager, facingSide, facingSector, otherSector, false);
             var prevOpening = GetMidTexOpening(TextureManager, facingSide, facingSector, otherSector, true);
-            double offset = GetTransferHeightHackOffset(TextureManager, facingSide, otherSide, opening.BottomZ, opening.TopZ, previous: false);
-            double prevOffset = 0;
+            var offset = GetTransferHeightHackOffset(TextureManager, facingSide, otherSide, opening.BottomZ, opening.TopZ, previous: false);
+            var prevOffset = offset;
 
             if (offset != 0)
-                prevOffset = GetTransferHeightHackOffset(TextureManager,facingSide, otherSide, opening.BottomZ, opening.TopZ, previous: true);
+            {
+                var check = facingSide.Line.Flags.Unpegged.Lower ? opening.BottomZ == prevOpening.BottomZ : opening.TopZ == prevOpening.TopZ;
+                if (check)
+                    prevOffset = GetTransferHeightHackOffset(TextureManager, facingSide, otherSide, opening.BottomZ, opening.TopZ, previous: true);
+            }
 
             int colorMapIndex = Renderer.GetColorMapBufferIndex(facingSector, LightBufferType.Wall);
             int lightIndex = Renderer.GetLightBufferIndex(facingSide, facingSide.Middle, facingSector);

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -62,3 +62,4 @@
 - Fix crash in sound management when adding in waiting looping sounds.
 - Fix issue with vanilla render sprite clipping where sprites exactly on lines would look like they are z-fighting.
 - Fix issue with vanilla midtextures not clipping sprites when reloading map.
+- Fix middle textures not rendering correctly when part of a transfer heights sector that is moving.


### PR DESCRIPTION
fixes #1255 