### PR TITLE
Message Stacking and ZDoom-styled Key Card Notifications

### DIFF
--- a/Core/Layer/Worlds/WorldLayer.Render.Hud.cs
+++ b/Core/Layer/Worlds/WorldLayer.Render.Hud.cs
@@ -123,6 +123,7 @@ public partial class WorldLayer
             DrawHudEffects(hud);
             hud.DrawPalette(false);
             DrawRecentConsoleMessages(hud);
+            DrawCenterMessages(hud);
             DrawPause(hud);
 
             if (automapVisible && m_config.Hud.AutoMap.MapTitle)
@@ -1059,6 +1060,9 @@ public partial class WorldLayer
             {
                 ConsoleMessage msg = node.Value;
                 node = node.Next;
+                
+                if (msg.IsCentered)
+                    continue;
 
                 if (messagesDrawn >= maxHudMessages || MessageTooOldToDraw(msg, World, m_console, m_parent.OptionsLastClosedNanos))
                     break;
@@ -1067,7 +1071,11 @@ public partial class WorldLayer
                 if (timeSinceMessage > MaxVisibleTimeNanos || m_parent.ConsoleLayer != null)
                     break;
 
-                m_messages.Add((msg.Message, CalculateFade(timeSinceMessage)));
+                string displayMessage = msg.Message;
+                if (msg.Count > 1)
+                    displayMessage += $" (x{msg.Count})";
+                
+                m_messages.Add((displayMessage, CalculateFade(timeSinceMessage)));
                 messagesDrawn++;
                 lastMessageTime = timeSinceMessage;
             }
@@ -1097,6 +1105,42 @@ public partial class WorldLayer
 
             m_messages.Clear();
         }
+    }
+    
+    private void DrawCenterMessages(IHudRenderContext hud)
+    {
+        ConsoleMessage? centerMsg = null;
+        long currentNanos = Ticker.NanoTime();
+        
+        lock (m_console.Messages)
+        {
+            var node = m_console.Messages.First;
+            while (node != null)
+            {
+                var msg = node.Value;
+
+                if (currentNanos - msg.TimeNanos > MaxVisibleTimeNanos)
+                    break;
+
+                if (msg.IsCentered)
+                {
+                    centerMsg = msg;
+                    break;
+                }
+                node = node.Next;
+            }
+        }
+
+        if (centerMsg == null)
+            return;
+
+        long timeSinceMessage = currentNanos - centerMsg.TimeNanos;
+        float alpha = CalculateFade(timeSinceMessage);
+        
+        int yPos = m_viewport.Height / 3;
+        
+        hud.Text(centerMsg.Message, SmallHudFont, m_infoFontSize, (0, yPos), 
+            both: Align.TopMiddle, alpha: alpha * m_hudAlpha);
     }
 
     private static bool MessageTooOldToDraw(ConsoleMessage msg, WorldBase world, HelionConsole console, long optionsLastClosedNanos)

--- a/Core/Layer/Worlds/WorldLayer.cs
+++ b/Core/Layer/Worlds/WorldLayer.cs
@@ -128,6 +128,15 @@ public partial class WorldLayer : IGameLayerParent
 
         World.LevelExiting += World_LevelExiting;
         World.WorldPaused += World_WorldPaused;
+        World.PlayerMessage += World_PlayerMessage;
+    }
+    
+    private void World_PlayerMessage(object? sender, PlayerMessageEvent e)
+    {
+        if (e.IsCentered)
+        {
+            m_console.AddMessage(e.Message, e.IsCentered);
+        }
     }
 
     private void World_WorldPaused(object? sender, EventArgs e)
@@ -350,6 +359,7 @@ public partial class WorldLayer : IGameLayerParent
 
         World.LevelExiting -= World_LevelExiting;
         World.WorldPaused -= World_WorldPaused;
+        World.PlayerMessage -= World_PlayerMessage;
         World.Dispose();
 
         Intermission?.Dispose();

--- a/Core/Util/Consoles/ConsoleMessage.cs
+++ b/Core/Util/Consoles/ConsoleMessage.cs
@@ -7,11 +7,15 @@ public class ConsoleMessage
     public string Message = string.Empty;
     public long TimeNanos;
     public Color Color;
+    public bool IsCentered;
+    public int Count = 1;
 
-    public void Set(string message, long timeNanos, Color color)
+    public void Set(string message, long timeNanos, Color color, bool isCentered)
     {
         Message = message;
         TimeNanos = timeNanos;
         Color = color;
+        IsCentered = isCentered;
+        Count = 1;
     }
 }

--- a/Core/Util/Consoles/HelionConsole.cs
+++ b/Core/Util/Consoles/HelionConsole.cs
@@ -149,7 +149,7 @@ public class HelionConsole : Target
         OnConsoleCommandEvent?.Invoke(this, new ConsoleCommandEventArgs(command));
     }
 
-    public void AddMessage(string message) => AddMessage(Color.White, message);
+    public void AddMessage(string message, bool isCentered = false) => AddMessage(Color.White, message, isCentered);
 
     /// <summary>
     /// Adds a new message to the console.
@@ -158,16 +158,29 @@ public class HelionConsole : Target
     /// If this message causes the console to exceed the capacity, then it
     /// will remove the older messages to make space for this message.
     /// </remarks>
-    /// <param name="color">The color of the message..</param>
+    /// <param name="color">The color of the message.</param>
     /// <param name="message">The message to add.</param>
