### PR TITLE
Fix failure in symbolic link creation on Debian.

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,12 +1,12 @@
 build:
 	dotnet publish -c Release -r linux-x64 -p:AOT=true
 install-system-wide: build
-	ln -s Publish/linux-x64_AOT/Helion /usr/local/bin
+	ln -s ${PWD}/Publish/linux-x64_AOT/Helion /usr/local/bin
 	cp Assets/Misc/helion.svg /usr/share/icons/hicolor/scalable/apps/Helion.svg
 	cp Assets/Misc/Helion.desktop /usr/share/applications/Helion.desktop
 	gtk-update-icon-cache /usr/share/icons/hicolor
 install-single-user: build
-	ln -s Publish/linux-x64_AOT/Helion ~/.local/bin
+	ln -s ${PWD}/Publish/linux-x64_AOT/Helion ~/.local/bin
 	mkdir -p ~/.local/share/icons/hicolor/scalable/apps/
 	cp Assets/Misc/helion.svg ~/.local/share/icons/hicolor/scalable/apps/Helion.svg
 	cp Assets/Misc/Helion.desktop ~/.local/share/applications/Helion.desktop


### PR DESCRIPTION
Apparently relative path linkings don't work on Debian like they do on Arch Linux.  Use ```${PWD}``` instead.