### PR TITLE
Sprite render performance

### DIFF
--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using Helion.Geometry.Vectors;
 using Helion.Render.OpenGL.Renderers.Legacy.World.Data;
 using Helion.Render.OpenGL.Renderers.Legacy.World.Geometry.Static;
@@ -16,6 +14,9 @@ using Helion.World.Entities;
 using Helion.World.Entities.Definition;
 using Helion.World.Geometry.Sectors;
 using OpenTK.Graphics.OpenGL;
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
 
 namespace Helion.Render.OpenGL.Renderers.Legacy.World.Entities;
 
@@ -99,6 +100,12 @@ public class EntityRenderer : IDisposable
         m_attackIndicator = m_config.Render.HealthBar.AttackIndicator;
         m_healthBarLimit = m_config.Render.HealthBar.HealthLimit;
         m_brightMaps = m_config.Render.Brightmaps;
+    }
+
+    public void ClearRenderPositions()
+    {
+        m_renderPositions.Clear();
+        m_spriteRenderPositions.Clear();
     }
 
     private static uint CalculateRotation(uint viewAngle, uint entityAngle)
@@ -206,17 +213,18 @@ public class EntityRenderer : IDisposable
             var spritePosKey = new SpritePosKey(entityPos, spriteIndex);
             if (m_spriteRenderPositions.Add(spritePosKey))
             {
-                if (m_renderPositions.TryGetValue(entityPos, out int count))
+                ref int count = ref CollectionsMarshal.GetValueRefOrAddDefault(m_renderPositions, entityPos, out bool exists);
+                if (exists)
                 {
-                    double nudge = NudgeFactor * count * Math.Sqrt(entity.RenderDistanceSquared);
-                    double angle = Math.Atan2(centerBottom.Y - position.Y, centerBottom.X - position.X);
+                    var nudge = NudgeFactor * count * Math.Sqrt(entity.RenderDistanceSquared);
+                    var angle = Math.Atan2(centerBottom.Y - position.Y, centerBottom.X - position.X);
                     nudgeAmount.X = Math.Cos(angle) * nudge;
                     nudgeAmount.Y = Math.Sin(angle) * nudge;
-                    m_renderPositions[entityPos] = count + 1;
+                    count++;
                 }
                 else
                 {
-                    m_renderPositions[entityPos] = 1;
+                    count = 1;
                 }
             }
         }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
