### PR TITLE
monster kill sector fix

### DIFF
--- a/Core/World/Special/Specials/SectorDamageSpecial.cs
+++ b/Core/World/Special/Specials/SectorDamageSpecial.cs
@@ -104,7 +104,7 @@ public class SectorDamageSpecial
         else
         {
             // The entity doesn't need to be on the kill sector floor z, but the highest floor z.
-            if (entity.HighestFloorSector.Floor.Z != entity.Position.Z)
+            if (entity.HighestFloorSector.Floor.Z > entity.Position.Z)
                 return;
         }
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -7,3 +7,4 @@
 - Fix sprite frames to correctly calculate when lowercase.
 - Fix dehacked frames loading incorrectly when a wad contains a dehacked patch and a dehacked patch is applied with the -deh parameter.
 - Fix NoBlockmap not working with scrolling floors and correctly ignore things with NoSector.
+- Fix MBF21 monster kill sector to kill monsters that are below the highest floor.


### PR DESCRIPTION
fix MBF21 monster kill sector to kill monsters that are below the highest floor