### PR TITLE
use multiple render targets for drawing flats and writing clip information

### DIFF
--- a/Core/Render/OpenGL/Framebuffer/PlaneClipFrameBuffer.cs
+++ b/Core/Render/OpenGL/Framebuffer/PlaneClipFrameBuffer.cs
@@ -10,7 +10,7 @@ public class PlaneClipFrameBuffer : IDisposable
 {
     private int m_framebuffer;
     private int m_texture;
-    private int m_clearBuffer;
+    private int m_clearBufferIndex;
     private Dimension m_dimension;
     private GLTexture2D? m_depthTexture;
 
@@ -36,7 +36,7 @@ public class PlaneClipFrameBuffer : IDisposable
         int depthTextureTarget;
         if (colorFramebuffer == null)
         {
-            m_clearBuffer = 0;
+            m_clearBufferIndex = 0;
             m_depthTexture = new GLTexture2D($"{name} Depth Stencil Attachment", m_dimension);
             m_depthTexture.Bind();
             GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Depth32fStencil8, width, height, 0, PixelFormat.DepthStencil, PixelType.Float32UnsignedInt248Rev, IntPtr.Zero);
@@ -47,7 +47,7 @@ public class PlaneClipFrameBuffer : IDisposable
         {
             if (colorFramebuffer.DepthTexture == null)
                 throw new Exception("Framebuffer must have a depth texture");
-            m_clearBuffer = 1;
+            m_clearBufferIndex = 1;
             depthTextureTarget = colorFramebuffer.DepthTexture.Name;
         }
 
@@ -92,7 +92,7 @@ public class PlaneClipFrameBuffer : IDisposable
     {
         GL.Clear(ClearBufferMask.DepthBufferBit);
         var clear = stackalloc float[3] { -1e30f, 1e30f, -1 };
-        GL.ClearBuffer(ClearBuffer.Color, m_clearBuffer, clear);
+        GL.ClearBuffer(ClearBuffer.Color, m_clearBufferIndex, clear);
         GL.Clear(ClearBufferMask.DepthBufferBit);
     }
 

--- a/Core/Render/OpenGL/Framebuffer/PlaneClipFrameBuffer.cs
+++ b/Core/Render/OpenGL/Framebuffer/PlaneClipFrameBuffer.cs
@@ -13,6 +13,7 @@ public class PlaneClipFrameBuffer : IDisposable
     private int m_clearBufferIndex;
     private Dimension m_dimension;
     private GLTexture2D? m_depthTexture;
+    private bool m_ownsDepthTexture;
 
     public void CreateOrUpdate(string name, Dimension dimension, GLFramebuffer? colorFramebuffer, bool forceCreate)
     {
@@ -36,6 +37,7 @@ public class PlaneClipFrameBuffer : IDisposable
         int depthTextureTarget;
         if (colorFramebuffer == null)
         {
+            m_ownsDepthTexture = true;
             m_clearBufferIndex = 0;
             m_depthTexture = new GLTexture2D($"{name} Depth Stencil Attachment", m_dimension);
             m_depthTexture.Bind();
@@ -90,10 +92,14 @@ public class PlaneClipFrameBuffer : IDisposable
 
     public unsafe void Clear()
     {
-        GL.Clear(ClearBufferMask.DepthBufferBit);
+        if (m_ownsDepthTexture)
+            GL.Clear(ClearBufferMask.DepthBufferBit);
+
         var clear = stackalloc float[3] { -1e30f, 1e30f, -1 };
         GL.ClearBuffer(ClearBuffer.Color, m_clearBufferIndex, clear);
-        GL.Clear(ClearBufferMask.DepthBufferBit);
+
+        if (m_ownsDepthTexture)
+            GL.Clear(ClearBufferMask.DepthBufferBit);
     }
 
     public static unsafe void StartRender()

--- a/Core/Render/OpenGL/Framebuffer/PlaneClipFrameBuffer.cs
+++ b/Core/Render/OpenGL/Framebuffer/PlaneClipFrameBuffer.cs
@@ -6,6 +6,12 @@ using System;
 
 namespace Helion.Render.OpenGL.Framebuffer;
 
+/// <summary>
+/// Writes clip info for vanilla sprite clipping emulation.
+/// Supports multiple render targets if colorFramebuffer is not null and will use the depth texture from that framebuffer.
+/// ColorAttachment0 will be fragColor, and ColorAttachment1 will be outPlane.
+/// If no colorFramebuffer is specified then this framebuffer will allocate and use it's own depth texture with ColorAttachment0 for outPlane.
+/// </summary>
 public class PlaneClipFrameBuffer : IDisposable
 {
     private int m_framebuffer;
@@ -15,6 +21,12 @@ public class PlaneClipFrameBuffer : IDisposable
     private GLTexture2D? m_depthTexture;
     private bool m_ownsDepthTexture;
 
+    /// <summary>
+    /// Creates or updates internal buffers and textures.
+    /// </summary>
+    /// <param name="name">The debug label name for buffers and textures</param>
+    /// <param name="dimension">The dimension to use for allocated buffers and textures</param>
+    /// <param name="forceCreate">If the underlying buffers and textures should be forced to be recreated</param>
     public void CreateOrUpdate(string name, Dimension dimension, GLFramebuffer? colorFramebuffer, bool forceCreate)
     {
         if (!ShouldRecreate(dimension, forceCreate))
@@ -49,6 +61,7 @@ public class PlaneClipFrameBuffer : IDisposable
         {
             if (colorFramebuffer.DepthTexture == null)
                 throw new Exception("Framebuffer must have a depth texture");
+            // Support using the depth buffer from another framebuffer
             m_clearBufferIndex = 1;
             depthTextureTarget = colorFramebuffer.DepthTexture.Name;
         }

--- a/Core/Render/OpenGL/Framebuffer/PlaneClipFrameBuffer.cs
+++ b/Core/Render/OpenGL/Framebuffer/PlaneClipFrameBuffer.cs
@@ -10,12 +10,13 @@ public class PlaneClipFrameBuffer : IDisposable
 {
     private int m_framebuffer;
     private int m_texture;
+    private int m_clearBuffer;
     private Dimension m_dimension;
     private GLTexture2D? m_depthTexture;
 
-    public void CreateOrUpdate(string name, Dimension dimension)
+    public void CreateOrUpdate(string name, Dimension dimension, GLFramebuffer? colorFramebuffer, bool forceCreate)
     {
-        if (m_framebuffer != 0 && dimension.Width == m_dimension.Width && dimension.Height == m_dimension.Height)
+        if (!ShouldRecreate(dimension, forceCreate))
             return;
 
         DeleteData();
@@ -32,28 +33,66 @@ public class PlaneClipFrameBuffer : IDisposable
         GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int)TextureMagFilter.Nearest);
         GL.BindTexture(TextureTarget.Texture2D, 0);
 
-        m_depthTexture = new GLTexture2D($"{name} Depth Stencil Attachment", m_dimension);
-        m_depthTexture.Bind();
-        GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Depth32fStencil8, width, height, 0, PixelFormat.DepthStencil, PixelType.Float32UnsignedInt248Rev, IntPtr.Zero);
-        m_depthTexture.Unbind();
+        int depthTextureTarget;
+        if (colorFramebuffer == null)
+        {
+            m_clearBuffer = 0;
+            m_depthTexture = new GLTexture2D($"{name} Depth Stencil Attachment", m_dimension);
+            m_depthTexture.Bind();
+            GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Depth32fStencil8, width, height, 0, PixelFormat.DepthStencil, PixelType.Float32UnsignedInt248Rev, IntPtr.Zero);
+            m_depthTexture.Unbind();
+            depthTextureTarget = m_depthTexture.Name;
+        }
+        else
+        {
+            if (colorFramebuffer.DepthTexture == null)
+                throw new Exception("Framebuffer must have a depth texture");
+            m_clearBuffer = 1;
+            depthTextureTarget = colorFramebuffer.DepthTexture.Name;
+        }
 
         m_framebuffer = GL.GenFramebuffer();
         GLHelper.ObjectLabel(ObjectLabelIdentifier.Framebuffer, m_framebuffer, $"{name} Framebuffer");
         GL.BindFramebuffer(FramebufferTarget.Framebuffer, m_framebuffer);
-        GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment0, TextureTarget.Texture2D, m_texture, 0);
-        GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.DepthStencilAttachment, TextureTarget.Texture2D, m_depthTexture.Name, 0);
-        GL.DrawBuffer(DrawBufferMode.ColorAttachment0);
+
+        if (colorFramebuffer == null)
+        {
+            GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment0, TextureTarget.Texture2D, m_texture, 0);
+        }
+        else
+        {
+            GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment0, TextureTarget.Texture2D, colorFramebuffer.ColorAttachment0.Name, 0);
+            GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment1, TextureTarget.Texture2D, m_texture, 0);
+        }
+
+        GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.DepthStencilAttachment, TextureTarget.Texture2D, depthTextureTarget, 0);
+
+        if (colorFramebuffer == null)
+            GL.DrawBuffer(DrawBufferMode.ColorAttachment0);
+        else
+            GL.DrawBuffers(2, [DrawBuffersEnum.ColorAttachment0, DrawBuffersEnum.ColorAttachment1]);
 
         var status = GL.CheckFramebufferStatus(FramebufferTarget.Framebuffer);
         if (status != FramebufferErrorCode.FramebufferComplete)
             throw new Exception("Failed to complete PlaneClip framebuffer");
     }
 
