### PR TITLE
entity sound fix when disposed

### DIFF
--- a/Core/Audio/Sounds/SoundManager.cs
+++ b/Core/Audio/Sounds/SoundManager.cs
@@ -3,7 +3,6 @@ using Helion.Resources.Archives.Collection;
 using Helion.Resources.Definitions.SoundInfo;
 using Helion.Util;
 using Helion.Util.RandomGenerators;
-using Helion.World;
 using Helion.World.Sound;
 using System;
 using System.Collections.Generic;

--- a/Core/World/Entities/Entity.cs
+++ b/Core/World/Entities/Entity.cs
@@ -118,6 +118,7 @@ public partial class Entity : IDisposable, ITickable, ISoundSource
     public readonly DynamicArray<LinkableNode<Entity>> SectorNodes = new();
     public readonly DynamicArray<int> IntersectMidTexLines = new(); 
     public bool IsDisposed;
+    public bool WaitSoundDispose;
 
     public ClosetFlags ClosetFlags;
 
@@ -1006,6 +1007,9 @@ public partial class Entity : IDisposable, ITickable, ISoundSource
         if (IsDisposed)
             return;
 
+        // The sound has a reference back to this entity to update base on position it can't be reused until the sound is complete.
+        WaitSoundDispose = AudioSource != null;
+
         Id = int.MinValue;
         IsDisposed = true;
         UnlinkFromWorld();
@@ -1032,8 +1036,8 @@ public partial class Entity : IDisposable, ITickable, ISoundSource
         m_overEntity = null;
         m_overEntityId = 0;
 
-        if (Index > 0 && World.DataCache.FreeEntity(this))
-            Definition = null!;
+        if (!WaitSoundDispose)
+            FreeToDataCache();
 
         Velocity = Vec3D.Zero;
 
@@ -1057,6 +1061,12 @@ public partial class Entity : IDisposable, ITickable, ISoundSource
         ChaseFailureSkipCount = 0;
         ClosetChaseSpeed = DefaultClosetChaseSpeed;
         Special = ZDoomLineSpecialType.None;
+    }
+
+    private void FreeToDataCache()
+    {
+        if (Index > 0 && World.DataCache.FreeEntity(this))
+            Definition = null!;
     }
 
     private void Unlink()
@@ -1127,6 +1137,13 @@ public partial class Entity : IDisposable, ITickable, ISoundSource
     {
         AudioSource = null;
         clearedSound = null;
+
+        if (IsDisposed && WaitSoundDispose)
+        {
+            WaitSoundDispose = false;
+            FreeToDataCache();
+        }
+
         return false;
     }
 

--- a/Core/World/Sound/WorldSoundManager.cs
+++ b/Core/World/Sound/WorldSoundManager.cs
@@ -237,10 +237,12 @@ public class WorldSoundManager : SoundManager, ITickable
             nextNode = node.Next;
             if (node.IsFinished())
             {
+                node.AudioData.SoundSource.TryClearSound(node.AudioData.SoundInfo.Name, SoundChannel.Default, out _);
                 PlayingSounds.RemoveAndFree(node, m_world.DataCache);
                 node = nextNode;
                 continue;
             }
+
             var distanceSquared = node.AudioData.SoundSource.GetDistanceSquaredFrom(listener.Entity);
             if (!CheckDistance(distanceSquared, node.AudioData.Attenuation))
             {


### PR DESCRIPTION
When an entity is disposed it's released back to the cache which makes it next to be used on allocation (LIFO). The sound manager still has a reference to that entity and updates it attenuation based on it's position. Rockets are removed before the sound is complete. If that entity is allocated to another then it's position is the newly spawned thing which causes the rocket sound to move. This changes the behavior of the entity to wait to release to the cache until it's active audio is done playing so that the sound can complete with the correct position even when disposed.