### PR TITLE
Render fillflats and adjust offsets of the viewport for SBARDEF

### DIFF
--- a/Core/Layer/Worlds/StatusBar/StatusBarRenderer.cs
+++ b/Core/Layer/Worlds/StatusBar/StatusBarRenderer.cs
@@ -7,6 +7,7 @@ using Helion.Render.Common;
 using Helion.Render.Common.Enums;
 using Helion.Render.Common.Renderers;
 using Helion.Resources;
+using Helion.Resources.Archives.Collection;
 using Helion.Resources.Definitions.StatusBar;
 using Helion.Resources.Definitions.StatusBar.Enums;
 using Helion.Resources.Definitions.MapInfo;
@@ -15,7 +16,6 @@ using Helion.Util;
 using Helion.World.Entities.Inventories;
 using Helion.World.Entities.Players;
 using Helion.World.StatusBar;
-using Helion.Resources.Archives.Collection;
 using Helion.World;
 
 namespace Helion.Layer.Worlds.StatusBar;
@@ -139,7 +139,16 @@ public class StatusBarRenderer
         int yOffset = layout.FullscreenRender ? 0 : (200 - layout.Height);
         Vec2I rootPos = (0, yOffset);
         
-        float widescreenOffset = GetWidescreenOffset(hud);
+        float windowAspect = (float)hud.WindowDimension.Width / hud.WindowDimension.Height;
+        float virtualAspect = 320f / 200f;
+
+        float hOffset = 0;
+        float vOffset = 0;
+
+        if (windowAspect > virtualAspect) 
+            hOffset = (200f * windowAspect - 320f) / 2f;
+        else if (windowAspect < virtualAspect)
+            vOffset = (320f / windowAspect - 200f) / 2f;
 
         if (!layout.FullscreenRender)
         {
@@ -149,47 +158,20 @@ public class StatusBarRenderer
 
             if (!string.IsNullOrEmpty(fillFlat) && hud.Textures.TryGet(fillFlat, out var bgHandle))
             {
-                if (widescreenOffset > 0)
+                int bgWidth = bgHandle.Dimension.Width;
+                int bgHeight = bgHandle.Dimension.Height;
+                if (bgHeight <= 0) bgHeight = 64;
+
+                int startX = (int)-Math.Ceiling(hOffset);
+                int endX = 320 + (int)Math.Ceiling(hOffset);
+                int startY = yOffset;
+                int endY = 200 + (int)Math.Ceiling(vOffset); 
+
+                for (int x = (startX / bgWidth - 1) * bgWidth; x < endX; x += bgWidth)
                 {
-                    int bgWidth = bgHandle.Dimension.Width;
-                    int bgHeight = bgHandle.Dimension.Height;
-                    if (bgHeight <= 0) bgHeight = 64;
-
-                    // If the layout claims the full 200 height (like Woof's overlay), 
-                    // we assume the "Solid" part is only the bottom 32 pixels (Standard Doom Bar).
-                    // We clamp the border drawing to that area so we don't cover the 3D view on the sides.
-                    int borderY = yOffset;
-                    int borderHeight = layout.Height;
-
-                    if (layout.Height >= 200)
+                    for (int y = startY; y < endY; y += bgHeight)
                     {
-                        borderHeight = 32;
-                        borderY = 200 - 32;
-                    }
-
-                    int verticalTiles = (borderHeight + bgHeight - 1) / bgHeight; 
-                    int iterations = (int)(widescreenOffset / bgWidth) + 1;
-
-                    // Draw Left Pillars
-                    int xPos = -bgWidth;
-                    for (int i = 0; i < iterations; i++)
-                    {
-                        for (int y = 0; y < verticalTiles; y++)
-                        {
-                            hud.Image(fillFlat, (xPos, borderY + (y * bgHeight)), anchor: Align.TopLeft);
-                        }
-                        xPos -= bgWidth;
-                    }
-
-                    // Draw Right Pillars
-                    xPos = 320;
-                    for (int i = 0; i < iterations; i++)
-                    {
-                        for (int y = 0; y < verticalTiles; y++)
-                        {
-                            hud.Image(fillFlat, (xPos, borderY + (y * bgHeight)), anchor: Align.TopLeft);
-                        }
-                        xPos += bgWidth;
+                        hud.Image(fillFlat, (x, y), anchor: Align.TopLeft);
                     }
                 }
             }
@@ -197,7 +179,7 @@ public class StatusBarRenderer
 
         foreach (var child in layout.Children)
         {
-            DrawElementWrapper(hud, child, rootPos, layout.Height, context, widescreenOffset);
+            DrawElementWrapper(hud, child, rootPos, layout.Height, context, hOffset);
         }
 
         hud.PopVirtualDimension();
@@ -982,22 +964,6 @@ public class StatusBarRenderer
             else if (dynRight) pos.X += offset;
         }
         return pos;