+    private bool ShouldRecreate(Dimension dimension, bool force)
+    {
+        if (force)
+            return true;
+
+        if (m_framebuffer != 0 && dimension.Width == m_dimension.Width && dimension.Height == m_dimension.Height)
+            return false;
+
+        return true;
+    }
+
     public unsafe void Clear()
     {
         GL.Clear(ClearBufferMask.DepthBufferBit);
         var clear = stackalloc float[3] { -1e30f, 1e30f, -1 };
-        GL.ClearBuffer(ClearBuffer.Color, 0, clear);
+        GL.ClearBuffer(ClearBuffer.Color, m_clearBuffer, clear);
         GL.Clear(ClearBufferMask.DepthBufferBit);
     }
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationPlaneClipShaderMrt.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationPlaneClipShaderMrt.cs
@@ -1,0 +1,9 @@
+﻿namespace Helion.Render.OpenGL.Renderers.Legacy.World;
+
+public class InterpolationPlaneClipShaderMrt : InterpolationShader
+{
+    public InterpolationPlaneClipShaderMrt() : base("PlaneClip MRT")
+    {
+
+    }
+}

--- a/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
@@ -169,6 +169,8 @@ public class InterpolationShader : RenderProgram
         if (this is InterpolationWallClipShader)
             return PlaneClip.WriteWallFragFunction();
 
