### PR TITLE
Enable Y-axis freelook inversion for controllers

### DIFF
--- a/Core/Layer/Worlds/WorldLayer.Input.cs
+++ b/Core/Layer/Worlds/WorldLayer.Input.cs
@@ -259,7 +259,10 @@ public partial class WorldLayer
             cmd.SideMoveSpeed = Math.Clamp(analogInput.Y * m_config.Controller.GameControllerStrafeScale, -1, 1) * Player.GetSideMovementSpeed();
             cmd.AngleTurn = analogInput.Z * Player.FastTurnSpeed * m_config.Controller.GameControllerTurnScale;
             cmd.PitchTurn = m_config.Mouse.Look
-                ? analogInput.W * Player.FastTurnSpeed * m_config.Controller.GameControllerPitchScale
+                ? analogInput.W
+                    * Player.FastTurnSpeed
+                    * m_config.Controller.GameControllerPitchScale
+                    * (m_config.Controller.GameControllerVerticalAimInvert ? -1 : 1)
                 : 0;
         }
 

--- a/Core/Util/Configs/Components/ConfigController.cs
+++ b/Core/Util/Configs/Components/ConfigController.cs
@@ -20,6 +20,10 @@ public class ConfigController : ConfigElement<ConfigController>
     [OptionMenu(OptionSectionType.Controller, "Enable Game Controller", spacer: true)]
     public readonly ConfigValue<bool> EnableGameController = new(true);
 
+    [ConfigInfo("Whether to invert thumbstick vertical axis for vertical aiming")]
+    [OptionMenu(OptionSectionType.Controller, "Thumbstick Vertical Aim Invert")]
+    public readonly ConfigValue<bool> GameControllerVerticalAimInvert = new(false);
+
     [ConfigInfo("Enable rumble feedback effects.")]
     [OptionMenu(OptionSectionType.Controller, "Enable Rumble")]
     public readonly ConfigValue<bool> EnableRumble = new(true);
@@ -49,6 +53,10 @@ public class ConfigController : ConfigElement<ConfigController>
     [ConfigInfo("Gyro axis to use for turning left and right.")]
     [OptionMenu(OptionSectionType.Controller, "Gyro Aim Turn Axis", spacer: true)]
     public readonly ConfigValue<GyroTurnAxis> GyroAimTurnAxis = new(GyroTurnAxis.Yaw);
+
+    [ConfigInfo("Whether to invert gyro vertical axis for vertical aiming")]
+    [OptionMenu(OptionSectionType.Controller, "Gyro Vertical Aim Invert")]
+    public readonly ConfigValue<bool> GyroVerticalAimInvert = new(false);
 
     [ConfigInfo("Vertical aiming sensitivity for gyro input.")]
     [OptionMenu(OptionSectionType.Controller, "Gyro Aim Vertical Sensitivity", sliderMin: 0, sliderMax: 10, sliderStep: .1)]

--- a/Core/World/Impl/SinglePlayer/SinglePlayerWorld.cs
+++ b/Core/World/Impl/SinglePlayer/SinglePlayerWorld.cs
@@ -613,14 +613,15 @@ public class SinglePlayerWorld : WorldBase
             if (hasYaw)
             {
                 gyroSpeed = hasPitch
-                    ? Math.Sqrt(yaw * yaw + pitch * pitch) * 365 / Math.Tau 
-                    : yaw * 365 / Math.Tau;
+                    ? Math.Sqrt(yaw * yaw + pitch * pitch) * 360 / Math.Tau
+                    : yaw * 360 / Math.Tau;
                 slowFastFactor = (gyroSpeed - Config.Controller.LowerGyroThreshold) / (Config.Controller.UpperGyroThreshold - Config.Controller.LowerGyroThreshold);
                 player.AddToYaw((float)(yaw * (Config.Controller.GyroAimHorizontalSensitivity + (Config.Controller.GyroAcceleration * slowFastFactor))), true);
             }
 
             if (hasPitch)
             {
+                pitch *= Config.Controller.GyroVerticalAimInvert ? -1 : 1;
                 player.AddToPitch((float)(pitch * (Config.Controller.GyroAimVerticalSensitivity + (Config.Controller.GyroAcceleration * slowFastFactor))), true);
             }
 


### PR DESCRIPTION
Allow user to invert Y-axis for thumbstick aiming and gyro aiming, separately.