-    }
-
-    private static float GetWidescreenOffset(IHudRenderContext hud)
-    {
-        var scaleWidth = hud.ArchiveCollection.Config.Hud.Width.Value * 320.0;
-        if (scaleWidth > hud.Dimension.Width * Constants.DoomVirtualAspectRatio || scaleWidth == 0)
-        {
-            float currentAspect = hud.WindowDimension.AspectRatio;
-            if (currentAspect > Constants.DoomVirtualAspectRatio)
-            {
-                float widthInDoomUnits = 320.0f * (currentAspect / Constants.DoomVirtualAspectRatio);
-                return (widthInDoomUnits - 320.0f) / 2.0f;
-            }
-        }
-
-        return -(hud.Dimension.Width - (int)scaleWidth) / 2;
     }
 
     private static bool ResolveGlyph(IHudRenderContext hud, string patch, out int width, out int height)

--- a/Core/Layer/Worlds/WorldLayer.Render.Hud.cs
+++ b/Core/Layer/Worlds/WorldLayer.Render.Hud.cs
@@ -115,6 +115,10 @@ public partial class WorldLayer
 
         // Check SBARDEF coverage
         StatusBarLayoutDef? activeSbarLayout = GetActiveStatusBarLayout();
+        int? sbarHeight = activeSbarLayout != null 
+            ? (activeSbarLayout.FullscreenRender ? 0 : activeSbarLayout.Height) 
+            : null;
+        
         StatusBarCoverage sbarCoverage = StatusBarCoverage.None;
         if (activeSbarLayout != null)
         {
@@ -122,10 +126,10 @@ public partial class WorldLayer
         }
 
         if ((m_renderHudOptions & RenderHudOptions.Weapon) != 0)
-            DrawWeapon(hud, hudContext);
+            DrawWeapon(hud, hudContext, sbarHeight);
 
         if ((m_renderHudOptions & RenderHudOptions.Crosshair) != 0 && m_config.Hud.Crosshair)
-            DrawCrosshair(hud);
+            DrawCrosshair(hud, sbarHeight);
 
         if ((m_renderHudOptions & RenderHudOptions.Hud) != 0)
         {
@@ -479,8 +483,7 @@ public partial class WorldLayer
         DrawFullStatusBar(hud);
     }
     
-
-    private void DrawWeapon(IHudRenderContext hud, HudRenderContext hudContext)
+    private void DrawWeapon(IHudRenderContext hud, HudRenderContext hudContext, int? sbarHeight = null)
     {
         if (!WorldStatic.World.DrawHud)
             return;
@@ -496,8 +499,8 @@ public partial class WorldLayer
             if (powerup != null && powerup.DrawPowerupEffect)
                 hudContext.DrawFuzz = true;
 
-            // Doom pushes the gun sprite up when the status bar is showing
-            int yOffset = m_config.Hud.StatusBarSize == StatusBarSizeType.Full ? HudView.FullSizeHudOffsetY : 0;
+            // Push the gun sprite up based on the status bar height
+            int yOffset = HudView.GetWeaponOffset(m_config.Hud.StatusBarSize.Value, sbarHeight);
             DrawHudWeapon(hud, Player.AnimationWeapon.FrameState, yOffset, flash: false);
             if (Player.AnimationWeapon.FlashState.Frame.BranchType != ActorStateBranch.Stop)
                 DrawHudWeapon(hud, Player.AnimationWeapon.FlashState, yOffset, flash: true);
@@ -644,8 +647,8 @@ public partial class WorldLayer
 
         return sprite;
     }
