### PR TITLE
implement frame limiter with sleep

### DIFF
--- a/Client/Client.cs
+++ b/Client/Client.cs
@@ -1,10 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Reflection;
-using System.Runtime.InteropServices;
-using System.Threading.Tasks;
 using Helion.Audio;
 using Helion.Audio.Impl;
 using Helion.Audio.Sounds;
@@ -38,6 +31,13 @@ using NLog;
 using OpenTK.Windowing.Common;
 using OpenTK.Windowing.Desktop;
 using OpenTK.Windowing.GraphicsLibraryFramework;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 using static Helion.Util.Assertion.Assert;
 
 namespace Helion.Client;
@@ -68,6 +68,7 @@ public partial class Client : IDisposable, IInputManagement
     private readonly SaveGameScreenshotGenerator m_screenshotGenerator;
     private readonly DiscordHandler m_discord = new();
     private readonly Stopwatch m_stopwatch = Stopwatch.StartNew();
+    private readonly FrameLimiter m_frameLimiter = new();
     private bool m_disposed;
     private bool m_takeScreenshot;
     private bool m_loadComplete;
@@ -95,6 +96,7 @@ public partial class Client : IDisposable, IInputManagement
         m_audioSystem = audioSystem;
         m_archiveCollection = archiveCollection;
 
+        InitTimer();
         InitGpuPreference();
 
         m_saveGameManager = new SaveGameManager(config, m_pathsManager, m_archiveCollection, commandLineArgs.SaveDir);
@@ -139,6 +141,15 @@ public partial class Client : IDisposable, IInputManagement
         RegisterConfigChanges();
         UpdateVolume();
         m_ticker.Start();
+    }
+
+    private static void InitTimer()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            if (!WinNative.TimeBeginPeriod(1))
+                HelionLog.Error("TimeBeginPeriod error");
+        }
     }
 
     private void InitGpuPreference()
@@ -313,6 +324,8 @@ public partial class Client : IDisposable, IInputManagement
         m_fpsTracker.FinishFrame();
 
         m_profiler.Render.Total.Stop();
+
+        m_frameLimiter.Limit(m_window.MaxFps);
     }
 
     private void Window_MainLoop(FrameEventArgs frameEventArgs)
@@ -513,6 +526,9 @@ public partial class Client : IDisposable, IInputManagement
     {
         if (m_disposed)
             return;
+
+        if (OperatingSystem.IsWindows())
+            WinNative.TimeEndPeriod(1);
 
         PackageDemo();
 

--- a/Client/Client.cs
+++ b/Client/Client.cs
@@ -74,6 +74,7 @@ public partial class Client : IDisposable, IInputManagement
     private bool m_loadComplete;
     private bool m_filesLoaded;
     private bool m_invalidateRng;
+    private uint m_minTimerResolution = 1;
     private OnLoadMapComplete? m_onLoadMapComplete;
     private LoadMapResult? m_loadMapResult;
     private QueueLoadMapParams? m_queueMapLoad;
@@ -143,11 +144,14 @@ public partial class Client : IDisposable, IInputManagement
         m_ticker.Start();
     }
 
-    private static void InitTimer()
+    private void InitTimer()
     {
         if (OperatingSystem.IsWindows())
         {
-            if (!WinNative.TimeBeginPeriod(1))
+            if (WinNative.TimeGetDevCaps(out var timeCaps))
+                m_minTimerResolution = timeCaps.wPeriodMin;
+
+            if (!WinNative.TimeBeginPeriod(m_minTimerResolution))
                 HelionLog.Error("TimeBeginPeriod error");
         }
     }
@@ -528,7 +532,7 @@ public partial class Client : IDisposable, IInputManagement
             return;
 
         if (OperatingSystem.IsWindows())
-            WinNative.TimeEndPeriod(1);
+            WinNative.TimeEndPeriod(m_minTimerResolution);
 
         PackageDemo();
 

--- a/Client/FrameLimiter.cs
+++ b/Client/FrameLimiter.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading;
+
+namespace Helion.Client;
+
+public sealed class FrameLimiter
+{
+    private readonly Stopwatch m_stopwatch = Stopwatch.StartNew();
+    private double m_drift;
+
+    public void Limit(int targetFps)
+    {
+        if (targetFps > 0)
+        {
+            var target = 1000.0 / targetFps;
+            var driftTarget = Math.Max(target - m_drift, 0);
+            m_drift = 0;
+            while (true)
+            {
+                var elapsed = m_stopwatch.Elapsed.TotalMilliseconds;
+                if (elapsed >= driftTarget)
+                {
+                    m_drift = Math.Clamp(elapsed - driftTarget, 0, target);
+                    break;
+                }
+
+                var sleepTime = driftTarget - elapsed;
+                if (sleepTime <= 0)
+                    break;
+
+                if (sleepTime < 2)
+                    Thread.Sleep(0);
+                else
+                    Thread.Sleep((int)(sleepTime - 1));
+            }
+        }
+
+        m_stopwatch.Restart();
+    }
+}

--- a/Client/GlobalSuppressions.cs
+++ b/Client/GlobalSuppressions.cs
@@ -1,0 +1,9 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Interoperability", "CA1401:P/Invokes should not be visible", Justification = "<Pending>", Scope = "member", Target = "~M:Helion.Client.WinNative.TimeBeginPeriod(System.UInt32)~System.UInt32")]
+[assembly: SuppressMessage("Interoperability", "CA1401:P/Invokes should not be visible", Justification = "<Pending>", Scope = "member", Target = "~M:Helion.Client.WinNative.TimeEndPeriod(System.UInt32)~System.UInt32")]

