### PR TITLE
Remove string allocations in hud and language lookups

### DIFF
--- a/Core/Layer/Worlds/WorldLayer.Render.Hud.cs
+++ b/Core/Layer/Worlds/WorldLayer.Render.Hud.cs
@@ -3,7 +3,6 @@ using Helion.Geometry.Boxes;
 using Helion.Geometry.Vectors;
 using Helion.Graphics;
 using Helion.Graphics.Fonts;
-using Helion.Graphics.Palettes;
 using Helion.Render;
 using Helion.Render.Common;
 using Helion.Render.Common.Context;
@@ -38,6 +37,8 @@ namespace Helion.Layer.Worlds;
 
 public partial class WorldLayer
 {
+    readonly record struct WorldMessage(string Message, float Alpha, int MessageCount);
+
     private const double DoomVerticalScale = (320 / 200.0) / (640 / 480.0);
     private const int MapFontSize = 12;
     private const int DebugFontSize = 8;
@@ -61,11 +62,12 @@ public partial class WorldLayer
     private int m_infoFontSize = DebugFontSize;
     private int m_mapHeaderFontSize = MapFontSize;
     private Dimension m_viewport;
-    private readonly List<(string message, float alpha)> m_messages = [];
+    private readonly List<WorldMessage> m_messages = [];
 
     private int m_healthWidth;
     private string m_weaponSprite = StringBuffer.GetStringExact(6);
     private string m_weaponFlashSprite = StringBuffer.GetStringExact(6);
+    private readonly string m_renderMessageBufferString = StringBuffer.GetString();
     private readonly SpanString m_weaponSpriteSpan = new("123456");
     private readonly SpanString m_weaponFlashSpriteSpan = new("123456");
 
@@ -82,6 +84,7 @@ public partial class WorldLayer
     private readonly SpanString m_fpsMinString = new();
     private readonly SpanString m_fpsMaxString = new();
     private readonly SpanString m_timeString = new();
+    private readonly SpanString m_renderMessageSpan = new(128);
 
     private readonly RenderableString m_renderFpsString;
     private readonly RenderableString m_renderFpsMinString;
@@ -1035,8 +1038,6 @@ public partial class WorldLayer
         hud.Text(m_maxAmmoString.AsSpan(), YellowFontName, FontSize, (313, y), anchor: Align.TopRight, alpha: m_hudAlpha);
     }
 
-    private int m_lastMessageCount;
-
     private void DrawRecentConsoleMessages(IHudRenderContext hud)
     {
         int maxHudMessages = m_config.Hud.MaxMessages.Value;
@@ -1070,12 +1071,8 @@ public partial class WorldLayer
                 long timeSinceMessage = currentNanos - msg.TimeNanos;
                 if (timeSinceMessage > MaxVisibleTimeNanos || m_parent.ConsoleLayer != null)
                     break;
-
-                string displayMessage = msg.Message;
-                if (msg.Count > 1)
-                    displayMessage += $" (x{msg.Count})";
-                
-                m_messages.Add((displayMessage, CalculateFade(timeSinceMessage)));
+                                
+                m_messages.Add(new(msg.Message, CalculateFade(timeSinceMessage), msg.Count));
                 messagesDrawn++;
                 lastMessageTime = timeSinceMessage;
             }
