### PR TITLE
ingore activating entity in boss death to match original behavior

### DIFF
--- a/Core/World/Entities/Definition/States/EntityActionFunctions.cs
+++ b/Core/World/Entities/Definition/States/EntityActionFunctions.cs
@@ -1495,7 +1495,7 @@ public static class EntityActionFunctions
         A_Fall(entity);
 
         var world = WorldStatic.World;
-        if (world.EntityAliveCount(entity.Definition.Id) == 0)
+        if (world.EntityAliveCount(entity.Definition.Id, entity) == 0)
         {
             var sectors = world.FindBySectorTag(666);
             foreach (var sector in sectors)

--- a/Core/World/IWorld.cs
+++ b/Core/World/IWorld.cs
@@ -159,7 +159,7 @@ public interface IWorld : IDisposable
     bool IsSectorIdValid(int sectorId) => sectorId >= 0 && sectorId < Sectors.Count;
     bool IsLineIdValid(int lineId) => lineId >= 0 && lineId < Lines.Count;
     int EntityCount(int entityDefinitionId);
-    int EntityAliveCount(int entityDefinitionId);
+    int EntityAliveCount(int entityDefinitionId, Entity? ignoreEntity = null);
     void NoiseAlert(Entity target, Entity source);
     void BossDeath(Entity entity);
     Player? GetLineOfSightPlayer(Entity entity, bool allAround);

--- a/Core/World/Special/BossActionMonsterCount.cs
+++ b/Core/World/Special/BossActionMonsterCount.cs
@@ -1,20 +1,11 @@
-﻿using Helion.Geometry.Segments;
-using Helion.Geometry.Vectors;
-using Helion.Maps.Shared;
+﻿using Helion.Maps.Shared;
 using Helion.Maps.Specials;
 using Helion.Maps.Specials.Compatibility;
 using Helion.Maps.Specials.Vanilla;
 using Helion.Maps.Specials.ZDoom;
-using Helion.Resources.Archives.Entries;
 using Helion.Resources.Definitions.MapInfo;
-using Helion.Util;
 using Helion.World.Entities;
 using Helion.World.Geometry.Lines;
-using Helion.World.Geometry.Sectors;
-using Helion.World.Geometry.Sides;
-using Helion.World.Geometry.Walls;
-using Helion.World.Physics;
-using System;
 
 namespace Helion.World.Special;
 
@@ -33,12 +24,12 @@ public class BossActionMonsterCount : IMonsterCounterSpecial
         EntityDefinitionId = entityDefinitionId;
     }
 
-    public SpecialTickStatus Tick()
+    public SpecialTickStatus Tick(Entity? ignoreEntity)
     {
         if (m_destroyed)
             return SpecialTickStatus.Destroy;
 
-        if (m_world.EntityAliveCount(EntityDefinitionId) == 0)
+        if (m_world.EntityAliveCount(EntityDefinitionId, ignoreEntity) == 0)
         {
             m_destroyed = true;
             ExecuteSpecial();
@@ -70,10 +61,5 @@ public class BossActionMonsterCount : IMonsterCounterSpecial
             return;
 
         m_world.SpecialManager.AddActivatedLineSpecial(specialType, specialArgs, compat);
-    }
-
-    public bool Use(Entity entity)
-    {
-        return false;
     }
 }

--- a/Core/World/Special/IMonsterCounterSpecial.cs
+++ b/Core/World/Special/IMonsterCounterSpecial.cs
@@ -1,6 +1,9 @@
-﻿namespace Helion.World.Special;
+﻿using Helion.World.Entities;
 
-public interface IMonsterCounterSpecial : ISpecial
+namespace Helion.World.Special;
+
+public interface IMonsterCounterSpecial
 {
+    SpecialTickStatus Tick(Entity? ignoreEntity);
     int EntityDefinitionId { get; }
 }

--- a/Core/World/WorldBase.cs
+++ b/Core/World/WorldBase.cs
@@ -1138,7 +1138,7 @@ public abstract partial class WorldBase : IWorld
         {
             var special = m_bossDeathSpecials[i];
             if (special.EntityDefinitionId == entity.Definition.Id)
-                special.Tick();
+                special.Tick(entity);
         }
     }
 
@@ -3079,16 +3079,19 @@ public abstract partial class WorldBase : IWorld
     }
 
     public int EntityCount(int entityDefinitionId) =>
-        EntityCount(entityDefinitionId, true);
+        EntityCount(entityDefinitionId, false);
 
-    public int EntityAliveCount(int entityDefinitionId) =>
-        EntityCount(entityDefinitionId, true);
+    public int EntityAliveCount(int entityDefinitionId, Entity? ignoreEntity = null) =>
+        EntityCount(entityDefinitionId, true, ignoreEntity);
 
-    private int EntityCount(int entityDefinitionId, bool checkAlive)
+    private int EntityCount(int entityDefinitionId, bool checkAlive, Entity? ignoreEntity = null)
     {
         int count = 0;
         for (var entity = EntityManager.Head; entity != null; entity = entity.Next)
         {
+            if (entity == ignoreEntity)
+                continue;
+
             if (entity.Definition.Id == entityDefinitionId && (!checkAlive || !entity.IsDead))
                 count++;
         }

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -33,3 +33,4 @@
 - Fix issue with lower wall gap correction and sprites.
 - Fix UDMF upper scale scale calculation.
 - Fix rendering of walls with negative scale values with pixel gap correction and correct offset handling.
+- Fix A_BossDeath and A_KeenDie to exclude self. Fixes Tele-Direct Atlantic Doom blueprints not opening door.

--- a/Tests/Unit/GameAction/BossAction.cs
+++ b/Tests/Unit/GameAction/BossAction.cs
@@ -16,7 +16,7 @@ public class BossAction
 
     public BossAction()
     {
-        World = WorldAllocator.LoadMap("Resources/bossaction.zip", "bossaction.WAD", "MAP01", GetType().Name, (world) => { }, IWadType.Doom2);
+        World = WorldAllocator.LoadMap("Resources/bossaction.zip", "bossaction.WAD", "MAP01", GetType().Name, (world) => { }, IWadType.Doom2, cacheWorld: false);
     }
 
     [Fact(DisplayName = "BossAction by actor name")]
@@ -39,6 +39,18 @@ public class BossAction
         sector.Floor.Z.Should().Be(128);
         var monster = GameActions.GetEntity(World, "ChaingunGuy");
         monster.Kill(null);
+        World.BossDeath(monster);
+        GameActions.TickWorld(World, 1);
+        GameActions.RunSectorPlaneSpecial(World, sector);
+        sector.Floor.Z.Should().Be(0);
+    }
+
+    [Fact(DisplayName = "BossAction activates when last entity is still alive")]
+    public void BossActionWhileAlive()
+    {
+        var sector = GameActions.GetSectorByTag(World, 420);
+        sector.Floor.Z.Should().Be(128);
+        var monster = GameActions.GetEntity(World, "ChaingunGuy");
         World.BossDeath(monster);
         GameActions.TickWorld(World, 1);
         GameActions.RunSectorPlaneSpecial(World, sector);


### PR DESCRIPTION
ignore activating entity in boss death (fixes Tele-Direct Atlantic Doom blueprints in MAP01)