--- a/Client/WinNative.cs
+++ b/Client/WinNative.cs
@@ -1,0 +1,24 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Helion.Client;
+
+public static class WinNative
+{
+    const string WinMM = "winmm.dll";
+
+    [DllImport(WinMM, EntryPoint = "timeBeginPeriod", SetLastError = true)]
+    private static extern uint _TimeBeginPeriod(uint uMilliseconds);
+
+    [DllImport(WinMM, EntryPoint = "timeEndPeriod", SetLastError = true)]
+    private static extern uint _TimeEndPeriod(uint uMilliseconds);
+
+    public static bool TimeBeginPeriod(uint uMilliseconds)
+    {
+        return _TimeBeginPeriod(uMilliseconds) == 0;
+    }
+
+    public static bool TimeEndPeriod(uint uMilliseconds)
+    {
+        return _TimeBeginPeriod(uMilliseconds) == 0;
+    }
+}

--- a/Client/WinNative.cs
+++ b/Client/WinNative.cs
@@ -2,15 +2,25 @@
 
 namespace Helion.Client;
 
-public static class WinNative
+public static partial class WinNative
 {
+    [StructLayout(LayoutKind.Sequential)]
+    public struct TimeCaps
+    {
+        public uint wPeriodMin;
+        public uint wPeriodMax;
+    }
+
     const string WinMM = "winmm.dll";
 
-    [DllImport(WinMM, EntryPoint = "timeBeginPeriod", SetLastError = true)]
-    private static extern uint _TimeBeginPeriod(uint uMilliseconds);
+    [LibraryImport(WinMM, EntryPoint = "timeBeginPeriod", SetLastError = true)]
+    private static partial uint _TimeBeginPeriod(uint uMilliseconds);
 
-    [DllImport(WinMM, EntryPoint = "timeEndPeriod", SetLastError = true)]
-    private static extern uint _TimeEndPeriod(uint uMilliseconds);
+    [LibraryImport(WinMM, EntryPoint = "timeEndPeriod", SetLastError = true)]
+    private static partial uint _TimeEndPeriod(uint uMilliseconds);
+
+    [LibraryImport(WinMM, EntryPoint = "timeGetDevCaps", SetLastError = true)]
+    private static partial uint _TimeGetDevCaps(ref TimeCaps pTC, uint cbTC);
 
     public static bool TimeBeginPeriod(uint uMilliseconds)
     {
@@ -19,6 +29,13 @@ public static class WinNative
 
     public static bool TimeEndPeriod(uint uMilliseconds)
     {
-        return _TimeBeginPeriod(uMilliseconds) == 0;
+        return _TimeEndPeriod(uMilliseconds) == 0;
+    }
+
+    public static bool TimeGetDevCaps(out TimeCaps timeCaps)
+    {
+        timeCaps = new TimeCaps();
+        var result = _TimeGetDevCaps(ref timeCaps, (uint)Marshal.SizeOf<TimeCaps>());
+        return result == 0;
     }
 }

--- a/Client/Window.cs
+++ b/Client/Window.cs
@@ -35,6 +35,7 @@ public class Window : GameWindow, IWindow
     private static readonly Logger Log = LogManager.GetCurrentClassLogger();
 
     public Renderer Renderer { get; }
+    public int MaxFps { get; private set; }
     private readonly IConfig m_config;
 
     public IInputManager InputManager => m_inputManager;
@@ -452,16 +453,19 @@ public class Window : GameWindow, IWindow
                 break;
         }
 
+
+        UpdateFrequency = 0;
+
         if (maxFps == 0)
         {
             _ = GetMonitors(out MonitorData? current);
-            UpdateFrequency = current?.RefreshRate > 0 && vsync != RenderVsyncMode.Off
+            MaxFps = current?.RefreshRate > 0 && vsync != RenderVsyncMode.Off
                 ? current.RefreshRate
                 : 0;
-
             return;
         }
-        UpdateFrequency = maxFps;
+
+        MaxFps = maxFps;
     }
 
     private void PerformDispose()

--- a/Core/Util/GCNotifier.cs
+++ b/Core/Util/GCNotifier.cs
@@ -6,7 +6,7 @@ public static class GCNotifier
 {
     public static event Action? GarbageCollected;
 
-    private class Sentinel
+    private sealed class Sentinel
     {
         ~Sentinel()
         {

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -13,3 +13,4 @@
 
 ## Misc:
 - Add compatibility for Eviternity II Annihilate Me skill level to swap incorrect usage of SpawnMulti to SpawnMultiCoopOnly.
+- Implemented custom frame limiter. Reduces CPU/power usage and yields better results since the OpenTK 4.9.4 upgrade in Helion 0.9.8.0 that was causing FPS drops on certain machines.


### PR DESCRIPTION
Implements our own custom frame limiter to remove dependence on OpenTK. The upgrade to OpenTK 4.9.4 had pretty bad results that causes frame drops and doesn't even appear to keep a consistent average when CPU usage in Helion isn't an issue.

This could potentially use more work in the future to deal with frame pacing issues where the the min fps is pushed lower because of the limiting. This was also an issue with OpenTK implementation.

fixes #1027 

Windows build
https://www.dropbox.com/scl/fi/jd5vhgypth2zreczi5n9y/Helion-Frame-Limit.zip?rlkey=6hgqkzowgozj359rio6drj6ep&st=xrhrty2c&dl=0