@@ -1090,23 +1087,42 @@ public partial class WorldLayer
 
             for (int i = m_messages.Count - 1; i >= 0; i--)
             {
-                (var message, var alpha) = m_messages[i];
-                hud.LineWrap(message, SmallHudFont, fontSize, (int)width, m_lineWrapStrings, out var drawHeight);
+                var msg = m_messages[i];
+                var renderMessageString = msg.Message;
+                var renderMessageLength = msg.Message.Length;
+                if (msg.MessageCount > 1)
+                {
+                    var renderMessage = GetRenderMessageWithCount(msg);
+                    StringBuffer.Clear(m_renderMessageBufferString);
+                    StringBuffer.Append(m_renderMessageBufferString, renderMessage.AsSpan());
+                    renderMessageString = m_renderMessageBufferString;
+                    renderMessageLength = StringBuffer.StringLength(m_renderMessageBufferString);
+                }
+
+                hud.LineWrap(renderMessageString, SmallHudFont, fontSize, (int)width, m_lineWrapStrings, out var drawHeight, length: renderMessageLength);
 
                 foreach (var line in m_lineWrapStrings)
                 {
                     hud.Text(line.Source.AsSpan(line.Start, line.Length), SmallHudFont, fontSize, (LeftOffset + m_hudPaddingX, offsetY + slideOffsetY),
-                        out Dimension drawArea, window: Align.TopLeft, scale: m_scale, alpha: alpha * m_hudAlpha);
+                        out Dimension drawArea, window: Align.TopLeft, scale: m_scale, alpha: msg.Alpha * m_hudAlpha);
                     offsetY += drawArea.Height + MessageSpacing;
-                }
+                }               
             }
-
-            m_lastMessageCount = m_messages.Count;
 
             m_messages.Clear();
         }
     }
-    
+
+    private SpanString GetRenderMessageWithCount(WorldMessage msg)
+    {
+        m_renderMessageSpan.Clear();
+        m_renderMessageSpan.Append(msg.Message);
+        m_renderMessageSpan.Append(" (x");
+        m_renderMessageSpan.Append(msg.MessageCount);
+        m_renderMessageSpan.Append(')');
+        return m_renderMessageSpan;
+    }
+
     private void DrawCenterMessages(IHudRenderContext hud)
     {
         ConsoleMessage? centerMsg = null;
@@ -1138,9 +1154,15 @@ public partial class WorldLayer
         float alpha = CalculateFade(timeSinceMessage);
         
         int yPos = m_viewport.Height / 3;
-        
-        hud.Text(centerMsg.Message, SmallHudFont, m_infoFontSize, (0, yPos), 
-            both: Align.TopMiddle, alpha: alpha * m_hudAlpha);
+
+        hud.LineWrap(centerMsg.Message, SmallHudFont, m_infoFontSize, m_viewport.Width, m_lineWrapStrings, out _);
+
+        foreach (var line in m_lineWrapStrings)
+        {
+            hud.Text(line.Source.AsSpan(line.Start, line.Length), SmallHudFont, m_infoFontSize, (0, yPos),
+                out Dimension drawArea, both: Align.TopMiddle, alpha: alpha * m_hudAlpha);
+            yPos += drawArea.Height + MessageSpacing;
+        }
     }
 
     private static bool MessageTooOldToDraw(ConsoleMessage msg, WorldBase world, HelionConsole console, long optionsLastClosedNanos)

--- a/Core/Resources/Definitions/Language/LanguageDefinition.cs
+++ b/Core/Resources/Definitions/Language/LanguageDefinition.cs
@@ -13,6 +13,8 @@ namespace Helion.Resources.Definitions.Language;
 
 public class LanguageDefinition
 {
+    private static readonly string[] NewLineSplit = ["\n", "\r\n"];
+
     public CultureInfo CultureInfo { get; set; } = CultureInfo.CurrentCulture;
 
     private readonly Dictionary<string, string> m_lookup = new(StringComparer.OrdinalIgnoreCase);
@@ -152,8 +154,6 @@ public class LanguageDefinition
         return data;
     }
 
-    private static readonly string[] NewLineSplit = new string[] { "\n", "\r\n" };
-
     public static string[] SplitMessageByNewLines(string text) => text.Split(NewLineSplit, StringSplitOptions.None);
 
     public bool TryGetMessages(string message, [NotNullWhen(true)] out string[]? messages)
@@ -164,7 +164,8 @@ public class LanguageDefinition
             return false;
         }
 
