### PR TITLE
Improve vanilla render performance with 16 bit float buffer

### DIFF
--- a/Core/Render/OpenGL/Framebuffer/PlaneClipFrameBuffer.cs
+++ b/Core/Render/OpenGL/Framebuffer/PlaneClipFrameBuffer.cs
@@ -27,7 +27,7 @@ public class PlaneClipFrameBuffer : IDisposable
         m_texture = GL.GenTexture();
         GL.BindTexture(TextureTarget.Texture2D, m_texture);
         GLHelper.ObjectLabel(ObjectLabelIdentifier.Texture, m_texture, $"{name} Texture");
-        GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgba32f, width, height, 0, PixelFormat.Rgba, PixelType.Float, IntPtr.Zero);
+        GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgba16f, width, height, 0, PixelFormat.Rgba, PixelType.Float, IntPtr.Zero);
         GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int)TextureMinFilter.Nearest);
         GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int)TextureMagFilter.Nearest);
         GL.BindTexture(TextureTarget.Texture2D, 0);

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
@@ -407,7 +407,7 @@ public class EntityProgram : RenderProgram
             
             if (wallClip.r >= 0) {
                 int byte0 = int(wallClip.r);
-                int byte1 = int(wallClip.a);
+                int byte1 = int(wallClip.g);
                 int packedByte = int(wallClip.b);
                 int byte2 = packedByte >> 2;
                 int upperLowerFlag = packedByte & 0x3;
@@ -438,7 +438,7 @@ public class EntityProgram : RenderProgram
                         return false;
                 }
 
-                if (wallClip.g < depthFrag) {
+                if (wallClip.a < depthFrag) {
                     // Discard if the sprite isn't on the same side of the line as the camera or when the sprite line doesn't intersect the line
                     return viewFront != entityFront || !lineIntersection(lineStart, lineEnd, minPosFrag.xy, maxPosFrag.xy);
                 }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
@@ -394,7 +394,7 @@ public class EntityProgram : RenderProgram
 
         bool discardPlaneClip() {
             ivec2 sampleCoords = ivec2(clamp(gl_FragCoord.xy / downScaleAmount, vec2(0.0), screenBounds / downScaleAmount));
-            vec3 wallClip = texelFetch(wallClipTexture, sampleCoords, 0).rgb;
+            vec4 wallClip = texelFetch(wallClipTexture, sampleCoords, 0).rgba;
             vec3 planeClip = texelFetch(planeClipTexture, sampleCoords, 0).rgb;
 
             // Floor
@@ -405,9 +405,17 @@ public class EntityProgram : RenderProgram
             if (planeClip.b == 2 && planeClip.g < depthFrag && zPosFrag >= planeClip.r)
                 return true;
             
-            if (wallClip.r >= 0) {
-                vec4 linePoints = texelFetch(mapDataTexture, int(wallClip.r));
-                vec3 floorHeights = texelFetch(lineHeightsTexture, int(wallClip.r)).rgb;
+            if (wallClip.r >= 0 || wallClip.a >= 0) {
+                int byte0 = int(wallClip.r);
+                int byte1 = int(wallClip.a);
+                int packedByte = int(wallClip.b);
+                int byte2 = packedByte >> 2;
+                int upperLowerFlag = packedByte & 0x3;
+
+                int lineId = byte0 | (byte1 << 8) | (byte2 << 16);
+
+                vec4 linePoints = texelFetch(mapDataTexture, lineId);
+                vec3 floorHeights = texelFetch(lineHeightsTexture, lineId).rgb;
                 float renderBlock = floorHeights.b;
                 float floorHeight = mix(floorHeights.r, floorHeights.g, timeFrac);
                 vec2 lineStart = linePoints.rg;
@@ -424,7 +432,7 @@ public class EntityProgram : RenderProgram
                 // lower wall
                 // renderBlock: 1 = front side, 2 = back side, 3 = both. Doom will clip if there is midtex.
                 float blockSide = mix(2, 1, float(viewFront));
-                if (wallClip.b == 1 && renderBlock != 3 && renderBlock != blockSide &&
+                if (upperLowerFlag == 1 && renderBlock != 3 && renderBlock != blockSide &&
                     distanceToWallSquared <= max(40*40, textureWidthFrag*textureWidthFrag) && 
                     viewPos.z > floorHeight && floorHeight <= zPosFrag) {
                         return false;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
@@ -405,7 +405,7 @@ public class EntityProgram : RenderProgram
             if (planeClip.b == 2 && planeClip.g < depthFrag && zPosFrag >= planeClip.r)
                 return true;
             
-            if (wallClip.r >= 0 || wallClip.a >= 0) {
+            if (wallClip.r >= 0) {
                 int byte0 = int(wallClip.r);
                 int byte1 = int(wallClip.a);
                 int packedByte = int(wallClip.b);

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/PlaneClip.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/PlaneClip.cs
@@ -37,7 +37,9 @@ public static class PlaneClip
                 int lineId = int(mapIdFrag);
                 int byte0 = lineId & 0xFF;
                 int byte1 = (lineId >> 8) & 0xFF;
+                // Pack lower and upper flags and overflow bytes after 65536 for line id.
+                // This should allow for 256x256x64 = 4,194,304 line ids.
                 int byte2 = ((lineId >> 16) & 0x3F) << 2 | int(lowerFrag + (upperFrag * 2));
-                outPlane = vec4(byte0, depthFrag, byte2, byte1);
+                outPlane = vec4(byte0, byte1, byte2, depthFrag);
             }";
 }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/PlaneClip.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/PlaneClip.cs
@@ -26,13 +26,18 @@ public static class PlaneClip
             flat in float lowerFrag;
             in float depthFrag;
 
-            layout (location = 0) out vec3 outPlane;
+            layout (location = 0) out vec4 outPlane;
 
             void main() {
                 // This is required for flood fill rendering that doesn't separate planes(floor/ceiling) from walls
                 // Planes are written with -1 and need to be discarded
                 if (mapIdFrag < 0)
                     discard;
-                outPlane = vec3(mapIdFrag, depthFrag, lowerFrag + (upperFrag * 2));
+                
+                int lineId = int(mapIdFrag);
+                int byte0 = lineId & 0xFF;
+                int byte1 = (lineId >> 8) & 0xFF;
+                int byte2 = ((lineId >> 16) & 0x3F) << 2 | int(lowerFrag + (upperFrag * 2));
+                outPlane = vec4(byte0, depthFrag, byte2, byte1);
             }";
 }

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -9,6 +9,7 @@
 - Small improvement on save performance in maps with a significant number of things.
 - Save game serilization improvements on memory usage.
 - Support doom UDMF namespace.
+- Improved performance with emulate vanilla rendering.
 
 ## Bug Fixes:
 - Fix sprite frames to correctly calculate when lowercase.


### PR DESCRIPTION
Use Rgba16f instead Rgba32f for the clip buffer to improve rendering performance.