### PR TITLE
Fix LevelCheat case sensitivity to allow Caps Lock input

### DIFF
--- a/Core/World/Cheats/LevelCheat.cs
+++ b/Core/World/Cheats/LevelCheat.cs
@@ -43,8 +43,8 @@ public class LevelCheat : ICheat
 
     public bool PartialMatch(ReadOnlySpan<char> str)
     {
-        if (m_code.AsSpan().StartsWith(str))
+        if (m_code.AsSpan().StartsWith(str, StringComparison.InvariantCultureIgnoreCase))
             return true;
-        return str.Length <= m_code.Length + 2 && str.StartsWith(m_code);
+        return str.Length <= m_code.Length + 2 && str.StartsWith(m_code, StringComparison.InvariantCultureIgnoreCase);
     }
 }


### PR DESCRIPTION
idclev## and idmus## wouldn't work if typed while Caps Lock was enabled. This PR fixes the issue and brings those two cheats in-line with other cheats that work with Caps Lock on.