### PR TITLE
Refactor sections to use lookups for SBARDEF rendering

### DIFF
--- a/Core/Layer/Worlds/StatusBar/StatusBarRenderer.cs
+++ b/Core/Layer/Worlds/StatusBar/StatusBarRenderer.cs
@@ -12,11 +12,11 @@ using Helion.Resources.Definitions.StatusBar.Enums;
 using Helion.Resources.Definitions.MapInfo;
 using Helion.Strings;
 using Helion.Util;
-using Helion.Util.Extensions;
-using Helion.World;
 using Helion.World.Entities.Inventories;
 using Helion.World.Entities.Players;
 using Helion.World.StatusBar;
+using Helion.Resources.Archives.Collection;
+using Helion.World;
 
 namespace Helion.Layer.Worlds.StatusBar;
 
@@ -65,14 +65,30 @@ public class StatusBarRenderer
         { "CRBLACK", Color.Black },
         { "CRUNTRANSLATED", Color.White }
     };
-    
-    private readonly List<RenderGlyph> m_glyphCache = new();
-    private readonly List<CoordData> m_coordPartsCache = new();
+
+    private readonly IWorld m_world;
+    private readonly ArchiveCollection m_archiveCollection;
+    private readonly List<RenderGlyph> m_glyphCache = [];
+    private readonly List<CoordData> m_coordPartsCache = [];
+    private readonly Dictionary<string, StatusBarNumberFontDef> m_fontNumberLookup = [];
+    private readonly Dictionary<string, StatusBarHudFontDef> m_hudFontLookup = [];
     private readonly SpanString m_fmtSpan = new();
     private readonly SpanString m_lookupKeySpan = new(64);
 
     private readonly record struct RenderGlyph(string Patch, int Width, int Offset);
     private readonly record struct CoordData(string Label, int Value, int LabelWidth, int ValWidth);
