### PR TITLE
fix changing hud.scale from console to automatically disable hud.autoscale so it isn't modified on restart

### DIFF
--- a/Client/Client.Commands.cs
+++ b/Client/Client.Commands.cs
@@ -45,6 +45,7 @@ public partial class Client
     private readonly Zdbsp m_zdbsp = new();
     private WorldModel? m_lastWorldModel;
     private bool m_isSecretExit;
+    private IConfigValue? m_configValueFromConsole;
     private LevelChangeEvent m_levelChangeEvent = LevelChangeEvent.Default;
 
     private string m_lastMapName = string.Empty;
@@ -740,6 +741,7 @@ public partial class Client
             }
         }
 
+        m_configValueFromConsole = component.Value;
         bool success = true;
         ConfigSetResult result = component.Value.Set(args.Args[0]);
         switch (result)
@@ -769,6 +771,7 @@ public partial class Client
         if (success && component.Attribute.GetSetWarningString(out var warning))
             HelionLog.Warn(warning);
 
+        m_configValueFromConsole = null;
         return true;
     }
 

--- a/Client/Client.cs
+++ b/Client/Client.cs
@@ -97,6 +97,7 @@ public partial class Client : IDisposable, IInputManagement
 
         m_config.Game.Rng.OnChanged += Rng_OnChanged;
         m_config.Render.PixelGapCorrection.OnChanged += PixelGapCorrection_OnChanged;
+        m_config.Hud.Scale.OnChanged += Scale_OnChanged;
 
         if (commandLineArgs.GlVersion.HasValue)
         {
@@ -130,6 +131,14 @@ public partial class Client : IDisposable, IInputManagement
         RegisterConfigChanges();
         UpdateVolume();
         m_ticker.Start();
+    }
+
+    private void Scale_OnChanged(object? sender, double e)
+    {
+        // Changing hud.scale isn't prevented in the console. Autoscale needs to be turned off.
+        // Otherwise it will be reset on restart because hud.autoscale is on.
+        if (m_configValueFromConsole == m_config.Hud.Scale && m_config.Hud.AutoScale.Value)
+            m_config.Hud.AutoScale.Set(false);
     }
 
     private static void GLFWErrorCallback(ErrorCode error, string description)


### PR DESCRIPTION
fixes #1341 