@@ -213,7 +213,7 @@ public class EntityRenderer : IDisposable
             var spritePosKey = new SpritePosKey(entityPos, spriteIndex);
             if (m_spriteRenderPositions.Add(spritePosKey))
             {
-                ref int count = ref CollectionsMarshal.GetValueRefOrAddDefault(m_renderPositions, entityPos, out bool exists);
+                ref int count = ref CollectionsMarshal.GetValueRefOrAddDefault(m_renderPositions, entityPos, out var exists);
                 if (exists)
                 {
                     var nudge = NudgeFactor * count * Math.Sqrt(entity.RenderDistanceSquared);

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
@@ -289,16 +289,15 @@ public class EntityRenderer : IDisposable
         ref var vertex = ref arrayData.Data[length];
         // Multiply the X offset by the rightNormal X/Y to move the sprite according to the player's view
         // Doom graphics are drawn left to right and not centered
-        vertex.Pos = new Vec3F(
-            (float)(entity.Position.X - nudgeAmount.X),
-            (float)(entity.Position.Y - nudgeAmount.Y),
-            (float)entity.Position.Z);
-        vertex.PrevPos = new Vec3F(
-            (float)(entity.PrevPosition.X - nudgeAmount.X),
-            (float)(entity.PrevPosition.Y - nudgeAmount.Y),
-            (float)entity.PrevPosition.Z);
+        vertex.Pos.X = (float)(entity.Position.X - nudgeAmount.X);
+        vertex.Pos.Y = (float)(entity.Position.Y - nudgeAmount.Y);
+        vertex.Pos.Z = (float)entity.Position.Z;
+        vertex.PrevPos.X = (float)(entity.PrevPosition.X - nudgeAmount.X);
+        vertex.PrevPos.Y = (float)(entity.PrevPosition.Y - nudgeAmount.Y);
+        vertex.PrevPos.Z = (float)entity.PrevPosition.Z;
         vertex.Options = VertexOptions.Entity(alpha, fuzz, spriteRotation.FlipU, colorMapIndex, lightLevel);
         vertex.ColorMapIndex = Renderer.GetColorMapBufferIndex(sector, LightBufferType.Floor);
+        vertex.OffsetXYZ = VertexOptions.EntityXYZ(texture.Offset.X, offsetZ);
 
         if (entity.Definition.Flags.SpawnCeiling && m_vanillaRender)
         {
@@ -310,7 +309,6 @@ public class EntityRenderer : IDisposable
             vertex.PrevPos.Z = entity.PrevPosition.Z != entity.Position.Z ? (float)entity.Sector.Ceiling.PrevZ : ceilingZ;
         }
 
-        vertex.OffsetXYZ = VertexOptions.EntityXYZ(texture.Offset.X, offsetZ);
         arrayData.Length = length + 1;
 
         if (m_healthBars && entity.Flags.Shootable && (m_healthBarLimit <= 0 || m_healthBarLimit <= entity.Properties.Health))

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -170,6 +170,7 @@ public class LegacyWorldRenderer : WorldRenderer
                 if (m_renderStatic)
                     RenderSides(world, index);
 
+                m_entityRenderer.ClearRenderPositions();
                 for (var entity = world.RenderBlockmap.HeadRenderEntities[index]; entity != null; entity = entity.RenderBlockNext)
                     RenderEntity(world, entity);
             }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/VertexOptions.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/VertexOptions.cs
@@ -25,17 +25,9 @@ public static class VertexOptions
     {
         // Packs LightLevelAdd with MapId
         // First bit is sign, next 8 are lightLevelAdd, last 23 are mapId
-        if (lightLevelAdd < 0)
-            return PackLightLevelAddAndMapId(mapId, Math.Abs(lightLevelAdd), 1);
-
-        return PackLightLevelAddAndMapId(mapId, lightLevelAdd, 0);
-    }
-
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static float PackLightLevelAddAndMapId(int mapId, int lightLevelAdd, int signFlag)
-    {
-        int packed = ((mapId & 0xFFFFFF) << 9) | ((lightLevelAdd & 0xFF) << 1) | signFlag;
+        int signMask = lightLevelAdd >> 31;
+        lightLevelAdd = (lightLevelAdd ^ signMask) - signMask;
+        int packed = ((mapId & 0xFFFFFF) << 9) | ((lightLevelAdd & 0xFF) << 1) | (signMask & 1);
         return BitConverter.Int32BitsToSingle(packed);
     }
 
@@ -50,19 +42,13 @@ public static class VertexOptions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static float EntityXYZ(int offsetXY, int offsetZ)
     {
-        int offsetXYSign = 0;
-        int offsetZSign = 0;
-        if (offsetXY < 0)
-        {
-            offsetXY = Math.Abs(offsetXY);
-            offsetXYSign = 1;
-        }
-
-        if (offsetZ < 0)
-        {
-            offsetZ = Math.Abs(offsetZ);
-            offsetZSign = 1;
-        }
+        // Shift negative bit for mask to get absolute value and sign bit to remove branches
+        int maskXY = offsetXY >> 31;
+        int maskZ = offsetZ >> 31;
+        offsetXY = (offsetXY ^ maskXY) - maskXY;
+        offsetZ = (offsetZ ^ maskZ) - maskZ;
+        int offsetXYSign = maskXY & 1;
+        int offsetZSign = maskZ & 1;
 
         int packed = (offsetXYSign << 31) | (offsetZSign << 30) | (offsetXY << 16) | offsetZ;
         return BitConverter.Int32BitsToSingle(packed);

--- a/Core/Render/OpenGL/Renderers/Legacy/World/VertexOptions.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/VertexOptions.cs
@@ -6,41 +6,41 @@ namespace Helion.Render.OpenGL.Renderers.Legacy.World;
 public static class VertexOptions
 {
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static float World(int topLeft, float alpha, int addAlpha, int upper, int lower, int lightLevelBufferIndex)
+    public static unsafe float World(int topLeft, float alpha, int addAlpha, int upper, int lower, int lightLevelBufferIndex)
     {
         int alphaByte = (int)(alpha * 255.0f);
         int packed = (alphaByte & 0xFF) | (topLeft << 8) | (addAlpha << 9) | (upper << 10) | (lower << 11) | (lightLevelBufferIndex << 12);
-        return BitConverter.Int32BitsToSingle(packed);
+        return *(float*)&packed;
     }
 
-    public static float ColorMapIndex(int colorMapIndex, int vertexLightLevel)
+    public static unsafe float ColorMapIndex(int colorMapIndex, int vertexLightLevel)
     {
         // First 8 bits are lightLevel, next 24 are colorMapIndex
         int packed = ((colorMapIndex & 0xFFFFFF) << 8) | ((vertexLightLevel) & 0xFF);
-        return BitConverter.Int32BitsToSingle(packed);
+        return *(float*)&packed;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static float LightLevelAdd(int mapId, int lightLevelAdd)
+    public static unsafe float LightLevelAdd(int mapId, int lightLevelAdd)
     {
         // Packs LightLevelAdd with MapId
         // First bit is sign, next 8 are lightLevelAdd, last 23 are mapId
         int signMask = lightLevelAdd >> 31;
         lightLevelAdd = (lightLevelAdd ^ signMask) - signMask;
         int packed = ((mapId & 0xFFFFFF) << 9) | ((lightLevelAdd & 0xFF) << 1) | (signMask & 1);
-        return BitConverter.Int32BitsToSingle(packed);
+        return *(float*)&packed;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static float Entity(float alpha, int fuzz, int flipU, int colormap, int lightLevel)
+    public static unsafe float Entity(float alpha, int fuzz, int flipU, int colormap, int lightLevel)
     {
         int alphaByte = (int)(alpha * 255.0f);
         int packed = (alphaByte & 0xFF) | (fuzz << 8) | (flipU << 9) | ((lightLevel & 0xFF) << 10) | (colormap << 18);
-        return BitConverter.Int32BitsToSingle(packed);
+        return *(float*)&packed;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static float EntityXYZ(int offsetXY, int offsetZ)
+    public static unsafe float EntityXYZ(int offsetXY, int offsetZ)
     {
         // Shift negative bit for mask to get absolute value and sign bit to remove branches
         int maskXY = offsetXY >> 31;
@@ -51,6 +51,6 @@ public static class VertexOptions
         int offsetZSign = maskZ & 1;
 
         int packed = (offsetXYSign << 31) | (offsetZSign << 30) | (offsetXY << 16) | offsetZ;
-        return BitConverter.Int32BitsToSingle(packed);
+        return *(float*)&packed;
     }
 }


### PR DESCRIPTION
Remove branches for abs functions when converting options to bit flags

Clear render position lookups per blockmap iteration since they can get bloated and sprites can't overlap from different blocks

Use CollectionsMarshal.GetValueRefOrAddDefault to remove multiple lookups

Set vertex properties instead of constructing with intermediate Vec3F