-    public void AddMessage(Color color, string message)
+    /// <param name="isCentered">If the message should be centered in the screen.</param>
+    public void AddMessage(Color color, string message, bool isCentered = false)
     {
         if (message.Length == 0)
             return;
+        
+        if (!isCentered && Messages.First != null)
+        {
+            ConsoleMessage lastMsg = Messages.First.Value;
+            if (!lastMsg.IsCentered && lastMsg.Message == message)
+            {
+                lastMsg.Count++;
+                if (!m_forceExpireMessages)
+                    lastMsg.TimeNanos = Ticker.NanoTime();
+                return;
+            }
+        }
 
         lock (Messages)
         {
-            var node = m_dataCache.GetConsoleMessageNode(m_dataCache.GetConsoleMessage(message, m_forceExpireMessages ? 0 : Ticker.NanoTime(), color));
+            var node = m_dataCache.GetConsoleMessageNode(m_dataCache.GetConsoleMessage(message, m_forceExpireMessages ? 0 : Ticker.NanoTime(), color, isCentered));
             Messages.AddFirst(node);
             RemoveExcessMessagesIfAny();
         }

--- a/Core/Util/DataCache.cs
+++ b/Core/Util/DataCache.cs
@@ -529,7 +529,7 @@ public class DataCache
         return new StairSpecial();
     }
 
-    public ConsoleMessage GetConsoleMessage(string message, long timeNanos, Color color)
+    public ConsoleMessage GetConsoleMessage(string message, long timeNanos, Color color, bool isCentered = false)
     {
         ConsoleMessage msg;
         if (m_consoleMessages.Length > 0)
@@ -537,7 +537,7 @@ public class DataCache
         else
             msg = new ConsoleMessage();
 
-        msg.Set(message, timeNanos, color);
+        msg.Set(message, timeNanos, color, isCentered);
         return msg;
     }
 

--- a/Core/World/IWorld.cs
+++ b/Core/World/IWorld.cs
@@ -148,8 +148,8 @@ public interface IWorld : IDisposable
     void RadiusExplosion(Entity damageSource, Entity attackSource, int radius, int maxDamage);
     SectorMoveStatus MoveSectorZ(double speed, double destZ, SectorMoveSpecial moveSpecial);
     void HandleEntityDeath(Entity deathEntity, Entity? deathSource, bool gibbed);
-    void DisplayMessage(string message);
-    void DisplayMessage(Player? player, Player? other, string message);
+    void DisplayMessage(string message, bool isCentered = false);
+    void DisplayMessage(Player? player, Player? other, string message, bool isCentered = false);
     // Checks if the entity will be blocked by another entity at the given position. Will use the entity definition's height and solid values.
     bool IsPositionBlockedByEntity(Entity entity, in Vec3D position);
     bool IsPositionBlocked(Entity entity);

--- a/Core/World/PlayerMessageEvent.cs
+++ b/Core/World/PlayerMessageEvent.cs
@@ -6,10 +6,12 @@ public readonly struct PlayerMessageEvent
 {
     public readonly Player Player;
     public readonly string Message;
+    public readonly bool IsCentered;
 
-    public PlayerMessageEvent(Player player, string message)
+    public PlayerMessageEvent(Player player, string message, bool isCentered = false)
     {
         Player = player;
         Message = message;
+        IsCentered = isCentered;
     }
 }

--- a/Core/World/WorldBase.cs
+++ b/Core/World/WorldBase.cs
@@ -1511,7 +1511,7 @@ public abstract partial class WorldBase : IWorld
         if (entity.PlayerObj != null && lockFail != null)
         {
             entity.PlayerObj.PlayUseFailSound();
-            DisplayMessage(entity.PlayerObj, null, GetLockFailMessage(line, lockFail));
+            DisplayMessage(entity.PlayerObj, null, GetLockFailMessage(line, lockFail), true);
         }
         return success;
     }
@@ -2497,17 +2497,17 @@ public abstract partial class WorldBase : IWorld
             DisplayMessage(player, killer.PlayerObj, obituary);
     }
 
-    public virtual void DisplayMessage(string message) => DisplayMessage(null, null, message);
+    public virtual void DisplayMessage(string message, bool isCentered = false) => DisplayMessage(null, null, message, isCentered);
 
-    public virtual void DisplayMessage(Player? player, Player? other, string message)
+    public virtual void DisplayMessage(Player? player, Player? other, string message, bool isCentered = false)
     {
         message = ArchiveCollection.Definitions.Language.GetMessage(player, other, message);
         if (message.Length > 0)
         {
-            if (player == null || player == GetCameraPlayer())
+            if (!isCentered && (player == null || player == GetCameraPlayer()))
                 HelionLog.Info(message);
             if (player != null && player == GetCameraPlayer())
-                PlayerMessage?.Invoke(this, new PlayerMessageEvent(player, message));
+                PlayerMessage?.Invoke(this, new PlayerMessageEvent(player, message, isCentered));
         }
     }
 


### PR DESCRIPTION
Implements https://github.com/Helion-Engine/Helion/issues/1384

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a7cbf37b-b424-41f6-afd3-4c477a463a67" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/5869e671-e418-4445-9693-beeb8eb3d844" />

Adds ZDoom-style centered notifications for alerting the player which key is needed to open a door or activate an object. Additionally, consecutive identical console messages (Such as `Picked up a clip.`) now append a multiplier rather than flood the console with identical messages.