+        var planeClip = this is InterpolationPlaneClipShaderMrt;
+
         return
             @"
             #version 330
@@ -178,10 +180,12 @@ public class InterpolationShader : RenderProgram
             flat in float addAlphaFrag;
             flat in float zPos;
             flat in float distFrag;
+            flat in float upperFrag;
+            flat in float lowerFrag;
             in float depthFrag;
             ${VertexGapVariables}
 
-            ${OutFragColor}
+            ${OutTargets}
 
             uniform int hasInvulnerability;
             uniform sampler2D boundTexture;
@@ -215,6 +219,7 @@ public class InterpolationShader : RenderProgram
                 ${LightLevelFragFunction}
                 ${SectorColorMapFragFunction}
                 ${FragColorFunction}
+                ${OutPlane}
             }
         "
         .Replace("${LightLevelFragFunction}", LightLevel.FragFunction)
@@ -223,8 +228,9 @@ public class InterpolationShader : RenderProgram
         .Replace("${SectorColorMapFragVariables}", SectorColorMap.FragVariables)
         .Replace("${SectorColorMapFragFunction}", SectorColorMap.FragFunction)
         .Replace("${OitVariables}", FragFunction.OitFragVariables(GetOitOptions()))
-        .Replace("${OutFragColor}", GetOutFragColor())
-        .Replace("${VertexGapVariables}", FragFunction.VertexGapVariables);
+        .Replace("${OutTargets}", GetOutTargets(planeClip))
+        .Replace("${VertexGapVariables}", FragFunction.VertexGapVariables)
+        .Replace("${OutPlane}", PlaneClip.GetOutPlane(planeClip));
     }
 
     private OitOptions GetOitOptions()
