### PR TITLE
Weapon switch preference

### DIFF
--- a/Core/Util/Configs/Components/ConfigPlayer.cs
+++ b/Core/Util/Configs/Components/ConfigPlayer.cs
@@ -19,41 +19,41 @@ public class ConfigPlayer: ConfigElement<ConfigPlayer>
 
     [ConfigInfo("")]
     [OptionMenu(OptionSectionType.Player, "Group 1 1st", spacer: true)]
-    public readonly ConfigValue<ConfigWeaponSlots> Group1Weapon1 = new(ConfigWeaponSlots.ShotgunOrSuperShotgun, OnlyValidEnums<ConfigWeaponSlots>());
+    public readonly ConfigValue<WeaponSlots> Group1Weapon1 = new(WeaponSlots.ShotgunOrSuperShotgun, OnlyValidEnums<WeaponSlots>());
     [ConfigInfo("")]
     [OptionMenu(OptionSectionType.Player, "        2nd")]
-    public readonly ConfigValue<ConfigWeaponSlots> Group1Weapon2 = new(ConfigWeaponSlots.ShotgunOrSuperShotgun, OnlyValidEnums<ConfigWeaponSlots>());
+    public readonly ConfigValue<WeaponSlots> Group1Weapon2 = new(WeaponSlots.ShotgunOrSuperShotgun, OnlyValidEnums<WeaponSlots>());
     [ConfigInfo("")]
     [OptionMenu(OptionSectionType.Player, "        3rd")]
-    public readonly ConfigValue<ConfigWeaponSlots> Group1Weapon3 = new(ConfigWeaponSlots.None, OnlyValidEnums<ConfigWeaponSlots>());
+    public readonly ConfigValue<WeaponSlots> Group1Weapon3 = new(WeaponSlots.None, OnlyValidEnums<WeaponSlots>());
 
     [ConfigInfo("")]
     [OptionMenu(OptionSectionType.Player, "Group 2 1st", spacer: true)]
-    public readonly ConfigValue<ConfigWeaponSlots> Group2Weapon1 = new(ConfigWeaponSlots.RocketLauncher, OnlyValidEnums<ConfigWeaponSlots>());
+    public readonly ConfigValue<WeaponSlots> Group2Weapon1 = new(WeaponSlots.RocketLauncher, OnlyValidEnums<WeaponSlots>());
     [ConfigInfo("")]
     [OptionMenu(OptionSectionType.Player, "        2nd")]
-    public readonly ConfigValue<ConfigWeaponSlots> Group2Weapon2 = new(ConfigWeaponSlots.Melee, OnlyValidEnums<ConfigWeaponSlots>());
+    public readonly ConfigValue<WeaponSlots> Group2Weapon2 = new(WeaponSlots.Melee, OnlyValidEnums<WeaponSlots>());
     [ConfigInfo("")]
     [OptionMenu(OptionSectionType.Player, "        3rd")]
-    public readonly ConfigValue<ConfigWeaponSlots> Group2Weapon3 = new(ConfigWeaponSlots.Melee, OnlyValidEnums<ConfigWeaponSlots>());
+    public readonly ConfigValue<WeaponSlots> Group2Weapon3 = new(WeaponSlots.Melee, OnlyValidEnums<WeaponSlots>());
 
     [ConfigInfo("")]
     [OptionMenu(OptionSectionType.Player, "Group 3 1st", spacer: true)]
-    public readonly ConfigValue<ConfigWeaponSlots> Group3Weapon1 = new(ConfigWeaponSlots.PlasmaRifle, OnlyValidEnums<ConfigWeaponSlots>());
+    public readonly ConfigValue<WeaponSlots> Group3Weapon1 = new(WeaponSlots.PlasmaRifle, OnlyValidEnums<WeaponSlots>());
     [ConfigInfo("")]
     [OptionMenu(OptionSectionType.Player, "        2nd")]
-    public readonly ConfigValue<ConfigWeaponSlots> Group3Weapon2 = new(ConfigWeaponSlots.BFG9000, OnlyValidEnums<ConfigWeaponSlots>());
+    public readonly ConfigValue<WeaponSlots> Group3Weapon2 = new(WeaponSlots.BFG9000, OnlyValidEnums<WeaponSlots>());
     [ConfigInfo("")]
     [OptionMenu(OptionSectionType.Player, "        3rd")]
-    public readonly ConfigValue<ConfigWeaponSlots> Group3Weapon3 = new(ConfigWeaponSlots.None, OnlyValidEnums<ConfigWeaponSlots>());
+    public readonly ConfigValue<WeaponSlots> Group3Weapon3 = new(WeaponSlots.None, OnlyValidEnums<WeaponSlots>());
 
     [ConfigInfo("")]
     [OptionMenu(OptionSectionType.Player, "Group 4 1st", spacer: true)]
-    public readonly ConfigValue<ConfigWeaponSlots> Group4Weapon1 = new(ConfigWeaponSlots.Chaingun, OnlyValidEnums<ConfigWeaponSlots>());
+    public readonly ConfigValue<WeaponSlots> Group4Weapon1 = new(WeaponSlots.Chaingun, OnlyValidEnums<WeaponSlots>());
     [ConfigInfo("")]
     [OptionMenu(OptionSectionType.Player, "        2nd")]
-    public readonly ConfigValue<ConfigWeaponSlots> Group4Weapon2 = new(ConfigWeaponSlots.Pistol, OnlyValidEnums<ConfigWeaponSlots>());
+    public readonly ConfigValue<WeaponSlots> Group4Weapon2 = new(WeaponSlots.Pistol, OnlyValidEnums<WeaponSlots>());
     [ConfigInfo("")]
     [OptionMenu(OptionSectionType.Player, "        3rd")]
-    public readonly ConfigValue<ConfigWeaponSlots> Group4Weapon3 = new(ConfigWeaponSlots.None, OnlyValidEnums<ConfigWeaponSlots>());
+    public readonly ConfigValue<WeaponSlots> Group4Weapon3 = new(WeaponSlots.None, OnlyValidEnums<WeaponSlots>());
 }