+
+    public StatusBarRenderer(IWorld world)
+    {
+        m_world = world;
+        m_archiveCollection = world.ArchiveCollection;
+        var sbarDef = world.ArchiveCollection.Definitions.StatusBarDefinition;
+        foreach (var f in sbarDef.NumberFonts)
+            m_fontNumberLookup[f.Name] = f;
+
+        foreach (var f in sbarDef.HudFonts)
+            m_hudFontLookup[f.Name] = f;
+    }
 
     public static StatusBarCoverage GetCoverage(StatusBarLayoutDef layout)
     {
@@ -129,7 +145,7 @@ public class StatusBarRenderer
         {
             string? fillFlat = layout.FillFlat;
             if (string.IsNullOrEmpty(fillFlat))
-                fillFlat = WorldStatic.World.GameInfo.BorderFlat;
+                fillFlat = m_world.GameInfo.BorderFlat;
 
             if (!string.IsNullOrEmpty(fillFlat) && hud.Textures.TryGet(fillFlat, out var bgHandle))
             {
@@ -298,7 +314,7 @@ public class StatusBarRenderer
             if (totalDuration > 0)
             {
                 double timePerLoop = totalDuration * Constants.TicksPerSecond;
-                long currentTick = WorldStatic.World.LevelTime;
+                long currentTick = m_world.LevelTime;
                 double animTime = currentTick % timePerLoop;
 
                 string patch = anim.Frames[0].Lump;
@@ -329,22 +345,12 @@ public class StatusBarRenderer
             return;
 
         Vec2I pos = ResolvePosition(comp, parentPos, widescreenOffset);
-        var config = WorldStatic.World.Config.Hud;
+        var config = m_world.Config.Hud;
         
         float alpha = comp.Translucency ? 0.5f : 1.0f;
         StatusBarAlignment alignment = comp.Alignment;
 
-        var sbarDef = WorldStatic.World.ArchiveCollection.Definitions.StatusBarDefinition;
-        
-        StatusBarHudFontDef? fontDef = null;
-        foreach (var f in sbarDef.HudFonts)
-        {
-            if (f.Name.EqualsIgnoreCase(comp.Font))
-            {
-                fontDef = f;
-                break;
-            }
-        }
+        m_hudFontLookup.TryGetValue(comp.Font, out var fontDef);       
         
         int fontHeight = 8;
         if (fontDef != null && StemToHelionFontMap.TryGetValue(fontDef.Stem, out var helionFontName))
@@ -361,7 +367,7 @@ public class StatusBarRenderer
                 break;
 
             case StatusBarComponentType.Time:
-                TimeSpan t = TimeSpan.FromSeconds(WorldStatic.World.LevelTime / 35.0);
+                TimeSpan t = TimeSpan.FromSeconds(m_world.LevelTime / 35.0);
                 m_fmtSpan.Clear();
                 m_fmtSpan.Append((int)t.TotalHours, 2);
                 m_fmtSpan.Append(':');
@@ -379,7 +385,7 @@ public class StatusBarRenderer
                 RenderLines(hud, speedText.AsSpan(), pos, fontDef, fontHeight, alignment, comp.Translation, alpha);
                 break;
             case StatusBarComponentType.LevelTitle:
-                string levelTitle = WorldStatic.World.MapInfo.GetDisplayNameWithPrefix(WorldStatic.World.ArchiveCollection.Language);
+                string levelTitle = m_world.MapInfo.GetDisplayNameWithPrefix(m_archiveCollection.Language);
                 RenderLines(hud, levelTitle.AsSpan(), pos, fontDef, fontHeight, alignment, comp.Translation, alpha);
                 break;
             case StatusBarComponentType.FpsCounter:
@@ -401,7 +407,7 @@ public class StatusBarRenderer
                 double duration = comp.Duration > 0 ? comp.Duration : 2.5;
                 double fadeInTime = 0.25;
                 double fadeOutTime = 1.0;
-                double timeSinceStart = WorldStatic.World.LevelTime / Constants.TicksPerSecond;
+                double timeSinceStart = m_world.LevelTime / Constants.TicksPerSecond;
 
                 if (timeSinceStart > duration + fadeOutTime) 
                     return; 
@@ -416,7 +422,7 @@ public class StatusBarRenderer
                     alpha *= (float)(1.0 - progress);
                 }
                 
-                string annTitle = WorldStatic.World.MapInfo.GetDisplayNameWithPrefix(WorldStatic.World.ArchiveCollection.Language);
+                string annTitle = m_world.MapInfo.GetDisplayNameWithPrefix(m_archiveCollection.Language);
                 RenderLines(hud, annTitle.AsSpan(), pos, fontDef, fontHeight, alignment, comp.Translation, alpha);
                 break;
             case StatusBarComponentType.RenderStats: 
@@ -707,19 +713,8 @@ public class StatusBarRenderer
             if (value < minVal) value = minVal;
         }
 
-        var sbarDef = WorldStatic.World.ArchiveCollection.Definitions.StatusBarDefinition;
-
-        StatusBarNumberFontDef? fontDef = null;
-        foreach (var f in sbarDef.NumberFonts)
-        {
-            if (f.Name.EqualsIgnoreCase(number.Font))
-            {
-                fontDef = f;
-                break;
-            }
-        }
-        
-        if (fontDef == null) return;
+        if (!m_fontNumberLookup.TryGetValue(number.Font, out var fontDef))
+            return;
 
         m_fmtSpan.Clear();
         m_fmtSpan.Append(value);
@@ -827,7 +822,7 @@ public class StatusBarRenderer
     private void DrawStatTotals(IHudRenderContext hud, StatusBarComponentDef comp, Vec2I pos, 
         StatusBarHudFontDef? fontDef, int fontHeight, float alpha)
     {
-        var stats = WorldStatic.World.LevelStats;
+        var stats = m_world.LevelStats;
         
         DrawStatPart(hud, "K: ", stats.KillCount, stats.TotalMonsters, ref pos, comp, fontDef, fontHeight, alpha);
         DrawStatPart(hud, "I: ", stats.ItemCount, stats.TotalItems, ref pos, comp, fontDef, fontHeight, alpha);
@@ -1082,10 +1077,10 @@ public class StatusBarRenderer
         return result;
     }
 
-    private static int ResolveNumberValue(Player player, StatusBarNumberType type, int param)
+    private int ResolveNumberValue(Player player, StatusBarNumberType type, int param)
     {
-        var composer = WorldStatic.EntityManager.DefinitionComposer;
-        var dehacked = WorldStatic.World.ArchiveCollection.Definitions.DehackedDefinition;
+        var composer = m_archiveCollection.EntityDefinitionComposer;
+        var dehacked = m_archiveCollection.Definitions.DehackedDefinition;
 
         switch (type)
         {
@@ -1147,9 +1142,9 @@ public class StatusBarRenderer
         return string.Empty;
     }
 
-    private static int GetMaxAmount(Player player, string name)
+    private int GetMaxAmount(Player player, string name)
     {
-        var composer = WorldStatic.EntityManager.DefinitionComposer;
+        var composer = m_archiveCollection.EntityDefinitionComposer;
         var def = composer.GetByName(name);
         if (def == null) return 0;
         

--- a/Core/Layer/Worlds/WorldLayer.Render.Hud.cs
+++ b/Core/Layer/Worlds/WorldLayer.Render.Hud.cs
@@ -74,7 +74,7 @@ public partial class WorldLayer
     private readonly SpanString m_weaponSpriteSpan = new("123456");
     private readonly SpanString m_weaponFlashSpriteSpan = new("123456");
     
-    private readonly StatusBarRenderer m_statusBarRenderer = new(); 
+    private readonly StatusBarRenderer m_statusBarRenderer; 
 
     private readonly SpanString m_healthString = new();
     private readonly SpanString m_armorString = new();
@@ -468,7 +468,7 @@ public partial class WorldLayer
                 }
             }
 
-            var context = new StatusBarContext(Player, automapVisible, isWidescreen, fps, consoleMsg, isCentered);
+            var context = new StatusBarContext(World, Player, automapVisible, isWidescreen, fps, consoleMsg, isCentered, Player.Inventory.HasItemOfClass(Inventory.BackPackBaseClassName));
             m_statusBarRenderer.Draw(hud, activeLayout, context);
             return;
         }

--- a/Core/Layer/Worlds/WorldLayer.cs
+++ b/Core/Layer/Worlds/WorldLayer.cs
@@ -1,11 +1,8 @@
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Reflection;
 using Helion.Audio;
 using Helion.Geometry;
 using Helion.Geometry.Vectors;
 using Helion.Graphics.Fonts;
+using Helion.Layer.Worlds.StatusBar;
 using Helion.Maps;
 using Helion.Models;
 using Helion.Render.Common.Enums;
@@ -32,6 +29,10 @@ using Helion.World.Geometry.Builder;
 using Helion.World.Impl.SinglePlayer;
 using Helion.World.StatusBar;
 using NLog;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
 using static Helion.Util.Assertion.Assert;
 
 namespace Helion.Layer.Worlds;
@@ -95,6 +96,7 @@ public partial class WorldLayer : IGameLayerParent
         m_profiler = profiler;
         World = world;
         CurrentMap = mapInfoDef;
+        m_statusBarRenderer = new StatusBarRenderer(World);
 
         m_drawHudAction = new(DrawHudContext);
         m_renderWorldAction = new(RenderWorld);

--- a/Core/World/Entities/Definition/EntityDefinition.cs
+++ b/Core/World/Entities/Definition/EntityDefinition.cs
@@ -39,6 +39,7 @@ public class EntityDefinition
     public int? PainState;
     public int? HealState;
     public string? BaseInventoryName;
+    public EntityDefinition? BaseInventoryDefinition;
     public string DehackedName = string.Empty;
     public bool DefinitionSet;
     public bool IgnoreVanillaSpriteLookup;

--- a/Core/World/Entities/Inventories/Inventory.cs
+++ b/Core/World/Entities/Inventories/Inventory.cs
@@ -144,6 +144,14 @@ public sealed class Inventory
             model.Powerups.Add(Powerups[i].ToPowerupModel());
     }
 