@@ -236,11 +242,12 @@ public class InterpolationShader : RenderProgram
         return OitOptions.None;
     }
 
-    private string GetOutFragColor()
+    private string GetOutTargets(bool planeClip)
     {
         var options = GetOitOptions();
         if (options == OitOptions.OitTransparentPass)
             return "";
-        return "out vec4 fragColor;";
+
+        return PlaneClip.GetOutTargets(planeClip);
     }
 }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -424,9 +424,10 @@ public class LegacyWorldRenderer : WorldRenderer
                 GL.ActiveTexture(BindTextures.BoundTexture);
                 SetStaticUniforms(m_staticWallClipProgram, renderInfo);
                 m_geometryRenderer.RenderStaticOneSidedCoverWalls();
-                GL.Disable(EnableCap.CullFace);
                 m_geometryRenderer.RenderStaticCoverWalls();
-                GL.Enable(EnableCap.CullFace);
+                GL.CullFace(TriangleFace.Front);
+                m_geometryRenderer.RenderStaticCoverWalls();
+                GL.CullFace(TriangleFace.Back);
                 m_staticWallClipProgram.Unbind();
             }
             else

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -34,10 +34,12 @@ public class LegacyWorldRenderer : WorldRenderer
     private readonly InterpolationShader m_interpolationProgram = new("Main");
     private readonly InterpolationTransparentShader m_interpolationTransparentProgram = new();
     private readonly InterpolationCompositeShader m_interpolationCompositeProgram = new();
-    private readonly InterpolationPlaneClipShader m_interpolationPlaneClipShader = new();
+    private readonly InterpolationPlaneClipShader m_interpolationPlaneClipProgram = new();
+    private readonly InterpolationPlaneClipShaderMrt m_interpolationPlaneClipMrtProgram = new();
     private readonly InterpolationWallClipShader m_interpolationWallClipShader = new();
     private readonly StaticShader m_staticProgram = new("Main");
     private readonly StaticPlaneClipShader m_staticPlaneClipProgram = new();
+    private readonly StaticPlaneClipShaderMrt m_staticPlaneClipMrtProgram = new();
     private readonly StaticWallClipShader m_staticWallClipProgram = new();
     private readonly RenderWorldDataManager m_worldDataManager = new();
     private readonly ArchiveCollection m_archiveCollection;
@@ -51,6 +53,7 @@ public class LegacyWorldRenderer : WorldRenderer
     private bool m_renderStatic;
     private bool m_lastRenderStatic;
     private bool m_pixelGapCorrection;
+    private bool m_downscaleVanillaBuffer;
     private int m_lastTicker = -1;
     private Entity? m_viewerEntity;
     private IWorld? m_previousWorld;
@@ -282,7 +285,9 @@ public class LegacyWorldRenderer : WorldRenderer
         var dimension = new Dimension(renderInfo.Viewport.Width, renderInfo.Viewport.Height);
         m_oitFrameBuffer.CreateOrUpdate(dimension, framebuffer.DepthTexture);
 
