### PR TITLE
add video option to simplify setting true color/palette with vanilla rendering options

### DIFF
--- a/Core/Layer/Options/OptionsLayer.cs
+++ b/Core/Layer/Options/OptionsLayer.cs
@@ -80,9 +80,25 @@ public class OptionsLayer : IGameLayer, IAnimationLayer
         m_config.Window.Virtual.Enable.OnChanged += WindowVirtualEnable_OnChanged;
         m_config.Window.Virtual.Dimension.OnChanged += WindowVirtualDimension_OnChanged;
         m_config.Window.MenuScale.OnChanged += Scale_OnChanged;
+        
+        if (m_config is FileConfig fileConfig)
+        {
+            fileConfig.AppRestartRequired += Config_AppRestartRequired;
+            fileConfig.MapRestartRequired += Config_MapRestartRequired;
+        }
 
         Animation = new(TimeSpan.FromMilliseconds(200), this);
         Animation.OnStart += Animation_OnStart;
+    }
+
+    private void Config_MapRestartRequired(object? sender, EventArgs e)
+    {
+        ShowMessage(ConfigInfoAttribute.MapRestartRequiredMessage);
+    }
+
+    private void Config_AppRestartRequired(object? sender, EventArgs e)
+    {
+        ShowRestartRequired();
     }
 
     private void Animation_OnStart(object? sender, IAnimationLayer e)
@@ -148,13 +164,18 @@ public class OptionsLayer : IGameLayer, IAnimationLayer
     {
         if (configAttr.RestartRequired)
         {
-            m_dialog = new MessageDialog(m_config.Window, "Restart required", ["Restart required for this change to take effect.", "", "Restart now?"], "Yes", "No");
-            m_dialog.OnClose += RestartDialog_OnClose;
+            ShowRestartRequired();
             return;
         }
 
         if (configAttr.GetSetWarningString(out var warningString))
             ShowMessage(warningString);
+    }
+
+    private void ShowRestartRequired()
+    {
+        m_dialog = new MessageDialog(m_config.Window, "Restart required", ["Restart required for this change to take effect.", "", "Restart now?"], "Yes", "No");
+        m_dialog.OnClose += RestartDialog_OnClose;
     }
 
     private void RestartDialog_OnClose(object? sender, DialogCloseArgs e)

--- a/Core/Util/Configs/Components/ConfigWindow.cs
+++ b/Core/Util/Configs/Components/ConfigWindow.cs
@@ -3,6 +3,7 @@ using Helion.Util.Configs.Impl;
 using Helion.Util.Configs.Options;
 using Helion.Util.Configs.Values;
 using OpenTK.Windowing.Common;
+using System;
 using System.ComponentModel;
 using static Helion.Util.Configs.Values.ConfigFilters;
 
@@ -23,6 +24,33 @@ public enum BlitFilter
     Auto,
     Nearest,
     Linear
+}
+
+[Flags]
+public enum ConfigRenderModeFlags
+{
+    SoftwareClip = 1,
+    FasterClip = 2,
+
+    TrueColor = 4,
+    Palette = 8,
+}
+
+public enum ConfigRenderMode
+{
+    [Description("True color (Fastest)")]
+    TrueColorFast = ConfigRenderModeFlags.TrueColor,
+    [Description("True color software (Accurate)")]
+    TrueColorClipAccurate = ConfigRenderModeFlags.TrueColor | ConfigRenderModeFlags.SoftwareClip,
+    [Description("True color software (Faster)")]
+    TrueColorClipFaster = ConfigRenderModeFlags.TrueColor | ConfigRenderModeFlags.SoftwareClip | ConfigRenderModeFlags.FasterClip,
+
+    [Description("Palette (Fastest)")]
+    PaletteFast = ConfigRenderModeFlags.Palette,
+    [Description("Palette software (Accurate)")]
+    PaletteClipAccurate = ConfigRenderModeFlags.Palette | ConfigRenderModeFlags.SoftwareClip,
+    [Description("Palette software (Faster)")]
+    PaletteClipFaster = ConfigRenderModeFlags.Palette | ConfigRenderModeFlags.SoftwareClip | ConfigRenderModeFlags.FasterClip,
 }
 
 public class ConfigWindowVirtual: ConfigElement<ConfigWindowVirtual>
@@ -46,8 +74,12 @@ public class ConfigWindowVirtual: ConfigElement<ConfigWindowVirtual>
 
 public class ConfigWindow: ConfigElement<ConfigWindow>
 {
+    [ConfigInfo("Render mode. Selections that combine video mode and software sprite clipping emulation", save: false)]
+    [OptionMenu(OptionSectionType.Video, "Render Mode")]
+    public readonly ConfigValue<ConfigRenderMode> RenderMode = new(ConfigRenderMode.TrueColorFast);
+
     [ConfigInfo("Display fullscreen or windowed.")]
-    [OptionMenu(OptionSectionType.Video, "Fullscreen/Window", allowReset: false)]
+    [OptionMenu(OptionSectionType.Video, "Fullscreen/Window", allowReset: false, spacer: true)]
     public readonly ConfigValue<RenderWindowState> State = new(RenderWindowState.Fullscreen, OnlyValidEnums<RenderWindowState>());
 
     [ConfigInfo("Window border.")]

--- a/Core/Util/Configs/ConfigEnums.cs
+++ b/Core/Util/Configs/ConfigEnums.cs
@@ -47,6 +47,7 @@ namespace Helion.Util.Configs
             { typeof(SkyRenderMode), Enum.GetValues<SkyRenderMode>() },
             { typeof(RenderContrastMode), Enum.GetValues<RenderContrastMode>() },
             { typeof(WeaponSwitch), Enum.GetValues<WeaponSwitch>() },
+            { typeof(ConfigRenderMode), Enum.GetValues<ConfigRenderMode>() },
         };
 
         public static Dictionary<Type, Dictionary<Enum, string>> KnownEnumLabels { get; } = new Dictionary<Type, Dictionary<Enum, string>>()
