### PR TITLE
Two-sided vanilla sprite clipping

### DIFF
--- a/Core/Render/OpenGL/Framebuffer/PlaneClipFrameBuffer.cs
+++ b/Core/Render/OpenGL/Framebuffer/PlaneClipFrameBuffer.cs
@@ -108,7 +108,7 @@ public class PlaneClipFrameBuffer : IDisposable
         if (m_ownsDepthTexture)
             GL.Clear(ClearBufferMask.DepthBufferBit);
 
-        var clear = stackalloc float[3] { -1e30f, 1e30f, -1 };
+        var clear = stackalloc float[4] { -255, -255, -255, -255 };
         GL.ClearBuffer(ClearBuffer.Color, m_clearBufferIndex, clear);
 
         if (m_ownsDepthTexture)

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillProgram.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillProgram.cs
@@ -139,7 +139,7 @@ public class FloodFillProgram : RenderProgram
     protected override string FragmentShader()
     {
         if (this is FloodFillWallClipProgram)
-            return PlaneClip.WriteWallFragFunction();
+            return PlaneClip.WriteWallFragFunction(WallClipFragOptions.None);
 
         return @"
             #version 330

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillRenderer.cs
@@ -13,7 +13,6 @@ using Helion.Util;
 using Helion.Util.Container;
 using Helion.World;
 using Helion.World.Geometry.Sectors;
-using Helion.World.Geometry.Walls;
 using Helion.World.Static;
 using OpenTK.Graphics.OpenGL;
 
@@ -30,11 +29,13 @@ public class FloodFillRenderer(LegacyGLTextureManager glTextureManager, FloodFil
     private readonly FloodFillWallClipProgram m_wallClipProgram = new();
     private readonly List<FloodFillInfo> m_floodFillInfos = [];
     private readonly Dictionary<int, int> m_textureHandleToFloodFillInfoIndex = [];
-    private readonly DynamicArray<FloodGeometry> m_floodGeometry = new();
+    private readonly DynamicArray<FloodGeometry> m_floodGeometry = [];
     private readonly LinkedList<FloodGeometry> m_freeData = [];
-    private readonly DynamicArray<LinkedListNode<FloodGeometry>> m_freeNodes = new();
+    private readonly DynamicArray<LinkedListNode<FloodGeometry>> m_freeNodes = [];
     private TextureManager? m_textureManager;
     private bool m_disposed;
+
+    private FloodGeometry NoGeometry;
 
     ~FloodFillRenderer()
     {
@@ -64,9 +65,6 @@ public class FloodFillRenderer(LegacyGLTextureManager glTextureManager, FloodFil
         m_floodFillInfos.Add(floodInfo);
         return floodInfo;
     }
-
-
-    private FloodGeometry NoGeometry;
 
     private ref FloodGeometry TryGetFloodGeometry(int floodKey, out bool success)
     {
@@ -302,30 +300,33 @@ public class FloodFillRenderer(LegacyGLTextureManager glTextureManager, FloodFil
         vbo.UploadSubData(bufferOffset, vertices);
     }
 
-    public void Render(RenderInfo renderInfo) => Render(m_program, renderInfo);
+    public void Render(RenderInfo renderInfo) => Render(m_program, renderInfo, false);
 
-    public void RenderWallClip(RenderInfo renderInfo) => Render(m_wallClipProgram, renderInfo);
+    public void RenderWallClip(RenderInfo renderInfo) => Render(m_wallClipProgram, renderInfo, true);
 
-    private void Render(FloodFillProgram program, RenderInfo renderInfo)
+    private void Render(FloodFillProgram program, RenderInfo renderInfo, bool wallClip)
     {
         program.Bind();
         SetUniforms(program, renderInfo);
 
         for (int i = 0; i < m_floodFillInfos.Count; i++)
         {
-            FloodFillInfo info = m_floodFillInfos[i];
+            var info = m_floodFillInfos[i];
             if (info.Vertices.Vbo.Empty)
                 continue;
 
-            GLLegacyTexture texture = m_glTextureManager.GetTexture(info.TextureHandle);
-            GLLegacyTexture? brightmapTexture = m_glTextureManager.GetBrightmapTexture(info.TextureHandle);
-            GL.ActiveTexture(BindTextures.BoundTexture);
-            texture.Bind();
-            GL.ActiveTexture(BindTextures.BrightmapTexture);
-            if (brightmapTexture != null)
-                brightmapTexture.Bind();
-            else
-                GL.BindTexture(TextureTarget.Texture2D, 0);
+            if (!wallClip)
+            {
+                var texture = m_glTextureManager.GetTexture(info.TextureHandle);
+                var brightmapTexture = m_glTextureManager.GetBrightmapTexture(info.TextureHandle);
+                GL.ActiveTexture(BindTextures.BoundTexture);
+                texture.Bind();
+                GL.ActiveTexture(BindTextures.BrightmapTexture);
+                if (brightmapTexture != null)
+                    brightmapTexture.Bind();
+                else
+                    GL.BindTexture(TextureTarget.Texture2D, 0);
+            }
 
             info.Vertices.Vbo.UploadIfNeeded();
             info.Vertices.Vao.Bind();

--- a/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
@@ -167,7 +167,10 @@ public class InterpolationShader : RenderProgram
             return PlaneClip.WritePlaneFragFunction();
 
         if (this is InterpolationWallClipShader)
-            return PlaneClip.WriteWallFragFunction();
+            return PlaneClip.WriteWallFragFunction(WallClipFragOptions.None);
+
+        if (this is InterpolationWallClipAlphaShader)
+            return PlaneClip.WriteWallFragFunction(WallClipFragOptions.AlphaSample);
 
         var planeClip = this is InterpolationPlaneClipShaderMrt;
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationWallClipAlphaShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationWallClipAlphaShader.cs
@@ -1,0 +1,8 @@
+﻿namespace Helion.Render.OpenGL.Renderers.Legacy.World;
+
+public class InterpolationWallClipAlphaShader : InterpolationShader
+{
+    public InterpolationWallClipAlphaShader() : base("WallClipAlhpa")
+    {
+    }
+}

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -37,10 +37,12 @@ public class LegacyWorldRenderer : WorldRenderer
     private readonly InterpolationPlaneClipShader m_interpolationPlaneClipProgram = new();
     private readonly InterpolationPlaneClipShaderMrt m_interpolationPlaneClipMrtProgram = new();
     private readonly InterpolationWallClipShader m_interpolationWallClipShader = new();
+    private readonly InterpolationWallClipAlphaShader m_interpolationWallClipAlphaProgram = new();
     private readonly StaticShader m_staticProgram = new("Main");
     private readonly StaticPlaneClipShader m_staticPlaneClipProgram = new();
     private readonly StaticPlaneClipShaderMrt m_staticPlaneClipMrtProgram = new();
     private readonly StaticWallClipShader m_staticWallClipProgram = new();
+    private readonly StaticWallClipAlphaShader m_staticWallClipAlphaProgram = new();
     private readonly RenderWorldDataManager m_worldDataManager = new();
     private readonly ArchiveCollection m_archiveCollection;
     private readonly LegacyGLTextureManager m_textureManager;
@@ -361,11 +363,10 @@ public class LegacyWorldRenderer : WorldRenderer
 
         RenderTwoSidedMiddleWalls(renderInfo);
 
-        if (m_downscaleVanillaBuffer)
-            RenderTwoSidedMiddleWallsToDepth(renderInfo);
-
         if (m_wallClipFrameBuffer != null || m_planeClipFrameBuffer != null)
             WriteSpriteClipBuffers(renderInfo, framebuffer);
+
+        GL.Clear(ClearBufferMask.DepthBufferBit);
 
         m_entityRenderer.RenderOpaque(renderInfo);
         RenderTransparent(renderInfo, framebuffer);
@@ -391,24 +392,11 @@ public class LegacyWorldRenderer : WorldRenderer
         if (m_planeClipFrameBuffer != null)
             WritePlaneClipData(m_planeClipFrameBuffer, useRenderInfo, framebuffer, false);
 
-        if (!m_downscaleVanillaBuffer)
-            RenderTwoSidedMiddleWallsToDepth(renderInfo);
-
         if (m_wallClipFrameBuffer != null)
             WritePlaneClipData(m_wallClipFrameBuffer, useRenderInfo, framebuffer, true);
 
         if (renderInfo.Uniforms.DownScaleAmount > 1)
             GL.Viewport(renderInfo.Viewport.X, renderInfo.Viewport.Y, renderInfo.Viewport.Width, renderInfo.Viewport.Height);
-    }
-
-    private void RenderTwoSidedMiddleWallsToDepth(RenderInfo renderInfo)
-    {
-        // TODO - this could be done with mrt shaders as an optimization instead of drawing twice
-        GL.Clear(ClearBufferMask.DepthBufferBit);
-        GL.ColorMask(false, false, false, false);
-        // Write two-sided middle walls to depth as these generally look better with normal discard handling
-        RenderTwoSidedMiddleWalls(renderInfo);
-        GL.ColorMask(true, true, true, true);
     }
 
     private void SetupClipBuffers(GLFramebuffer framebuffer, Dimension dimension, bool downscaleChanged)
@@ -452,6 +440,11 @@ public class LegacyWorldRenderer : WorldRenderer
                 m_geometryRenderer.RenderWallClipPortals(renderInfo);
                 GL.Enable(EnableCap.CullFace);
                 m_interpolationWallClipShader.Unbind();
+
+                m_interpolationWallClipAlphaProgram.Bind();
+                SetStaticUniforms(m_staticWallClipAlphaProgram, renderInfo);
+                m_geometryRenderer.RenderStaticTwoSidedWalls();
+                m_interpolationWallClipAlphaProgram.Unbind();
             }
             else
             {
@@ -474,6 +467,11 @@ public class LegacyWorldRenderer : WorldRenderer
                 m_geometryRenderer.RenderStaticCoverWalls();
                 GL.CullFace(TriangleFace.Back);
                 m_staticWallClipProgram.Unbind();
+
+                m_staticWallClipAlphaProgram.Bind();
+                SetStaticUniforms(m_staticWallClipAlphaProgram, renderInfo);
+                m_geometryRenderer.RenderStaticTwoSidedWalls();
+                m_staticWallClipAlphaProgram.Unbind();
             }
             else
             {

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -427,6 +427,7 @@ public class LegacyWorldRenderer : WorldRenderer
     {
         planeClipFrameBuffer.BindFrameBuffer();
         PlaneClipFrameBuffer.StartRender();
+        GL.Disable(EnableCap.Blend);
 
         if (m_renderStatic)
         {
@@ -442,8 +443,8 @@ public class LegacyWorldRenderer : WorldRenderer
                 m_interpolationWallClipShader.Unbind();
 
                 m_interpolationWallClipAlphaProgram.Bind();
-                SetStaticUniforms(m_staticWallClipAlphaProgram, renderInfo);
-                m_geometryRenderer.RenderStaticTwoSidedWalls();
+                SetInterpolationUniforms(m_interpolationWallClipAlphaProgram, renderInfo, false);
+                m_worldDataManager.RenderTwoSidedMiddleWalls();
                 m_interpolationWallClipAlphaProgram.Unbind();
             }
             else

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/PlaneClip.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/PlaneClip.cs
@@ -49,21 +49,13 @@ public static class PlaneClip
                 // Pack lower and upper flags and overflow bytes after 65536 for line id.
                 // This should allow for 256x256x64 = 4,194,304 line ids.
                 int byte2 = ((lineId >> 16) & 0x3F) << 2 | int(lowerFrag + (upperFrag * 2));
-                outPlane = vec4(${LineIdSet}, byte1, byte2, depthFrag);
+                
+                // mapIdFrag check is required for flood fill rendering that doesn't separate planes(floor/ceiling) from walls
+                // Planes are written with -1 and need to be ignored
+                outPlane = vec4(mix(byte0, -255, float(mapIdFrag < 0)), byte1, byte2, depthFrag);
             }"
         .Replace("${InVars}", alphaSample ? "in vec2 uvFrag;" : "")
-        .Replace("${AlphaTexture}", GetAlphaSample(alphaSample))
-        .Replace("${LineIdSet}", GetLineIdSet(alphaSample));
-    }
-
-    private static string GetLineIdSet(bool alphaSample)
-    {                
-        // mapIdFrag check is required for flood fill rendering that doesn't separate planes(floor/ceiling) from walls
-        // Planes are written with -1 and need to be ignored
-        if (alphaSample)
-            return "mix(byte0, -1, float(mapIdFrag < 0 || alpha <= 0))";
-
-        return "byte0";
+        .Replace("${AlphaTexture}", GetAlphaSample(alphaSample));
     }
 
     private static string GetAlphaSample(bool alphaSample)
@@ -71,7 +63,8 @@ public static class PlaneClip
         if (!alphaSample)
             return "";
 
-        return @"float alpha = texture(boundTexture, uvFrag.xy).a;";
+        return @"float alpha = texture(boundTexture, uvFrag.xy).a;
+                if (alpha <= 0) discard;";
     }
 
     public static string GetOutPlane(bool planeClip)

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/PlaneClip.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/PlaneClip.cs
@@ -1,5 +1,11 @@
 ﻿namespace Helion.Render.OpenGL.Renderers.Legacy.World.Shader;
 
+public enum WallClipFragOptions
+{
+    None,
+    AlphaSample
+}
+
 public static class PlaneClip
 {
     public static string WritePlaneFragFunction() =>
@@ -17,7 +23,10 @@ public static class PlaneClip
                 {GetOutPlane(true)}
             }}";
 
-    public static string WriteWallFragFunction() =>
+    public static string WriteWallFragFunction(WallClipFragOptions options)
+    {
+        var alphaSample = (options & WallClipFragOptions.AlphaSample) != 0;
+        return
          @"
             #version 330
 
@@ -25,14 +34,14 @@ public static class PlaneClip
             flat in float upperFrag;
             flat in float lowerFrag;
             in float depthFrag;
+            ${InVars}
+
+            uniform sampler2D boundTexture;
 
             layout (location = 0) out vec4 outPlane;
 
             void main() {
-                // This is required for flood fill rendering that doesn't separate planes(floor/ceiling) from walls
-                // Planes are written with -1 and need to be discarded
-                if (mapIdFrag < 0)
-                    discard;
+                ${AlphaTexture}
                 
                 int lineId = int(mapIdFrag);
                 int byte0 = lineId & 0xFF;
@@ -40,8 +49,30 @@ public static class PlaneClip
                 // Pack lower and upper flags and overflow bytes after 65536 for line id.
                 // This should allow for 256x256x64 = 4,194,304 line ids.
                 int byte2 = ((lineId >> 16) & 0x3F) << 2 | int(lowerFrag + (upperFrag * 2));
-                outPlane = vec4(byte0, byte1, byte2, depthFrag);
-            }";
+                outPlane = vec4(${LineIdSet}, byte1, byte2, depthFrag);
+            }"
+        .Replace("${InVars}", alphaSample ? "in vec2 uvFrag;" : "")
+        .Replace("${AlphaTexture}", GetAlphaSample(alphaSample))
+        .Replace("${LineIdSet}", GetLineIdSet(alphaSample));
+    }
+
+    private static string GetLineIdSet(bool alphaSample)
+    {                
+        // mapIdFrag check is required for flood fill rendering that doesn't separate planes(floor/ceiling) from walls
+        // Planes are written with -1 and need to be ignored
+        if (alphaSample)
+            return "mix(byte0, -1, float(mapIdFrag < 0 || alpha <= 0))";
+
+        return "byte0";
+    }
+
+    private static string GetAlphaSample(bool alphaSample)
+    {
+        if (!alphaSample)
+            return "";
+
+        return @"float alpha = texture(boundTexture, uvFrag.xy).a;";
+    }
 
     public static string GetOutPlane(bool planeClip)
     {

--- a/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
@@ -139,7 +139,10 @@ public class StaticShader : RenderProgram
             return PlaneClip.WritePlaneFragFunction();
 
         if (this is StaticWallClipShader)
-            return PlaneClip.WriteWallFragFunction();
+            return PlaneClip.WriteWallFragFunction(WallClipFragOptions.None);
+
+        if (this is StaticWallClipAlphaShader)
+            return PlaneClip.WriteWallFragFunction(WallClipFragOptions.AlphaSample);
 
         bool planeClip = this is StaticPlaneClipShaderMrt;
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/StaticWallClipAlphaShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/StaticWallClipAlphaShader.cs
@@ -1,6 +1,6 @@
 ﻿namespace Helion.Render.OpenGL.Renderers.Legacy.World;
 
-internal class StaticWallClipAlphaShader : StaticShader
+internal sealed class StaticWallClipAlphaShader : StaticShader
 {
     public StaticWallClipAlphaShader() : base("WallClipAlpha")
     {

--- a/Core/Render/OpenGL/Renderers/Legacy/World/StaticWallClipAlphaShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/StaticWallClipAlphaShader.cs
@@ -1,0 +1,9 @@
+﻿namespace Helion.Render.OpenGL.Renderers.Legacy.World;
+
+internal class StaticWallClipAlphaShader : StaticShader
+{
+    public StaticWallClipAlphaShader() : base("WallClipAlpha")
+    {
+
+    }
+}

--- a/Core/World/Geometry/Sectors/Sector.cs
+++ b/Core/World/Geometry/Sectors/Sector.cs
@@ -376,7 +376,7 @@ public sealed class Sector
     public void ApplySectorModel(IWorld world, in SectorModel sectorModel, WorldModelPopulateResult result)
     {
         var textureManager = world.ArchiveCollection.TextureManager;
-        IList<Sector> sectors = world.Sectors;
+        var sectors = world.Sectors;
         SoundValidationCount = sectorModel.SoundValidationCount;
         SoundBlock = sectorModel.SoundBlock;
         if (sectorModel.SoundTarget.HasValue && result.Entities.TryGetValue(sectorModel.SoundTarget.Value, out var soundTarget))
@@ -492,7 +492,7 @@ public sealed class Sector
         }
     }
 
-    private static bool IsSectorIdValid(IList<Sector> sectors, int id) => id >= 0 && id < sectors.Count;
+    private static bool IsSectorIdValid(List<Sector> sectors, int id) => id >= 0 && id < sectors.Count;
 
     public LinkableNode<Entity> Link(Entity entity)
     {

--- a/Core/World/Impl/SinglePlayer/MarkSpecials.cs
+++ b/Core/World/Impl/SinglePlayer/MarkSpecials.cs
@@ -361,7 +361,7 @@ public class MarkSpecials
             MarkSpecialLines(world, lines, frontTag, backTag);
     }
 
-    private void MarkSpecialLines(IWorld world, IList<Line> lines, int frontTag, int backTag)
+    private void MarkSpecialLines(IWorld world, List<Line> lines, int frontTag, int backTag)
     {
         for (int i = 0; i < lines.Count; i++)
         {


### PR DESCRIPTION
Two-sided middle walls were previously just writing to the depth buffer. This changes writes them to the clip buffer to match vanilla sprite clipping behavior.

This does include a minor performance increase. The wall clip shaders are simpler and the previous depth write was running through the full and more complex fragment shader. 

Disable blending when writing clip information.

Removes discard check for wall clip writing.

No longer wastes time binding textures in the flood fill renderer when writing wall clip information.