### PR TITLE
fix PerformUploadCapacity being called continuously

### DIFF
--- a/Core/Render/OpenGL/Buffer/ArrayBufferObject.cs
+++ b/Core/Render/OpenGL/Buffer/ArrayBufferObject.cs
@@ -8,8 +8,14 @@ public abstract class ArrayBufferObject<T> : BufferObject<T> where T : struct
     protected override BufferTarget Target => BufferTarget.ArrayBuffer;
     protected abstract BufferUsageHint Hint { get; }
 
-    protected ArrayBufferObject(string objectLabel, int capacity = DefaultCapacity) : base(objectLabel, capacity)
+    private IntPtr m_ptr;
+
+    protected unsafe ArrayBufferObject(string objectLabel, int capacity = DefaultCapacity) : base(objectLabel, capacity)
     {
+        fixed (T* ptr = &Data.Data[0])
+        {
+            m_ptr = (IntPtr)ptr;
+        }
     }
 
     protected override void PerformUpload()
@@ -22,20 +28,24 @@ public abstract class ArrayBufferObject<T> : BufferObject<T> where T : struct
         GL.BufferData(Target, BytesPerElement * Data.Capacity, Data.Data, Hint);
     }
 
-    protected override void BufferSubData(int index, int length)
+    protected unsafe override void BufferSubData(int index, int length)
     {
-        // If the underlying array was resized then the new array needs to be uploaded
-        // This should be handled with BufferObject.UploadIfNeeded
-        if (m_dataVersion != Data.Version)
+        fixed (T* buffer = &Data.Data[0])
         {
-            Uploaded = false;
-            return;
+            var ptr = (IntPtr)buffer;
+            // If the underlying array was resized then the new array needs to be uploaded
+            // This should be handled with BufferObject.UploadIfNeeded
+            if (ptr != m_ptr)
+            {
+                m_ptr = ptr;
+                Uploaded = false;
+                return;
+            }
+
+            IntPtr offset = new(BytesPerElement * index);
+            int size = BytesPerElement * length;
+
+            GL.BufferSubData(Target, offset, size, ptr + (BytesPerElement * index));
         }
-
-        IntPtr offset = new(BytesPerElement * index);
-        int size = BytesPerElement * length;
-        IntPtr ptr = GetVboArray() + (BytesPerElement * index);
-
-        GL.BufferSubData(Target, offset, size, ptr);
     }
 }

--- a/Core/Render/OpenGL/Buffer/BufferObject.cs
+++ b/Core/Render/OpenGL/Buffer/BufferObject.cs
@@ -20,9 +20,6 @@ public abstract class BufferObject<T> : IDisposable where T : struct
     public DynamicArray<T> Data;
     protected readonly int BufferId;
     protected bool Uploaded;
-    protected int m_dataVersion;
-    private IntPtr m_vboArrayPtr;
-    private GCHandle m_pinnedArray;
     private bool m_disposed;
 
     protected abstract BufferTarget Target { get; }
@@ -40,9 +37,6 @@ public abstract class BufferObject<T> : IDisposable where T : struct
         Data = new DynamicArray<T>(capacity);
         Label = label;
         BufferId = GL.GenBuffer();
-        m_pinnedArray = GCHandle.Alloc(Data.Data, GCHandleType.Pinned);
-        m_vboArrayPtr = m_pinnedArray.AddrOfPinnedObject();
-        m_dataVersion = Data.Version;
 
         Bind();
         GLHelper.ObjectLabel(ObjectLabelIdentifier.Buffer, BufferId, $"{LabelPrefix}: {label}");
@@ -56,19 +50,6 @@ public abstract class BufferObject<T> : IDisposable where T : struct
 
     protected abstract void PerformUpload();
     protected abstract void PerformUploadCapacity();
-
-    public IntPtr GetVboArray()
-    {
-        if (m_dataVersion != Data.Version)
-        {
-            m_pinnedArray.Free();
-            m_pinnedArray = GCHandle.Alloc(Data.Data, GCHandleType.Pinned);
-            m_vboArrayPtr = m_pinnedArray.AddrOfPinnedObject();
-            m_dataVersion = Data.Version;
-        }
-
-        return m_vboArrayPtr;
-    }
 
     public void Add(T element)
     {
@@ -151,7 +132,6 @@ public abstract class BufferObject<T> : IDisposable where T : struct
 
         GL.DeleteBuffer(BufferId);
         Data = null!; // Encourage the GC to collect things.
-        m_pinnedArray.Free();
 
         m_disposed = true;
     }


### PR DESCRIPTION
Remove handle alloc and reliance on data version and use fixed pointers instead

Maps that trigger moving sectors that are continually created and destroyed can invoke PerformUploadCapacity each time it happens. This is especially noticeable on large maps with vanilla rendering that causes the cover wall geometry that's a single texture to be uploaded. Noticeable on Sunder MAP21.