### PR TITLE
Fix more issues with waiting sounds

### DIFF
--- a/Core/Audio/Impl/MockAudioSource.cs
+++ b/Core/Audio/Impl/MockAudioSource.cs
@@ -32,7 +32,7 @@ internal sealed class MockAudioSource : IAudioSource
 
     public void CacheFree()
     {
-
+        AudioData = default;
     }
 
     public void Tick()

--- a/Core/Audio/Sounds/SoundManager.cs
+++ b/Core/Audio/Sounds/SoundManager.cs
@@ -2,7 +2,9 @@ using Helion.Geometry.Vectors;
 using Helion.Resources.Archives.Collection;
 using Helion.Resources.Definitions.SoundInfo;
 using Helion.Util;
+using Helion.Util.Container;
 using Helion.Util.RandomGenerators;
+using Helion.World.Entities;
 using Helion.World.Sound;
 using System;
 using System.Collections.Generic;
@@ -17,6 +19,8 @@ public class SoundManager : IDisposable
     public readonly IAudioSourceManager AudioManager;
     private readonly IRandom m_random = new TrueRandom();
     private readonly IAudioSystem m_audioSystem;
+    private readonly DynamicArray<WaitingSound> m_sortSounds = new(128);
+    private readonly Comparison<WaitingSound> m_waitingSoundDistanceSort = new(WaitingSoundDistanceSort);
     protected int m_maxConcurrentSounds = 32;
     protected int m_sameSoundLimit;
     protected int m_sameSoundWindow;
@@ -196,40 +200,46 @@ public class SoundManager : IDisposable
 
     protected void UpdateWaitingLoopSounds()
     {
+        SortWaitingSoundsByDistance(m_waitingLoopSounds, m_sortSounds);
         var gametick = GetGameTick();
-        LinkedListNode<WaitingSound>? node = m_waitingLoopSounds.First;
-        LinkedListNode<WaitingSound>? nextNode;
-        LinkedListNode<WaitingSound>? nextNextNode;
-        while (node != null)
+
+        for (int i = 0; i < m_sortSounds.Count; i++)
         {
-            if (node.List == null)
-                break;
+            ref var sound = ref m_sortSounds.Data[i];
+            var distanceSquared = sound.DistanceSquared; // DistanceSquared is set in SortWaitingSoundsByDistance
 
-            nextNode = node.Next;
-            nextNextNode = nextNode?.Next;
-            var distanceSquared = GetDistanceSquared(node.Value.SoundSource);
-
-            if (!CheckDistance(distanceSquared, node.Value.SoundParams.Attenuation))
-            {
-                node = nextNode;
+            if (!CheckDistance(distanceSquared, sound.SoundParams.Attenuation))
                 continue;
-            }
 
-            if ((IsMaxSoundCount || HitSoundLimit(node.Value.SoundInfo, gametick)) && !BumpSoundByPriority(node.Value.Priority, distanceSquared, node.Value.SoundParams.Attenuation))
-            {
-                node = nextNode;
+            if ((IsMaxSoundCount || HitSoundLimit(sound.SoundInfo, gametick)) && !BumpSoundByPriority(sound.Priority, distanceSquared, sound.SoundParams.Attenuation))
                 continue;
-            }
 
-            var value = node.Value;
-            var elaspedSeconds = (GetGameTick() - value.GameTick) / 35f;
-            CreateSound(value.SoundSource, value.Position, value.Velocity, value.OffsetSeconds + elaspedSeconds, value.SoundInfo.Name, value.SoundParams, out _);
-
-            // CreateSound can remove the nextNode in the chain. Need to check if it was removed and use the next one ahead.
-            node = nextNode;
-            if (node?.List == null)
-                node = nextNextNode;
+            var elaspedSeconds = (GetGameTick() - sound.GameTick) / 35f;
+            CreateSound(sound.SoundSource, sound.Position, sound.Velocity, sound.OffsetSeconds + elaspedSeconds, sound.SoundInfo.Name, sound.SoundParams, out _);
         }
+    }
+
+    private void SortWaitingSoundsByDistance(WaitingSoundList sounds, DynamicArray<WaitingSound> sortSounds)
+    {
+        sortSounds.EnsureCapacity(sounds.Count);
+        int index = 0;
+        foreach (var sound in sounds)
+            sortSounds.Data[index++] = sound;
+
+        sortSounds.Length = index;
+        
+        for (int i = 0; i < sortSounds.Length; i++)
+        {
+            ref var sound = ref sortSounds.Data[i];
+            sound.DistanceSquared = GetDistanceSquared(sound.SoundSource);
+        }
+
+        sortSounds.Sort(m_waitingSoundDistanceSort);
+    }
+
+    private static int WaitingSoundDistanceSort(WaitingSound x, WaitingSound y)
+    {
+        return x.DistanceSquared.CompareTo(y.DistanceSquared);
     }
 
     public void ClearSounds()

--- a/Core/Audio/Sounds/SoundManager.cs
+++ b/Core/Audio/Sounds/SoundManager.cs
@@ -4,7 +4,6 @@ using Helion.Resources.Definitions.SoundInfo;
 using Helion.Util;
 using Helion.Util.Container;
 using Helion.Util.RandomGenerators;
-using Helion.World.Entities;
 using Helion.World.Sound;
 using System;
 using System.Collections.Generic;
@@ -198,8 +197,11 @@ public class SoundManager : IDisposable
 
     protected virtual int GetGameTick() => 0;
 
