### PR TITLE
fix alpha wall rendering with vanilla render

### DIFF
--- a/Core/Render/OpenGL/Framebuffer/PlaneClipFrameBuffer.cs
+++ b/Core/Render/OpenGL/Framebuffer/PlaneClipFrameBuffer.cs
@@ -108,7 +108,7 @@ public class PlaneClipFrameBuffer : IDisposable
         if (m_ownsDepthTexture)
             GL.Clear(ClearBufferMask.DepthBufferBit);
 
-        var clear = stackalloc float[4] { -255, -255, -255, -255 };
+        var clear = stackalloc float[4] { -255, 1e30f, -255, 1e30f };
         GL.ClearBuffer(ClearBuffer.Color, m_clearBufferIndex, clear);
 
         if (m_ownsDepthTexture)


### PR DESCRIPTION
correctly initialize depth values so alpha walls aren't discarded when sampling unwritten pixels