### PR TITLE
melee move fix

### DIFF
--- a/Core/World/Entities/Definition/States/EntityActionFunctions.cs
+++ b/Core/World/Entities/Definition/States/EntityActionFunctions.cs
@@ -771,6 +771,7 @@ public static class EntityActionFunctions
             entity.Flags.Attacking = true;
             entity.PlayAttackSound();
             entity.FrameState.SetFrameIndex(entity, entity.Definition.MeleeState.Value);
+            return;
         }
 
         if (entity.IsDisposed)

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -42,3 +42,4 @@
 - Fix logging missing sound errors when config option is off.
 - Fix changing hud.scale from console to automatically disable hud.autoscale so it isn't modified on restart.
 - Fix friendly monsters passing through two-sided impassible lines.
+- Fix monsters attempting to move immediately after melee attack to match original behavior.

--- a/Tests/Unit/GameAction/Nightmare.cs
+++ b/Tests/Unit/GameAction/Nightmare.cs
@@ -53,6 +53,7 @@ public class Nightmare
         demon.Position.Y.Should().Be(-124);
 
         GameActions.TickWorld(World, () => demon.FrameState.Frame.ActionFunction != EntityActionFunctions.A_SargAttack, () => { });
+        Player.Velocity = Vec3D.Zero;
         // Normal duration for attack is 8. Should be halved.
         GameActions.TickWorld(World, 4);
         (demon.FrameState.Frame.ActionFunction == EntityActionFunctions.A_FaceTarget).Should().BeTrue();


### PR DESCRIPTION
Fix monsters attempting to move immediately after melee attack to match original behavior

fixes #1375 