### PR TITLE
Clarify title for PUSS X Summer of Slaughter screenshot

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -25,7 +25,7 @@ image:https://i.imgur.com/iA4bVzs.png[Knee-Deep in Knee-Deep in ZDoom Z1M1] +
 Knee-Deep in Knee-Deep in ZDoom Z1M1
 
 image:https://i.imgur.com/dVbYPg4.png[PUSSX Summer of Slaught MAP32] +
-PUSS X Summer of Slaughter MAP32 (SOS_BOOM.wad)
+PUSS X Summer of Slaughter MAP31: No Living Land (MAP32 in SOS_BOOM.wad)
 
 image:https://i.imgur.com/XyD6UA2.png[Sunlust MAP28] +
 Sunlust MAP28


### PR DESCRIPTION
The "official" position of the map is MAP31 according to the idgames `.txt`, but it is MAP32 in the BOOM WAD.