### PR TITLE
Palette color lookup

### DIFF
--- a/Core/Graphics/Image.cs
+++ b/Core/Graphics/Image.cs
@@ -111,7 +111,7 @@ public class Image
     }
 
     public static Image? FromImageSharp<TPixel>(SixLabors.ImageSharp.Image<TPixel> data, Vec2I imageOffset = default, ResourceNamespace ns = ResourceNamespace.Global,
-        Palette? paletteTranslation = null, byte[]? colorTranslation = null)
+        Palette? paletteTranslation = null, PaletteColorLookup? paletteTranslationColorLookup = null, byte[]? colorTranslation = null)
         where TPixel : unmanaged, IPixel<TPixel>
     {
         var indices = paletteTranslation == null ? null : new ushort[data.Height * data.Width];
@@ -131,9 +131,9 @@ public class Image
                 argbData[offset + 2] = tempPixel.G;
                 argbData[offset + 3] = tempPixel.B;
 
-                if (indices != null && paletteTranslation != null && tempPixel.A != 0)
+                if (indices != null && paletteTranslation != null && paletteTranslationColorLookup != null && tempPixel.A != 0)
                 {
-                    var nearestIndex = paletteTranslation.GetNearestColorIndex(new(tempPixel.R, tempPixel.G, tempPixel.B));
+                    var nearestIndex = paletteTranslationColorLookup.GetIndex(tempPixel.R, tempPixel.G, tempPixel.B);
                     indices[index] = nearestIndex;
 
                     if (colorTranslation != null)

--- a/Core/Graphics/Palettes/Colormap.cs
+++ b/Core/Graphics/Palettes/Colormap.cs
@@ -132,13 +132,13 @@ public class Colormap
         return From(palette, translated, null);
     }
 
-    public static Colormap? TranslateToNearestMatch(Palette palette, byte[] colorMap, PaletteColor translateColor)
+    public static Colormap? TranslateToNearestMatch(Palette palette, PaletteColorLookup paletteColorLookup, byte[] colorMap, PaletteColor translateColor)
     {
-        var translated = TranslateIndicesNearest(palette, colorMap, translateColor);
+        var translated = TranslateIndicesNearest(palette, paletteColorLookup, colorMap, translateColor);
         return From(palette, translated, null);
     }
 
-    private static byte[] TranslateIndicesNearest(Palette palette, byte[] colorMap, PaletteColor translateColor)
+    private static byte[] TranslateIndicesNearest(Palette palette, PaletteColorLookup paletteColorLookup, byte[] colorMap, PaletteColor translateColor)
     {
         var hsl = ToHsl(translateColor);
         var translate = new byte[colorMap.Length];
@@ -160,7 +160,7 @@ public class Colormap
                     continue;
                 }
 
-                var newIndex = ShiftToHsl(palette, color, hsl);
+                var newIndex = ShiftToHsl(paletteColorLookup, color, hsl);
                 translate[dataIndex] = newIndex;
                 lookup[color] = newIndex;
             }
@@ -184,7 +184,7 @@ public class Colormap
         };
     }
 
-    private static byte ShiftToHsl(Palette palette, Color color, HslShift toHsl)
+    private static byte ShiftToHsl(PaletteColorLookup paletteColorLookup, Color color, HslShift toHsl)
     {
         var hsl = HslConverter.ToHsl(color);
 
@@ -198,7 +198,7 @@ public class Colormap
         hsl.Z = Math.Clamp(hsl.Z + toHsl.AddL, 0, 1);
 
         var newColor = HslConverter.ToColor(hsl);
-        return palette.GetNearestColorIndex(newColor);
+        return paletteColorLookup.GetIndex(newColor);
     }
 
     public static Colormap? CreateTranslatedColormap(Palette palette, byte[] colorMap, byte[] translateTable)

--- a/Core/Graphics/Palettes/Palette.cs
+++ b/Core/Graphics/Palettes/Palette.cs
@@ -21,7 +21,6 @@ public class Palette
 
     private readonly List<Color[]> layers;
     private readonly Vector3[] m_paletteNormalized = new Vector3[256];