--- a/Core/Util/Configs/Components/ConfigWeapons.cs
+++ b/Core/Util/Configs/Components/ConfigWeapons.cs
@@ -1,0 +1,88 @@
+﻿using Helion.Util.Configs.Impl;
+using Helion.Util.Configs.Options;
+using Helion.Util.Configs.Values;
+using Helion.World.Entities.Definition;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace Helion.Util.Configs.Components;
+
+public enum WeaponSwitch
+{
+    Always,
+    Never,
+    Preference,
+    [Description("Preference Except Attacking")]
+    PreferenceNoAttack
+}
+
+public class ConfigWeaponPreference : ConfigElement<ConfigWeaponPreference>
+{
+    const int PriorityMin = 0;
+    const int PriorityMax = 10;
+    private readonly Dictionary<string, ConfigValue<int>> m_weaponLookup;
+
+    public ConfigWeaponPreference()
+    {
+        m_weaponLookup = new(StringComparer.OrdinalIgnoreCase)
+        {
+            { "Fist", Fist },
+            { "Chainsaw", Chainsaw },
+            { "Pistol", Pistol },
+            { "Shotgun", Shotgun },
+            { "SuperShotgun", SuperShotgun },
+            { "Chaingun", Chaingun },
+            { "RocketLauncher", RocketLauncher },
+            { "PlasmaRifle", PlasmaRifle },
+            { "BFG9000", BFG9000 }
+        };
+    }
+
+    [ConfigInfo("Weapon pickup selection preference.")]
+    [OptionMenu(OptionSectionType.Weapons, "Pickup Preference")]
+    public ConfigValue<WeaponSwitch> Preference = new(WeaponSwitch.Always);
+
+    [ConfigInfo("Disable selecting weapon with no ammo.")]
+    [OptionMenu(OptionSectionType.Weapons, "No Ammo Select")]
+    public ConfigValue<bool> NoAmmoSelect = new(true);
+
+    [ConfigInfo("", save: false, legacy: true)]
+    [OptionMenu(OptionSectionType.Weapons, "", disabled: true, spacer: true)]
+    public readonly ConfigValueHeader Header = new("Weapon Priority");
+    [ConfigInfo("Fist")]
+    [OptionMenu(OptionSectionType.Weapons, "Fist", sliderMin: PriorityMin, sliderMax: PriorityMax, sliderStep: 1, spacer: true)]
+    public ConfigValue<int> Fist = new(0, ConfigFilters.Clamp(PriorityMin, PriorityMax));
+    [ConfigInfo("Chainsaw")]
+    [OptionMenu(OptionSectionType.Weapons, "Chainsaw", sliderMin: PriorityMin, sliderMax: PriorityMax, sliderStep: 1)]
+    public ConfigValue<int> Chainsaw = new(1, ConfigFilters.Clamp(PriorityMin, PriorityMax));
+    [ConfigInfo("Pistol")]
+    [OptionMenu(OptionSectionType.Weapons, "Pistol", sliderMin: PriorityMin, sliderMax: PriorityMax, sliderStep: 1)]
+    public ConfigValue<int> Pistol = new(1, ConfigFilters.Clamp(PriorityMin, PriorityMax));
+    [ConfigInfo("Shotgun")]
+    [OptionMenu(OptionSectionType.Weapons, "Shotgun", sliderMin: PriorityMin, sliderMax: PriorityMax, sliderStep: 1)]
+    public ConfigValue<int> Shotgun = new(2, ConfigFilters.Clamp(PriorityMin, PriorityMax));
+    [ConfigInfo("SuperShotgun")]
+    [OptionMenu(OptionSectionType.Weapons, "Super Shotgun", sliderMin: PriorityMin, sliderMax: PriorityMax, sliderStep: 1)]
+    public ConfigValue<int> SuperShotgun = new(4, ConfigFilters.Clamp(PriorityMin, PriorityMax));
+    [ConfigInfo("Chaingun")]
+    [OptionMenu(OptionSectionType.Weapons, "Chaingun", sliderMin: PriorityMin, sliderMax: PriorityMax, sliderStep: 1)]
+    public ConfigValue<int> Chaingun = new(3, ConfigFilters.Clamp(PriorityMin, PriorityMax));
+    [ConfigInfo("RocketLauncher")]
+    [OptionMenu(OptionSectionType.Weapons, "Rocket Launcher", sliderMin: PriorityMin, sliderMax: PriorityMax, sliderStep: 1)]
+    public ConfigValue<int> RocketLauncher = new(1, ConfigFilters.Clamp(PriorityMin, PriorityMax));
+    [ConfigInfo("PlasmaRifle")]
+    [OptionMenu(OptionSectionType.Weapons, "Plasma Rifle", sliderMin: PriorityMin, sliderMax: PriorityMax, sliderStep: 1)]
+    public ConfigValue<int> PlasmaRifle = new(5, ConfigFilters.Clamp(PriorityMin, PriorityMax));
+    [ConfigInfo("BFG9000")]
+    [OptionMenu(OptionSectionType.Weapons, "BFG9000", sliderMin: PriorityMin, sliderMax: PriorityMax, sliderStep: 1)]
+    public ConfigValue<int> BFG9000 = new(2, ConfigFilters.Clamp(PriorityMin, PriorityMax));
+
+    public int GetWeaponPriority(EntityDefinition definition)
+    {
+        if (m_weaponLookup.TryGetValue(definition.Name, out var value))
+            return value.Value;
+
+        return 0;
+    }
+}

--- a/Core/Util/Configs/Components/ConfigWeapons.cs
+++ b/Core/Util/Configs/Components/ConfigWeapons.cs
@@ -19,13 +19,13 @@ public enum WeaponSwitch
     PreferenceExceptAttack
 }
 
-public class ConfigWeaponPreference : ConfigElement<ConfigWeaponPreference>
+public class ConfigWeapons : ConfigElement<ConfigWeapons>
 {
     const int PriorityMin = 0;
     const int PriorityMax = 10;
     private readonly Dictionary<string, ConfigValue<int>> m_weaponLookup;
 
-    public ConfigWeaponPreference()
+    public ConfigWeapons()
     {
         m_weaponLookup = new(StringComparer.OrdinalIgnoreCase)
         {
@@ -42,8 +42,8 @@ public class ConfigWeaponPreference : ConfigElement<ConfigWeaponPreference>
     }
 
     [ConfigInfo("Weapon pickup selection preference.", demo: true)]
-    [OptionMenu(OptionSectionType.Weapons, "Pickup Preference")]
-    public ConfigValue<WeaponSwitch> Preference = new(WeaponSwitch.Always);
+    [OptionMenu(OptionSectionType.Weapons, "Pickup Switch Preference")]
+    public ConfigValue<WeaponSwitch> SwitchPreference = new(WeaponSwitch.Always);
 
     [ConfigInfo("Disable selecting weapon with no ammo.", demo: true)]
     [OptionMenu(OptionSectionType.Weapons, "No Ammo Select")]

--- a/Core/Util/Configs/Components/ConfigWeapons.cs
+++ b/Core/Util/Configs/Components/ConfigWeapons.cs
@@ -11,10 +11,12 @@ namespace Helion.Util.Configs.Components;
 public enum WeaponSwitch
 {
     Always,
+    [Description("Always Except Attacking")]
+    AlwaysExceptAttack,
     Never,
     Preference,
     [Description("Preference Except Attacking")]
-    PreferenceNoAttack
+    PreferenceExceptAttack
 }
 
 public class ConfigWeaponPreference : ConfigElement<ConfigWeaponPreference>
@@ -39,42 +41,42 @@ public class ConfigWeaponPreference : ConfigElement<ConfigWeaponPreference>
         };
     }
 
-    [ConfigInfo("Weapon pickup selection preference.")]
+    [ConfigInfo("Weapon pickup selection preference.", demo: true)]
     [OptionMenu(OptionSectionType.Weapons, "Pickup Preference")]
     public ConfigValue<WeaponSwitch> Preference = new(WeaponSwitch.Always);
 
-    [ConfigInfo("Disable selecting weapon with no ammo.")]
+    [ConfigInfo("Disable selecting weapon with no ammo.", demo: true)]
     [OptionMenu(OptionSectionType.Weapons, "No Ammo Select")]
     public ConfigValue<bool> NoAmmoSelect = new(true);
 
     [ConfigInfo("", save: false, legacy: true)]
     [OptionMenu(OptionSectionType.Weapons, "", disabled: true, spacer: true)]
     public readonly ConfigValueHeader Header = new("Weapon Priority");
-    [ConfigInfo("Fist")]
+    [ConfigInfo("Fist", demo: true)]
     [OptionMenu(OptionSectionType.Weapons, "Fist", sliderMin: PriorityMin, sliderMax: PriorityMax, sliderStep: 1, spacer: true)]
     public ConfigValue<int> Fist = new(0, ConfigFilters.Clamp(PriorityMin, PriorityMax));
