### PR TITLE
Follow standard directory layout in AppImage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -341,3 +341,8 @@ ASALocalRun/
 
 # Ignore Publish directory
 Publish/
+
+# Ignore AppDir/AppImage related artifacts
+AppImage/
+Helion.AppImage
+appimagetool-x86_64.AppImage

--- a/Core/Resources/Archives/Collection/ArchiveCollection.cs
+++ b/Core/Resources/Archives/Collection/ArchiveCollection.cs
@@ -316,9 +316,20 @@ public class ArchiveCollection : IResources, IPathResolver
         // if we have already loaded it.
         if (loadDefaultAssets && m_archives.Empty())
         {
-            var assetsArchive = LoadSpecial(Constants.AssetsFileName, ArchiveType.Assets, LoadArchiveOptions.CalculateMd5 | LoadArchiveOptions.IsBundled);
+            Archive? assetsArchive = null;
+
+            if (OperatingSystem.IsLinux())
+            {
+                // On Linux, if we're installed according to the standard pattern, our assets should be in /opt/Helion/assets.pk3 or similar
+                assetsArchive = LoadSpecial(Constants.AssetsFileName, ArchiveType.Assets, LoadArchiveOptions.CalculateMd5 | LoadArchiveOptions.IsBundled)
+                    ?? LoadSpecial($"../..{Constants.LinuxAssetsFilePath}{Constants.AssetsFileName}", ArchiveType.Assets, LoadArchiveOptions.CalculateMd5 | LoadArchiveOptions.IsBundled);
+            }
+            else
+            {
+                assetsArchive = LoadSpecial(Constants.AssetsFileName, ArchiveType.Assets, LoadArchiveOptions.CalculateMd5 | LoadArchiveOptions.IsBundled);
+            }
             if (assetsArchive == null)
-                return false;
+                    return false;
 
             m_archives.Add(assetsArchive);
         }

--- a/Core/Util/Constants.cs
+++ b/Core/Util/Constants.cs
@@ -20,6 +20,11 @@ public static class Constants
     public const string AssetsFileName = "assets.pk3";
 
     /// <summary>
+    /// The shared location for assets files on Linux operating systems
+    /// </summary>
+    public const string LinuxAssetsFilePath = "/opt/Helion/";
+
+    /// <summary>
     /// How many gameticks occur per second.
     /// </summary>
     public const double TicksPerSecond = 35.0;

--- a/Core/Util/PathsManager.cs
+++ b/Core/Util/PathsManager.cs
@@ -92,7 +92,10 @@ public class PathsManager
         m_userDataFolder = StandardizePath(GetConfigFolder(forcePortableMode || File.Exists(portableConfigFile)));
         m_applicationFolders = [StandardizePath(AppContext.BaseDirectory)];
         if (OperatingSystem.IsLinux())
+        {
             m_applicationFolders.Add(StandardizePath("/usr/share/helion"));
+            m_applicationFolders.Add("../../opt/Helion");  // Relative path is intentional--handles installation to /usr/bin and "appdir" layout.
+        }
         m_wadEnvFolders = [.. GetWadFoldersFromEnvVars().Select(StandardizePath)];
         m_wadCommonFolders = [.. GetWadFoldersFromSteamAndLinuxDirs().Select(StandardizePath)];
     }

--- a/Scripts/buildAndPackageAppImage.sh
+++ b/Scripts/buildAndPackageAppImage.sh
@@ -20,14 +20,18 @@ rm -rf Helion.AppImage;
 cd ..
 echo 'Copying files for AppImage';
 mkdir -p AppImage/usr/bin;
-cp -r Publish/linux-x64_AOT/* AppImage/usr/bin;
+cp Publish/linux-x64_AOT/Helion AppImage/usr/bin;
+
+mkdir -p AppImage/opt/Helion;
+cp -r Publish/linux-x64_AOT/* AppImage/opt/Helion;
+rm AppImage/opt/Helion/Helion;
 
 # Copy all transitive dependencies; patch Helion ELF to use copied lib dir
-mkdir -p AppImage/lib;
-ldd Publish/linux-x64_AOT/Helion | awk 'NF == 4 { system("cp " $3 " AppImage/lib") }';
+mkdir -p AppImage/usr/lib;
+ldd Publish/linux-x64_AOT/Helion | awk 'NF == 4 { system("cp " $3 " AppImage/usr/lib") }';
 rm AppImage/lib/libm.so.*;
 rm AppImage/lib/libc.so.*;
-patchelf --force-rpath --set-rpath '$ORIGIN'/../../lib AppImage/usr/bin/Helion
+patchelf --force-rpath --set-rpath '$ORIGIN'/../usr/lib AppImage/usr/bin/Helion
 
 # Copy icon and .desktop file
 cp -r Scripts/appImageResources/* AppImage;


### PR DESCRIPTION
Follow the "standard" AppDir pattern:

1. Executables go in /usr/bin
2. Dependency libraries available in normal Linux go in /usr/lib
3. Data files go in /opt/Helion
4. Search behavior in code should honor (3) when loading SoundFonts and the assets.pk3 file

This is a prerequisite for packaging the AOT version for Linux in a variety of ways, including plain `.tar` files, `.deb`, etc.