+    public static EntityDefinition? GetBaseInventoryDefinition(EntityDefinition definition)
+    {
+        if (definition.BaseInventoryName == null)
+            GetBaseInventoryName(definition);
+
+        return definition.BaseInventoryDefinition;
+    }
+
     public static string GetBaseInventoryName(EntityDefinition definition)
     {
         if (definition.BaseInventoryName != null)
@@ -165,6 +173,7 @@ public sealed class Inventory
             return definition.BaseInventoryName;
         }
 
+        definition.BaseInventoryDefinition = definition;
         definition.BaseInventoryName = definition.Name;
         return definition.BaseInventoryName;
     }

--- a/Core/World/StatusBar/StatusBarConditionResolver.cs
+++ b/Core/World/StatusBar/StatusBarConditionResolver.cs
@@ -13,6 +13,9 @@ namespace Helion.World.StatusBar;
 
 public static class StatusBarConditionResolver
 {
+    private static readonly Dictionary<int, EntityDefinition?> Id24AmmoTypeLookup = [];
+    private static readonly Dictionary<int, EntityDefinition?> Id24PickupLookup = [];
+
     public static bool Evaluate(StatusBarContext context, List<StatusBarConditionDef>? conditions)
     {
         if (conditions == null || conditions.Count == 0)
@@ -28,9 +31,10 @@ public static class StatusBarConditionResolver
 
     private static bool CheckSingle(StatusBarContext context, StatusBarConditionDef c)
     {
+        var world = context.World;
         var player = context.Player;
-        var composer = WorldStatic.EntityManager.DefinitionComposer;
-        var gameConf = WorldStatic.World.ArchiveCollection.Definitions.GameConfDefinition;
+        var composer = context.World.EntityManager.DefinitionComposer;
+        var gameConf = context.World.ArchiveCollection.Definitions.GameConfDefinition;
 
         return c.Condition switch
         {
@@ -53,18 +57,18 @@ public static class StatusBarConditionResolver
             StatusBarConditionType.GameVersionGe => CheckGameVersion(gameConf, c.Param, greaterEqual: true),
             StatusBarConditionType.GameVersionLt => CheckGameVersion(gameConf, c.Param, greaterEqual: false),
             
-            StatusBarConditionType.SessionTypeEq => CheckSessionType(c.Param, equals: true),
-            StatusBarConditionType.SessionTypeNeq => CheckSessionType(c.Param, equals: false),
+            StatusBarConditionType.SessionTypeEq => CheckSessionType(world, c.Param, equals: true),
+            StatusBarConditionType.SessionTypeNeq => CheckSessionType(world, c.Param, equals: false),
             
             StatusBarConditionType.GameModeEq => CheckGameMode(gameConf, c.Param, equals: true),
             StatusBarConditionType.GameModeNeq => CheckGameMode(gameConf, c.Param, equals: false),
             
-            StatusBarConditionType.HudModeEq => CheckHudMode(c.Param),
+            StatusBarConditionType.HudModeEq => CheckHudMode(world, c.Param),
             
             // v1.1 Extensions
             StatusBarConditionType.AutomapModeEq => CheckAutomap(context, c.Param),
-            StatusBarConditionType.WidgetEnabled => CheckWidgetEnabled(c.Param),
-            StatusBarConditionType.WidgetDisabled => !CheckWidgetEnabled(c.Param),
+            StatusBarConditionType.WidgetEnabled => CheckWidgetEnabled(world, player, c.Param),
+            StatusBarConditionType.WidgetDisabled => !CheckWidgetEnabled(world, player, c.Param),
             StatusBarConditionType.WeaponNotOwned => !CheckWeaponOwned(player, c.Param, composer),
             
             StatusBarConditionType.HealthGe => player.Health >= c.Param,
@@ -79,19 +83,19 @@ public static class StatusBarConditionResolver
 
             StatusBarConditionType.SelectedAmmoGe => CheckSelectedAmmo(player, c.Param, greaterEqual: true),
             StatusBarConditionType.SelectedAmmoLt => CheckSelectedAmmo(player, c.Param, greaterEqual: false),
-            StatusBarConditionType.SelectedAmmoPercentGe => CheckSelectedAmmoPercent(player, c.Param, greaterEqual: true),
-            StatusBarConditionType.SelectedAmmoPercentLt => CheckSelectedAmmoPercent(player, c.Param, greaterEqual: false),
+            StatusBarConditionType.SelectedAmmoPercentGe => CheckSelectedAmmoPercent(world, player, context.HasBackPack, c.Param, greaterEqual: true),
+            StatusBarConditionType.SelectedAmmoPercentLt => CheckSelectedAmmoPercent(world, player, context.HasBackPack, c.Param, greaterEqual: false),
 
             StatusBarConditionType.AmmoGe => CheckAmmoAmount(player, c.Param2, c.Param, greaterEqual: true, composer),
             StatusBarConditionType.AmmoLt => CheckAmmoAmount(player, c.Param2, c.Param, greaterEqual: false, composer),
-            StatusBarConditionType.AmmoPercentGe => CheckAmmoPercent(player, c.Param2, c.Param, greaterEqual: true, composer),
-            StatusBarConditionType.AmmoPercentLt => CheckAmmoPercent(player, c.Param2, c.Param, greaterEqual: false, composer),
+            StatusBarConditionType.AmmoPercentGe => CheckAmmoPercent(player, context.HasBackPack, c.Param2, c.Param, greaterEqual: true, composer),
+            StatusBarConditionType.AmmoPercentLt => CheckAmmoPercent(player, context.HasBackPack, c.Param2, c.Param, greaterEqual: false, composer),
 
             StatusBarConditionType.WidescreenModeEq => CheckWidescreen(context, c.Param),
             
-            StatusBarConditionType.EpisodeEq => CheckEpisode(c.Param),
-            StatusBarConditionType.LevelGe => CheckLevel(c.Param, greaterEqual: true),
-            StatusBarConditionType.LevelLt => CheckLevel(c.Param, greaterEqual: false),
+            StatusBarConditionType.EpisodeEq => CheckEpisode(world, c.Param),
+            StatusBarConditionType.LevelGe => CheckLevel(world, c.Param, greaterEqual: true),
+            StatusBarConditionType.LevelLt => CheckLevel(world, c.Param, greaterEqual: false),
 
             _ => false
         };
@@ -101,6 +105,9 @@ public static class StatusBarConditionResolver
 
     private static bool TryGetId24PickupType(EntityDefinitionComposer composer, int pickupItemType, [NotNullWhen(true)] out EntityDefinition? definition)
     {
+        if (Id24PickupLookup.TryGetValue(pickupItemType, out definition))
+            return definition != null;
+
         string? entityName = pickupItemType switch
         {
             // Keys
@@ -140,7 +147,6 @@ public static class StatusBarConditionResolver
 
         if (entityName != null)
         {
-            // FIX: Use GetByName instead of GetByNameOrDefault
             definition = composer.GetByName(entityName);
             
             if (definition == null)
@@ -151,15 +157,21 @@ public static class StatusBarConditionResolver
                 else if (entityName == "InvulnerabilitySphere") 
                     definition = composer.GetByName("Invulnerability");
             }
+
+            Id24PickupLookup[pickupItemType] = definition;
             return definition != null;
         }
 
         definition = null;
+        Id24PickupLookup[pickupItemType] = null;
         return false;
     }
 
     public static bool TryGetId24AmmoType(EntityDefinitionComposer composer, int ammoTypeIndex, [NotNullWhen(true)] out EntityDefinition? def)
     {
+        if (Id24AmmoTypeLookup.TryGetValue(ammoTypeIndex, out def))
+            return def != null;
+
         string? ammoName = ammoTypeIndex switch
         {
             0 => "Clip",
@@ -172,10 +184,12 @@ public static class StatusBarConditionResolver
         if (ammoName != null)
         {
             def = composer.GetByName(ammoName);
+            Id24AmmoTypeLookup[ammoTypeIndex] = def;
             return def != null;
         }
 
         def = null;
+        Id24AmmoTypeLookup[ammoTypeIndex] = null;
         return false;
     }
     
@@ -251,10 +265,9 @@ public static class StatusBarConditionResolver
         return greaterEqual ? currentIndex >= param : currentIndex < param;
     }
 
-    private static bool CheckSessionType(int param, bool equals)
+    private static bool CheckSessionType(IWorld world, int param, bool equals)
     {
         int currentType = 0; // Single Player
-        var world = WorldStatic.World;
         if (world.WorldType == WorldType.Deathmatch) currentType = 2;
         else if (world.WorldType == WorldType.Cooperative) currentType = 1;
         return equals ? (currentType == param) : (currentType != param);
@@ -268,10 +281,10 @@ public static class StatusBarConditionResolver
         return equals ? (currentIndex == param) : (currentIndex != param);
     }
 
-    private static bool CheckHudMode(int param)
+    private static bool CheckHudMode(IWorld world, int param)
     {
         // 0 = Standard, 1 = Compact. Helion treats Minimal as Compact.
-        int mode = WorldStatic.World.Config.Hud.StatusBarSize.Value == StatusBarSizeType.Minimal ? 1 : 0;
+        int mode = world.Config.Hud.StatusBarSize.Value == StatusBarSizeType.Minimal ? 1 : 0;
         return mode == param;
     }
 
@@ -313,14 +326,17 @@ public static class StatusBarConditionResolver
         return greaterEqual ? amount >= param : amount < param;
     }
 
-    private static bool CheckSelectedAmmoPercent(Player player, int param, bool greaterEqual)
+    private static bool CheckSelectedAmmoPercent(IWorld world, Player player, bool hasBackPack, int param, bool greaterEqual)
     {
         if (player.Weapon == null) return false;
         string ammoType = player.Weapon.Definition.Properties.Weapons.AmmoType;
         if (string.IsNullOrEmpty(ammoType)) return false;
+
+        var def = world.EntityManager.DefinitionComposer.GetByName(ammoType);
+        if (def == null) return false;
         
-        int amount = player.Inventory.Amount(ammoType);
-        int max = GetMaxAmount(player, ammoType);
+        int amount = player.Inventory.Amount(def);
+        int max = GetMaxAmount(def, hasBackPack);
         if (max == 0) return false;
 
         int percent = (int)((amount / (float)max) * 100);
@@ -336,13 +352,13 @@ public static class StatusBarConditionResolver
         return greaterEqual ? amount >= val : amount < val;
     }
     
-    private static bool CheckAmmoPercent(Player player, int ammoTypeIndex, int val, bool greaterEqual, EntityDefinitionComposer composer)
+    private static bool CheckAmmoPercent(Player player, bool hasBackPack, int ammoTypeIndex, int val, bool greaterEqual, EntityDefinitionComposer composer)
     {
         if (!TryGetId24AmmoType(composer, ammoTypeIndex, out var def))
             return false;
 
-        int amount = player.Inventory.Amount(def.Name);
-        int max = GetMaxAmount(player, def.Name);
+        int amount = player.Inventory.Amount(def);
+        int max = GetMaxAmount(def, hasBackPack);
         if (max == 0) return false;
 
         int percent = (int)((amount / (float)max) * 100);
@@ -354,9 +370,9 @@ public static class StatusBarConditionResolver
         return (param == 1) == context.Widescreen;
     }
 
-    private static bool CheckEpisode(int param)
+    private static bool CheckEpisode(IWorld world, int param)
     {
-        var mapName = WorldStatic.World.MapInfo.MapName;
+        var mapName = world.MapInfo.MapName;
         if (mapName.Length >= 2 && char.ToUpperInvariant(mapName[0]) == 'E' && char.IsDigit(mapName[1]))
         {
             if (int.TryParse(mapName.AsSpan(1, 1), out int ep))
@@ -367,12 +383,12 @@ public static class StatusBarConditionResolver
         return param == 1;
     }
 
-    private static bool CheckLevel(int param, bool greaterEqual)
+    private static bool CheckLevel(IWorld world, int param, bool greaterEqual)
     {
-        return greaterEqual ? WorldStatic.World.MapInfo.LevelNumber >= param : WorldStatic.World.MapInfo.LevelNumber < param;
+        return greaterEqual ? world.MapInfo.LevelNumber >= param : world.MapInfo.LevelNumber < param;
     }
     
-    private static bool CheckWidgetEnabled(int param)
+    private static bool CheckWidgetEnabled(IWorld world, Player player, int param)
     {
         // Mappings based on DSDA/Woof standards
         // 0: Level Stats (Kills/Items/Secrets)
@@ -381,31 +397,27 @@ public static class StatusBarConditionResolver
         // 3: FPS
         // 6: Speedometer
         
-        var config = WorldStatic.World.Config.Hud;
+        var config = world.Config.Hud;
         
         return param switch
         {
             0 => config.ShowStats.Value,
             1 => config.ShowStats.Value, // Helion groups Time with Stats usually
-            2 => WorldStatic.World.GetCameraPlayer().Cheats.IsCheatActive(Cheats.CheatType.ShowPosition),
+            2 => player.Cheats.IsCheatActive(Cheats.CheatType.ShowPosition),
             3 => config.ShowFPS.Value,
             // Helion doesn't have specific booleans for Speedometer yet, default to allowed
             _ => true 
         };
     }
     
-    private static int GetMaxAmount(Player player, string name)
-    {
-        var composer = WorldStatic.EntityManager.DefinitionComposer;
-        var def = composer.GetByName(name);
-        if (def == null) return 0;
-        
-        string baseName = Inventory.GetBaseInventoryName(def);
-        var baseDef = composer.GetByName(baseName);
-        if (baseDef != null) def = baseDef;
+    private static int GetMaxAmount(EntityDefinition def, bool hasBackPack)
+    {        
+        var baseDef = Inventory.GetBaseInventoryDefinition(def);
+        if (baseDef != null)
+            def = baseDef;
 
         int max = def.Properties.Inventory.MaxAmount;
-        if (player.Inventory.HasItemOfClass(Inventory.BackPackBaseClassName) 
+        if (hasBackPack
             && def.IsType(Inventory.AmmoClassName) 
             && def.Properties.Ammo.BackpackMaxAmount > max)
         {

--- a/Core/World/StatusBar/StatusBarContext.cs
+++ b/Core/World/StatusBar/StatusBarContext.cs
@@ -3,10 +3,12 @@ using Helion.World.Entities.Players;
 namespace Helion.World.StatusBar;
 
 public readonly record struct StatusBarContext(
+    IWorld World,
     Player Player, 
     bool AutomapVisible, 
     bool Widescreen,
     int Fps,
     string? ConsoleMessage,
-    bool IsMessageCentered
+    bool IsMessageCentered,
+    bool HasBackPack
 );


### PR DESCRIPTION
refactor to use lookups for fonts and definitions

use faster functions by EntityDefinition instead of definition name string where applicable

refactor to pass IWorld instead of relying on WorldStatic