### PR TITLE
Check ammo flash state fix

### DIFF
--- a/Core/World/Entities/Definition/States/EntityActionFunctions.cs
+++ b/Core/World/Entities/Definition/States/EntityActionFunctions.cs
@@ -3029,7 +3029,7 @@ public static class EntityActionFunctions
         int state = frame.DehackedArgs1;
         int amount = frame.DehackedArgs2 == 0 ? weapon.Definition.Properties.Weapons.AmmoUse : frame.DehackedArgs2;
         var entityFrameTable = WorldStatic.World.ArchiveCollection.Definitions.EntityFrameTable;
-        if (entity.PlayerObj!.Inventory.Amount(weapon.Definition.Properties.Weapons.AmmoType) < amount &&
+        if (entity.PlayerObj!.Inventory.Amount(weapon.Definition.Properties.Weapons.AmmoType) <= amount &&
             entityFrameTable.VanillaFrameMap.TryGetValue(state, out EntityFrame? newFrame))
         {
             var player = entity.PlayerObj!;

--- a/Core/World/Entities/Definition/States/EntityActionFunctions.cs
+++ b/Core/World/Entities/Definition/States/EntityActionFunctions.cs
@@ -3070,7 +3070,12 @@ public static class EntityActionFunctions
         Weapon weapon = entity.PlayerObj!.Weapon!;
         var entityFrameTable = WorldStatic.World.ArchiveCollection.Definitions.EntityFrameTable;
         if (entityFrameTable.VanillaFrameMap.TryGetValue(state, out EntityFrame? newFrame))
-            weapon.FrameState.SetState(entity, newFrame);
+        {
+            if (entity.PlayerObj!.WeaponFlashState)
+                weapon.FlashState.SetState(entity, newFrame);
+            else
+                weapon.FrameState.SetState(entity, newFrame);
+        }
     }
 
     private static void A_GunFlashTo(Entity entity)

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -8,3 +8,5 @@
 - Fix dehacked frames loading incorrectly when a wad contains a dehacked patch and a dehacked patch is applied with the -deh parameter.
 - Fix NoBlockmap not working with scrolling floors and correctly ignore things with NoSector.
 - Fix MBF21 monster kill sector to kill monsters that are below the highest floor.
+- Fix A_CheckAmmo to be inclusive to fix check failing when player has exactly the correct amount of ammo.
+- Fix A_RefireTo to correctly check and set the flash frame state.


### PR DESCRIPTION
Fix A_CheckAmmo to be inclusive to fix check failing when player has exactly the correct amount of ammo.

Fix A_RefireTo to correctly check and set the flash frame state.