-        SetupClipBuffers(framebuffer, dimension);
+        var prevDownscale = m_downscaleVanillaBuffer;
+        m_downscaleVanillaBuffer = m_config.Render.DownScaleVanillaRenderSampleBuffer.Value > 1;
+        SetupClipBuffers(framebuffer, dimension, prevDownscale != m_downscaleVanillaBuffer);
 
         if (m_lastTicker != world.GameTicker)
             m_entityRenderer.Start(renderInfo);
@@ -332,8 +337,12 @@ public class LegacyWorldRenderer : WorldRenderer
         SetInterpolationUniforms(m_interpolationProgram, renderInfo, false);
         m_interpolationProgram.VertexGapClampUV(m_pixelGapCorrection);
         m_worldDataManager.RenderWalls();
-        m_interpolationProgram.VertexGapClampUV(false);
-        m_worldDataManager.RenderFlats();
+
+        if (m_downscaleVanillaBuffer)
+        {
+            m_interpolationProgram.VertexGapClampUV(false);
+            m_worldDataManager.RenderFlats();
+        }
 
         if (m_renderStatic)
         {
@@ -342,17 +351,18 @@ public class LegacyWorldRenderer : WorldRenderer
             SetStaticUniforms(m_staticProgram, renderInfo);
             m_staticProgram.VertexGapClampUV(m_pixelGapCorrection);
             m_geometryRenderer.RenderStaticGeometryWalls();
-            m_staticProgram.VertexGapClampUV(false);
-            m_geometryRenderer.RenderStaticGeometryFlats();
+
+            if (m_downscaleVanillaBuffer)
+            {
+                m_staticProgram.VertexGapClampUV(false);
+                m_geometryRenderer.RenderStaticGeometryFlats();
+            }
         }
 
         RenderTwoSidedMiddleWalls(renderInfo);
 
-        GL.Clear(ClearBufferMask.DepthBufferBit);
-        GL.ColorMask(false, false, false, false);
-        // Write two-sided middle walls to depth as these generally look better with normal discard handling
-        RenderTwoSidedMiddleWalls(renderInfo);
-        GL.ColorMask(true, true, true, true);
+        if (m_downscaleVanillaBuffer)
+            RenderTwoSidedMiddleWallsToDepth(renderInfo);
 
         if (m_wallClipFrameBuffer != null || m_planeClipFrameBuffer != null)
             WriteSpriteClipBuffers(renderInfo, framebuffer);
@@ -378,22 +388,36 @@ public class LegacyWorldRenderer : WorldRenderer
             GL.Viewport(viewport.X, viewport.Y, viewport.Width, viewport.Height);
         }
 
-        if (m_wallClipFrameBuffer != null)
-            WritePlaneClipData(m_wallClipFrameBuffer, useRenderInfo, framebuffer, true);
-
         if (m_planeClipFrameBuffer != null)
             WritePlaneClipData(m_planeClipFrameBuffer, useRenderInfo, framebuffer, false);
+
+        if (!m_downscaleVanillaBuffer)
+            RenderTwoSidedMiddleWallsToDepth(renderInfo);
+
+        if (m_wallClipFrameBuffer != null)
+            WritePlaneClipData(m_wallClipFrameBuffer, useRenderInfo, framebuffer, true);
 
         if (renderInfo.Uniforms.DownScaleAmount > 1)
             GL.Viewport(renderInfo.Viewport.X, renderInfo.Viewport.Y, renderInfo.Viewport.Width, renderInfo.Viewport.Height);
     }
 
