### PR TITLE
Remove IlcInstructionSet from Client.csproj

### DIFF
--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -24,9 +24,7 @@
     <OptimizationPreference>Speed</OptimizationPreference>
     <!-- See https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/optimizing.md for instruction set info -->
     <!-- x86-x64-v3: Haswell and newer (~2013) with FMA and AVX2.  x86-64-v4: AVX-512 required. -->
-    <IlcInstructionSet>x86-x64-v3</IlcInstructionSet>
-    <!-- NLog tries to get the path incorrectly -->
-    <NoWarn>$(NoWarn);IL3000;IL3002</NoWarn>
+    <!--<IlcInstructionSet>x86-x64-v3</IlcInstructionSet>-->
 
     <!-- Avoid copying symbols for release AOT builds, as these are miserable to debug even with symbols (and the files are huge) -->
     <CopyOutputSymbolsToPublishDirectory Condition="'$(Configuration)'=='Release'">false</CopyOutputSymbolsToPublishDirectory>


### PR DESCRIPTION
This should allow for a "generic" x86-64 build.  Also remove a warning suppression that is no longer needed because nLog fixed their code.