### PR TITLE
fix weapon 4 issues with Blues Brothers 2025

### DIFF
--- a/Core/World/Entities/Players/Player.cs
+++ b/Core/World/Entities/Players/Player.cs
@@ -1529,13 +1529,16 @@ public class Player : Entity
     {
         if (PendingWeapon == null)
         {
+            PendingWeapon = Weapon;
+
             // The Weapon reference exists on clear inventory while lowering the weapon. Need to clear the reference if no longer owned.
-            if (Weapon != null && !Inventory.Weapons.OwnsWeapon(Weapon.Definition))
+            if (PendingWeapon != null && !Inventory.Weapons.OwnsWeapon(PendingWeapon.Definition))
             {
+                PendingWeapon = null;
                 Weapon = null;
                 AnimationWeapon = null;
             }
-            return;
+            return;            
         }
 
         if (PendingWeapon.Definition.Properties.Weapons.UpSound.Length > 0)

--- a/Core/World/WorldBase.cs
+++ b/Core/World/WorldBase.cs
@@ -3252,7 +3252,7 @@ public abstract partial class WorldBase : IWorld
         if (!checkEntity.Flags.Shootable)
             return GridIterationStatus.Continue;
 
-        if (!m_newTracerTargetData.Owner.ValidEnemyTarget(checkEntity))
+        if (m_newTracerTargetData.Owner == checkEntity || !m_newTracerTargetData.Owner.ValidEnemyTarget(checkEntity))
             return GridIterationStatus.Continue;
 
         if (m_newTracerTargetData.FieldOfViewRadians > 0 &&

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -44,3 +44,5 @@
 - Fix friendly monsters passing through two-sided impassible lines.
 - Fix monsters attempting to move immediately after melee attack to match original behavior.
 - Fix issue with midtex clipping when upper/lower texture is missing that blocked sprite rendering with vanilla render option. (Fixes Blues Brothers 2025 MAP01 near megasphere)
+- Fix A_Lower not able to call A_Raise when no pending weapon is set through dehacked. (Fixes Blues Brothers 2025 weapon slot 4)
+- Fix A_FindTracer to ignore things when same owner. (Fixes Blues Brothers 2025 weapon slot 4)

--- a/Tests/Unit/GameAction/Inventory/Inventory_Weapon.cs
+++ b/Tests/Unit/GameAction/Inventory/Inventory_Weapon.cs
@@ -4,6 +4,7 @@ using Helion.Tests.Unit.GameAction.Util;
 using Helion.Util;
 using Helion.Util.Extensions;
 using Helion.World.Entities;
+using Helion.World.Entities.Inventories;
 using Helion.World.Entities.Players;
 using System;
 using Xunit;
@@ -658,6 +659,23 @@ public partial class Inventory
         Player.Inventory.Weapons.HasWeaponSlot(3).Should().BeTrue();
         Player.Inventory.Remove("Shotgun", 1);
         Player.Inventory.Weapons.HasWeaponSlot(3).Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "Lower weapon will eventually raise even with no pending weapon (can happen through dehacked)")]
+    public void LowerWeaponWithNoPendingWeapon()
+    {
+        Player.Inventory.Weapons.HasWeaponSlot(1).Should().BeTrue();
+        Player.PendingWeapon.Should().BeNull();
+        InventoryUtil.AssertWeapon(Player.Weapon, "Pistol");
+
+        Player.ForceLowerWeapon(false);
+        Player.PendingWeapon.Should().BeNull();
+
+        GameActions.TickWorld(World, () => Player.WeaponOffset.Y < 122, () => { });
+        GameActions.TickWorld(World, () => Player.WeaponOffset.Y > Constants.WeaponTop, () => { });
+
+        Player.Weapon!.FrameState.Frame.ActionFunction.Should().NotBeNull();
+        Player.Weapon!.FrameState.Frame.ActionFunction!.Method.Name.Should().Be("A_WeaponReady");
     }
 
     private Entity CreateEntity(string name, Vec3D pos)


### PR DESCRIPTION
Fix A_Raise not being called after A_Lower when no pending weapon is set

Fix A_FindTracer to ignore same owner

fixes #1377 
fixes #1378 