-    protected void UpdateWaitingLoopSounds()
+    protected void UpdateWaitingSounds()
     {
+        if (m_waitingLoopSounds.Count == 0)
+            return;
+
         SortWaitingSoundsByDistance(m_waitingLoopSounds, m_sortSounds);
         var gametick = GetGameTick();
 
@@ -341,17 +343,17 @@ public class SoundManager : IDisposable
                 }
             }
 
-            node.Stop();
-            audioSources.RemoveAndFree(node, ArchiveCollection.DataCache);
-            soundStopped = true;
-
             if (option == StopSoundOption.BySound && node.AudioData.Loop)
             {
                 var stopSoundSource = node.AudioData.SoundSource;
-                var stopSoundParams = new SoundParams(stopSoundSource, loop: true, node.AudioData.Attenuation, node.AudioData.Volume);
+                var stopSoundParams = new SoundParams(stopSoundSource, node.AudioData.Loop, node.AudioData.Attenuation, node.AudioData.Volume);
                 CreateWaitingLoopSound(stopSoundSource, node.GetPosition().Double, node.GetVelocity().Double, 
                     node.AudioData.SoundInfo, node.AudioData.Priority, node.GetOffsetSeconds(), gametick, stopSoundParams);
             }
+
+            node.Stop();
+            audioSources.RemoveAndFree(node, ArchiveCollection.DataCache);
+            soundStopped = true;
 
             break;
         }
@@ -552,9 +554,9 @@ public class SoundManager : IDisposable
 
         if (lowestPriorityNode != null && priority <= lowestPriority && (distanceSquared < farthestDistanceSquared || attenuation == Attenuation.None))
         {
+            AddWaitingSoundFromBumpedSound(lowestPriorityNode);
             lowestPriorityNode.Stop();
             audioSources.RemoveAndFree(lowestPriorityNode, ArchiveCollection.DataCache);
-            AddWaitingSoundFromBumpedSound(lowestPriorityNode);
             return true;
         }
 
@@ -629,9 +631,7 @@ public class SoundManager : IDisposable
     {
         AudioManager.Tick();
 
-        // Note: We do not set the position here since everything should be
-        // attenuated globally.
-        UpdateWaitingLoopSounds();
+        UpdateWaitingSounds();
         PlaySounds();
 
         if (PlayingSounds.Count == 0)

--- a/Core/Audio/Sounds/WaitingSound.cs
+++ b/Core/Audio/Sounds/WaitingSound.cs
@@ -14,4 +14,5 @@ public struct WaitingSound(ISoundSource source, Vec3D? position, Vec3D? velocity
     public SoundParams SoundParams = soundParams;
     public float OffsetSeconds = offsetSeconds;
     public int GameTick = gameTick;
+    public double DistanceSquared;
 }

--- a/Core/Util/DataCache.cs
+++ b/Core/Util/DataCache.cs
@@ -245,9 +245,13 @@ public class DataCache
     }
 
     public void FreeAudioSource(IAudioSource audioSource)
-    {        
+    {
         if (audioSource is not OpenALAudioSource)
+        {
+            audioSource.AudioData.SoundSource.ClearSound(audioSource, audioSource.AudioData.SoundChannelType);
+            audioSource.CacheFree();
             return;
+        }
 
         // Clear any positional audio effects
         audioSource.SetVelocity(0, 0, 0);

--- a/Core/World/Sound/WorldSoundManager.cs
+++ b/Core/World/Sound/WorldSoundManager.cs
@@ -7,6 +7,7 @@ using Helion.Util.Configs.Components;
 using Helion.Util.RandomGenerators;
 using Helion.World.Entities;
 using Helion.World.Entities.Players;
+using Helion.World.Geometry.Sectors;
 
 namespace Helion.World.Sound;
 
@@ -86,6 +87,11 @@ public class WorldSoundManager : SoundManager, ITickable
 
     public IAudioSource? CreateSoundOn(ISoundSource soundSource, string sound, SoundParams soundParams)
     {
+        if (soundSource is SectorPlane plane && plane.Sector.Id == 434)
+        {
+            int lol = 1;
+        }
+
         if (!soundSource.CanMakeSound())
             return null;
 

--- a/Core/World/Sound/WorldSoundManager.cs
+++ b/Core/World/Sound/WorldSoundManager.cs
@@ -7,7 +7,6 @@ using Helion.Util.Configs.Components;
 using Helion.Util.RandomGenerators;
 using Helion.World.Entities;
 using Helion.World.Entities.Players;
-using Helion.World.Geometry.Sectors;
 
 namespace Helion.World.Sound;
 
@@ -87,11 +86,6 @@ public class WorldSoundManager : SoundManager, ITickable
 
     public IAudioSource? CreateSoundOn(ISoundSource soundSource, string sound, SoundParams soundParams)
     {
-        if (soundSource is SectorPlane plane && plane.Sector.Id == 434)
-        {
-            int lol = 1;
-        }
-
         if (!soundSource.CanMakeSound())
             return null;
 
@@ -229,7 +223,7 @@ public class WorldSoundManager : SoundManager, ITickable
 
         var listener = m_world.GetListener();
         AudioManager.SetListener(listener.Position, listener.Angle, listener.Pitch);
-        UpdateWaitingLoopSounds();
+        UpdateWaitingSounds();
         PlaySounds();
         AudioManager.Tick();
 


### PR DESCRIPTION
Sort waiting sounds by distance so they aren't continually moved in and out of sounds to play.

Fix calls that use the audio data from the node after it was released that was preventing looping sounds from going back to the wait list.