-    [ConfigInfo("Chainsaw")]
+    [ConfigInfo("Chainsaw", demo: true)]
     [OptionMenu(OptionSectionType.Weapons, "Chainsaw", sliderMin: PriorityMin, sliderMax: PriorityMax, sliderStep: 1)]
     public ConfigValue<int> Chainsaw = new(1, ConfigFilters.Clamp(PriorityMin, PriorityMax));
-    [ConfigInfo("Pistol")]
+    [ConfigInfo("Pistol", demo: true)]
     [OptionMenu(OptionSectionType.Weapons, "Pistol", sliderMin: PriorityMin, sliderMax: PriorityMax, sliderStep: 1)]
     public ConfigValue<int> Pistol = new(1, ConfigFilters.Clamp(PriorityMin, PriorityMax));
-    [ConfigInfo("Shotgun")]
+    [ConfigInfo("Shotgun", demo: true)]
     [OptionMenu(OptionSectionType.Weapons, "Shotgun", sliderMin: PriorityMin, sliderMax: PriorityMax, sliderStep: 1)]
     public ConfigValue<int> Shotgun = new(2, ConfigFilters.Clamp(PriorityMin, PriorityMax));
-    [ConfigInfo("SuperShotgun")]
+    [ConfigInfo("SuperShotgun", demo: true)]
     [OptionMenu(OptionSectionType.Weapons, "Super Shotgun", sliderMin: PriorityMin, sliderMax: PriorityMax, sliderStep: 1)]
     public ConfigValue<int> SuperShotgun = new(4, ConfigFilters.Clamp(PriorityMin, PriorityMax));
-    [ConfigInfo("Chaingun")]
+    [ConfigInfo("Chaingun", demo: true)]
     [OptionMenu(OptionSectionType.Weapons, "Chaingun", sliderMin: PriorityMin, sliderMax: PriorityMax, sliderStep: 1)]
     public ConfigValue<int> Chaingun = new(3, ConfigFilters.Clamp(PriorityMin, PriorityMax));
-    [ConfigInfo("RocketLauncher")]
+    [ConfigInfo("RocketLauncher", demo: true)]
     [OptionMenu(OptionSectionType.Weapons, "Rocket Launcher", sliderMin: PriorityMin, sliderMax: PriorityMax, sliderStep: 1)]
     public ConfigValue<int> RocketLauncher = new(1, ConfigFilters.Clamp(PriorityMin, PriorityMax));
-    [ConfigInfo("PlasmaRifle")]
+    [ConfigInfo("PlasmaRifle", demo: true)]
     [OptionMenu(OptionSectionType.Weapons, "Plasma Rifle", sliderMin: PriorityMin, sliderMax: PriorityMax, sliderStep: 1)]
     public ConfigValue<int> PlasmaRifle = new(5, ConfigFilters.Clamp(PriorityMin, PriorityMax));
-    [ConfigInfo("BFG9000")]
+    [ConfigInfo("BFG9000", demo: true)]
     [OptionMenu(OptionSectionType.Weapons, "BFG9000", sliderMin: PriorityMin, sliderMax: PriorityMax, sliderStep: 1)]
     public ConfigValue<int> BFG9000 = new(2, ConfigFilters.Clamp(PriorityMin, PriorityMax));
 

--- a/Core/Util/Configs/Components/WeaponSlots.cs
+++ b/Core/Util/Configs/Components/WeaponSlots.cs
@@ -2,7 +2,8 @@ using System.ComponentModel;
 
 namespace Helion.Util.Config.Components;
 
-public enum ConfigWeaponSlots {
+public enum WeaponSlots
+{
     [Description("--")]
     None = -1,
     [Description("Chainsaw/Fist")]

--- a/Core/Util/Configs/ConfigEnums.cs
+++ b/Core/Util/Configs/ConfigEnums.cs
@@ -42,10 +42,11 @@ namespace Helion.Util.Configs
             { typeof(RenderColorMode), Enum.GetValues<RenderColorMode>() },
             { typeof(BlitFilter), Enum.GetValues<BlitFilter>() },
             { typeof(GyroTurnAxis), Enum.GetValues<GyroTurnAxis>() },
-            { typeof(ConfigWeaponSlots), Enum.GetValues<ConfigWeaponSlots>() },
+            { typeof(WeaponSlots), Enum.GetValues<WeaponSlots>() },
             { typeof(RngMethod), Enum.GetValues<RngMethod>() },
             { typeof(SkyRenderMode), Enum.GetValues<SkyRenderMode>() },
             { typeof(RenderContrastMode), Enum.GetValues<RenderContrastMode>() },
+            { typeof(WeaponSwitch), Enum.GetValues<WeaponSwitch>() },
         };
 
         public static Dictionary<Type, Dictionary<Enum, string>> KnownEnumLabels { get; } = new Dictionary<Type, Dictionary<Enum, string>>()
@@ -67,9 +68,10 @@ namespace Helion.Util.Configs
             { typeof(RenderColorMode), GetDescriptions<RenderColorMode>() },
             { typeof(BlitFilter), GetDescriptions<BlitFilter>() },
             { typeof(GyroTurnAxis), GetDescriptions<GyroTurnAxis>() },
-            { typeof(ConfigWeaponSlots), GetDescriptions<ConfigWeaponSlots>()},
+            { typeof(WeaponSlots), GetDescriptions<WeaponSlots>()},
             { typeof(RngMethod), GetDescriptions<RngMethod>()},
-            { typeof(SkyRenderMode), GetDescriptions<SkyRenderMode>()}
+            { typeof(SkyRenderMode), GetDescriptions<SkyRenderMode>()},
+            { typeof(WeaponSwitch), GetDescriptions<WeaponSwitch>()},
         };
 
         private static Dictionary<Enum, string> GetDescriptions<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] T>() where T : struct, Enum

--- a/Core/Util/Configs/IConfig.cs
+++ b/Core/Util/Configs/IConfig.cs
@@ -26,6 +26,7 @@ public interface IConfig
     ConfigWindow Window { get; }
     ConfigDemo Demo { get; }
     ConfigSlowTick SlowTick { get; }
+    ConfigWeaponPreference WeaponPreference { get; }
     IConfigKeyMapping Keys { get; }
     IConfigAliasMapping Aliases { get; }
 

--- a/Core/Util/Configs/IConfig.cs
+++ b/Core/Util/Configs/IConfig.cs
@@ -26,7 +26,7 @@ public interface IConfig
     ConfigWindow Window { get; }
     ConfigDemo Demo { get; }
     ConfigSlowTick SlowTick { get; }
-    ConfigWeaponPreference WeaponPreference { get; }
+    ConfigWeapons Weapons { get; }
     IConfigKeyMapping Keys { get; }
     IConfigAliasMapping Aliases { get; }
 

--- a/Core/Util/Configs/Impl/Config.cs
+++ b/Core/Util/Configs/Impl/Config.cs
@@ -34,7 +34,7 @@ public class Config : ConfigElement<Config>, IConfig
     public ConfigWindow Window { get; } = new();
     public ConfigDemo Demo { get; } = new();
     public ConfigSlowTick SlowTick { get; } = new();
-    public ConfigWeaponPreference WeaponPreference { get; } = new();
+    public ConfigWeapons Weapons { get; } = new();
     public IConfigKeyMapping Keys => KeyMapping;
     public IConfigAliasMapping Aliases { get; }
     protected readonly ConfigKeyMapping KeyMapping = new();