-    private void SetupClipBuffers(GLFramebuffer framebuffer, Dimension dimension)
+    private void RenderTwoSidedMiddleWallsToDepth(RenderInfo renderInfo)
+    {
+        // TODO - this could be done with mrt shaders as an optimization instead of drawing twice
+        GL.Clear(ClearBufferMask.DepthBufferBit);
+        GL.ColorMask(false, false, false, false);
+        // Write two-sided middle walls to depth as these generally look better with normal discard handling
+        RenderTwoSidedMiddleWalls(renderInfo);
+        GL.ColorMask(true, true, true, true);
+    }
+
+    private void SetupClipBuffers(GLFramebuffer framebuffer, Dimension dimension, bool downscaleChanged)
     {
         bool bind = false;
         if (m_planeClipFrameBuffer != null)
         {
-            m_planeClipFrameBuffer.CreateOrUpdate("PlaneClip", dimension);
+            var colorBuffer = m_downscaleVanillaBuffer ? null : framebuffer;
+            m_planeClipFrameBuffer.CreateOrUpdate("PlaneClip", dimension, colorBuffer, downscaleChanged);
             m_planeClipFrameBuffer.BindFrameBuffer();
             m_planeClipFrameBuffer.Clear();
             bind = true;
@@ -401,7 +425,7 @@ public class LegacyWorldRenderer : WorldRenderer
 
         if (m_wallClipFrameBuffer != null)
         {
-            m_wallClipFrameBuffer.CreateOrUpdate("WallClip", dimension);
+            m_wallClipFrameBuffer.CreateOrUpdate("WallClip", dimension, null, false);
             m_wallClipFrameBuffer.BindFrameBuffer();
             m_wallClipFrameBuffer.Clear();
             bind = true;
@@ -432,11 +456,13 @@ public class LegacyWorldRenderer : WorldRenderer
             }
             else
             {
-                m_staticPlaneClipProgram.Bind();
+                StaticShader program = m_downscaleVanillaBuffer ? m_staticPlaneClipProgram : m_staticPlaneClipMrtProgram;
+                program.Bind();
                 GL.ActiveTexture(BindTextures.BoundTexture);
-                SetStaticUniforms(m_staticPlaneClipProgram, renderInfo);
+                program.VertexGapClampUV(false);
+                SetStaticUniforms(program, renderInfo);
                 m_geometryRenderer.RenderStaticGeometryFlats();
-                m_staticPlaneClipProgram.Unbind();
+                program.Unbind();
             }
         }
 
@@ -453,11 +479,12 @@ public class LegacyWorldRenderer : WorldRenderer
         }
         else
         {
-            m_interpolationPlaneClipShader.Bind();
+            InterpolationShader program = m_downscaleVanillaBuffer ? m_interpolationPlaneClipProgram : m_interpolationPlaneClipMrtProgram;
+            program.Bind();
             GL.ActiveTexture(BindTextures.BoundTexture);
-            SetInterpolationUniforms(m_interpolationPlaneClipShader, renderInfo, false);
+            SetInterpolationUniforms(program, renderInfo, false);
             m_worldDataManager.RenderFlats();
-            m_interpolationPlaneClipShader.Unbind();
+            program.Unbind();
         }
 
         PlaneClipFrameBuffer.UnbindFrameBuffer();

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/PlaneClip.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/PlaneClip.cs
@@ -42,4 +42,26 @@ public static class PlaneClip
                 int byte2 = ((lineId >> 16) & 0x3F) << 2 | int(lowerFrag + (upperFrag * 2));
                 outPlane = vec4(byte0, byte1, byte2, depthFrag);
             }";
+
+    public static string GetOutPlane(bool planeClip)
+    {
+        if (!planeClip)
+            return string.Empty;
+
+        return @"
+            fragColor = vec4(fragColor.r, fragColor.g, fragColor.b, 1);
+            outPlane = vec3(zPos, depthFrag, lowerFrag + (upperFrag * 2));
+";
+    }
+
+    public static string GetOutTargets(bool planeClip)
+    {
+        if (!planeClip)
+            return "out vec4 fragColor;";
+
+        return @"
+            layout (location = 0) out vec4 fragColor;
+            layout (location = 1) out vec3 outPlane;
+";
+    }
 }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/PlaneClip.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/PlaneClip.cs