-    private readonly Dictionary<Color, byte> m_colorToIndex = [];
 
     public int Count => layers.Count;
     public Color[] DefaultLayer => layers[0];
@@ -37,7 +36,6 @@ public class Palette
         {
             var c = colors[i];
             m_paletteNormalized[i] = new Vector3(c.R / 255f, c.G / 255f, c.B / 255f);
-            m_colorToIndex[c] = (byte)i;
         }
     }
 
@@ -127,22 +125,18 @@ public class Palette
             data[i + 2] = (byte)i;
         }
 
-        Palette? palette = From(data);
-        if (palette == null)
-            throw new NullReferenceException("Failed to create the default palette, shouldn't be possible");
-
+        var palette = From(data) ?? throw new NullReferenceException("Failed to create the default palette, shouldn't be possible");
         DefaultPalette = palette;
         return palette;
     }
 
-    public byte GetNearestColorIndex(Color color)
-    {
-        if (m_colorToIndex.TryGetValue(color, out var index))
-            return index;
+    public byte GetNearestColorIndex(Color color) => GetNearestColorIndex(color.R, color.G, color.B);
 
+    public byte GetNearestColorIndex(byte r, byte g, byte b)
+    {
         byte bestIndex = 0;
         var nearest = float.MaxValue;
-        var colorNormalized = new Vector3(color.R / 255f, color.G / 255f, color.B / 255f);
+        var colorNormalized = new Vector3(r / 255f, g / 255f, b / 255f);
         for (int i = 0; i < m_paletteNormalized.Length; i++)
         {
             var paletteColor = m_paletteNormalized[i];
@@ -154,7 +148,6 @@ public class Palette
             }
         }
 
-        m_colorToIndex[color] = bestIndex;
         return bestIndex;
     }
 }

--- a/Core/Graphics/Palettes/PaletteColorLookup.cs
+++ b/Core/Graphics/Palettes/PaletteColorLookup.cs
@@ -1,0 +1,38 @@
+﻿namespace Helion.Graphics.Palettes;
+
+public class PaletteColorLookup
+{
+    const int Scale = 8;
+    const int ScaleSize = 256 / Scale;
+    public readonly byte[] Lookup;
+
+    public PaletteColorLookup(Palette palette)
+    {
+        Lookup = new byte[ScaleSize * ScaleSize * ScaleSize];
+
+        for (int r = 0; r < ScaleSize; r++)
+        {
+            for (int g = 0; g < ScaleSize; g++)
+            {
+                for (int b = 0; b < ScaleSize; b++)
+                {
+                    var flatIndex = r * ScaleSize * ScaleSize + g * ScaleSize + b;
+                    var closest = palette.GetNearestColorIndex((byte)(r * Scale), (byte)(g * Scale), (byte)(b * Scale));
+                    Lookup[flatIndex] = closest;
+                }
+            }
+        }
+    }
+
+    public byte GetIndex(Color color)
+    {
+        var flatIndex = (color.R / Scale) * ScaleSize * ScaleSize + (color.G / Scale) * ScaleSize + (color.B / Scale);
+        return Lookup[flatIndex];
+    }
+
+    public byte GetIndex(byte r, byte g, byte b)
+    {
+        var flatIndex = (r / Scale) * ScaleSize * ScaleSize + (g / Scale) * ScaleSize + (b / Scale);
+        return Lookup[flatIndex];
+    }
+}

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Sky/Sphere/SkySphereTexture.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Sky/Sphere/SkySphereTexture.cs
@@ -250,10 +250,10 @@ public class SkySphereTexture(ArchiveCollection archiveCollection, LegacyGLTextu
         }
 
         GetAverageColors(skyImage, out var topColor, out var bottomColor);