@@ -136,7 +136,7 @@ public class Config : ConfigElement<Config>, IConfig
     /// </summary>
     public List<(IConfigValue, OptionMenuAttribute, ConfigInfoAttribute)> GetAllConfigFields()
     {
-        List<(IConfigValue, OptionMenuAttribute, ConfigInfoAttribute)> fields = new();
+        List<(IConfigValue, OptionMenuAttribute, ConfigInfoAttribute)> fields = [];
 
         foreach (PropertyInfo propertyInfo in typeof(Config).GetProperties())
         {

--- a/Core/Util/Configs/Impl/Config.cs
+++ b/Core/Util/Configs/Impl/Config.cs
@@ -34,6 +34,7 @@ public class Config : ConfigElement<Config>, IConfig
     public ConfigWindow Window { get; } = new();
     public ConfigDemo Demo { get; } = new();
     public ConfigSlowTick SlowTick { get; } = new();
+    public ConfigWeaponPreference WeaponPreference { get; } = new();
     public IConfigKeyMapping Keys => KeyMapping;
     public IConfigAliasMapping Aliases { get; }
     protected readonly ConfigKeyMapping KeyMapping = new();

--- a/Core/Util/Configs/Options/OptionSectionType.cs
+++ b/Core/Util/Configs/Options/OptionSectionType.cs
@@ -18,4 +18,5 @@ public enum OptionSectionType
     SlowTick,
     Demo,
     Console,
+    Weapons
 }

--- a/Core/World/Entities/Inventories/Inventory.cs
+++ b/Core/World/Entities/Inventories/Inventory.cs
@@ -529,6 +529,19 @@ public sealed class Inventory
         Weapons.Remove(name);
     }
 
+    public bool CheckAmmo(Weapon weapon, int ammoCount = -1)
+    {
+        // Inifinite if no ammo type (fist, chainsaw)
+        string ammoType = weapon.Definition.Properties.Weapons.AmmoType;
+        if (ammoType.Length == 0)
+            return true;
+
+        if (ammoCount == -1)
+            ammoCount = Amount(weapon.Definition.Properties.Weapons.AmmoType);
+
+        return ammoCount >= weapon.Definition.Properties.Weapons.AmmoUse;
+    }
+
     public List<InventoryItem> GetInventoryItems() => ItemList;
     public List<InventoryItem> GetKeys() => Keys;
 

--- a/Core/World/Entities/Inventories/Weapons.cs
+++ b/Core/World/Entities/Inventories/Weapons.cs
@@ -62,9 +62,9 @@ public sealed class Weapons
 
     public List<Weapon> GetOwnedWeapons() => m_ownedWeapons;
 
-    public WeaponSlot GetNextSlot(Player player) => CycleSlot(player, player.WeaponSlot, player.WeaponSubSlot, true, false);
-    public WeaponSlot GetPreviousSlot(Player player) => CycleSlot(player, player.WeaponSlot, player.WeaponSubSlot, false, false);
-    public WeaponSlot GetNextSubSlot(Player player) => CycleSlot(player, player.WeaponSlot, player.WeaponSubSlot, true, true);
+    public WeaponSlot GetNextSlot(Player player) => CycleSlot(player.WeaponSlot, player.WeaponSubSlot, true, false);
+    public WeaponSlot GetPreviousSlot(Player player) => CycleSlot(player.WeaponSlot, player.WeaponSubSlot, false, false);
+    public WeaponSlot GetNextSubSlot(Player player) => CycleSlot(player.WeaponSlot, player.WeaponSubSlot, true, true);
 
     public WeaponSlot GetNextSlot(Player player, int amount)
     {
@@ -79,14 +79,14 @@ public sealed class Weapons
         amount = Math.Abs(amount % m_ownedWeapons.Count);
         while (amount > 0)
         {
-            slot = CycleSlot(player, slot.Slot, slot.SubSlot, direction, false);
+            slot = CycleSlot(slot.Slot, slot.SubSlot, direction, false);
             amount--;
         }
 
         return slot;
     }
 
-    private WeaponSlot CycleSlot(Player player, int slot, int subSlot, bool next, bool wrapSubSlot)
+    private WeaponSlot CycleSlot(int slot, int subSlot, bool next, bool wrapSubSlot)
     {
         if (m_ownedWeapons.Count == 0)
             return DefaultSlot;
@@ -199,7 +199,7 @@ public sealed class Weapons
 
     public bool CheckSelection(Weapon weapon)
     {
-        if (WorldStatic.World.Config.WeaponPreference.NoAmmoSelect)
+        if (WorldStatic.World.Config.Weapons.NoAmmoSelect)
             return true;
 
         return m_inventory.CheckAmmo(weapon);

--- a/Core/World/Entities/Inventories/Weapons.cs
+++ b/Core/World/Entities/Inventories/Weapons.cs
@@ -164,6 +164,9 @@ public sealed class Weapons
 
     public bool CanSelectWeapon(Weapon weapon)
     {
+        if (!CheckSelection(weapon))
+            return false;
+
         bool allowSwitch = true;
         bool disallowSwitch = false;
         ref var weaponDef = ref weapon.Definition.Properties.Weapons;
@@ -192,6 +195,14 @@ public sealed class Weapons
         }
 
         return allowSwitch;
+    }
+
+    public bool CheckSelection(Weapon weapon)
+    {
+        if (WorldStatic.World.Config.WeaponPreference.NoAmmoSelect)
+            return true;
+
+        return m_inventory.CheckAmmo(weapon);
     }
 
     public Weapon? Add(EntityDefinition definition, Player owner, EntityManager entityManager,
@@ -239,7 +250,7 @@ public sealed class Weapons
             if (!m_weaponSlotLookup.TryGetValue(weapon.Definition.Id, out var weaponSlot))
                 continue;
 
-            if (weaponSlot.Slot < min)
+            if (weaponSlot.Slot < min && CheckSelection(weapon))
                 min = weaponSlot.Slot;
         }
 
@@ -257,7 +268,7 @@ public sealed class Weapons
             if (!m_weaponSlotLookup.TryGetValue(weapon.Definition.Id, out var weaponSlot))
                 continue;
 
-            if (weaponSlot.Slot > max)
+            if (weaponSlot.Slot > max && CheckSelection(weapon))
                 max = weaponSlot.Slot;
         }
 

--- a/Core/World/Entities/Players/Player.cs
+++ b/Core/World/Entities/Players/Player.cs
@@ -2,7 +2,6 @@ using Helion.Audio;
 using Helion.Geometry.Boxes;
 using Helion.Geometry.Segments;
 using Helion.Geometry.Vectors;
-using Helion.Maps.Specials;
 using Helion.Maps.Specials.ZDoom;
 using Helion.Models;
 using Helion.Render.Common.World;
@@ -12,6 +11,7 @@ using Helion.Resources.Definitions.MapInfo;
 using Helion.Resources.Definitions.SoundInfo;
 using Helion.Util;
 using Helion.Util.Config.Components;
+using Helion.Util.Configs.Components;
 using Helion.Util.Extensions;
 using Helion.World.Cheats;
 using Helion.World.Entities.Definition;
@@ -957,8 +957,8 @@ public class Player : Entity
         return TickCommands.None;
     }
 
