### PR TITLE
Dehacked param load fix

### DIFF
--- a/Core/Resources/Archives/Collection/ArchiveCollection.cs
+++ b/Core/Resources/Archives/Collection/ArchiveCollection.cs
@@ -371,30 +371,32 @@ public class ArchiveCollection : IResources, IPathResolver
         if (loadDefaultAssets)
         {
             // Load all definitions - Even if a map doesn't load them there are cases where they are needed (backpack ammo etc)
-            EntityDefinitionComposer.LoadAllDefinitions();
+            EntityDefinitionComposer.LoadAllDefinitions();       
+            if (dehackedPatch != null && !LoadDehackedPatch(dehackedPatch))
+                return false;            
             ApplyDehackedPatch();
             EntityFrameTable.AddCustomFrames();
             SetCustomKeyColors();
 
             if (iwad != null || files.Any())
                 Definitions.BuildTranslationColorMaps(Data);
-
-            if (dehackedPatch != null)
-            {
-                try
-                {
-                    Definitions.ParseDehackedPatch(File.ReadAllText(dehackedPatch));
-                    ApplyDehackedPatch();
-                }
-                catch (IOException)
-                {
-                    HelionLog.Error($"Unable to open dehacked patch {dehackedPatch}");
-                    return false;
-                }
-            }
         }
 
         return true;
+    }
+
+    private bool LoadDehackedPatch(string dehackedPatch)
+    {
+        try
+        {
+            Definitions.ParseDehackedPatch(File.ReadAllText(dehackedPatch));
+            return true;
+        }
+        catch (IOException)
+        {
+            HelionLog.Error($"Unable to open dehacked patch {dehackedPatch}");
+            return false;
+        }
     }
 
     private void SetCustomKeyColors()

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,4 +4,5 @@
 - Simplify bit packing strategy on vertex data using floatBitsToInt. Decreases entity sprite vertex size and increase range on line ids for vanilla sprite clipping emulation from 65k to over 8 million and sector light index from ~500k to over 1 million.
 
 ## Bug Fixes:
-- Fix sprite frames to correctly calculate when lowercase
+- Fix sprite frames to correctly calculate when lowercase.
+- Fix dehacked frames loading incorrectly when a wad contains a dehacked patch and a dehacked patch is applied with the -deh parameter.


### PR DESCRIPTION
Fix dehacked frames loading incorrectly when a wad contains a dehacked patch and a dehacked patch is applied with the -deh parameter.