### PR TITLE
add findinactivekeylines command

### DIFF
--- a/Client/Client.Commands.cs
+++ b/Client/Client.Commands.cs
@@ -294,7 +294,7 @@ public partial class Client
             HelionLog.Info($"No map markers to remove.");
     }
 
-    [ConsoleCommand("findkeys", "Finds the next key in the map.")]
+    [ConsoleCommand("findkeys", "Finds all keys in the automap.")]
     private void CommandFindKey(ConsoleCommandEventArgs args)
     {
         if (m_layerManager.WorldLayer == null)
@@ -303,16 +303,25 @@ public partial class Client
         m_layerManager.WorldLayer.World.FindKeys();
     }
 
-    [ConsoleCommand("findkeylines", "Finds the next locked key line in the map.")]
+    [ConsoleCommand("findkeylines", "Marks all key lines the automap.")]
     private void CommandFindKeyLine(ConsoleCommandEventArgs args)
     {
         if (m_layerManager.WorldLayer == null)
             return;
 
-        m_layerManager.WorldLayer.World.FindKeyLines();
+        m_layerManager.WorldLayer.World.FindKeyLines(FindKeyLineOptions.None);
     }
 
-    [ConsoleCommand("findexits", "Finds the next exit line/sector in the map.")]
+    [ConsoleCommand("findinactivekeylines", "Marks all the key lines in the automap that haven't been activated.")]
+    private void CommandFindInactiveKeyLine(ConsoleCommandEventArgs args)
+    {
+        if (m_layerManager.WorldLayer == null)
+            return;
+
+        m_layerManager.WorldLayer.World.FindKeyLines(FindKeyLineOptions.Inactive);
+    }
+
+    [ConsoleCommand("findexits", "Marks all exit lines/sectors in the automap.")]
     private void CommandFindExit(ConsoleCommandEventArgs args)
     {
         if (m_layerManager.WorldLayer == null)

--- a/Core/World/Entities/Definition/Flags/EntityFlags.cs
+++ b/Core/World/Entities/Definition/Flags/EntityFlags.cs
@@ -499,7 +499,7 @@ public struct EntityFlags
         Flags3 = 0;
     }
 
-    internal class EntityFlagsDebugView(EntityFlags flags)
+    internal sealed class EntityFlagsDebugView(EntityFlags flags)
     {
         private readonly EntityFlags m_flags = flags;
 

--- a/Core/World/FindKeyLineOptions.cs
+++ b/Core/World/FindKeyLineOptions.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Helion.World;
+
+[Flags]
+public enum FindKeyLineOptions
+{
+    None,
+    Inactive = 1
+}

--- a/Core/World/Geometry/Lines/Line.cs
+++ b/Core/World/Geometry/Lines/Line.cs
@@ -199,6 +199,8 @@ public sealed class Line
             DataChanges |= LineDataTypes.Activated;
         else
             DataChanges &= ~LineDataTypes.Activated;
+
+        DataChanges |= LineDataTypes.EverActivated;
     }
 
     public void SetAlpha(float alpha)

--- a/Core/World/Geometry/Lines/LineDataTypes.cs
+++ b/Core/World/Geometry/Lines/LineDataTypes.cs
@@ -10,4 +10,5 @@ public enum LineDataTypes
     Automap = 4,
     Args = 8,
     Alpha = 16,
+    EverActivated = 32
 }

--- a/Core/World/IWorld.cs
+++ b/Core/World/IWorld.cs
@@ -183,7 +183,7 @@ public interface IWorld : IDisposable
     void EntityTeleported(Entity entity);
     bool PlayLevelMusic(string name, byte[]? data, MusicFlags flags = MusicFlags.Loop);
     void FindKeys();
-    void FindKeyLines();
+    void FindKeyLines(FindKeyLineOptions options);
     void FindExits();
     bool SetSkillLevel(SkillLevel skill);
     Subsector ToSubsector(double x, double y);

--- a/Core/World/Impl/SinglePlayer/MarkSpecials.cs
+++ b/Core/World/Impl/SinglePlayer/MarkSpecials.cs
@@ -25,9 +25,11 @@ public class MarkSpecials
     private static readonly Vec3F[] TracerColors =  [new(1f, 0.2f, 0.2f), new(0.2f, 1f, 0.2f), new(0.2f, 0.2f, 1f), new(0.8f, 0.2f, 0.8f), new(0.8f, 0.8f, 0.8f)];
     private static readonly Color[] AutomapColors = [Color.Red, Color.Green, Color.Blue, Color.Purple, Color.Yellow];
 
-    public readonly DynamicArray<Sector> MarkedSectors = new();
-    public readonly DynamicArray<Line> MarkedLines = new();
-    private readonly DynamicArray<int> m_playerTracers = new();
+    private static readonly List<Line> ActivatedLines = [];
+
+    public readonly DynamicArray<Sector> MarkedSectors = [];
+    public readonly DynamicArray<Line> MarkedLines = [];
+    private readonly DynamicArray<int> m_playerTracers = [];
     private readonly Dictionary<int, List<Line>> m_tagToLines = [];
     private readonly HashSet<int> m_searchedSectors = [];
     private bool m_mappedLineTags;
@@ -153,7 +155,7 @@ public class MarkSpecials
         }
     }
 
-    public static void FindKeyLines(IWorld world, List<object> lines)
+    public static void FindKeyLines(IWorld world, List<object> lines, FindKeyLineOptions options)
     {
         for (int i = 0; i < world.Lines.Count; i++)
         {
@@ -161,9 +163,37 @@ public class MarkSpecials
             if (line.Special == null)
                 continue;
 
-            if (LockSpecialUtil.IsLockSpecial(line, out _))
-                lines.Add(line);
+            if (!LockSpecialUtil.IsLockSpecial(line, out _))
+                continue;
+
+            if ((options & FindKeyLineOptions.Inactive) != 0)
+            {
+                if ((line.DataChanges & (LineDataTypes.Activated | LineDataTypes.EverActivated)) != 0)
+                {
+                    ActivatedLines.Add(line);
+                    continue;
+                }
+
+                // Ignore lines that are part of the same activated sector but were never activated
+                if (line.Back != null && FindSectorLineBackSide(ActivatedLines, line.Back.Sector.Id))
+                    continue;
+            }
+
+            lines.Add(line);
         }
+
+        ActivatedLines.Clear();
+    }
+
+    private static bool FindSectorLineBackSide(List<Line> lines, int sectorId)
+    {
+        foreach (Line addedLine in lines)
+        {
+            if (addedLine.Back != null && addedLine.Back.Sector.Id == sectorId)
+                return true;
+        }
+
+        return false;
     }
 
     public static void FindExits(IWorld world, List<object> items)

--- a/Core/World/WorldBase.cs
+++ b/Core/World/WorldBase.cs
@@ -2548,11 +2548,11 @@ public abstract partial class WorldBase : IWorld
             HighlightAreas.Add(new HighlightArea(((Entity)m_findObjects[i]).Position, HighlightSize));
     }
 
-    public void FindKeyLines()
+    public void FindKeyLines(FindKeyLineOptions options)
     {
         m_findObjects.Clear();
         HighlightAreas.Clear();
-        MarkSpecials.FindKeyLines(this, m_findObjects);
+        MarkSpecials.FindKeyLines(this, m_findObjects, options);
         if (m_findObjects.Count == 0)
         {
             DisplayMessage("No keys found");


### PR DESCRIPTION
Adds findinactivekeylines command that will only mark key lines in the automap if they were never activated. If multiple lines are in the same sector and one is activated then the others will be ignored.

Clean up info on other find functions.