-    private ConfigWeaponSlots[,] m_WeaponGroups = new ConfigWeaponSlots[4,3];
-    private ConfigWeaponSlots[,] GetWeaponGroups()
+    private WeaponSlots[,] m_WeaponGroups = new WeaponSlots[4,3];
+    private WeaponSlots[,] GetWeaponGroups()
     {
         m_WeaponGroups[0,0] = WorldStatic.World.Config.Player.Group1Weapon1;
         m_WeaponGroups[0,1] = WorldStatic.World.Config.Player.Group1Weapon2;
@@ -991,7 +991,7 @@ public class Player : Entity
         for (int slotIndex = 0; slotIndex < weaponGroups.GetLength(1); slotIndex++) 
         {
             var slot = weaponGroups[groupNumber,slotIndex];
-            if (slot != ConfigWeaponSlots.None) 
+            if (slot != WeaponSlots.None) 
             {
                 Weapon? weapon = null;
                 if (WeaponSlot == (int)slot)
@@ -1175,7 +1175,7 @@ public class Player : Entity
 
         int oldCount = Inventory.Amount(baseAmmoDef);
         bool success = Inventory.Add(baseAmmoDef, giveAmount, flags);
-        if (success && autoSwitchWeapon)
+        if (success && autoSwitchWeapon && ShouldSwitch(weaponDef))
             CheckAutoSwitchAmmo(baseAmmoDef, oldCount);
         return success;
     }
@@ -1309,14 +1309,38 @@ public class Player : Entity
         if (ownedWeapon)
             return;
 
-        Weapon? newWeapon = Inventory.Weapons.GetWeapon(definition.Name);
+        var newWeapon = Inventory.Weapons.GetWeapon(definition.Name);
         if (newWeapon == null)
             return;
 
         if (!Inventory.Weapons.CanSelectWeapon(newWeapon))
             return;
 
+        if (!ShouldSwitch(definition))
+            return;
+
         ChangeWeapon(newWeapon);
+    }
+
+    private bool ShouldSwitch(EntityDefinition? definition)
+    {
+        return World.Config.WeaponPreference.Preference.Value switch
+        {
+            WeaponSwitch.Never => false,
+            WeaponSwitch.Preference => definition != null && ShouldSwitchPreference(definition),
+            WeaponSwitch.PreferenceNoAttack => !TickCommand.Has(TickCommands.Attack) && definition != null && ShouldSwitchPreference(definition),
+            _ => true,
+        };
+    }
+
+    private bool ShouldSwitchPreference(EntityDefinition definition)
+    {
+        if (Weapon == null)
+            return true;
+
+        var currentPriority = World.Config.WeaponPreference.GetWeaponPriority(Weapon.Definition);
+        var pickupPriority = World.Config.WeaponPreference.GetWeaponPriority(definition);
+        return pickupPriority > currentPriority;
     }
 
     /// <summary>
@@ -1458,15 +1482,7 @@ public class Player : Entity
     /// </summary>
     public bool CheckAmmo(Weapon weapon, int ammoCount = -1)
     {
-        // Inifinite if no ammo type (fist, chainsaw)
-        string ammoType = weapon.Definition.Properties.Weapons.AmmoType;
-        if (ammoType.Length == 0)
-            return true;
-
-        if (ammoCount == -1)
-            ammoCount = Inventory.Amount(weapon.Definition.Properties.Weapons.AmmoType);
-
-        return ammoCount >= weapon.Definition.Properties.Weapons.AmmoUse;
+        return Inventory.CheckAmmo(weapon, ammoCount);
     }
 
     public bool CanFireWeapon()

--- a/Core/World/Entities/Players/Player.cs
+++ b/Core/World/Entities/Players/Player.cs
@@ -52,7 +52,7 @@ public class Player : Entity
     private const int JumpDelayTicks = 7;
     private const int SlowTurnTicks = 6;
     private const double MaxPitch = Camera.MaxPitch;
-    private static readonly PowerupType[] PowerupsWithBrightness = { PowerupType.LightAmp, PowerupType.Invulnerable };
+    private static readonly PowerupType[] PowerupsWithBrightness = [PowerupType.LightAmp, PowerupType.Invulnerable];
     private static readonly Logger Log = LogManager.GetCurrentClassLogger();
 
     // These are set instantly from mouse movement.
@@ -105,8 +105,8 @@ public class Player : Entity
     public WeakEntity Attacker = WeakEntity.Default;
     public WeakEntity CrosshairTarget = WeakEntity.Default;
     public PlayerStatusBar StatusBar;
-    public PlayerCheats Cheats = new PlayerCheats();
-    public PlayerInfo Info = new PlayerInfo();
+    public PlayerCheats Cheats = new();
+    public PlayerInfo Info = new();
     public PlayerTracers Tracers = new();
     public bool IsVooDooDoll;
     public bool IsSyncVooDoo;
@@ -234,8 +234,8 @@ public class Player : Entity
 
         StatusBar = new PlayerStatusBar(this);
 
-        foreach (CheatType cheat in playerModel.Cheats)
-            Cheats.SetCheatActive(cheat);
+        for (int i = 0; i < playerModel.Cheats.Count; i++)
+            Cheats.SetCheatActive((CheatType)playerModel.Cheats[i]);
 
         SetPlayerInfo();
         SetupEvents();
@@ -906,8 +906,8 @@ public class Player : Entity
     private static int GetWeaponSlot(TickCommands tickCommand) =>
         (int)tickCommand - (int)TickCommands.WeaponSlot1 + 1;
 
-    private static readonly TickCommands[] WeaponSlotCommands = new TickCommands[]
-    {
+    private static readonly TickCommands[] WeaponSlotCommands =
+    [
         TickCommands.WeaponSlot1,
         TickCommands.WeaponSlot2,
         TickCommands.WeaponSlot3,
@@ -915,7 +915,7 @@ public class Player : Entity
         TickCommands.WeaponSlot5,
         TickCommands.WeaponSlot6,
         TickCommands.WeaponSlot7,
-    };
+    ];
 
     private static TickCommands GetWeaponSlotCommand(TickCommand tickCommand)
     {
@@ -940,13 +940,13 @@ public class Player : Entity
     private static int GetWeaponGroupIndex(TickCommands tickCommand) =>
         (int)tickCommand - (int)TickCommands.WeaponGroup1;
     
-    private static readonly TickCommands[] WeaponGroupCommands = new TickCommands[]
-    {
+    private static readonly TickCommands[] WeaponGroupCommands =
+    [
         TickCommands.WeaponGroup1,
         TickCommands.WeaponGroup2,
         TickCommands.WeaponGroup3,
         TickCommands.WeaponGroup4
-    };
+    ];
 
     private static TickCommands GetWeaponGroupCommand(TickCommand tickCommand)
     {
@@ -957,7 +957,7 @@ public class Player : Entity
         return TickCommands.None;
     }
 
-    private WeaponSlots[,] m_WeaponGroups = new WeaponSlots[4,3];
+    private readonly WeaponSlots[,] m_WeaponGroups = new WeaponSlots[4,3];
     private WeaponSlots[,] GetWeaponGroups()
     {
         m_WeaponGroups[0,0] = WorldStatic.World.Config.Player.Group1Weapon1;
@@ -1324,7 +1324,7 @@ public class Player : Entity
 
     private bool ShouldSwitch(EntityDefinition? definition)
     {
-        return World.Config.WeaponPreference.Preference.Value switch
+        return World.Config.Weapons.SwitchPreference.Value switch
         {
             WeaponSwitch.Never => false,
             WeaponSwitch.AlwaysExceptAttack => !TickCommand.Has(TickCommands.Attack),
@@ -1340,8 +1340,8 @@ public class Player : Entity
         if (currentWeapon == null)
             return true;
 
-        var currentPriority = World.Config.WeaponPreference.GetWeaponPriority(currentWeapon.Definition);
-        var pickupPriority = World.Config.WeaponPreference.GetWeaponPriority(definition);
+        var currentPriority = World.Config.Weapons.GetWeaponPriority(currentWeapon.Definition);
+        var pickupPriority = World.Config.Weapons.GetWeaponPriority(definition);
         return pickupPriority > currentPriority;
     }
 
@@ -1589,8 +1589,7 @@ public class Player : Entity
         if (Weapon == null)
             return;
         var weapon = Weapon.Definition.Properties.Weapons;
-        if (weapon.AmmoTypeDef == null)
-            weapon.AmmoTypeDef = WorldStatic.World.EntityManager.DefinitionComposer.GetByName(weapon.AmmoType);
+        weapon.AmmoTypeDef ??= WorldStatic.World.EntityManager.DefinitionComposer.GetByName(weapon.AmmoType);
         if (weapon.AmmoTypeDef != null)
             Inventory.Add(weapon.AmmoTypeDef, amount);
     }

--- a/Core/World/Entities/Players/Player.cs
+++ b/Core/World/Entities/Players/Player.cs
@@ -1327,18 +1327,20 @@ public class Player : Entity
         return World.Config.WeaponPreference.Preference.Value switch
         {
             WeaponSwitch.Never => false,
+            WeaponSwitch.AlwaysExceptAttack => !TickCommand.Has(TickCommands.Attack),
             WeaponSwitch.Preference => definition != null && ShouldSwitchPreference(definition),
-            WeaponSwitch.PreferenceNoAttack => !TickCommand.Has(TickCommands.Attack) && definition != null && ShouldSwitchPreference(definition),
+            WeaponSwitch.PreferenceExceptAttack => !TickCommand.Has(TickCommands.Attack) && definition != null && ShouldSwitchPreference(definition),
             _ => true,
         };
     }
 
     private bool ShouldSwitchPreference(EntityDefinition definition)
     {
-        if (Weapon == null)
+        var currentWeapon = PendingWeapon ?? Weapon;
+        if (currentWeapon == null)
             return true;
 
-        var currentPriority = World.Config.WeaponPreference.GetWeaponPriority(Weapon.Definition);
+        var currentPriority = World.Config.WeaponPreference.GetWeaponPriority(currentWeapon.Definition);
         var pickupPriority = World.Config.WeaponPreference.GetWeaponPriority(definition);
         return pickupPriority > currentPriority;
     }

--- a/Core/World/Entities/Players/TickCommand.cs
+++ b/Core/World/Entities/Players/TickCommand.cs
@@ -1,13 +1,12 @@
 using Helion.Util.Container;
-using System.Collections.Generic;
 
 namespace Helion.World.Entities.Players;
 
 public class TickCommand
 {
     // These commands are only processed once even if held down.
-    private static readonly TickCommands[] SinglePressCommands = new[]
-    {
+    private static readonly TickCommands[] SinglePressCommands =
+    [
         TickCommands.Use,
         TickCommands.NextWeapon,
         TickCommands.PreviousWeapon,
@@ -23,11 +22,10 @@ public class TickCommand
         TickCommands.WeaponGroup3,
         TickCommands.WeaponGroup4,
         TickCommands.CenterView
-    };
+    ];
 
     private readonly DynamicArray<TickCommands> m_commands = new();
     private readonly DynamicArray<TickCommands> m_previousCommands = new();
-    private readonly List<TickCommands> m_returnCommands = new();
 
     public double AngleTurn { get; set; }
     public double PitchTurn { get; set; }

--- a/Core/World/WorldBase.cs
+++ b/Core/World/WorldBase.cs
@@ -63,7 +63,6 @@ using Helion.Resources.Definitions.Compatibility;
 using Helion.Maps.Components;
 using System.Runtime.CompilerServices;
 using Helion.Resources.Definitions.SoundInfo;
-using NAudio.SoundFont;
 
 namespace Helion.World;
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -3,6 +3,7 @@
 ## Features:
 - Simplify bit packing strategy on vertex data using floatBitsToInt. Decreases entity sprite vertex size and increase range on line ids for vanilla sprite clipping emulation from 65k to over 8 million and sector light index from ~500k to over 1 million.
 - Add support to initial loading to only load assets.pk3 once.
+- Weapon switch pickup preferences and priority configuration. Includes options for always, always except when attacking, never, priority, and priority except when attacking.
 
 ## Bug Fixes:
 - Fix sprite frames to correctly calculate when lowercase.

--- a/Tests/Unit/GameAction/Inventory/Inventory.cs
+++ b/Tests/Unit/GameAction/Inventory/Inventory.cs
@@ -27,8 +27,8 @@ namespace Helion.Tests.Unit.GameAction
         public void Dispose()
         {
             InventoryUtil.Reset(World, Player);
-            World.Config.WeaponPreference.Preference.Set(WeaponSwitch.Always);
-            World.Config.WeaponPreference.NoAmmoSelect.Set(true);
+            World.Config.Weapons.SwitchPreference.Set(WeaponSwitch.Always);
+            World.Config.Weapons.NoAmmoSelect.Set(true);
         }
 
         private void WorldInit(SinglePlayerWorld world)

--- a/Tests/Unit/GameAction/Inventory/Inventory.cs
+++ b/Tests/Unit/GameAction/Inventory/Inventory.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using Helion.Resources.IWad;
 using Helion.Tests.Unit.GameAction.Util;
+using Helion.Util.Configs.Components;
 using Helion.Util.Extensions;
 using Helion.World.Cheats;
 using Helion.World.Entities.Players;
@@ -26,6 +27,8 @@ namespace Helion.Tests.Unit.GameAction
         public void Dispose()
         {
             InventoryUtil.Reset(World, Player);
+            World.Config.WeaponPreference.Preference.Set(WeaponSwitch.Always);
+            World.Config.WeaponPreference.NoAmmoSelect.Set(true);
         }
 
         private void WorldInit(SinglePlayerWorld world)

--- a/Tests/Unit/GameAction/Inventory/Inventory_WeaponSwitchPreference.cs
+++ b/Tests/Unit/GameAction/Inventory/Inventory_WeaponSwitchPreference.cs
@@ -32,10 +32,25 @@ public partial class Inventory
         }
     }
 
-    [Fact(DisplayName = "Weapon preference priority ignore attack")]
+    [Fact(DisplayName = "Weapon pick doesn't switch while attacking")]
+    public void AlwaysNoAttack()
+    {
+        World.Config.WeaponPreference.Preference.Set(WeaponSwitch.AlwaysExceptAttack);
+        SetWeaponPreferencePriority();
+
+        Player.GiveItem(GameActions.GetEntityDefinition(World, "RocketLauncher"), null);
+        InventoryUtil.AssertWeapon(Player.PendingWeapon, "RocketLauncher");
+        InventoryUtil.RunWeaponSwitch(World, Player, "RocketLauncher");
+        Player.TickCommand.Add(TickCommands.Attack);
+
+        Player.GiveItem(GameActions.GetEntityDefinition(World, "SuperShotgun"), null);
+        Player.PendingWeapon.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "Weapon preference priority doesn't switch while attack")]
     public void WeaponPreference()
     {
-        World.Config.WeaponPreference.Preference.Set(WeaponSwitch.PreferenceNoAttack);
+        World.Config.WeaponPreference.Preference.Set(WeaponSwitch.PreferenceExceptAttack);
         SetWeaponPreferencePriority();
 
         Player.GiveItem(GameActions.GetEntityDefinition(World, "RocketLauncher"), null);
@@ -78,6 +93,22 @@ public partial class Inventory
         Player.GiveItem(GameActions.GetEntityDefinition(World, "RocketLauncher"), null);
         InventoryUtil.AssertHasWeapon(Player, "RocketLauncher");
         Player.PendingWeapon.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "Pending weapon preference priority")]