-        var palette = m_archiveCollection.Palette;
+        var paletteColorLookup = m_archiveCollection.PaletteColorLookup;
         var glTexture = CreateTexture(skyImage, $"[SKY][{textureIndex}]");
         texture = new(glTexture, textureIndex, topColor, bottomColor,
-            palette.GetNearestColorIndex(FromRgba(topColor)), palette.GetNearestColorIndex(FromRgba(bottomColor)), false);
+            paletteColorLookup.GetIndex(FromRgba(topColor)), paletteColorLookup.GetIndex(FromRgba(bottomColor)), false);
         return true;
     }
 

--- a/Core/Resources/Archives/Collection/ArchiveCollection.cs
+++ b/Core/Resources/Archives/Collection/ArchiveCollection.cs
@@ -59,6 +59,7 @@ public class ArchiveCollection : IResources, IPathResolver
 
     public IWadBaseType IWadType { get; private set; } = IWadBaseType.None;
     public Palette Palette => Data.Palette;
+    public PaletteColorLookup PaletteColorLookup => Data.PaletteColorLookup;
     public Colormap Colormap => Data.Colormap;
     public IWadInfo IWadInfo => GetIWadInfo();
     public Archive? Assets => m_archives.FirstOrDefault(x => x.ArchiveType == ArchiveType.Assets);
