### PR TITLE
Lower cover wall gap fix

### DIFF
--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/CoverWallUtil.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/CoverWallUtil.cs
@@ -77,7 +77,7 @@ public class CoverWallUtil
         // Adjust cover wall offsets to not block extra pixels from the the backside
         return new Heights
         (
-            location == WallLocation.Lower ? (float)WorldStatic.LineVertexGap : ProjectHeight,
+            location == WallLocation.Lower ? -(float)WorldStatic.LineVertexGap : ProjectHeight,
             location == WallLocation.Upper ? (float)WorldStatic.LineVertexGap : ProjectHeight
         );
     }

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -30,3 +30,4 @@
 - Fix borderless window option in Windows to not be promoted to exclusive fullscreen.
 - Fix holes in floors that can be caused by self-referencing lines. (Fixes BTSX E1 MAP02 exit).
 - Fix looping sounds with same sound limit feature not playing when coming back into player's sound range.
+- Fix issue with lower wall gap correction and sprites.


### PR DESCRIPTION
Correct inverted lower gap correction with lower cover walls. This was causing sprite pixels to be discarded that shouldn't be and was mostly only noticeable against more opposing colors.

<img width="1922" height="1119" alt="image" src="https://github.com/user-attachments/assets/98db479b-1fce-4282-9c93-a11c6ca90bfe" />
