### PR TITLE
Udmf parser

### DIFF
--- a/Client/Client.Commands.cs
+++ b/Client/Client.Commands.cs
@@ -503,7 +503,7 @@ public partial class Client
     [ConsoleCommandArg("value", "A decimal value between 0.0 and 1.0")]
     private void CommandSetSoundVolume(ConsoleCommandEventArgs args)
     {
-        if (!SimpleParser.TryParseFloat(args.Args[0], out float volume))
+        if (!NumberParser.TryParseFloat(args.Args[0], out float volume))
         {
             Log.Warn($"Unable to parse sound volume for input: {args.Args[0]}");
             return;

--- a/Client/Client.Commands.cs
+++ b/Client/Client.Commands.cs
@@ -6,6 +6,7 @@ using Helion.Maps;
 using Helion.Maps.Bsp.Zdbsp;
 using Helion.Models;
 using Helion.Render.OpenGL.Shared;
+using Helion.Resources.Archives.Collection;
 using Helion.Resources.Definitions;
 using Helion.Resources.Definitions.MapInfo;
 using Helion.Util;
@@ -847,7 +848,7 @@ public partial class Client
 
             m_lastWorldModel = worldModel;
             var sameMap = m_lastMapName.EqualsIgnoreCase(mapInfoDef.MapName) && m_lastLoadedMap != null;
-            var map = sameMap ? m_lastLoadedMap : m_archiveCollection.FindMap(mapInfoDef.MapName);
+            var map = sameMap ? m_lastLoadedMap : m_archiveCollection.FindMap(mapInfoDef.MapName, FindMapOptions.Default);
 
             if (map == null)
             {
@@ -858,7 +859,7 @@ public partial class Client
             if (!sameMap)
             {
                 var mapCompat = map.CompatibilityDefinition;
-                if (!m_zdbsp.RunZdbsp(map.ArchivePath, map.Name, out var compiledMap))
+                if (!m_zdbsp.RunZdbsp(map.ArchivePath, mapInfoDef.MapName, out var compiledMap))
                 {
                     Log.Error("Failed to run zdbsp.");
                     return result;

--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -30,6 +30,6 @@
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.4" />
     <PackageReference Include="ini-parser-net8" Version="2.6.2.1" />
     <PackageReference Include="xBRZNet" Version="1.2.0" />
-    <PackageReference Include="zdbspSharp" Version="1.0.6" />
+    <PackageReference Include="zdbspSharp" Version="1.0.7" />
   </ItemGroup>
 </Project>

--- a/Core/Maps/Bsp/Zdbsp/Zdbsp.cs
+++ b/Core/Maps/Bsp/Zdbsp/Zdbsp.cs
@@ -43,7 +43,7 @@ public class Zdbsp
                 return false;
             }
 
-            outputMap = archiveCollection.FindMap(mapName);
+            outputMap = archiveCollection.FindMap(mapName, FindMapOptions.LoadMapData);
             m_stopwatch.Stop();
             Log.Info($"Completed map load {m_stopwatch.Elapsed}");
             archiveCollection.Dispose();

--- a/Core/Maps/Doom/DoomMap.cs
+++ b/Core/Maps/Doom/DoomMap.cs
@@ -35,30 +35,66 @@ public class DoomMap : IMap
     public string MD5 { get; set; }
     public string Name { get; }
     public MapType MapType => MapType.Doom;
-    public List<DoomLine> Lines;
-    public List<DoomSector> Sectors;
-    public List<DoomSide> Sides;
-    public List<DoomThing> Things;
-    public List<DoomVertex> Vertices;
+    public List<DoomLine> Lines = [];
+    public List<DoomSector> Sectors = [];
+    public List<DoomSide> Sides= [];
+    public List<DoomThing> Things = [];
+    public List<DoomVertex> Vertices = [];
     public GLComponents? GL { get; private set; }
     public byte[]? Reject { get; set; }
     public CompatibilityMapDefinition? CompatibilityDefinition { get; set; }
 
-    private DoomMap(Archive archive, string name, List<DoomVertex> vertices, List<DoomSector> sectors, List<DoomSide> sides, 
-        List<DoomLine> lines,  List<DoomThing> things, GLComponents? gl, byte[]? reject,
-        CompatibilityMapDefinition? compatibility)
+    private MapEntryCollection? m_map;
+    private bool m_loaded;
+
+    private DoomMap(MapEntryCollection map, string archiveFullPath, string name,  CompatibilityMapDefinition? compatibility)
     {
-        ArchivePath = archive.FullPath;
+        m_map = map;
+        ArchivePath = archiveFullPath;
         Name = name;
+        CompatibilityDefinition = compatibility;
+        MD5 = string.Empty;
+    }
+
+    public void LoadData()
+    {
+        if (m_loaded)
+            return;
+
+        var map = m_map;
+        m_loaded = true;
+        m_map = null;
+
+        if (map == null)
+            return;
+
+        List<DoomVertex>? vertices = CreateVertices(map.Vertices?.ReadData());
+        if (vertices == null)
+            return;
+
+        List<DoomSector>? sectors = CreateSectors(map.Sectors?.ReadData());
+        if (sectors == null)
+            return;
+
+        List<DoomSide>? sides = CreateSides(map.Sidedefs?.ReadData(), sectors, CompatibilityDefinition);
+        if (sides == null)
+            return;
+
+        List<DoomLine>? lines = CreateLines(map.Linedefs?.ReadData(), vertices, sides, CompatibilityDefinition);
+        if (lines == null)
+            return;
+
+        List<DoomThing>? things = CreateThings(map.Things?.ReadData());
+        if (things == null)
+            return;
+
+        GL = GLComponents.Read(map);
+        Reject = map.Reject?.ReadData();
         Vertices = vertices;
         Sectors = sectors;
         Sides = sides;
         Lines = lines;
         Things = things;
-        GL = gl;
-        Reject = reject;
-        CompatibilityDefinition = compatibility;
-        MD5 = string.Empty;
     }
 
     public void ClearAllExceptThings()
@@ -85,30 +121,12 @@ public class DoomMap : IMap
     /// do mutation to the geometry if not null.</param>
     /// <returns>The compiled map, or null if the map was malformed due to
     /// missing or bad data.</returns>
-    public static DoomMap? Create(Archive archive, MapEntryCollection map, CompatibilityMapDefinition? compatibility)
+    public static DoomMap? Create(Archive archive, MapEntryCollection map, CompatibilityMapDefinition? compatibility, bool loadData)
     {
-        List<DoomVertex>? vertices = CreateVertices(map.Vertices?.ReadData());
-        if (vertices == null)
-            return null;
-
-        List<DoomSector>? sectors = CreateSectors(map.Sectors?.ReadData());
-        if (sectors == null)
-            return null;
-
-        List<DoomSide>? sides = CreateSides(map.Sidedefs?.ReadData(), sectors, compatibility);
-        if (sides == null)
-            return null;
-
-        List<DoomLine>? lines = CreateLines(map.Linedefs?.ReadData(), vertices, sides, compatibility);
-        if (lines == null)
-            return null;
-
-        List<DoomThing>? things = CreateThings(map.Things?.ReadData());
-        if (things == null)
-            return null;
-
-        GLComponents? gl = GLComponents.Read(map);
-        return new(archive, map.Name, vertices, sectors, sides, lines, things, gl, map.Reject?.ReadData(), compatibility);
+        var doomMap = new DoomMap(map, archive.FullPath, map.Name, compatibility);
+        if (loadData)
+            doomMap.LoadData();
+        return doomMap;
     }
 
     public IReadOnlyList<ILine> GetLines() => Lines;

--- a/Core/Maps/Hexen/HexenMap.cs
+++ b/Core/Maps/Hexen/HexenMap.cs
@@ -30,30 +30,61 @@ public class HexenMap : IMap
     public string MD5 { get; set; }
     public string Name { get; }
     public MapType MapType => MapType.Hexen;
-    public List<HexenLine> Lines;
-    public List<DoomSector> Sectors;
-    public List<DoomSide> Sides;
-    public List<HexenThing> Things;
-    public List<DoomVertex> Vertices;
+    public List<HexenLine> Lines = [];
+    public List<DoomSector> Sectors = [];
+    public List<DoomSide> Sides = [];
+    public List<HexenThing> Things = [];
+    public List<DoomVertex> Vertices = [];
     public GLComponents? GL { get; private set; }
     public byte[]? Reject { get; set; }
     public CompatibilityMapDefinition? CompatibilityDefinition { get; set; }
 
-    private HexenMap(Archive archive, string name, List<DoomVertex> vertices, List<DoomSector> sectors, List<DoomSide> sides,
-        List<HexenLine> lines, List<HexenThing> things, GLComponents? gl, byte[]? reject,
-        CompatibilityMapDefinition? compatibility)
+    private MapEntryCollection? m_map;
+    private bool m_loaded;
+
+    private HexenMap(MapEntryCollection map, string archiveFullPath, string name, CompatibilityMapDefinition? compatibility)
     {
-        ArchivePath = archive.FullPath;
+        m_map = map;
+        ArchivePath = archiveFullPath;
         Name = name;
-        Vertices = vertices;
-        Sectors = sectors;
-        Sides = sides;
-        Lines = lines;
-        Things = things;
-        GL = gl;
-        Reject = reject;
         CompatibilityDefinition = compatibility;
         MD5 = string.Empty;
+    }
+
+    public void LoadData()
+    {
+        if (m_loaded)
+            return;
+
+        var map = m_map;
+        m_loaded = true;
+        m_map = null;
+
+        if (map == null)
+            return;
+
+        var vertices = DoomMap.CreateVertices(map.Vertices?.ReadData());
+        if (vertices == null)
+            return;
+
+        var sectors = DoomMap.CreateSectors(map.Sectors?.ReadData());
+        if (sectors == null)
+            return;
+
+        var sides = DoomMap.CreateSides(map.Sidedefs?.ReadData(), sectors, CompatibilityDefinition);
+        if (sides == null)
+            return;
+
+        var lines = CreateLines(map.Linedefs?.ReadData(), vertices, sides, CompatibilityDefinition);
+        if (lines == null)
+            return;
+
+        var things = CreateThings(map.Things?.ReadData());
+        if (things == null)
+            return;
+
+        GL = GLComponents.Read(map);
+        Reject = map.Reject?.ReadData();
     }
 
     public void ClearAllExceptThings()
@@ -80,30 +111,12 @@ public class HexenMap : IMap
     /// do mutation to the geometry if not null.</param>
     /// <returns>The compiled map, or null if the map was malformed due to
     /// missing or bad data.</returns>
-    public static HexenMap? Create(Archive archive, MapEntryCollection map, CompatibilityMapDefinition? compatibility)
+    public static HexenMap? Create(Archive archive, MapEntryCollection map, CompatibilityMapDefinition? compatibility, bool loadData)
     {
-        List<DoomVertex>? vertices = DoomMap.CreateVertices(map.Vertices?.ReadData());
-        if (vertices == null)
-            return null;
-
-        List<DoomSector>? sectors = DoomMap.CreateSectors(map.Sectors?.ReadData());
-        if (sectors == null)
-            return null;
-
-        List<DoomSide>? sides = DoomMap.CreateSides(map.Sidedefs?.ReadData(), sectors, compatibility);
-        if (sides == null)
-            return null;
-
-        List<HexenLine>? lines = CreateLines(map.Linedefs?.ReadData(), vertices, sides, compatibility);
-        if (lines == null)
-            return null;
-
-        List<HexenThing>? things = CreateThings(map.Things?.ReadData());
-        if (things == null)
-            return null;
-
-        GLComponents? gl = GLComponents.Read(map);
-        return new HexenMap(archive, map.Name, vertices, sectors, sides, lines, things, gl, map.Reject?.ReadData(), compatibility);
+        var hexenMap = new HexenMap(map, archive.FullPath, map.Name, compatibility);
+        if (loadData)
+            hexenMap.LoadData();
+        return hexenMap;
     }
 
     public IReadOnlyList<ILine> GetLines() => Lines;
@@ -118,7 +131,6 @@ public class HexenMap : IMap
         if (lineData == null || lineData.Length % BytesPerLine != 0)
             return null;
 
-        int zdoomLineSpecialCount = Enum.GetNames(typeof(ZDoomLineSpecialType)).Length;
         int numLines = lineData.Length / BytesPerLine;
         using ByteReader reader = new(lineData);
         List<HexenLine> lines = new(numLines);
@@ -150,12 +162,6 @@ public class HexenMap : IMap
 
             if (leftSidedef != DoomMap.NoSidedef)
                 back = sides[leftSidedef];
-
-            if ((int)specialType >= zdoomLineSpecialCount)
-            {
-                Log.Warn("Line {0} has corrupt line value (type = {1}), setting line type to 'None'", id, specialType);
-                specialType = ZDoomLineSpecialType.None;
-            }
 
             HexenLine line = new(id, startVertex, endVertex, front, back, lineFlags, specialType, args);
             lines.Add(line);

--- a/Core/Maps/Hexen/HexenMap.cs
+++ b/Core/Maps/Hexen/HexenMap.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using Helion.Geometry;
 using Helion.Geometry.Vectors;
 using Helion.Maps.Components;
@@ -14,7 +12,10 @@ using Helion.Resources.Archives;
 using Helion.Resources.Definitions.Compatibility;
 using Helion.Resources.Definitions.Compatibility.Lines;
 using Helion.Util.Bytes;
+using Helion.World.Geometry.Lines;
 using NLog;
+using System;
+using System.Collections.Generic;
 using static Helion.Util.Assertion.Assert;
 
 namespace Helion.Maps.Hexen;
@@ -82,6 +83,12 @@ public class HexenMap : IMap
         var things = CreateThings(map.Things?.ReadData());
         if (things == null)
             return;
+
+        Lines = lines;
+        Sides = sides;
+        Sectors = sectors;
+        Vertices = vertices;
+        Things = things;
 
         GL = GLComponents.Read(map);
         Reject = map.Reject?.ReadData();

--- a/Core/Maps/IMap.cs
+++ b/Core/Maps/IMap.cs
@@ -29,22 +29,23 @@ public interface IMap
     CompatibilityMapDefinition? CompatibilityDefinition { get; set; }
     void ClearAllExceptThings();
     void ClearAll();
+    void LoadData();
 
-    public static IMap? Read(Archive archive, MapEntryCollection mapEntries, CompatibilityMapDefinition? compatibility = null)
+    public static IMap? Read(Archive archive, MapEntryCollection mapEntries, CompatibilityMapDefinition? compatibility = null, bool loadData = true)
     {
-        var map = Create(archive, mapEntries, compatibility);
+        var map = Create(archive, mapEntries, compatibility, loadData);
         if (map != null)
             map.MD5 = mapEntries.GetMD5();
         return map;
     }
 
-    private static IMap? Create(Archive archive, MapEntryCollection mapEntries, CompatibilityMapDefinition? compatibility = null)
+    private static IMap? Create(Archive archive, MapEntryCollection mapEntries, CompatibilityMapDefinition? compatibility = null, bool loadData = true)
     {
         return mapEntries.MapType switch
         {
-            MapType.Doom => DoomMap.Create(archive, mapEntries, compatibility),
-            MapType.Hexen => HexenMap.Create(archive, mapEntries, compatibility),
-            MapType.UDMF => UdmfMap.Create(archive, mapEntries, compatibility),
+            MapType.Doom => DoomMap.Create(archive, mapEntries, compatibility, loadData),
+            MapType.Hexen => HexenMap.Create(archive, mapEntries, compatibility, loadData),
+            MapType.UDMF => UdmfMap.Create(archive, mapEntries, compatibility, loadData),
             _ => null
         };
     }

--- a/Core/Maps/Udmf/UdmfMap.cs
+++ b/Core/Maps/Udmf/UdmfMap.cs
@@ -5,10 +5,12 @@ using Helion.Maps.Specials.ZDoom;
 using Helion.Maps.Udmf.Components;
 using Helion.Resources.Archives;
 using Helion.Resources.Definitions.Compatibility;
+using Helion.Util.Container;
 using Helion.Util.Extensions;
 using Helion.Util.Parser;
 using System;
 using System.Collections.Generic;
+using System.IO;
 
 namespace Helion.Maps.Udmf;
 
@@ -23,7 +25,7 @@ public class UdmfMap : IMap
     public string ArchivePath { get; set; }
     public string MD5 { get; set; }
     public string Name { get; }
-    public readonly UdmfNamespace UdmfNamespace;
+    public UdmfNamespace UdmfNamespace { get; private set; }
 
     public MapType MapType => MapType.UDMF;
     public List<UdmfLine> Lines;
@@ -41,6 +43,9 @@ public class UdmfMap : IMap
     public IReadOnlyList<IThing> GetThings() => Things;
     public IReadOnlyList<IVertex> GetVertices() => Vertices;
 
+    private MapEntryCollection? m_map;
+    private bool m_loaded;
+
     public void ClearAllExceptThings()
     {
         Lines = [];
@@ -56,28 +61,51 @@ public class UdmfMap : IMap
         Things = [];
     }
 
-    public static UdmfMap? Create(Archive archive, MapEntryCollection map, CompatibilityMapDefinition? compatibility)
+    public void LoadData()
+    {
+        if (m_loaded || m_map == null)
+            return;
+
+        var map = m_map;
+        m_loaded = true;
+        m_map = null;
+
+        if (map.Textmap == null)
+            return;
+
+        GL = GLComponents.Read(map);
+        Reject = map.Reject?.ReadData();
+
+        using var textmapStream = map.Textmap.GetStream();
+        UdmfNamespace = Parse(textmapStream, Vertices, Sectors, Sides, Lines, Things);
+    }
+
+    public static UdmfMap? Create(Archive archive, MapEntryCollection map, CompatibilityMapDefinition? compatibility, bool loadData)
     {
         if (map.Textmap == null)
             return null;
 
-        List<UdmfVertex> vertices = new(4096);
-        List<UdmfSide> sides = new(2048);
-        List<UdmfLine> lines = new(2048);
-        List<UdmfThing> things = new(1024);
-        List<UdmfSector> sectors = new(1024);
+        if (loadData)
+        {
+            List<UdmfVertex> vertices = new(4096);
+            List<UdmfSide> sides = new(4096);
+            List<UdmfLine> lines = new(4096);
+            List<UdmfThing> things = new(2048);
+            List<UdmfSector> sectors = new(2048);
+            var udmfMap = new UdmfMap(map, archive.FullPath, map.Name, UdmfNamespace.Unknown, vertices, sectors, sides, lines, things, null, null, compatibility);
+            udmfMap.LoadData();
+            return udmfMap;
+        }
 
-        var ns = Parse(map.Textmap.ReadDataAsString(), vertices, sectors, sides, lines, things);
-
-        GLComponents? gl = GLComponents.Read(map);
-        return new(archive, map.Name, ns, vertices, sectors, sides, lines, things, gl, map.Reject?.ReadData(), compatibility);
+        return new UdmfMap(map, archive.FullPath, map.Name, UdmfNamespace.Unknown, [], [], [], [], [], null, null, compatibility);
     }
 
-    public UdmfMap(Archive archive, string name, UdmfNamespace ns, List<UdmfVertex> vertices, List<UdmfSector> sectors, List<UdmfSide> sides,
+    public UdmfMap(MapEntryCollection map, string archiveFullPath, string name, UdmfNamespace ns, List<UdmfVertex> vertices, List<UdmfSector> sectors, List<UdmfSide> sides,
         List<UdmfLine> lines, List<UdmfThing> things, GLComponents? gl, byte[]? reject,
         CompatibilityMapDefinition? compatibility)
     {
-        ArchivePath = archive.FullPath;
+        m_map = map;
+        ArchivePath = archiveFullPath;
         Name = name;
         Vertices = vertices;
         Sectors = sectors;
@@ -91,53 +119,51 @@ public class UdmfMap : IMap
         UdmfNamespace = ns;
     }
 
-    private static bool CheckSpecial(char c) => c == '=' || c == '{' || c == '}' || c == ';';
-
-    private static UdmfNamespace Parse(string textmap, List<UdmfVertex> vertices, List<UdmfSector> sectors, List<UdmfSide> sides,
+    private static UdmfNamespace Parse(Stream textmap, List<UdmfVertex> vertices, List<UdmfSector> sectors, List<UdmfSide> sides,
         List<UdmfLine> lines, List<UdmfThing> things)
     {
-        var parser = new SimpleParser();
-        parser.SetSpecialCallback(CheckSpecial);
-        parser.Parse(textmap);
+        DynamicArray<char> typeArray = new(256);
+        DynamicArray<char> valueArray = new(256);
+        var parser = new StreamParser(textmap);
 
         parser.ConsumeString("namespace");
         parser.Consume('=');
-        var ns = parser.ConsumeStringSpan();
+        var ns = parser.ConsumeString();
         parser.Consume(';');
 
         var udmfNamespace = ParseNamespaceOrThrow(ns);
 
         while (!parser.IsDone())
         {
-            var type = parser.ConsumeStringSpan();
+            var type = parser.ConsumeStringSpan(typeArray);
             if (type.EqualsIgnoreCase("vertex"))
             {
                 parser.Consume('{');
-                ParseVertex(parser, vertices);
+                ParseVertex(parser, vertices, typeArray, valueArray);
                 parser.Consume('}');
             }
             else if (type.EqualsIgnoreCase("linedef"))
             {
                 parser.Consume('{');
-                ParseLine(parser, lines);
+                ParseLine(parser, lines, typeArray, valueArray);
                 parser.Consume('}');
             }
             else if (type.EqualsIgnoreCase("sidedef"))
             {
                 parser.Consume('{');
-                ParseSide(parser, sides);
+                ParseSide(parser, sides, typeArray, valueArray);
                 parser.Consume('}');
             }
             else if (type.EqualsIgnoreCase("sector"))
             {
                 parser.Consume('{');
-                ParseSector(parser, sectors);
+                ParseSector(parser, sectors, typeArray, valueArray);
                 parser.Consume('}');
             }
             else if (type.EqualsIgnoreCase("thing"))
             {
                 parser.Consume('{');
-                ParseThing(parser, things);
+                ParseThing(parser, things, typeArray, valueArray);
                 parser.Consume('}');
             }
             else
@@ -175,39 +201,40 @@ public class UdmfMap : IMap
         throw new Exception($"Unsupported udmf namespace: {ns}");
     }
 
-    private static void ConsumeUnknownBlockOrProperty(SimpleParser parser)
+    private static void ConsumeUnknownBlockOrProperty(StreamParser parser)
     {
-        if (parser.Peek("="))
+        var next = parser.ConsumeString();
+        if (next.EqualsIgnoreCase("="))
             ConsumeUnknownProperty(parser);
-        else if (parser.Peek("{"))
+        else if (next.EqualsIgnoreCase("{"))
             ConsumeUnknownBlock(parser);
         else
-            throw new Exception("Malformed UDMF TEXTMAP. Expected '=' or '{' but found: " + parser.PeekString());
+            throw new Exception("Malformed UDMF TEXTMAP. Expected '=' or '{' but found: " + parser.ConsumeString());
     }
 
-    private static void ConsumeUnknownProperty(SimpleParser parser)
+    private static void ConsumeUnknownProperty(StreamParser parser)
     {
         parser.Consume('=');
-        parser.ConsumeStringSpan();
+        parser.ConsumeString();
         parser.Consume(';');
     }
 
-    private static void ConsumeUnknownBlock(SimpleParser parser)
+    private static void ConsumeUnknownBlock(StreamParser parser)
     {
         parser.Consume('{');
         while (!parser.Peek('}'))
-            parser.ConsumeStringSpan();
+            parser.ConsumeString();
 
         parser.Consume('}');
     }
 
-    private static void ParseThing(SimpleParser parser, List<UdmfThing> things)
+    private static void ParseThing(StreamParser parser, List<UdmfThing> things, DynamicArray<char> typeArray, DynamicArray<char> valueArray)
     {
         var thing = new UdmfThing();
         double x = 0, y = 0, z = double.MinValue;
         while (!IsBlockComplete(parser))
         {
-            var prop = ParseProperty(parser);
+            var prop = ParseProperty(parser, typeArray, valueArray);
             if (prop.Name.EqualsIgnoreCase("x"))
                 x = parser.ParseDouble(prop.Value);
             else if (prop.Name.EqualsIgnoreCase("y"))
@@ -287,12 +314,12 @@ public class UdmfMap : IMap
         }
     }
 
-    private static void ParseSide(SimpleParser parser, List<UdmfSide> sides)
+    private static void ParseSide(StreamParser parser, List<UdmfSide> sides, DynamicArray<char> typeArray, DynamicArray<char> valueArray)
     {
         UdmfSide side = new();
         while (!IsBlockComplete(parser))
         {
-            var prop = ParseProperty(parser);
+            var prop = ParseProperty(parser, typeArray, valueArray);
             if (prop.Name.EqualsIgnoreCase("sector"))
                 side.SectorId = parser.ParseInt(prop.Value);
             else if (prop.Name.EqualsIgnoreCase("texturetop"))
@@ -356,12 +383,12 @@ public class UdmfMap : IMap
         sides.Add(side);
     }
 
-    private static void ParseSector(SimpleParser parser, List<UdmfSector> sectors)
+    private static void ParseSector(StreamParser parser, List<UdmfSector> sectors, DynamicArray<char> typeArray, DynamicArray<char> valueArray)
     {
         UdmfSector sector = new() { Id = sectors.Count };
         while (!IsBlockComplete(parser))
         {
-            var prop = ParseProperty(parser);
+            var prop = ParseProperty(parser, typeArray, valueArray);
             if (prop.Name.EqualsIgnoreCase("heightfloor"))
                 sector.FloorZ = (short)parser.ParseInt(prop.Value);
             else if (prop.Name.EqualsIgnoreCase("heightceiling"))
@@ -425,12 +452,12 @@ public class UdmfMap : IMap
         sectors.Add(sector);
     }
 
-    private static void ParseLine(SimpleParser parser, List<UdmfLine> lines)
+    private static void ParseLine(StreamParser parser, List<UdmfLine> lines, DynamicArray<char> typeArray, DynamicArray<char> valueArray)
     {
         UdmfLine line = new();
         while (!IsBlockComplete(parser))
         {
-            var prop = ParseProperty(parser);
+            var prop = ParseProperty(parser, typeArray, valueArray);
             if (prop.Name.EqualsIgnoreCase("v1"))
                 line.StartVertex = parser.ParseInt(prop.Value);
             else if (prop.Name.EqualsIgnoreCase("v2"))
@@ -544,13 +571,13 @@ public class UdmfMap : IMap
         lines.Add(line);
     }
 
-    private static void ParseVertex(SimpleParser parser, List<UdmfVertex> vertices)
+    private static void ParseVertex(StreamParser parser, List<UdmfVertex> vertices, DynamicArray<char> typeArray, DynamicArray<char> valueArray)
     {
         double x = 0, y = 0;
 
         while (!IsBlockComplete(parser))
         {
-            var prop = ParseProperty(parser);
+            var prop = ParseProperty(parser, typeArray, valueArray);
             if (prop.Name.EqualsIgnoreCase("x"))
                 x = parser.ParseDouble(prop.Value);
             else if (prop.Name.EqualsIgnoreCase("y"))
@@ -560,14 +587,14 @@ public class UdmfMap : IMap
         vertices.Add(new(vertices.Count, new(x, y)));
     }
 
-    private static Property ParseProperty(SimpleParser parser)
+    private static Property ParseProperty(StreamParser parser, DynamicArray<char> typeArray, DynamicArray<char> valueArray)
     {
-        var type = parser.ConsumeStringSpan();
+        var type = parser.ConsumeStringSpan(typeArray);
         parser.Consume('=');
-        var value = parser.ConsumeStringSpan();
+        var value = parser.ConsumeStringSpan(valueArray);
         parser.Consume(';');
         return new(type, value);
     }
 
-    private static bool IsBlockComplete(SimpleParser parser) => parser.Peek('}');
+    private static bool IsBlockComplete(StreamParser parser) => parser.Peek('}');
 }

--- a/Core/Maps/Udmf/UdmfMap.cs
+++ b/Core/Maps/Udmf/UdmfMap.cs
@@ -10,6 +10,7 @@ using Helion.Util.Extensions;
 using Helion.Util.Loggers;
 using Helion.Util.Parser;
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.IO;
 
@@ -46,6 +47,9 @@ public sealed class UdmfMap : IMap
 
     private MapEntryCollection? m_map;
     private bool m_loaded;
+
+    private static readonly char[] ParseChars = [';', ')', '(', '{', '}'];
+    private static readonly FrozenSet<char> ParseCharSet = ParseChars.ToFrozenSet();
 
     public void ClearAllExceptThings()
     {
@@ -125,7 +129,7 @@ public sealed class UdmfMap : IMap
     {
         DynamicArray<char> typeArray = new(256);
         DynamicArray<char> valueArray = new(256);
-        var parser = new StreamParser(textmap);
+        var parser = new StreamParser(textmap, ParseCharSet);
         var stringLookup = new Dictionary<string, string>(256);
         var altLookup = stringLookup.GetAlternateLookup<ReadOnlySpan<char>>();
 

--- a/Core/Maps/Udmf/UdmfMap.cs
+++ b/Core/Maps/Udmf/UdmfMap.cs
@@ -7,7 +7,6 @@ using Helion.Resources.Archives;
 using Helion.Resources.Definitions.Compatibility;
 using Helion.Util.Container;
 using Helion.Util.Extensions;
-using Helion.Util.Loggers;
 using Helion.Util.Parser;
 using System;
 using System.Collections.Frozen;

--- a/Core/Maps/Udmf/UdmfMap.cs
+++ b/Core/Maps/Udmf/UdmfMap.cs
@@ -7,6 +7,7 @@ using Helion.Resources.Archives;
 using Helion.Resources.Definitions.Compatibility;
 using Helion.Util.Container;
 using Helion.Util.Extensions;
+using Helion.Util.Loggers;
 using Helion.Util.Parser;
 using System;
 using System.Collections.Generic;
@@ -125,6 +126,8 @@ public class UdmfMap : IMap
         DynamicArray<char> typeArray = new(256);
         DynamicArray<char> valueArray = new(256);
         var parser = new StreamParser(textmap);
+        var stringLookup = new Dictionary<string, string>(256);
+        var altLookup = stringLookup.GetAlternateLookup<ReadOnlySpan<char>>();
 
         parser.ConsumeString("namespace");
         parser.Consume('=');
@@ -151,13 +154,13 @@ public class UdmfMap : IMap
             else if (type.EqualsIgnoreCase("sidedef"))
             {
                 parser.Consume('{');
-                ParseSide(parser, sides, typeArray, valueArray);
+                ParseSide(parser, sides, typeArray, valueArray, altLookup);
                 parser.Consume('}');
             }
             else if (type.EqualsIgnoreCase("sector"))
             {
                 parser.Consume('{');
-                ParseSector(parser, sectors, typeArray, valueArray);
+                ParseSector(parser, sectors, typeArray, valueArray, altLookup);
                 parser.Consume('}');
             }
             else if (type.EqualsIgnoreCase("thing"))
@@ -314,7 +317,18 @@ public class UdmfMap : IMap
         }
     }
 
-    private static void ParseSide(StreamParser parser, List<UdmfSide> sides, DynamicArray<char> typeArray, DynamicArray<char> valueArray)
+    private static string GetString(Dictionary<string, string>.AlternateLookup<ReadOnlySpan<char>> lookup, ReadOnlySpan<char> str)
+    {
+        if (lookup.TryGetValue(str, out var value))
+            return value;
+
+        var newString = str.ToString();
+        lookup[newString] = newString;
+        return newString;
+    }
+
+    private static void ParseSide(StreamParser parser, List<UdmfSide> sides, DynamicArray<char> typeArray, DynamicArray<char> valueArray, 
+        Dictionary<string, string>.AlternateLookup<ReadOnlySpan<char>> stringLookup)
     {
         UdmfSide side = new();
         while (!IsBlockComplete(parser))
@@ -323,11 +337,11 @@ public class UdmfMap : IMap
             if (prop.Name.EqualsIgnoreCase("sector"))
                 side.SectorId = parser.ParseInt(prop.Value);
             else if (prop.Name.EqualsIgnoreCase("texturetop"))
-                side.UpperTexture = string.Intern(prop.Value.ToString());
+                side.UpperTexture = GetString(stringLookup, prop.Value);
             else if (prop.Name.EqualsIgnoreCase("texturemiddle"))
-                side.MiddleTexture = string.Intern(prop.Value.ToString());
+                side.MiddleTexture = GetString(stringLookup, prop.Value);
             else if (prop.Name.EqualsIgnoreCase("texturebottom"))
-                side.LowerTexture = string.Intern(prop.Value.ToString());
+                side.LowerTexture = GetString(stringLookup, prop.Value);
             else if (prop.Name.EqualsIgnoreCase("offsetx"))
                 side.Offset.X = parser.ParseInt(prop.Value);
             else if (prop.Name.EqualsIgnoreCase("offsety"))
@@ -383,7 +397,8 @@ public class UdmfMap : IMap
         sides.Add(side);
     }
 
-    private static void ParseSector(StreamParser parser, List<UdmfSector> sectors, DynamicArray<char> typeArray, DynamicArray<char> valueArray)
+    private static void ParseSector(StreamParser parser, List<UdmfSector> sectors, DynamicArray<char> typeArray, DynamicArray<char> valueArray,
+        Dictionary<string, string>.AlternateLookup<ReadOnlySpan<char>> stringLookup)
     {
         UdmfSector sector = new() { Id = sectors.Count };
         while (!IsBlockComplete(parser))
@@ -394,9 +409,9 @@ public class UdmfMap : IMap
             else if (prop.Name.EqualsIgnoreCase("heightceiling"))
                 sector.CeilingZ = (short)parser.ParseInt(prop.Value);
             else if (prop.Name.EqualsIgnoreCase("texturefloor"))
-                sector.FloorTexture = string.Intern(prop.Value.ToString());
+                sector.FloorTexture = GetString(stringLookup, prop.Value);
             else if (prop.Name.EqualsIgnoreCase("textureceiling"))
-                sector.CeilingTexture = string.Intern(prop.Value.ToString());
+                sector.CeilingTexture = GetString(stringLookup, prop.Value);
             else if (prop.Name.EqualsIgnoreCase("lightlevel"))
                 sector.LightLevel = (short)parser.ParseInt(prop.Value);
             else if (prop.Name.EqualsIgnoreCase("id"))
@@ -444,9 +459,9 @@ public class UdmfMap : IMap
             else if (prop.Name.EqualsIgnoreCase("leakiness"))
                 sector.Leakiness = parser.ParseInt(prop.Value);
             else if (prop.Name.EqualsIgnoreCase("skyfloor"))
-                sector.SkyFloor = string.Intern(prop.Value.ToString());
+                sector.SkyFloor = GetString(stringLookup, prop.Value);
             else if (prop.Name.EqualsIgnoreCase("skyceiling"))
-                sector.SkyCeiling = string.Intern(prop.Value.ToString());
+                sector.SkyCeiling = GetString(stringLookup, prop.Value);
         }
 
         sectors.Add(sector);

--- a/Core/Maps/Udmf/UdmfMap.cs
+++ b/Core/Maps/Udmf/UdmfMap.cs
@@ -15,7 +15,7 @@ using System.IO;
 
 namespace Helion.Maps.Udmf;
 
-public class UdmfMap : IMap
+public sealed class UdmfMap : IMap
 {
     readonly ref struct Property(ReadOnlySpan<char> name, ReadOnlySpan<char> value)
     {

--- a/Core/Resources/Archives/Collection/ArchiveCollection.cs
+++ b/Core/Resources/Archives/Collection/ArchiveCollection.cs
@@ -169,7 +169,7 @@ public class ArchiveCollection : IResources, IPathResolver
         return null;
     }
 
-    public IMap? FindMap(string mapName)
+    public IMap? FindMap(string mapName, FindMapOptions options = FindMapOptions.Default)
     {
         ClearLastLoadedTempMap();
 
@@ -201,7 +201,7 @@ public class ArchiveCollection : IResources, IPathResolver
                 // confusing to the user in the case where they ask for the
                 // most recent map which is corrupt, but then get some
                 // earlier map in the pack which is not corrupt.
-                map = IMap.Read(archive, mapEntryCollection, compat);
+                map = IMap.Read(archive, mapEntryCollection, compat, (options & FindMapOptions.LoadMapData) != 0);
                 if (map != null)
                 {
                     m_lastLoadedMapIsTemp = false;

--- a/Core/Resources/Archives/Collection/FindMapOptions.cs
+++ b/Core/Resources/Archives/Collection/FindMapOptions.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Helion.Resources.Archives.Collection;
+
+[Flags]
+public enum FindMapOptions
+{
+    Default,
+    LoadMapData
+}

--- a/Core/Resources/Archives/DirectoryArchive/DirectoryArchive.cs
+++ b/Core/Resources/Archives/DirectoryArchive/DirectoryArchive.cs
@@ -23,6 +23,12 @@ public class DirectoryArchive : Archive
         return File.ReadAllBytes(entry.FilePath);
     }
 
+    public Stream GetStream(DirectoryArchiveEntry entry)
+    {
+        Invariant(entry.Parent == this, "Bad entry parent");
+        return new FileStream(entry.FilePath, FileMode.Open);
+    }
+
     public override void Dispose()
     {
         GC.SuppressFinalize(this);

--- a/Core/Resources/Archives/DirectoryArchive/DirectoryArchiveEntry.cs
+++ b/Core/Resources/Archives/DirectoryArchive/DirectoryArchiveEntry.cs
@@ -20,6 +20,11 @@ public class DirectoryArchiveEntry : Entry
         return Parent.ReadData(this);
     }
 
+    public override Stream GetStream()
+    {
+        return Parent.GetStream(this);
+    }
+
     public override void ExtractToFile(string path)
     {
         File.Copy(FilePath, path, true);

--- a/Core/Resources/Archives/Entries/Entry.cs
+++ b/Core/Resources/Archives/Entries/Entry.cs
@@ -1,3 +1,5 @@
+using System.IO;
+
 namespace Helion.Resources.Archives.Entries;
 
 /// <summary>
@@ -16,6 +18,7 @@ public abstract class Entry
     /// Reads all the raw data for this entry.
     /// </summary>
     public abstract byte[] ReadData();
+    public abstract Stream GetStream();
 
     public string ReadDataAsString() => System.Text.Encoding.UTF8.GetString(ReadData());
 

--- a/Core/Resources/Archives/PK3/PK3.cs
+++ b/Core/Resources/Archives/PK3/PK3.cs
@@ -27,19 +27,6 @@ public class PK3 : Archive, IDisposable
         GC.SuppressFinalize(this);
     }
 
-    public byte[] ReadData(PK3Entry entry)
-    {
-        Invariant(entry.Parent == this, "Bad entry parent");
-
-        using var stream = entry.ZipEntry.Open();
-        var entryLength = entry.ZipEntry.Length;
-        byte[] data = new byte[entryLength];
-        int writeLength = 0;
-        while(writeLength < entryLength)
-            writeLength += stream.Read(data, writeLength, data.Length - writeLength);
-        return data;
-    }
-
     private static bool ZipEntryDirectory(ZipArchiveEntry entry)
     {
         bool isSeparator = entry.FullName.EndsWith(DirectorySeparatorChar) ||

--- a/Core/Resources/Archives/PK3/PK3Entry.cs
+++ b/Core/Resources/Archives/PK3/PK3Entry.cs
@@ -1,5 +1,6 @@
-using System.IO.Compression;
 using Helion.Resources.Archives.Entries;
+using System.IO;
+using System.IO.Compression;
 
 namespace Helion.Resources.Archives;
 
@@ -17,7 +18,18 @@ public class PK3Entry : Entry
 
     public override byte[] ReadData()
     {
-        return Parent.ReadData(this);
+        using var stream = ZipEntry.Open();
+        var entryLength = ZipEntry.Length;
+        byte[] data = new byte[entryLength];
+        int writeLength = 0;
+        while (writeLength < entryLength)
+            writeLength += stream.Read(data, writeLength, data.Length - writeLength);
+        return data;
+    }
+
+    public override Stream GetStream()
+    {
+        return ZipEntry.Open();
     }
 
     public override void ExtractToFile(string path)

--- a/Core/Resources/Archives/Wad/Wad.cs
+++ b/Core/Resources/Archives/Wad/Wad.cs
@@ -6,6 +6,7 @@ using Helion.Resources.Archives.Entries;
 using Helion.Util;
 using Helion.Util.Bytes;
 using Helion.Util.Extensions;
+using Helion.Util.Streams;
 using static Helion.Util.Assertion.Assert;
 
 namespace Helion.Resources.Archives;
@@ -62,6 +63,12 @@ public class Wad : Archive
 
         m_byteReader.Offset(entry.Offset);
         return m_byteReader.ReadBytes(entry.Size);
+    }
+
+    public Stream GetStream(WadEntry entry)
+    {
+        Precondition(entry.Parent == this, "Bad entry parent");
+        return new SubStream(m_byteReader.BaseStream, entry.Offset, entry.Size);
     }
 
     public override void Dispose()

--- a/Core/Resources/Archives/Wad/WadEntry.cs
+++ b/Core/Resources/Archives/Wad/WadEntry.cs
@@ -22,6 +22,11 @@ public class WadEntry : Entry
         return Parent.ReadData(this);
     }
 
+    public override Stream GetStream()
+    {
+        return Parent.GetStream(this);
+    }
+
     public override void ExtractToFile(string path)
     {
         File.WriteAllBytes(path, ReadData());

--- a/Core/Resources/IResources.cs
+++ b/Core/Resources/IResources.cs
@@ -20,6 +20,7 @@ using Helion.Graphics.Fonts;
 using Helion.Resources.Definitions.Texture;
 using Helion.Resources.Textures;
 using Helion.Resources.Images;
+using Helion.Resources.Archives.Collection;
 
 namespace Helion.Resources;
 
@@ -56,7 +57,7 @@ public interface IResources : IDisposable
     Entry? FindEntryByPath(string path);
     IEnumerable<Entry> GetEntriesByNamespace(ResourceNamespace resourceNamespace);
     MapEntryCollection? GetMapEntryCollection(string mapName);
-    IMap? FindMap(string mapName);
+    IMap? FindMap(string mapName, FindMapOptions options = FindMapOptions.LoadMapData);
     Font? GetFont(string name);
     Archive? GetArchiveByFileName(string fileName);
 }

--- a/Core/Util/Parser/NumberParser.cs
+++ b/Core/Util/Parser/NumberParser.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Globalization;
+
+namespace Helion.Util.Parser;
+
+public static class NumberParser
+{
+    private static readonly NumberFormatInfo DecimalFormat = new() { NumberDecimalSeparator = "." };
+
+    public static bool TryParseDouble(string text, out double d) =>
+        double.TryParse(text, NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign, DecimalFormat, out d);
+    public static bool TryParseDouble(ReadOnlySpan<char> text, out double d) =>
+        double.TryParse(text, NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign, DecimalFormat, out d);
+
+    public static bool TryParseFloat(string text, out float f) =>
+        float.TryParse(text, NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign, DecimalFormat, out f);
+    public static bool TryParseFloat(ReadOnlySpan<char> text, out float f) =>
+        float.TryParse(text, NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign, DecimalFormat, out f);
+
+}

--- a/Core/Util/Parser/ParserBase.cs
+++ b/Core/Util/Parser/ParserBase.cs
@@ -446,7 +446,7 @@ public abstract class ParserBase
     /// </exception>
     protected double ConsumeFloat()
     {
-        if (PeekFloat() && SimpleParser.TryParseDouble(Tokens[CurrentTokenIndex++].Text, out double number))
+        if (PeekFloat() && NumberParser.TryParseDouble(Tokens[CurrentTokenIndex++].Text, out double number))
             return number;
 
         Token token = Tokens[CurrentTokenIndex];

--- a/Core/Util/Parser/SimpleParser.cs
+++ b/Core/Util/Parser/SimpleParser.cs
@@ -37,18 +37,6 @@ public class SimpleParser
     private bool m_split;
     private string m_data = string.Empty;
 
-    private static readonly NumberFormatInfo DecimalFormat = new() { NumberDecimalSeparator = "." };
-
-    public static bool TryParseDouble(string text, out double d) =>
-        double.TryParse(text, NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign, DecimalFormat, out d);
-    public static bool TryParseDouble(ReadOnlySpan<char> text, out double d) =>
-        double.TryParse(text, NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign, DecimalFormat, out d);
-
-    public static bool TryParseFloat(string text, out float f) =>
-        float.TryParse(text, NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign, DecimalFormat, out f);
-    public static bool TryParseFloat(ReadOnlySpan<char> text, out float f) =>
-        float.TryParse(text, NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign, DecimalFormat, out f);
-
     private static readonly char[] SpecialChars = ['{', '}', '=', ';', ',', '[', ']'];
 
     public SimpleParser(ParseType parseType = ParseType.Normal, bool keepBeginningSpaces = false)
@@ -402,7 +390,7 @@ public class SimpleParser
         }
 
         AssertData();
-        return TryParseDouble(GetDataSpan(m_index), out d);
+        return NumberParser.TryParseDouble(GetDataSpan(m_index), out d);
     }
 
     public string ConsumeString()
@@ -478,7 +466,7 @@ public class SimpleParser
 
         var token = m_tokens[m_index];
         var data = GetDataSpan(m_index);
-        if (TryParseDouble(data, out double d))
+        if (NumberParser.TryParseDouble(data, out double d))
         {
             m_index++;
             return d;
@@ -504,14 +492,14 @@ public class SimpleParser
 
     public double ParseDouble(ReadOnlySpan<char> data)
     {
-        if (!TryParseDouble(data, out var d))
+        if (!NumberParser.TryParseDouble(data, out var d))
             throw new ParserException(GetCurrentLine(), -1, -1, $"Could not parse {data} as a double.");
         return d;
     }
 
     public float ParseFloat(ReadOnlySpan<char> data)
     {
-        if (!TryParseFloat(data, out var d))
+        if (!NumberParser.TryParseFloat(data, out var d))
             throw new ParserException(GetCurrentLine(), -1, -1, $"Could not parse {data} as a float.");
         return d;
     }

--- a/Core/Util/Parser/StreamParser.cs
+++ b/Core/Util/Parser/StreamParser.cs
@@ -8,6 +8,7 @@ namespace Helion.Util.Parser;
 public sealed class StreamParser
 {
     public bool LastTokenWasQuoted;
+    private bool m_peek;
 
     private readonly StreamReader m_stream;
     private readonly DynamicArray<char> m_buffer = new(1024);
@@ -44,7 +45,7 @@ public sealed class StreamParser
 
     public string ConsumeString()
     {
-        return GetNextToken();
+        return ReadNextTokenSpan().ToString();
     }
 
     // Uses the passed buffer to read the next token and returns the buffer data as a span.
@@ -60,10 +61,12 @@ public sealed class StreamParser
 
     public bool Peek(char c)
     {
-        if (m_stream.EndOfStream)
-            return false;
-
-        return c == m_stream.Peek();
+        if (!m_peek)
+        {
+            ReadNextTokenSpan();
+            m_peek = true;
+        }
+        return m_buffer.Length == 1 && m_buffer[0] == c;
     }
 
     public double ParseDouble(ReadOnlySpan<char> data)
@@ -87,29 +90,26 @@ public sealed class StreamParser
         return d;
     }
 
-    public bool ConsumeIf(char c)
-    {
-        if (Peek(c))
-        {
-            ConsumeStringSpan(m_buffer);
-            return true;
-        }
-
-        return false;
-    }
-
     public ParserException MakeException(string exception)
     {
         throw new ParserException(m_line, -1, -1, exception);
     }
 
-    private string GetNextToken()
-    {
-        return ReadNextTokenSpan().ToString();
-    }
-
     private ReadOnlySpan<char> ReadNextTokenSpan(DynamicArray<char>? buffer = null)
     {
+        if (m_peek)
+        {
+            m_peek = false;
+            if (buffer != null && buffer != m_buffer)
+            {
+                buffer.EnsureCapacity(m_buffer.Length);
+                Array.Copy(m_buffer.Data, buffer.Data, m_buffer.Length);
+                buffer.Length = m_buffer.Length;
+                return buffer.Data.AsSpan(0, buffer.Length);
+            }
+            return m_buffer.Data.AsSpan(0, m_buffer.Length);
+        }
+
         LastTokenWasQuoted = false;
         buffer ??= m_buffer;
         buffer.Clear();
@@ -123,6 +123,7 @@ public sealed class StreamParser
             {
                 if (c == '\n')
                     m_line++;
+
                 m_stream.Read();
 
                 var peekChar = m_stream.Peek();
@@ -137,6 +138,7 @@ public sealed class StreamParser
                 if (hasSpecial)
                 {
                     buffer.Data[0] = c;
+                    buffer.Length = 1;
                     return buffer.Data.AsSpan(0, 1);
                 }
 
@@ -169,7 +171,6 @@ public sealed class StreamParser
                     }
                     continue;
                 }
-
                 else
                 {
                     buffer.Add('/');
@@ -205,10 +206,12 @@ public sealed class StreamParser
             }
             if (c == ' ' || c == '\r' || c == '\t' || m_specialChars.Contains(c))
                 break;
+
+            m_stream.Read();
             if (c == '/' && m_stream.Peek() == '/')
                 break;
 
-            buffer.Add((char)m_stream.Read());
+            buffer.Add(c);
         }
 
         while (m_stream.Peek() == '\n')

--- a/Core/Util/Parser/StreamParser.cs
+++ b/Core/Util/Parser/StreamParser.cs
@@ -2,194 +2,193 @@
 using System;
 using System.IO;
 
-namespace Helion.Util.Parser
+namespace Helion.Util.Parser;
+
+public sealed class StreamParser(Stream utf8Stream)
 {
-    public class StreamParser(Stream utf8Stream)
+    private readonly StreamReader m_stream = new(utf8Stream, System.Text.Encoding.UTF8);
+    private readonly DynamicArray<char> m_buffer = new(1024);
+    private int m_line;
+
+    public void Consume(char c)
     {
-        private readonly StreamReader m_stream = new(utf8Stream, System.Text.Encoding.UTF8);
-        private readonly DynamicArray<char> m_buffer = new(1024);
-        private int m_line;
+        var data = ReadNextTokenSpan();
+        if (data.Length != 1 || data[0] != c)
+            throw new ParserException(m_line, -1, -1, $"Expected {c} but got {data}");
+    }
 
-        public void Consume(char c)
+    public double ConsumeDouble()
+    {
+        var data = ReadNextTokenSpan();
+        if (!NumberParser.TryParseDouble(data, out var d))
+            throw new ParserException(m_line, -1, -1, $"Expected double but got {data}");
+        return d;
+    }
+
+    public void ConsumeString(string str)
+    {
+        var data = ReadNextTokenSpan();
+        if (!data.Equals(str, StringComparison.OrdinalIgnoreCase))
+            throw new ParserException(m_line, -1, -1, $"Expected {str} but got {data}");
+    }
+
+    public string ConsumeString()
+    {
+        return GetNextToken();
+    }
+
+    // Uses the passed buffer to read the next token and returns the buffer data as a span.
+    public ReadOnlySpan<char> ConsumeStringSpan(DynamicArray<char> buffer)
+    {
+        return ReadNextTokenSpan(buffer);
+    }
+
+    public bool IsDone()
+    {
+        return m_stream.EndOfStream;
+    }
+
+    public bool Peek(char c)
+    {
+        if (m_stream.EndOfStream)
+            return false;
+
+        return c == m_stream.Peek();
+    }
+
+    public double ParseDouble(ReadOnlySpan<char> data)
+    {
+        if (!NumberParser.TryParseDouble(data, out var d))
+            throw new ParserException(m_line, -1, -1, $"Could not parse {data} as a double.");
+        return d;
+    }
+
+    public float ParseFloat(ReadOnlySpan<char> data)
+    {
+        if (!NumberParser.TryParseFloat(data, out var d))
+            throw new ParserException(m_line, -1, -1, $"Could not parse {data} as a float.");
+        return d;
+    }
+
+    public int ParseInt(ReadOnlySpan<char> data)
+    {
+        if (!int.TryParse(data, out var d))
+            throw new ParserException(m_line, -1, -1, $"Could not parse {data} as a int.");
+        return d;
+    }
+
+    private string GetNextToken()
+    {
+        return ReadNextTokenSpan().ToString();
+    }
+
+    private ReadOnlySpan<char> ReadNextTokenSpan(DynamicArray<char>? buffer = null)
+    {
+        buffer ??= m_buffer;
+        buffer.Clear();
+        int nextChar;
+
+        while ((nextChar = m_stream.Peek()) != -1)
         {
-            var data = ReadNextTokenSpan();
-            if (data.Length != 1 || data[0] != c)
-                throw new ParserException(m_line, -1, -1, $"Expected {c} but got {data}");
-        }
-
-        public double ConsumeDouble()
-        {
-            var data = ReadNextTokenSpan();
-            if (!NumberParser.TryParseDouble(data, out var d))
-                throw new ParserException(m_line, -1, -1, $"Expected double but got {data}");
-            return d;
-        }
-
-        public void ConsumeString(string str)
-        {
-            var data = ReadNextTokenSpan();
-            if (!data.Equals(str, StringComparison.OrdinalIgnoreCase))
-                throw new ParserException(m_line, -1, -1, $"Expected {str} but got {data}");
-        }
-
-        public string ConsumeString()
-        {
-            return GetNextToken();
-        }
-
-        // Uses the passed buffer to read the next token and returns the buffer data as a span.
-        public ReadOnlySpan<char> ConsumeStringSpan(DynamicArray<char> buffer)
-        {
-            return ReadNextTokenSpan(buffer);
-        }
-
-        public bool IsDone()
-        {
-            return m_stream.EndOfStream;
-        }
-
-        public bool Peek(char c)
-        {
-            if (m_stream.EndOfStream)
-                return false;
-
-            return c == m_stream.Peek();
-        }
-
-        public double ParseDouble(ReadOnlySpan<char> data)
-        {
-            if (!NumberParser.TryParseDouble(data, out var d))
-                throw new ParserException(m_line, -1, -1, $"Could not parse {data} as a double.");
-            return d;
-        }
-
-        public float ParseFloat(ReadOnlySpan<char> data)
-        {
-            if (!NumberParser.TryParseFloat(data, out var d))
-                throw new ParserException(m_line, -1, -1, $"Could not parse {data} as a float.");
-            return d;
-        }
-
-        public int ParseInt(ReadOnlySpan<char> data)
-        {
-            if (!int.TryParse(data, out var d))
-                throw new ParserException(m_line, -1, -1, $"Could not parse {data} as a int.");
-            return d;
-        }
-
-        private string GetNextToken()
-        {
-            return ReadNextTokenSpan().ToString();
-        }
-
-        private ReadOnlySpan<char> ReadNextTokenSpan(DynamicArray<char>? buffer = null)
-        {
-            buffer ??= m_buffer;
-            buffer.Clear();
-            int nextChar;
-
-            while ((nextChar = m_stream.Peek()) != -1)
+            var c = (char)nextChar;  
+            if (c == ' ' || c == ';' || c == '\r' || c == '\n' || c == '(' || c == ')')
             {
-                var c = (char)nextChar;  
-                if (c == ' ' || c == ';' || c == '\r' || c == '\n' || c == '(' || c == ')')
+                if (c == '\n')
+                    m_line++;
+                m_stream.Read();
+
+                var peekChar = m_stream.Peek();
+                while (peekChar == '\n' || peekChar == '\r')
                 {
                     if (c == '\n')
                         m_line++;
                     m_stream.Read();
+                    peekChar = m_stream.Peek();
+                }
 
-                    var peekChar = m_stream.Peek();
-                    while (peekChar == '\n' || peekChar == '\r')
+                if (c == ';')
+                    return ";";
+                if (c == ')')
+                    return ")";
+                if (c == '(')
+                    return "(";
+
+                continue;
+            }
+
+            if (c == '/')
+            {
+                m_stream.Read();
+                var nextCommentChar = m_stream.Peek();
+                if (m_stream.Peek() == '/')
+                {
+                    m_stream.Read();
+                    while ((nextChar = m_stream.Read()) != -1 && nextChar != '\n' && nextChar != '\r') ;
+                    continue;
+                }
+                else if (nextCommentChar == '*')
+                {
+                    m_stream.Read();
+                    while ((nextChar = m_stream.Read()) != -1)
                     {
-                        if (c == '\n')
-                            m_line++;
-                        m_stream.Read();
-                        peekChar = m_stream.Peek();
+                        if ((char)nextChar == '*')
+                        {
+                            if (m_stream.Peek() == '/')
+                            {
+                                m_stream.Read();
+                                break;
+                            }
+                        }
                     }
-
-                    if (c == ';')
-                        return ";";
-                    if (c == ')')
-                        return ")";
-                    if (c == '(')
-                        return "(";
-
                     continue;
                 }
 
-                if (c == '/')
+                else
                 {
-                    m_stream.Read();
-                    var nextCommentChar = m_stream.Peek();
-                    if (m_stream.Peek() == '/')
-                    {
-                        m_stream.Read();
-                        while ((nextChar = m_stream.Read()) != -1 && nextChar != '\n' && nextChar != '\r') ;
-                        continue;
-                    }
-                    else if (nextCommentChar == '*')
-                    {
-                        m_stream.Read();
-                        while ((nextChar = m_stream.Read()) != -1)
-                        {
-                            if ((char)nextChar == '*')
-                            {
-                                if (m_stream.Peek() == '/')
-                                {
-                                    m_stream.Read();
-                                    break;
-                                }
-                            }
-                        }
-                        continue;
-                    }
-
-                    else
-                    {
-                        buffer.Add('/');
-                        break;
-                    }
+                    buffer.Add('/');
+                    break;
                 }
-
-                break;
             }
 
-            if ((char)m_stream.Peek() == '"')
-            {
-                m_stream.Read();
-                while ((nextChar = m_stream.Read()) != -1)
-                {
-                    var c = (char)nextChar;
-                    if (c == '"')
-                        break;
+            break;
+        }
 
-                    buffer.Add(c);
-                }
-                return buffer.Data.AsSpan(0, buffer.Length);
-            }
-
-            while ((nextChar = m_stream.Peek()) != -1)
+        if ((char)m_stream.Peek() == '"')
+        {
+            m_stream.Read();
+            while ((nextChar = m_stream.Read()) != -1)
             {
                 var c = (char)nextChar;
-                if (c == '\n')
-                {
-                    m_line++;
-                    break;
-                }
-                if (c == ' ' || c == ';' || c == '\r')
-                    break;
-                if (c == '/' && m_stream.Peek() == '/')
+                if (c == '"')
                     break;
 
-                buffer.Add((char)m_stream.Read());
+                buffer.Add(c);
             }
-
-            while (m_stream.Peek() == '\n')
-                m_stream.Read();
-
-            if (buffer.Length == 0)
-                throw new ParserException(m_line, -1, -1, "Hit end of file when expecting data.");
-
             return buffer.Data.AsSpan(0, buffer.Length);
         }
+
+        while ((nextChar = m_stream.Peek()) != -1)
+        {
+            var c = (char)nextChar;
+            if (c == '\n')
+            {
+                m_line++;
+                break;
+            }
+            if (c == ' ' || c == ';' || c == '\r')
+                break;
+            if (c == '/' && m_stream.Peek() == '/')
+                break;
+
+            buffer.Add((char)m_stream.Read());
+        }
+
+        while (m_stream.Peek() == '\n')
+            m_stream.Read();
+
+        if (buffer.Length == 0)
+            throw new ParserException(m_line, -1, -1, "Hit end of file when expecting data.");
+
+        return buffer.Data.AsSpan(0, buffer.Length);
     }
 }

--- a/Core/Util/Parser/StreamParser.cs
+++ b/Core/Util/Parser/StreamParser.cs
@@ -1,14 +1,24 @@
 ﻿using Helion.Util.Container;
 using System;
+using System.Collections.Frozen;
 using System.IO;
 
 namespace Helion.Util.Parser;
 
-public sealed class StreamParser(Stream utf8Stream)
+public sealed class StreamParser
 {
-    private readonly StreamReader m_stream = new(utf8Stream, System.Text.Encoding.UTF8);
+    public bool LastTokenWasQuoted;
+
+    private readonly StreamReader m_stream;
     private readonly DynamicArray<char> m_buffer = new(1024);
+    private readonly FrozenSet<char> m_specialChars;
     private int m_line;
+
+    public StreamParser(Stream utf8Stream, FrozenSet<char> specialChars)
+    {
+        m_stream = new(utf8Stream, System.Text.Encoding.UTF8);
+        m_specialChars = specialChars;
+    }
 
     public void Consume(char c)
     {
@@ -77,6 +87,22 @@ public sealed class StreamParser(Stream utf8Stream)
         return d;
     }
 
+    public bool ConsumeIf(char c)
+    {
+        if (Peek(c))
+        {
+            ConsumeStringSpan(m_buffer);
+            return true;
+        }
+
+        return false;
+    }
+
+    public ParserException MakeException(string exception)
+    {
+        throw new ParserException(m_line, -1, -1, exception);
+    }
+
     private string GetNextToken()
     {
         return ReadNextTokenSpan().ToString();
@@ -84,14 +110,16 @@ public sealed class StreamParser(Stream utf8Stream)
 
     private ReadOnlySpan<char> ReadNextTokenSpan(DynamicArray<char>? buffer = null)
     {
+        LastTokenWasQuoted = false;
         buffer ??= m_buffer;
         buffer.Clear();
         int nextChar;
 
         while ((nextChar = m_stream.Peek()) != -1)
         {
-            var c = (char)nextChar;  
-            if (c == ' ' || c == ';' || c == '\r' || c == '\n' || c == '(' || c == ')')
+            var c = (char)nextChar;
+            var hasSpecial = m_specialChars.Contains(c);
+            if (hasSpecial || c == ' ' || c == '\r' || c == '\n')
             {
                 if (c == '\n')
                     m_line++;
@@ -106,12 +134,11 @@ public sealed class StreamParser(Stream utf8Stream)
                     peekChar = m_stream.Peek();
                 }
 
-                if (c == ';')
-                    return ";";
-                if (c == ')')
-                    return ")";
-                if (c == '(')
-                    return "(";
+                if (hasSpecial)
+                {
+                    buffer.Data[0] = c;
+                    return buffer.Data.AsSpan(0, 1);
+                }
 
                 continue;
             }
@@ -155,6 +182,7 @@ public sealed class StreamParser(Stream utf8Stream)
 
         if ((char)m_stream.Peek() == '"')
         {
+            LastTokenWasQuoted = true;
             m_stream.Read();
             while ((nextChar = m_stream.Read()) != -1)
             {
@@ -175,7 +203,7 @@ public sealed class StreamParser(Stream utf8Stream)
                 m_line++;
                 break;
             }
-            if (c == ' ' || c == ';' || c == '\r')
+            if (c == ' ' || c == '\r' || m_specialChars.Contains(c))
                 break;
             if (c == '/' && m_stream.Peek() == '/')
                 break;

--- a/Core/Util/Parser/StreamParser.cs
+++ b/Core/Util/Parser/StreamParser.cs
@@ -1,0 +1,204 @@
+﻿using Helion.Util.Container;
+using System;
+using System.IO;
+
+namespace Helion.Util.Parser
+{
+    public class StreamParser
+    {
+        private readonly StreamReader m_stream;
+        private readonly DynamicArray<char> m_buffer = new(1024);
+        private int m_line;
+
+        public StreamParser(Stream stream)
+        {
+            m_stream = new StreamReader(stream);
+        }
+
+        public void Consume(char c)
+        {
+            var data = ReadNextTokenSpan();
+            if (data.Length != 1 || data[0] != c)
+                throw new ParserException(m_line, -1, -1, $"Expected {c} but got {data}");
+        }
+
+        public double ConsumeDouble()
+        {
+            var data = ReadNextTokenSpan();
+            if (!SimpleParser.TryParseDouble(data, out var d))
+                throw new ParserException(m_line, -1, -1, $"Expected double but got {data}");
+            return d;
+        }
+
+        public void ConsumeString(string str)
+        {
+            var data = ReadNextTokenSpan();
+            if (!data.Equals(str, StringComparison.OrdinalIgnoreCase))
+                throw new ParserException(m_line, -1, -1, $"Expected {str} but got {data}");
+        }
+
+        public string ConsumeString()
+        {
+            return GetNextToken();
+        }
+
+        // Uses the passed buffer to read the next token and returns the buffer data as a span.
+        public ReadOnlySpan<char> ConsumeStringSpan(DynamicArray<char> buffer)
+        {
+            return ReadNextTokenSpan(buffer);
+        }
+
+        public bool IsDone()
+        {
+            return m_stream.EndOfStream;
+        }
+
+        public bool Peek(char c)
+        {
+            if (m_stream.EndOfStream)
+                return false;
+
+            return c == m_stream.Peek();
+        }
+
+        public double ParseDouble(ReadOnlySpan<char> data)
+        {
+            if (!SimpleParser.TryParseDouble(data, out var d))
+                throw new ParserException(m_line, -1, -1, $"Could not parse {data} as a double.");
+            return d;
+        }
+
+        public float ParseFloat(ReadOnlySpan<char> data)
+        {
+            if (!SimpleParser.TryParseFloat(data, out var d))
+                throw new ParserException(m_line, -1, -1, $"Could not parse {data} as a float.");
+            return d;
+        }
+
+        public int ParseInt(ReadOnlySpan<char> data)
+        {
+            if (!int.TryParse(data, out var d))
+                throw new ParserException(m_line, -1, -1, $"Could not parse {data} as a int.");
+            return d;
+        }
+
+        private string GetNextToken()
+        {
+            AssertData();
+            return ReadNextTokenSpan().ToString();
+        }
+
+        private ReadOnlySpan<char> ReadNextTokenSpan(DynamicArray<char>? buffer = null)
+        {
+            buffer ??= m_buffer;
+            buffer.Clear();
+            int nextChar;
+
+            while ((nextChar = m_stream.Peek()) != -1)
+            {
+                var c = (char)nextChar;  
+                if (c == ' ' || c == ';' || c == '\r' || c == '\n' || c == '(' || c == ')')
+                {
+                    if (c == '\n')
+                        m_line++;
+                    m_stream.Read();
+
+                    var peekChar = m_stream.Peek();
+                    while (peekChar == '\n' || peekChar == '\r')
+                    {
+                        if (c == '\n')
+                            m_line++;
+                        m_stream.Read();
+                        peekChar = m_stream.Peek();
+                    }
+
+                    if (c == ';')
+                        return ";";
+                    if (c == ')')
+                        return ")";
+                    if (c == '(')
+                        return "(";
+
+                    continue;
+                }
+
+                if (c == '/')
+                {
+                    m_stream.Read();
+                    var nextCommentChar = m_stream.Peek();
+                    if (m_stream.Peek() == '/')
+                    {
+                        m_stream.Read();
+                        while ((nextChar = m_stream.Read()) != -1 && nextChar != '\n' && nextChar != '\r') ;
+                        continue;
+                    }
+                    else if (nextCommentChar == '*')
+                    {
+                        m_stream.Read();
+                        while ((nextChar = m_stream.Read()) != -1)
+                        {
+                            if ((char)nextChar == '*')
+                            {
+                                if (m_stream.Peek() == '/')
+                                {
+                                    m_stream.Read();
+                                    break;
+                                }
+                            }
+                        }
+                        continue;
+                    }
+
+                    else
+                    {
+                        buffer.Add('/');
+                        break;
+                    }
+                }
+
+                break;
+            }
+
+            if ((char)m_stream.Peek() == '"')
+            {
+                m_stream.Read();
+                while ((nextChar = m_stream.Read()) != -1)
+                {
+                    var c = (char)nextChar;
+                    if (c == '"')
+                        break;
+
+                    buffer.Add(c);
+                }
+                return buffer.Data.AsSpan(0, buffer.Length);
+            }
+
+            while ((nextChar = m_stream.Peek()) != -1)
+            {
+                var c = (char)nextChar;
+                if (c == '\n')
+                {
+                    m_line++;
+                    break;
+                }
+                if (c == ' ' || c == ';' || c == '\r')
+                    break;
+                if (c == '/' && m_stream.Peek() == '/')
+                    break;
+
+                buffer.Add((char)m_stream.Read());
+            }
+
+            while (m_stream.Peek() == '\n')
+                m_stream.Read();
+
+            return buffer.Data.AsSpan(0, buffer.Length);
+        }
+
+        private void AssertData()
+        {
+            if (m_stream.EndOfStream)
+                throw new ParserException(m_line, -1, -1, "Hit end of file when expecting data.");
+        }
+    }
+}

--- a/Core/Util/Parser/StreamParser.cs
+++ b/Core/Util/Parser/StreamParser.cs
@@ -4,16 +4,11 @@ using System.IO;
 
 namespace Helion.Util.Parser
 {
-    public class StreamParser
+    public class StreamParser(Stream utf8Stream)
     {
-        private readonly StreamReader m_stream;
+        private readonly StreamReader m_stream = new(utf8Stream, System.Text.Encoding.UTF8);
         private readonly DynamicArray<char> m_buffer = new(1024);
         private int m_line;
-
-        public StreamParser(Stream stream)
-        {
-            m_stream = new StreamReader(stream);
-        }
 
         public void Consume(char c)
         {
@@ -25,7 +20,7 @@ namespace Helion.Util.Parser
         public double ConsumeDouble()
         {
             var data = ReadNextTokenSpan();
-            if (!SimpleParser.TryParseDouble(data, out var d))
+            if (!NumberParser.TryParseDouble(data, out var d))
                 throw new ParserException(m_line, -1, -1, $"Expected double but got {data}");
             return d;
         }
@@ -63,14 +58,14 @@ namespace Helion.Util.Parser
 
         public double ParseDouble(ReadOnlySpan<char> data)
         {
-            if (!SimpleParser.TryParseDouble(data, out var d))
+            if (!NumberParser.TryParseDouble(data, out var d))
                 throw new ParserException(m_line, -1, -1, $"Could not parse {data} as a double.");
             return d;
         }
 
         public float ParseFloat(ReadOnlySpan<char> data)
         {
-            if (!SimpleParser.TryParseFloat(data, out var d))
+            if (!NumberParser.TryParseFloat(data, out var d))
                 throw new ParserException(m_line, -1, -1, $"Could not parse {data} as a float.");
             return d;
         }
@@ -84,7 +79,6 @@ namespace Helion.Util.Parser
 
         private string GetNextToken()
         {
-            AssertData();
             return ReadNextTokenSpan().ToString();
         }
 
@@ -192,13 +186,10 @@ namespace Helion.Util.Parser
             while (m_stream.Peek() == '\n')
                 m_stream.Read();
 
-            return buffer.Data.AsSpan(0, buffer.Length);
-        }
-
-        private void AssertData()
-        {
-            if (m_stream.EndOfStream)
+            if (buffer.Length == 0)
                 throw new ParserException(m_line, -1, -1, "Hit end of file when expecting data.");
+
+            return buffer.Data.AsSpan(0, buffer.Length);
         }
     }
 }

--- a/Core/Util/Parser/StreamParser.cs
+++ b/Core/Util/Parser/StreamParser.cs
@@ -69,6 +69,17 @@ public sealed class StreamParser
         return m_buffer.Length == 1 && m_buffer[0] == c;
     }
 
+    public bool Peek(string str)
+    {
+        if (!m_peek)
+        {
+            ReadNextTokenSpan();
+            m_peek = true;
+        }
+        var peekSpan = m_buffer.Data.AsSpan(0, m_buffer.Length);
+        return str.AsSpan(0, str.Length).Equals(peekSpan, StringComparison.OrdinalIgnoreCase);
+    }
+
     public double ParseDouble(ReadOnlySpan<char> data)
     {
         if (!NumberParser.TryParseDouble(data, out var d))

--- a/Core/Util/Parser/StreamParser.cs
+++ b/Core/Util/Parser/StreamParser.cs
@@ -119,7 +119,7 @@ public sealed class StreamParser
         {
             var c = (char)nextChar;
             var hasSpecial = m_specialChars.Contains(c);
-            if (hasSpecial || c == ' ' || c == '\r' || c == '\n')
+            if (hasSpecial || c == ' ' || c == '\r' || c == '\n' || c == '\t')
             {
                 if (c == '\n')
                     m_line++;
@@ -129,7 +129,7 @@ public sealed class StreamParser
                 while (peekChar == '\n' || peekChar == '\r')
                 {
                     if (c == '\n')
-                        m_line++;
+                        m_line++; 
                     m_stream.Read();
                     peekChar = m_stream.Peek();
                 }
@@ -203,7 +203,7 @@ public sealed class StreamParser
                 m_line++;
                 break;
             }
-            if (c == ' ' || c == '\r' || m_specialChars.Contains(c))
+            if (c == ' ' || c == '\r' || c == '\t' || m_specialChars.Contains(c))
                 break;
             if (c == '/' && m_stream.Peek() == '/')
                 break;

--- a/Core/Util/Parser/Tokenizer.cs
+++ b/Core/Util/Parser/Tokenizer.cs
@@ -190,7 +190,7 @@ public class Tokenizer
         m_textIndex--;
         m_lineCharOffset--;
 
-        Postcondition(SimpleParser.TryParseDouble(text, out double _), "Returning a number token but cannot parse a number out of it");
+        Postcondition(NumberParser.TryParseDouble(text, out double _), "Returning a number token but cannot parse a number out of it");
     }
 
     private void ConsumeSlashTokenOrComments()

--- a/Core/Util/Streams/SubStream.cs
+++ b/Core/Util/Streams/SubStream.cs
@@ -1,54 +1,53 @@
 ﻿using System;
 using System.IO;
 
-namespace Helion.Util.Streams
+namespace Helion.Util.Streams;
+
+public sealed class SubStream : Stream
 {
-    public class SubStream : Stream
+    private readonly Stream m_base;
+    private readonly long m_start;
+    private readonly long m_end;
+
+    public SubStream(Stream baseStream, long start, int length)
     {
-        private readonly Stream m_base;
-        private readonly long m_start;
-        private readonly long m_end;
-
-        public SubStream(Stream baseStream, long start, int length)
-        {
-            m_base = baseStream;
-            m_start = start;
-            m_end = start + length;
-            m_base.Seek(m_start, SeekOrigin.Begin);
-        }
-
-        public override bool CanRead => m_base.CanRead;
-        public override bool CanSeek => true;
-        public override bool CanWrite => false;
-        public override long Length => m_end - m_start;
-        public override long Position
-        {
-            get => m_base.Position - m_start;
-            set => m_base.Position = m_start + value;
-        }
-
-        public override int Read(byte[] buffer, int offset, int count)
-        {
-            long remaining = m_end - m_base.Position;
-            if (remaining <= 0)
-                return 0;
-            return m_base.Read(buffer, offset, (int)Math.Min(count, remaining));
-        }
-
-        public override long Seek(long offset, SeekOrigin origin)
-        {
-            long target = origin switch
-            {
-                SeekOrigin.Begin => m_end + offset,
-                SeekOrigin.Current => m_base.Position + offset,
-                SeekOrigin.End => m_end + offset,
-                _ => throw new ArgumentOutOfRangeException(nameof(origin))
-            };
-            return m_base.Seek(target, SeekOrigin.Begin) - m_end;
-        }
-
-        public override void Flush() => throw new NotSupportedException();
-        public override void SetLength(long value) => throw new NotSupportedException();
-        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        m_base = baseStream;
+        m_start = start;
+        m_end = start + length;
+        m_base.Seek(m_start, SeekOrigin.Begin);
     }
+
+    public override bool CanRead => m_base.CanRead;
+    public override bool CanSeek => true;
+    public override bool CanWrite => false;
+    public override long Length => m_end - m_start;
+    public override long Position
+    {
+        get => m_base.Position - m_start;
+        set => m_base.Position = m_start + value;
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        long remaining = m_end - m_base.Position;
+        if (remaining <= 0)
+            return 0;
+        return m_base.Read(buffer, offset, (int)Math.Min(count, remaining));
+    }
+
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        long target = origin switch
+        {
+            SeekOrigin.Begin => m_end + offset,
+            SeekOrigin.Current => m_base.Position + offset,
+            SeekOrigin.End => m_end + offset,
+            _ => throw new ArgumentOutOfRangeException(nameof(origin))
+        };
+        return m_base.Seek(target, SeekOrigin.Begin) - m_end;
+    }
+
+    public override void Flush() => throw new NotSupportedException();
+    public override void SetLength(long value) => throw new NotSupportedException();
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
 }

--- a/Core/Util/Streams/SubStream.cs
+++ b/Core/Util/Streams/SubStream.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.IO;
+
+namespace Helion.Util.Streams
+{
+    public class SubStream : Stream
+    {
+        private readonly Stream m_base;
+        private readonly long m_start;
+        private readonly long m_end;
+
+        public SubStream(Stream baseStream, long start, int length)
+        {
+            m_base = baseStream;
+            m_start = start;
+            m_end = start + length;
+            m_base.Seek(m_start, SeekOrigin.Begin);
+        }
+
+        public override bool CanRead => m_base.CanRead;
+        public override bool CanSeek => true;
+        public override bool CanWrite => false;
+        public override long Length => m_end - m_start;
+        public override long Position
+        {
+            get => m_base.Position - m_start;
+            set => m_base.Position = m_start + value;
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            long remaining = m_end - m_base.Position;
+            if (remaining <= 0)
+                return 0;
+            return m_base.Read(buffer, offset, (int)Math.Min(count, remaining));
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            long target = origin switch
+            {
+                SeekOrigin.Begin => m_end + offset,
+                SeekOrigin.Current => m_base.Position + offset,
+                SeekOrigin.End => m_end + offset,
+                _ => throw new ArgumentOutOfRangeException(nameof(origin))
+            };
+            return m_base.Seek(target, SeekOrigin.Begin) - m_end;
+        }
+
+        public override void Flush() => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+}

--- a/Tests/Unit/Util/Parser/StreamParserTest.cs
+++ b/Tests/Unit/Util/Parser/StreamParserTest.cs
@@ -12,7 +12,7 @@ public class StreamParserTest
     [Fact]
     public void ParseSingleLine()
     {
-        var str = @"/block1;{test/test;}";
+        var str = @"/block1;    {          test/test;}";
         var parser = CreateParser(str);
         parser.ConsumeString().Should().Be("/block1");
         parser.Peek(';').Should().BeTrue();

--- a/Tests/Unit/Util/Parser/StreamParserTest.cs
+++ b/Tests/Unit/Util/Parser/StreamParserTest.cs
@@ -1,0 +1,89 @@
+﻿using FluentAssertions;
+using Helion.Util.Container;
+using Helion.Util.Parser;
+using System.Collections.Frozen;
+using System.IO;
+using Xunit;
+
+namespace Helion.Tests.Unit.Util.Parser;
+
+public class StreamParserTest
+{
+    [Fact]
+    public void ParseSingleLine()
+    {
+        var str = @"/block1;{test/test;}";
+        var parser = CreateParser(str);
+        parser.ConsumeString().Should().Be("/block1");
+        parser.Peek(';').Should().BeTrue();
+        parser.Peek('{').Should().BeFalse();
+        parser.Consume(';');
+        parser.Peek('{').Should().BeTrue();
+        parser.ConsumeString().Should().Be("{");
+        parser.ConsumeString().Should().Be("test/test");
+        parser.ConsumeString().Should().Be(";");
+        parser.ConsumeString("}");
+        parser.IsDone().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ParseWithNewLines()
+    {
+        var str = @"
+    block1 // comment 
+    {
+        test1=""value 1"";
+        test2 = ""value 2"";
+        something(test3);
+        test4 = 420.69;
+    /*
+    multi-line
+    comment
+    */
+    }";
+        var array = new DynamicArray<char>();
+        var parser = CreateParser(str);
+        parser.ConsumeStringSpan(array).ToString().Should().Be("block1");
+        parser.Peek('{').Should().BeTrue();
+        parser.Consume('{');
+        parser.ConsumeString().Should().Be("test1");
+        parser.ConsumeString().Should().Be("=");
+        parser.ConsumeString().Should().Be("value 1");
+        parser.ConsumeString().Should().Be(";");
+        parser.ConsumeString().Should().Be("test2");
+        parser.ConsumeString().Should().Be("=");
+        parser.ConsumeString().Should().Be("value 2");
+        parser.ConsumeString().Should().Be(";");
+        parser.ConsumeString().Should().Be("something");
+        parser.ConsumeString().Should().Be("(");
+        parser.ConsumeString().Should().Be("test3");
+        parser.ConsumeString().Should().Be(")");
+        parser.ConsumeString().Should().Be(";");
+        parser.ConsumeString("test4");
+        parser.Consume('=');
+        parser.ConsumeDouble().Should().Be(420.69);
+        parser.Consume(';');
+        parser.ConsumeString().Should().Be("}");
+
+        var throws = false;
+        try
+        {
+            parser.ConsumeString();
+        }
+        catch
+        {
+            throws = true;
+        }
+
+        throws.Should().BeTrue();
+        parser.IsDone().Should().BeTrue();
+    }
+
+    private static StreamParser CreateParser(string str)
+    {
+        char[] ParseChars = [';', '=', ')', '(', '{', '}'];
+        var ParseCharSet = ParseChars.ToFrozenSet();
+        var ms = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(str));
+        return new StreamParser(ms, ParseCharSet);
+    }
+}

--- a/Tests/Unit/Util/Parser/StreamParserTest.cs
+++ b/Tests/Unit/Util/Parser/StreamParserTest.cs
@@ -20,6 +20,7 @@ public class StreamParserTest
         parser.Consume(';');
         parser.Peek('{').Should().BeTrue();
         parser.ConsumeString().Should().Be("{");
+        parser.Peek("Test/Test").Should().BeTrue();
         parser.ConsumeString().Should().Be("test/test");
         parser.ConsumeString().Should().Be(";");
         parser.ConsumeString("}");


### PR DESCRIPTION
Implement StreamParser that takes a generic stream. Uses significantly less memory with improved parsing performance.

Updates udmf parsing to use StreamParser.

Maps are no longer parsed and loaded twice. Internal data structures are read after nodes are built with zdbsp.