+    public void PendingWeaponPreferencePriority()
+    {
+        World.Config.WeaponPreference.Preference.Set(WeaponSwitch.Preference);
+        SetWeaponPreferencePriority();
+
+        Player.GiveItem(GameActions.GetEntityDefinition(World, "SuperShotgun"), null);
+        InventoryUtil.AssertHasWeapon(Player, "SuperShotgun");
+        Player.ChangeWeapon(InventoryUtil.GetWeapon(Player, "SuperShotgun"));
+        InventoryUtil.AssertWeapon(Player.PendingWeapon, "SuperShotgun");
+        InventoryUtil.AssertWeapon(Player.Weapon, "Pistol");
+
+        Player.GiveItem(GameActions.GetEntityDefinition(World, "PlasmaRifle"), null);
+        InventoryUtil.AssertWeapon(Player.PendingWeapon, "SuperShotgun");
     }
 
     [Fact(DisplayName = "Player doesn't switch to weapon with no ammo by slot command")]

--- a/Tests/Unit/GameAction/Inventory/Inventory_WeaponSwitchPreference.cs
+++ b/Tests/Unit/GameAction/Inventory/Inventory_WeaponSwitchPreference.cs
@@ -1,0 +1,173 @@
+﻿using FluentAssertions;
+using Helion.Tests.Unit.GameAction.Util;
+using Helion.Util.Configs.Components;
+using Helion.World.Entities.Players;
+using Xunit;
+
+namespace Helion.Tests.Unit.GameAction;
+
+public partial class Inventory
+{
+    private static readonly string[] WeaponNames =
+    [
+        "Shotgun",
+        "Chaingun",
+        "RocketLauncher",
+        "PlasmaRifle",
+        "BFG9000",
+        "Chainsaw",
+        "SuperShotgun"
+    ];
+
+    [Fact(DisplayName = "Never switch weapon pickup")]
+    public void NeverSwitch()
+    {
+        World.Config.WeaponPreference.Preference.Set(WeaponSwitch.Never);
+
+        foreach (var weapon in WeaponNames)
+        {
+            Player.GiveItem(GameActions.GetEntityDefinition(World, weapon), null);
+            InventoryUtil.AssertHasWeapon(Player, weapon);
+            Player.PendingWeapon.Should().BeNull();
+        }
+    }
+
+    [Fact(DisplayName = "Weapon preference priority ignore attack")]
+    public void WeaponPreference()
+    {
+        World.Config.WeaponPreference.Preference.Set(WeaponSwitch.PreferenceNoAttack);
+        SetWeaponPreferencePriority();
+
+        Player.GiveItem(GameActions.GetEntityDefinition(World, "RocketLauncher"), null);
+        InventoryUtil.AssertHasWeapon(Player, "RocketLauncher");
+        InventoryUtil.RunWeaponSwitch(World, Player, "RocketLauncher");
+        Player.TickCommand.Add(TickCommands.Attack);
+
+        Player.GiveItem(GameActions.GetEntityDefinition(World, "SuperShotgun"), null);
+        Player.PendingWeapon.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "Weapon preference priority")]
+    public void WeaponPreferencePriority()
+    {
+        World.Config.WeaponPreference.Preference.Set(WeaponSwitch.Preference);
+        SetWeaponPreferencePriority();
+
+        Player.GiveItem(GameActions.GetEntityDefinition(World, "Chainsaw"), null);
+        InventoryUtil.AssertHasWeapon(Player, "Chainsaw");
+        InventoryUtil.RunWeaponSwitch(World, Player, "Chainsaw");
+
+        Player.GiveItem(GameActions.GetEntityDefinition(World, "Shotgun"), null);
+        InventoryUtil.AssertHasWeapon(Player, "Shotgun");
+        InventoryUtil.RunWeaponSwitch(World, Player, "Shotgun");
+
+        // Same priority
+        Player.GiveItem(GameActions.GetEntityDefinition(World, "Chaingun"), null);
+        InventoryUtil.AssertHasWeapon(Player, "Chaingun");
+        Player.PendingWeapon.Should().BeNull();
+
+        Player.GiveItem(GameActions.GetEntityDefinition(World, "SuperShotgun"), null);
+        InventoryUtil.AssertHasWeapon(Player, "SuperShotgun");
+        InventoryUtil.RunWeaponSwitch(World, Player, "SuperShotgun");
+
+        // Lower priority
+        Player.GiveItem(GameActions.GetEntityDefinition(World, "PlasmaRifle"), null);
+        InventoryUtil.AssertHasWeapon(Player, "PlasmaRifle");
+        Player.PendingWeapon.Should().BeNull();
+
+        Player.GiveItem(GameActions.GetEntityDefinition(World, "RocketLauncher"), null);
+        InventoryUtil.AssertHasWeapon(Player, "RocketLauncher");
+        Player.PendingWeapon.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "Player doesn't switch to weapon with no ammo by slot command")]
+    public void NoAmmoSelectBySlotCommand()
+    {
+        World.Config.WeaponPreference.NoAmmoSelect.Set(false);
+        Player.GiveItem(GameActions.GetEntityDefinition(World, "Shotgun"), null);
+        InventoryUtil.AssertHasWeapon(Player, "Shotgun");
+        InventoryUtil.RunWeaponSwitch(World, Player, "Shotgun");
+        Player.Inventory.SetAmount(GameActions.GetEntityDefinition(World, "Shell"), 0);
+
+        Player.TickCommand.Add(TickCommands.WeaponSlot2);
+        World.Tick();
+        InventoryUtil.RunWeaponSwitch(World, Player, "Pistol");
+
+        Player.TickCommand.Add(TickCommands.WeaponSlot3);
+        World.Tick();
+        Player.PendingWeapon.Should().BeNull();
+        World.Tick();
+        InventoryUtil.AssertWeapon(Player.Weapon, "Pistol");
+
+        Player.Inventory.SetAmount(GameActions.GetEntityDefinition(World, "Shell"), 1);
+        Player.TickCommand.Add(TickCommands.WeaponSlot3);
+        World.Tick();
+        InventoryUtil.AssertWeapon(Player.PendingWeapon, "Shotgun");
+        Player.PendingWeapon.Should().NotBeNull();
+    }
+
+    [Fact(DisplayName = "Player doesn't switch to weapon with no ammo by cycle command")]
+    public void NoAmmoSelectByCycleCommand()
+    {
+        World.Config.WeaponPreference.NoAmmoSelect.Set(false);
+        Player.GiveItem(GameActions.GetEntityDefinition(World, "Shotgun"), null);
+        InventoryUtil.AssertHasWeapon(Player, "Shotgun");
+        InventoryUtil.RunWeaponSwitch(World, Player, "Shotgun");
+        Player.Inventory.SetAmount(GameActions.GetEntityDefinition(World, "Shell"), 0);
+
+        Player.TickCommand.Add(TickCommands.WeaponSlot2);
+        World.Tick();
+        InventoryUtil.RunWeaponSwitch(World, Player, "Pistol");
+
+        Player.TickCommand.Add(TickCommands.PreviousWeapon);
+        World.Tick();
+        InventoryUtil.AssertWeapon(Player.PendingWeapon, "Fist");
+        InventoryUtil.RunWeaponSwitch(World, Player, "Fist");
+
+        Player.TickCommand.Add(TickCommands.PreviousWeapon);
+        World.Tick();
+        InventoryUtil.AssertWeapon(Player.PendingWeapon, "Pistol");
+        InventoryUtil.RunWeaponSwitch(World, Player, "Pistol");
+
+        Player.PendingWeapon.Should().BeNull();
+        InventoryUtil.AssertWeapon(Player.Weapon, "Pistol");
+
+        Player.TickCommand.Add(TickCommands.NextWeapon);
+        World.Tick();
+        InventoryUtil.AssertWeapon(Player.PendingWeapon, "Fist");
+        InventoryUtil.RunWeaponSwitch(World, Player, "Fist");
+
+        Player.TickCommand.Add(TickCommands.NextWeapon);
+        World.Tick();
+        InventoryUtil.AssertWeapon(Player.PendingWeapon, "Pistol");
+        InventoryUtil.RunWeaponSwitch(World, Player, "Pistol");
+
+        Player.TickCommand.Add(TickCommands.NextWeapon);
+        World.Tick();
+        InventoryUtil.AssertWeapon(Player.PendingWeapon, "Fist");
+        InventoryUtil.RunWeaponSwitch(World, Player, "Fist");
+
+        Player.Inventory.SetAmount(GameActions.GetEntityDefinition(World, "Clip"), 0);
+        Player.TickCommand.Add(TickCommands.NextWeapon);
+        World.Tick();
+        Player.PendingWeapon.Should().BeNull();
+        World.Tick();
+
+        Player.Inventory.SetAmount(GameActions.GetEntityDefinition(World, "Shell"), 1);
+        Player.TickCommand.Add(TickCommands.NextWeapon);
+        World.Tick();
+        InventoryUtil.AssertWeapon(Player.PendingWeapon, "Shotgun");
+        InventoryUtil.RunWeaponSwitch(World, Player, "Shotgun");
+    }
+
+    private void SetWeaponPreferencePriority()
+    {
+        World.Config.WeaponPreference.SuperShotgun.Set(10);
+        World.Config.WeaponPreference.PlasmaRifle.Set(9);
+        World.Config.WeaponPreference.Shotgun.Set(8);
+        World.Config.WeaponPreference.Chaingun.Set(8);
+        World.Config.WeaponPreference.RocketLauncher.Set(2);
+        World.Config.WeaponPreference.Chainsaw.Set(1);
+        World.Config.WeaponPreference.Pistol.Set(0);
+    }
+}