@@ -72,6 +73,7 @@ namespace Helion.Util.Configs
             { typeof(RngMethod), GetDescriptions<RngMethod>()},
             { typeof(SkyRenderMode), GetDescriptions<SkyRenderMode>()},
             { typeof(WeaponSwitch), GetDescriptions<WeaponSwitch>()},
+            { typeof(ConfigRenderMode), GetDescriptions<ConfigRenderMode>()},
         };
 
         private static Dictionary<Enum, string> GetDescriptions<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] T>() where T : struct, Enum

--- a/Core/Util/Configs/Impl/FileConfig.cs
+++ b/Core/Util/Configs/Impl/FileConfig.cs
@@ -29,6 +29,9 @@ public class FileConfig : Config
     private readonly string m_filePath;
     private bool m_noFileExistedWhenRead;
 
+    public event EventHandler? AppRestartRequired;
+    public event EventHandler? MapRestartRequired;
+
     public FileConfig(string filePath, bool addDefaultsIfNew)
     {
         m_filePath = filePath;
@@ -40,6 +43,52 @@ public class FileConfig : Config
         // their default state. This is okay and should not be considered as
         // "changed".
         UnsetChangedFlag();
+        DetermineRenderMode();
+        Window.RenderMode.OnChanged += RenderMode_OnChanged;
+    }
+
+    private void RenderMode_OnChanged(object? sender, ConfigRenderMode e)
+    {
+        var colorMode = Window.ColorMode.Value;
+        var vanillaRender = Render.VanillaRender.Value;
+
+        var mode = (ConfigRenderModeFlags)e;
+        if ((mode & ConfigRenderModeFlags.TrueColor) == 0)
+            Window.ColorMode.Set(RenderColorMode.Palette);
+        else
+            Window.ColorMode.Set(RenderColorMode.TrueColor);
+
+        Render.VanillaRender.Set((mode & ConfigRenderModeFlags.SoftwareClip) != 0);
+
+        if ((mode & ConfigRenderModeFlags.FasterClip) == 0)
+            Render.DownScaleVanillaRenderSampleBuffer.Set(1);
+        else
+            Render.DownScaleVanillaRenderSampleBuffer.Set(2);
+
+        if (colorMode != Window.ColorMode.Value)
+            AppRestartRequired?.Invoke(this, EventArgs.Empty);
+        if (vanillaRender != Render.VanillaRender.Value)
+            MapRestartRequired?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void DetermineRenderMode()
+    {
+        ConfigRenderModeFlags flags = default;
+
+        if (Window.ColorMode.Value == RenderColorMode.TrueColor)
+            flags |= ConfigRenderModeFlags.TrueColor;
+        else
+            flags |= ConfigRenderModeFlags.Palette;
+
+        if (Render.VanillaRender)
+        {
+            flags |= ConfigRenderModeFlags.SoftwareClip;
+
+            if (Render.DownScaleVanillaRenderSampleBuffer > 1)
+                flags |= ConfigRenderModeFlags.FasterClip;
+        }
+
+        Window.RenderMode.Set((ConfigRenderMode)flags);
     }
 
     private void MigrateValues()

--- a/Core/Util/Configs/Values/ConfigInfoAttribute.cs
+++ b/Core/Util/Configs/Values/ConfigInfoAttribute.cs
@@ -8,6 +8,9 @@ namespace Helion.Util.Configs.Values;
 [AttributeUsage(AttributeTargets.Field)]
 public class ConfigInfoAttribute : Attribute
 {
+    public const string MapRestartRequiredMessage = "Map restart required for this change to take effect.";
+    public const string AppRestartRequiredMessage = "App restart required for this change to take effect.";
+
     /// <summary>
     /// A high level description of the attribute.
     /// </summary>
@@ -55,9 +58,9 @@ public class ConfigInfoAttribute : Attribute
     {
         message = string.Empty;
         if (MapRestartRequired)
-            message = "Map restart required for this change to take effect.";
+            message = MapRestartRequiredMessage;
         if (RestartRequired)
-            message = "App restart required for this change to take effect.";
+            message = AppRestartRequiredMessage;
         return message.Length > 0;
     }
 }


### PR DESCRIPTION
Add video option to simplify setting true color/palette with vanilla rendering options

The idea is to simplify these settings of having options across video and render.

This also makes the vanilla software sprite clip emulation more forward facing since it's sort of hidden.