@@ -3,7 +3,7 @@
 public static class PlaneClip
 {
     public static string WritePlaneFragFunction() =>
-         @"
+         $@"
             #version 330
 
             flat in float zPos;
@@ -13,9 +13,9 @@ public static class PlaneClip
 
             layout (location = 0) out vec3 outPlane;
 
-            void main() {
-                outPlane = vec3(zPos, depthFrag, lowerFrag + (upperFrag * 2));
-            }";
+            void main() {{
+                {GetOutPlane(true)}
+            }}";
 
     public static string WriteWallFragFunction() =>
          @"
@@ -48,10 +48,7 @@ public static class PlaneClip
         if (!planeClip)
             return string.Empty;
 
-        return @"
-            fragColor = vec4(fragColor.r, fragColor.g, fragColor.b, 1);
-            outPlane = vec3(zPos, depthFrag, lowerFrag + (upperFrag * 2));
-";
+        return "outPlane = vec3(zPos, depthFrag, lowerFrag + (upperFrag * 2));";
     }
 
     public static string GetOutTargets(bool planeClip)

--- a/Core/Render/OpenGL/Renderers/Legacy/World/StaticPlaneClipShaderMrt.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/StaticPlaneClipShaderMrt.cs
@@ -1,0 +1,9 @@
+﻿namespace Helion.Render.OpenGL.Renderers.Legacy.World;
+
+public class StaticPlaneClipShaderMrt : StaticShader
+{
+    public StaticPlaneClipShaderMrt() : base("PlaneClipMRT")
+    {
+
+    }
+}

--- a/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
@@ -141,6 +141,8 @@ public class StaticShader : RenderProgram
         if (this is StaticWallClipShader)
             return PlaneClip.WriteWallFragFunction();
 
+        bool planeClip = this is StaticPlaneClipShaderMrt;
+
         return @"
             #version 330
 
@@ -152,9 +154,10 @@ public class StaticShader : RenderProgram
             flat in float mapIdFrag;
             flat in float upperFrag;
             flat in float lowerFrag;
+            in float depthFrag;
             ${VertexGapVariables}
 
-            out vec4 fragColor;
+            ${OutTargets}
 
             uniform int hasInvulnerability;
             uniform sampler2D boundTexture;
@@ -171,6 +174,7 @@ public class StaticShader : RenderProgram
                 ${LightLevelFragFunction}
                 ${SectorColorMapFragFunction}
                 ${FragColorFunction}
+                ${OutPlane}
             }
         "
         .Replace("${LightLevelFragFunction}", LightLevel.FragFunction)
@@ -178,6 +182,8 @@ public class StaticShader : RenderProgram
         .Replace("${FragColorFunction}", FragFunction.FragColorFunction(FragColorFunctionOptions.AddAlpha | FragColorFunctionOptions.Colormap | FragColorFunctionOptions.VertexGapClampUV | FragColorFunctionOptions.Brightmaps))
         .Replace("${SectorColorMapFragVariables}", SectorColorMap.FragVariables)
         .Replace("${SectorColorMapFragFunction}", SectorColorMap.FragFunction)
-        .Replace("${VertexGapVariables}", FragFunction.VertexGapVariables);
-    }  
+        .Replace("${VertexGapVariables}", FragFunction.VertexGapVariables)
+        .Replace("${OutTargets}", PlaneClip.GetOutTargets(planeClip))
+        .Replace("${OutPlane}", PlaneClip.GetOutPlane(planeClip));
+    }
 }


### PR DESCRIPTION
Use two render targets to draw flats to the clip texture and main framebuffer color texture in the same draw pass. This eliminates drawing flats twice, once for main color framebuffer, and a second for the clip texture.

This change still allows for downscaling the clip buffers but multiple render targets cannot be used in this case. I only left the downscale option since it appears to be significantly faster on iGPUs than the MRT. On my RTX 4070 the opposite is true where MRT is faster than downscaling.

Large performance improvement with emulate vanilla rendering.