### PR TITLE
Add AppImage to release builds; fix some AppImage issues

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -18,7 +18,6 @@ on:
 
 jobs:
   buildReleaseLinux:
-
     runs-on: ubuntu-22.04
 
     steps:
@@ -52,7 +51,7 @@ jobs:
     - name: Make Release
       uses: ncipollo/release-action@v1
       with:
-        artifacts: "*.zip,*.AppImage"
+        artifacts: "*.zip,Helion.AppImage"
         bodyFile: "RELEASENOTES.md"
   
   buildReleaseWindows:

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install Linux prereqs
-      run: sudo apt -y install clang zlib1g libsndfile1-dev libmpg123-dev libglib2.0-dev libasound2-dev
+      run: sudo apt -y install clang zlib1g libsndfile1-dev libmpg123-dev libglib2.0-dev libasound2-dev patchelf
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -46,10 +46,13 @@ jobs:
       run: zip -r ../../Helion-${{ github.ref_name }}-linux-x64_AOT.zip *
       working-directory: Publish/linux-x64_AOT
       
+    - name: Make Linux AppImage
+      run: Scripts/buildAndPackageAppImage.sh
+      
     - name: Make Release
       uses: ncipollo/release-action@v1
       with:
-        artifacts: "*.zip"
+        artifacts: "*.zip,*.AppImage"
         bodyFile: "RELEASENOTES.md"
   
   buildReleaseWindows:

--- a/Scripts/appImageResources/AppRun
+++ b/Scripts/appImageResources/AppRun
@@ -1,4 +1,2 @@
 #!/bin/bash
-export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
-export LD_LIBRARY_PATH=$APPDIR/lib
 exec $APPDIR/usr/bin/Helion $@

--- a/Scripts/buildAndPackageAppImage.sh
+++ b/Scripts/buildAndPackageAppImage.sh
@@ -22,9 +22,12 @@ echo 'Copying files for AppImage';
 mkdir -p AppImage/usr/bin;
 cp -r Publish/linux-x64_AOT/* AppImage/usr/bin;
 
-# Copy all transitive dependencies
+# Copy all transitive dependencies; patch Helion ELF to use copied lib dir
 mkdir -p AppImage/lib;
 ldd Publish/linux-x64_AOT/Helion | awk 'NF == 4 { system("cp " $3 " AppImage/lib") }';
+rm AppImage/lib/libm.so.*;
+rm AppImage/lib/libc.so.*;
+patchelf --force-rpath --set-rpath '$ORIGIN'/../../lib AppImage/usr/bin/Helion
 
 # Copy icon and .desktop file
 cp -r Scripts/appImageResources/* AppImage;


### PR DESCRIPTION
1. Add AppImage to official release build
2. Remove libc, libm from AppImage package, as these appear to be unsafe to package across Linux versions (tested with build on Ubuntu 22.04, run on Kubuntu 25.04)
3. Rather than hijacking `LD_LIBRARY_PATH`, run `patchelf` to change RPATH to point to captive lib directory.