@@ -316,8 +317,7 @@ public class ArchiveCollection : IResources, IPathResolver
         // if we have already loaded it.
         if (loadDefaultAssets && m_archives.Empty())
         {
-            Archive? assetsArchive = null;
-
+            Archive? assetsArchive;
             if (OperatingSystem.IsLinux())
             {
                 // On Linux, if we're installed according to the standard pattern, our assets should be in /opt/Helion/assets.pk3 or similar
@@ -328,8 +328,9 @@ public class ArchiveCollection : IResources, IPathResolver
             {
                 assetsArchive = LoadSpecial(Constants.AssetsFileName, ArchiveType.Assets, LoadArchiveOptions.CalculateMd5 | LoadArchiveOptions.IsBundled);
             }
+
             if (assetsArchive == null)
-                    return false;
+                return false;
 
             m_archives.Add(assetsArchive);
         }
@@ -376,7 +377,7 @@ public class ArchiveCollection : IResources, IPathResolver
             SetCustomKeyColors();
 
             if (iwad != null || files.Any())
-                Definitions.BuildTranslationColorMaps(Data.Palette, Data.Colormap);
+                Definitions.BuildTranslationColorMaps(Data);
 
             if (dehackedPatch != null)
             {

--- a/Core/Resources/Data/DataEntries.cs
+++ b/Core/Resources/Data/DataEntries.cs
@@ -22,8 +22,17 @@ public class DataEntries
 
     private Palette? m_latestPalette;
     private Colormap? m_latestColormap;
+    private PaletteColorLookup? m_paletteColorLookup;
 
     public Palette Palette => m_latestPalette ?? Palette.GetDefaultPalette();
+    public PaletteColorLookup PaletteColorLookup => GetOrCreateLookup();
+
+    private PaletteColorLookup GetOrCreateLookup()
+    {
+        m_paletteColorLookup ??= new(Palette);
+        return m_paletteColorLookup;
+    }
+
     public Colormap Colormap => m_latestColormap ?? Colormap.GetDefaultColormap();
     public byte[] ColormapData { get; private set; } = [];
 

--- a/Core/Resources/Definitions/DefinitionEntries.cs
+++ b/Core/Resources/Definitions/DefinitionEntries.cs
@@ -8,6 +8,7 @@ using Helion.Graphics.Palettes;
 using Helion.Resources.Archives;
 using Helion.Resources.Archives.Collection;
 using Helion.Resources.Archives.Entries;
+using Helion.Resources.Data;
 using Helion.Resources.Definitions.Animdefs;
 using Helion.Resources.Definitions.Boom;
 using Helion.Resources.Definitions.Compatibility;
@@ -298,8 +299,9 @@ public class DefinitionEntries
             action(entry);
     }
 
-    public void BuildTranslationColorMaps(Palette palette, Colormap baseColorMap)
+    public void BuildTranslationColorMaps(DataEntries dataEntries)
     {
+        var baseColorMap = dataEntries.Colormap;
         if (GetGameConfPlayerTranslations(out var playerColormaps))
         {
             var translatedColorMaps = new List<Colormap>(Colormaps.Count + playerColormaps.Length);
@@ -318,7 +320,7 @@ public class DefinitionEntries
         }
         else
         {
-            SetPlayerColorMaps(palette, baseColorMap);
+            SetPlayerColorMaps(dataEntries, baseColorMap);
         }
 
         for (int i = 0; i < Colormaps.Count; i++)
@@ -352,11 +354,12 @@ public class DefinitionEntries
         return true;
     }
 
-    private void SetPlayerColorMaps(Palette palette, Colormap baseColorMap)
+    private void SetPlayerColorMaps(DataEntries dataEntries, Colormap baseColorMap)
     {
         if (m_archiveCollection.Data.ColormapData.Length == 0)
             return;
 
+        var palette = dataEntries.Palette;
         var colormapBytes = m_archiveCollection.Data.ColormapData;
         int colorCount = (int)TranslateColor.Count;
         // First player colormap is default
@@ -382,14 +385,14 @@ public class DefinitionEntries
         Colormaps.AddRange(translatedColormaps);
 
         if (DehackedDefinition != null && DehackedDefinition.HasBloodColor)
-            CreateBloodColorMaps(palette, colormapBytes, DehackedDefinition.BloodColors);
+            CreateBloodColorMaps(palette, dataEntries.PaletteColorLookup, colormapBytes, DehackedDefinition.BloodColors);
     }
 
-    private void CreateBloodColorMaps(Palette palette, byte[] colormapBytes, IEnumerable<PaletteColor> paletteColors)
+    private void CreateBloodColorMaps(Palette palette, PaletteColorLookup paletteColorLookup, byte[] colormapBytes, IEnumerable<PaletteColor> paletteColors)
     {
         foreach (var paletteColor in paletteColors)
         {
-            var colormap = Colormap.TranslateToNearestMatch(palette, colormapBytes, paletteColor);
+            var colormap = Colormap.TranslateToNearestMatch(palette, paletteColorLookup, colormapBytes, paletteColor);
             if (colormap == null)
                 continue;
 

--- a/Core/Resources/Images/ArchiveImageRetriever.cs
+++ b/Core/Resources/Images/ArchiveImageRetriever.cs
@@ -217,13 +217,20 @@ public class ArchiveImageRetriever(ArchiveCollection archiveCollection, bool fin
                     offset = PngChunk.GetPngOffset(new BinaryReader(inputStream));
 
                 Palette? paletteTransltion = null;
+                PaletteColorLookup? paletteTranslationColorLookup = null;
                 if (m_findNearestPaletteIndex && !AlwaysTrueColor(entry))
+                {
                     paletteTransltion = m_archiveCollection.Palette;
+                    paletteTranslationColorLookup = m_archiveCollection.PaletteColorLookup;
+                }
                 // Only search for nearest palette colors if colorTranslation is set (e.g. for blood colors)
                 else if (!m_findNearestPaletteIndex && !AlwaysTrueColor(entry) && colorTranslation != null)
+                {
                     paletteTransltion = m_archiveCollection.Palette;
+                    paletteTranslationColorLookup = m_archiveCollection.PaletteColorLookup;
+                }
 
-                image = Image.FromImageSharp(img, offset, entry.Namespace, paletteTransltion, colorTranslation);
+                image = Image.FromImageSharp(img, offset, entry.Namespace, paletteTransltion, paletteTranslationColorLookup, colorTranslation);
             }
             catch
             {


### PR DESCRIPTION
Create palette color lookup to instantly convert true color rgb to nearest palette index.

This creates a quantized lookup using 32KB. Removes the original dictionary that can get bloated since it was mapped by full RGB colors.

This byte index lookup table will also be used in the future for TRANMAP emulation to get the palette index of a true color RGB on the GPU.