-
-    private void DrawCrosshair(IHudRenderContext hud)
+    
+    private void DrawCrosshair(IHudRenderContext hud, int? sbarHeight = null)
     {
         int Width = Math.Max((int)(1 * m_scale), 1);
         int HalfWidth = Math.Max(Width / 2, 1);
@@ -674,7 +677,7 @@ public partial class WorldLayer
             totalCrosshairLength += 1;
 
         Vec2I center = m_viewport.Vector / 2;
-        center -= HudView.GetViewPortOffset(m_config.Hud.StatusBarSize, m_viewport);
+        center -= HudView.GetViewPortOffset(m_config.Hud.StatusBarSize.Value, m_viewport, sbarHeight);
 
         Vec2I horizontal = center - new Vec2I(crosshairLength, HalfWidth);
         Vec2I vertical = center - new Vec2I(HalfWidth, crosshairLength);

--- a/Core/Layer/Worlds/WorldLayer.Render.cs
+++ b/Core/Layer/Worlds/WorldLayer.Render.cs
@@ -1,8 +1,11 @@
+using Helion.Geometry.Boxes;
 using Helion.Geometry.Vectors;
 using Helion.Graphics;
 using Helion.Render.Common.Context;
 using Helion.Render.Common.Renderers;
 using Helion.Render.Common.World;
+using Helion.Resources.Definitions.StatusBar;
+using Helion.World.StatusBar;
 using System;
 
 namespace Helion.Layer.Worlds;
@@ -29,7 +32,30 @@ public partial class WorldLayer
 
         SetWorldContextVars();
 
-        ctx.World(m_worldContext, m_renderWorldAction);
+        StatusBarLayoutDef? activeSbar = GetActiveStatusBarLayout();
+        int sbarHeight = activeSbar != null
+            ? (activeSbar.FullscreenRender ? 0 : activeSbar.Height)
+            : (m_config.Hud.StatusBarSize.Value == StatusBarSizeType.Full ? 32 : 0);
+
+        int nativeWidth = ctx.Surface.Dimension.Width;
+        int nativeHeight = ctx.Surface.Dimension.Height;
+
+        int nativeBarHeight = (int)(nativeHeight / 200.0 * sbarHeight);
+
+        int viewportBottom = nativeBarHeight;
+        int viewportHeight = nativeHeight - viewportBottom;
+
+        Box2I viewportArea = new((0, viewportBottom), (nativeWidth, nativeHeight));
+
+        m_worldContext.Viewport = (nativeWidth, viewportHeight);
+
+        ctx.Viewport(viewportArea, () =>
+        {
+            ctx.World(m_worldContext, m_renderWorldAction);
+        });
+
+        m_worldContext.Viewport = ctx.Surface.Dimension;
+
         m_profiler.Render.World.Stop();
     }
 

--- a/Core/Layer/Worlds/WorldLayer.Render.cs
+++ b/Core/Layer/Worlds/WorldLayer.Render.cs
@@ -20,6 +20,8 @@ public partial class WorldLayer
     private Action<IHudRenderContext> m_drawHudAction;
     private readonly Action<IWorldRenderContext> m_renderWorldAction;
     private readonly Action<IWorldRenderContext> m_renderAutomapAction;
+    private readonly Action m_renderWorldViewportAction;
+    private IRenderableSurfaceContext? m_renderableWorldSurfaceContext;
 
     private RenderHudOptions m_renderHudOptions;
 
@@ -44,15 +46,13 @@ public partial class WorldLayer
 
         int viewportBottom = nativeBarHeight;
         int viewportHeight = nativeHeight - viewportBottom;
-
         Box2I viewportArea = new((0, viewportBottom), (nativeWidth, nativeHeight));
 
         m_worldContext.Viewport = (nativeWidth, viewportHeight);
 
-        ctx.Viewport(viewportArea, () =>
-        {
-            ctx.World(m_worldContext, m_renderWorldAction);
-        });
+        m_renderableWorldSurfaceContext = ctx;
+        ctx.Viewport(viewportArea, m_renderWorldViewportAction);
+        m_renderableWorldSurfaceContext = null;
 
         m_worldContext.Viewport = ctx.Surface.Dimension;
 
@@ -79,6 +79,11 @@ public partial class WorldLayer
     void RenderWorld(IWorldRenderContext context)
     {
         context.Draw(World);
+    }
+    
+    private void RenderWorldViewportContext()
+    {
+        m_renderableWorldSurfaceContext?.World(m_worldContext, m_renderWorldAction);
     }
 
     public void RenderHud(IRenderableSurfaceContext ctx, RenderHudOptions options)

