### PR TITLE
SpanString.Append fix

### DIFF
--- a/Core/Strings/SpanString.cs
+++ b/Core/Strings/SpanString.cs
@@ -34,15 +34,17 @@ public partial class SpanString
 
         int length = m_chars.Length;
         int copyLength = text.Length * sizeof(char);
-        m_chars.EnsureCapacity(m_chars.Length + text.Length);
+        m_chars.EnsureCapacity(length + text.Length);
+
         fixed (char* to = m_chars.Data)
+        fixed (char* from = text)
         {
-            fixed (char* from = text)
-            {
-                Buffer.MemoryCopy(from, to + length,
-                    (m_chars.Capacity * sizeof(char)) - (text.Length * sizeof(char)),
-                    copyLength);
-            }
+            Buffer.MemoryCopy(
+                from,
+                to + length,
+                (m_chars.Capacity - length) * sizeof(char),
+                copyLength
+            );
         }
 
         m_chars.SetLength(length + text.Length);

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -5,6 +5,7 @@
 
 ## Bug Fixes:
 - Fix not cooperative flag check for solo-net.
+- Fix crash that can happen with hud string rendering.
 
 ## Misc:
 - Add compatibility for Eviternity II Annihilate Me skill level to swap incorrect usage of SpawnMulti to SpawnMultiCoopOnly.


### PR DESCRIPTION
Correct MemoryCopy destinationSizeInBytes to use length from the buffer. Otherwise it can end up smaller than it is and cause the function to throw