-        if (!m_lookup.TryGetValue(message[1..], out string? translatedMessage))
+        var altLookup = m_lookup.GetAlternateLookup<ReadOnlySpan<char>>();
+        if (!altLookup.TryGetValue(message.AsSpan(1), out var translatedMessage))
         {
             messages = null;
             return false;
@@ -177,7 +178,7 @@ public class LanguageDefinition
     public string[] GetMessages(string message)
     {
         if (message.Length > 0 && message[0] == '$')
-            return SplitMessageByNewLines(LookupMessage(message[1..]));
+            return SplitMessageByNewLines(LookupMessage(message.AsSpan(1)));
 
         return SplitMessageByNewLines(message);
     }
@@ -185,25 +186,16 @@ public class LanguageDefinition
     public string GetMessage(string message)
     {
         if (message.Length > 0 && message[0] == '$')
-            return LookupMessage(message[1..]);
+            return LookupMessage(message.AsSpan(1));
 
         return message;
     }
-
-    private readonly Dictionary<string, string> m_messageTranslation = new(StringComparer.OrdinalIgnoreCase);
 
     public string GetMessage(Player? player, Player? other, string message)
     {
         if (message.Length > 0 && message[0] == '$')
         {
-            // Until dictionary supports ReadOnlySpan<char>...
-            if (!m_messageTranslation.TryGetValue(message, out var withoutMarker))
-            {
-                withoutMarker = message[1..];
-                m_messageTranslation[message] = withoutMarker;
-            }
-
-            message = LookupMessage(withoutMarker);
+            message = LookupMessage(message.AsSpan(1));
             if (player == null)
                 return message;
             return AddMessageParams(player, other, message);
@@ -216,15 +208,14 @@ public class LanguageDefinition
     {
         const int Length = 32;
         key = null;
-        if (text.Length > Length)
-            text = text.Substring(0, Length);
+        var trimmedText = text.Length > Length ? text.AsSpan(0, Length) : text.AsSpan();
 
         foreach (var data in m_lookup)
         {
-            if (data.Value.Length < text.Length)
+            if (data.Value.Length < trimmedText.Length)
                 continue;
 
-            if (data.Value.StartsWith(text, StringComparison.OrdinalIgnoreCase))
+            if (data.Value.StartsWith(trimmedText, StringComparison.OrdinalIgnoreCase))
             {
                 key = data.Key;
                 return true;
@@ -244,9 +235,10 @@ public class LanguageDefinition
         return message;
     }
 
-    private string LookupMessage(string message)
+    private string LookupMessage(ReadOnlySpan<char> message)
     {
-        if (m_lookup.TryGetValue(message, out string? translatedMessage))
+        var altLookup = m_lookup.GetAlternateLookup<ReadOnlySpan<char>>();
+        if (altLookup.TryGetValue(message, out var translatedMessage))
             return translatedMessage;
 
         return string.Empty;

--- a/Core/Util/Extensions/HudExtensions.cs
+++ b/Core/Util/Extensions/HudExtensions.cs
@@ -116,7 +116,7 @@ public static class HudExtensions
     }
 
     public static void LineWrap(this IHudRenderContext hud, string inputText, string font, int fontSize, int maxWidth, List<StringSlice> lines,
-        out int requiredHeight)
+        out int requiredHeight, int length = -1)
     {
         lines.Clear();
         if (string.IsNullOrEmpty(inputText))
@@ -134,9 +134,12 @@ public static class HudExtensions
 
         var spaceWidth = hud.MeasureText(" ", font, fontSize).Width;
 
-        for (int i = 0; i < inputText.Length; i++)
+        if (length == -1)
+            length = inputText.Length;
+
+        for (int i = 0; i < length; i++)
         {
-            if (inputText[i] == ' ' || i == inputText.Length - 1)
+            if (inputText[i] == ' ' || i == length - 1)
             {
                 splitStart = splitEnd;
                 splitEnd = i;


### PR DESCRIPTION
Remove string allocations for appending message counts

Add line wrap check for center hud message

Use alternate ReadOnlySpan<char> lookup to remove string allocations for language key lookups