### PR TITLE
Midtex sprite clip fix

### DIFF
--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
@@ -764,7 +764,10 @@ public class GeometryRenderer : IDisposable
         SideTexture visibleTextures, Action<Side, DynamicVertex[], WallLocation> render)
     {
         var clipPlanes = GetMidTexClipPlanes(side, facingSector, otherSector, out var opening, out var prevOpening);
-        if (((visibleTextures & SideTexture.Lower) == 0 || (side.FloodTextures & SideTexture.Lower) != 0) && (clipPlanes & SectorPlanes.Floor) != 0)
+        if (
+            ((visibleTextures & SideTexture.Lower) == 0 || (side.FloodTextures & SideTexture.Lower) != 0) &&
+            (side.PartnerSide == null || (side.PartnerSide.FloodTextures & SideTexture.Lower) == 0) &&
+            (clipPlanes & SectorPlanes.Floor) != 0)
         {
             var bottomZ = (float)opening.MinBottomZ;
             var prevBottomZ = (float)prevOpening.MinBottomZ;
@@ -779,7 +782,10 @@ public class GeometryRenderer : IDisposable
             render(side, m_wallVertices, WallLocation.Lower);
         }
 
-        if (((visibleTextures & SideTexture.Upper) == 0 || (side.FloodTextures & SideTexture.Upper) != 0) && (clipPlanes & SectorPlanes.Ceiling) != 0)
+        if (
+            ((visibleTextures & SideTexture.Upper) == 0 || (side.FloodTextures & SideTexture.Upper) != 0) &&
+            (side.PartnerSide == null || (side.PartnerSide.FloodTextures & SideTexture.Upper) == 0) &&
+            (clipPlanes & SectorPlanes.Ceiling) != 0)
         {
             var topZ = (float)opening.MaxTopZ;
             var prevTopZ = (float)prevOpening.MaxTopZ;

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -43,3 +43,4 @@
 - Fix changing hud.scale from console to automatically disable hud.autoscale so it isn't modified on restart.
 - Fix friendly monsters passing through two-sided impassible lines.
 - Fix monsters attempting to move immediately after melee attack to match original behavior.
+- Fix issue with midtex clipping when upper/lower texture is missing that blocked sprite rendering with vanilla render option. (Fixes Blues Brothers 2025 MAP01 near megasphere)


### PR DESCRIPTION
Fix issue with midtex clipping when upper/lower texture is missing that blocked sprite rendering with vanilla render option. (Fixes Blues Brothers 2025 MAP01 near megasphere)