--- a/Tests/Unit/GameAction/Inventory/Inventory_WeaponSwitchPreference.cs
+++ b/Tests/Unit/GameAction/Inventory/Inventory_WeaponSwitchPreference.cs
@@ -22,7 +22,7 @@ public partial class Inventory
     [Fact(DisplayName = "Never switch weapon pickup")]
     public void NeverSwitch()
     {
-        World.Config.WeaponPreference.Preference.Set(WeaponSwitch.Never);
+        World.Config.Weapons.SwitchPreference.Set(WeaponSwitch.Never);
 
         foreach (var weapon in WeaponNames)
         {
@@ -35,7 +35,7 @@ public partial class Inventory
     [Fact(DisplayName = "Weapon pick doesn't switch while attacking")]
     public void AlwaysNoAttack()
     {
-        World.Config.WeaponPreference.Preference.Set(WeaponSwitch.AlwaysExceptAttack);
+        World.Config.Weapons.SwitchPreference.Set(WeaponSwitch.AlwaysExceptAttack);
         SetWeaponPreferencePriority();
 
         Player.GiveItem(GameActions.GetEntityDefinition(World, "RocketLauncher"), null);
@@ -50,7 +50,7 @@ public partial class Inventory
     [Fact(DisplayName = "Weapon preference priority doesn't switch while attack")]
     public void WeaponPreference()
     {
-        World.Config.WeaponPreference.Preference.Set(WeaponSwitch.PreferenceExceptAttack);
+        World.Config.Weapons.SwitchPreference.Set(WeaponSwitch.PreferenceExceptAttack);
         SetWeaponPreferencePriority();
 
         Player.GiveItem(GameActions.GetEntityDefinition(World, "RocketLauncher"), null);
@@ -65,7 +65,7 @@ public partial class Inventory
     [Fact(DisplayName = "Weapon preference priority")]
     public void WeaponPreferencePriority()
     {
-        World.Config.WeaponPreference.Preference.Set(WeaponSwitch.Preference);
+        World.Config.Weapons.SwitchPreference.Set(WeaponSwitch.Preference);
         SetWeaponPreferencePriority();
 
         Player.GiveItem(GameActions.GetEntityDefinition(World, "Chainsaw"), null);
@@ -98,7 +98,7 @@ public partial class Inventory
     [Fact(DisplayName = "Pending weapon preference priority")]
     public void PendingWeaponPreferencePriority()
     {
-        World.Config.WeaponPreference.Preference.Set(WeaponSwitch.Preference);
+        World.Config.Weapons.SwitchPreference.Set(WeaponSwitch.Preference);
         SetWeaponPreferencePriority();
 
         Player.GiveItem(GameActions.GetEntityDefinition(World, "SuperShotgun"), null);
@@ -114,7 +114,7 @@ public partial class Inventory
     [Fact(DisplayName = "Player doesn't switch to weapon with no ammo by slot command")]
     public void NoAmmoSelectBySlotCommand()
     {
-        World.Config.WeaponPreference.NoAmmoSelect.Set(false);
+        World.Config.Weapons.NoAmmoSelect.Set(false);
         Player.GiveItem(GameActions.GetEntityDefinition(World, "Shotgun"), null);
         InventoryUtil.AssertHasWeapon(Player, "Shotgun");
         InventoryUtil.RunWeaponSwitch(World, Player, "Shotgun");
@@ -140,7 +140,7 @@ public partial class Inventory
     [Fact(DisplayName = "Player doesn't switch to weapon with no ammo by cycle command")]
     public void NoAmmoSelectByCycleCommand()
     {
-        World.Config.WeaponPreference.NoAmmoSelect.Set(false);
+        World.Config.Weapons.NoAmmoSelect.Set(false);
         Player.GiveItem(GameActions.GetEntityDefinition(World, "Shotgun"), null);
         InventoryUtil.AssertHasWeapon(Player, "Shotgun");
         InventoryUtil.RunWeaponSwitch(World, Player, "Shotgun");
@@ -193,12 +193,12 @@ public partial class Inventory
 
     private void SetWeaponPreferencePriority()
     {
-        World.Config.WeaponPreference.SuperShotgun.Set(10);
-        World.Config.WeaponPreference.PlasmaRifle.Set(9);
-        World.Config.WeaponPreference.Shotgun.Set(8);
-        World.Config.WeaponPreference.Chaingun.Set(8);
-        World.Config.WeaponPreference.RocketLauncher.Set(2);
-        World.Config.WeaponPreference.Chainsaw.Set(1);
-        World.Config.WeaponPreference.Pistol.Set(0);
+        World.Config.Weapons.SuperShotgun.Set(10);
+        World.Config.Weapons.PlasmaRifle.Set(9);
+        World.Config.Weapons.Shotgun.Set(8);
+        World.Config.Weapons.Chaingun.Set(8);
+        World.Config.Weapons.RocketLauncher.Set(2);
+        World.Config.Weapons.Chainsaw.Set(1);
+        World.Config.Weapons.Pistol.Set(0);
     }
 }


### PR DESCRIPTION
Weapon switch pickup preferences and priority configuration. Includes options for always, always except when attacking, never, priority, and priority except when attacking.

fixes #681 