--- a/Core/Layer/Worlds/WorldLayer.cs
+++ b/Core/Layer/Worlds/WorldLayer.cs
@@ -101,6 +101,7 @@ public partial class WorldLayer : IGameLayerParent
         m_drawHudAction = new(DrawHudContext);
         m_renderWorldAction = new(RenderWorld);
         m_renderAutomapAction = new(RenderAutomap);
+        m_renderWorldViewportAction = new (RenderWorldViewportContext);
         m_virtualDrawFullStatusBarAction = new(VirtualDrawFullStatusBar);
         m_virtualStatusBarBackgroundAction = new(VirtualStatusBarBackground);
         m_virtualDrawPauseAction = new(VirtualDrawPause);

--- a/Core/Layer/Worlds/WorldLayer.cs
+++ b/Core/Layer/Worlds/WorldLayer.cs
@@ -101,7 +101,7 @@ public partial class WorldLayer : IGameLayerParent
         m_drawHudAction = new(DrawHudContext);
         m_renderWorldAction = new(RenderWorld);
         m_renderAutomapAction = new(RenderAutomap);
-        m_renderWorldViewportAction = new (RenderWorldViewportContext);
+        m_renderWorldViewportAction = new(RenderWorldViewportContext);
         m_virtualDrawFullStatusBarAction = new(VirtualDrawFullStatusBar);
         m_virtualStatusBarBackgroundAction = new(VirtualStatusBarBackground);
         m_virtualDrawPauseAction = new(VirtualDrawPause);

--- a/Core/Render/Common/Context/WorldRenderContext.cs
+++ b/Core/Render/Common/Context/WorldRenderContext.cs
@@ -8,7 +8,7 @@ public class WorldRenderContext
 {
     public readonly Camera Camera;
     public float InterpolationFrac;
-    public Dimension Viewport { get; } = (640, 480);
+    public Dimension Viewport { get; set; } = (640, 480);
     public bool DrawAutomap;
     public Vec2I AutomapOffset { get; set; } = (0, 0);
     public double AutomapScale { get; set; } = 1.0;

--- a/Core/Util/Configs/Components/ConfigHud.cs
+++ b/Core/Util/Configs/Components/ConfigHud.cs
@@ -12,10 +12,21 @@ public static class HudView
 {
     public const int FullSizeHudOffsetY = 16;
 
-    public static Vec2I GetViewPortOffset(StatusBarSizeType statusBarSize, Dimension viewport)
+    public static int GetWeaponOffset(StatusBarSizeType statusBarSize, int? customHeight = null)
     {
-        if (statusBarSize == StatusBarSizeType.Full)
-            return (0, (int)(viewport.Height / 200.0 * FullSizeHudOffsetY));
+        int height = customHeight ?? (statusBarSize == StatusBarSizeType.Full ? 32 : 0);
+        return height / 2;
+    }
+
+    public static Vec2I GetViewPortOffset(StatusBarSizeType statusBarSize, Dimension viewport, int? customHeight = null)
+    {
+        int height = customHeight ?? (statusBarSize == StatusBarSizeType.Full ? 32 : 0);
+        
+        if (height > 0)
+        {
+            return (0, (int)(viewport.Height / 200.0 * (height / 2.0)));
+        }
+        
         return (0, 0);
     }
 }


### PR DESCRIPTION
Fixes #1432.

Included are test SBARDEF huds that look Exactly like Vanilla Doom, but rendered at varying heights, including the more eccentric Status Bar heights of 190px and 200px.

[Vanilla20.zip](https://github.com/user-attachments/files/24321504/Vanilla20.zip)
[Vanilla60.zip](https://github.com/user-attachments/files/24321506/Vanilla60.zip)
[Vanilla120.zip](https://github.com/user-attachments/files/24321507/Vanilla120.zip)
[Vanilla190.zip](https://github.com/user-attachments/files/24321508/Vanilla190.zip)
[Vanilla200.zip](https://github.com/user-attachments/files/24321509/Vanilla200.zip)

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/98c0763e-3800-49b5-9b91-b79d876a6e6f" />

It's spec compliant!