### PR TITLE
Add ability to change map in console with a number

### DIFF
--- a/Client/Client.Commands.cs
+++ b/Client/Client.Commands.cs
@@ -436,6 +436,11 @@ public partial class Client
                 return;
             }
 
+            if (mapName.All(char.IsDigit))
+            {
+                mapName = "MAP" + int.Parse(mapName, CultureInfo.InvariantCulture).ToString("D2", CultureInfo.InvariantCulture);
+            }
+
             MapInfoDef mapInfo = GetMapInfo(mapName);
             NewGame(mapInfo);
         }

--- a/Client/Client.Commands.cs
+++ b/Client/Client.Commands.cs
@@ -435,10 +435,11 @@ public partial class Client
                 NewGame(m_archiveCollection.Definitions.MapInfoDefinition.MapInfo.GetStartMapOrDefault(m_archiveCollection, mapName));
                 return;
             }
-
-            if (mapName.All(char.IsDigit))
+            
+            if (MapWarp.GetMap(mapName, m_archiveCollection, out var selectedMapInfo))
             {
-                mapName = "MAP" + int.Parse(mapName, CultureInfo.InvariantCulture).ToString("D2", CultureInfo.InvariantCulture);
+                NewGame(selectedMapInfo);
+                return;
             }
 
             MapInfoDef mapInfo = GetMapInfo(mapName);


### PR DESCRIPTION
Currently when you type `map 1` in the console, it doesn't work because it can't find the map `1`. The game expect `MAP01`.
With this PR, if the map given in the command is a number, it converts to 'MAPxx'.

I hope it looks okay!