### PR TITLE
Introduce SBARDEF Cropping, Minor 1.2 fixes (List dynamic_string margins, Powerup Conditionals, and Timers)

### DIFF
--- a/Core/Graphics/Image.cs
+++ b/Core/Graphics/Image.cs
@@ -209,6 +209,38 @@ public class Image
             this.Namespace,
             upscaleFactor: upscalingFactor);
     }
+    
+    public Image CloneCrop(int x, int y, int width, int height, Vec2I newOffset)
+    {
+        int srcX = Math.Max(0, Math.Min(x, Width));
+        int srcY = Math.Max(0, Math.Min(y, Height));
+    
+        int actualWidth = Math.Max(0, Math.Min(width, Width - srcX));
+        int actualHeight = Math.Max(0, Math.Min(height, Height - srcY));
+
+        if (actualWidth <= 0 || actualHeight <= 0)
+            return new Image(1, 1, ImageType, newOffset, Namespace);
+
+        uint[] newPixels = new uint[actualWidth * actualHeight];
+        ushort[]? newIndices = m_indices.Length > 0 ? new ushort[actualWidth * actualHeight] : null;
+
+        for (int row = 0; row < actualHeight; row++)
+        {
+            int srcRowOffset = (srcY + row) * Width + srcX;
+            int dstRowOffset = row * actualWidth;
+        
+            Array.Copy(m_pixels, srcRowOffset, newPixels, dstRowOffset, actualWidth);
+
+            if (newIndices == null) continue;
+            
+            for (int col = 0; col < actualWidth; col++)
+            {
+                newIndices[dstRowOffset + col] = m_indices[srcRowOffset + col];
+            }
+        }
+
+        return new Image(newPixels, (actualWidth, actualHeight), ImageType, newOffset, Namespace, newIndices);
+    }
 
     public static Image PaletteToArgb(PaletteImage image, Palette palette, bool[] fullBright, bool storeIndices, bool clearBlackPixels, byte[]? colorTranslation = null)
     {

--- a/Core/Graphics/Image.cs
+++ b/Core/Graphics/Image.cs
@@ -210,38 +210,6 @@ public class Image
             upscaleFactor: upscalingFactor);
     }
     
-    public Image CloneCrop(int x, int y, int width, int height, Vec2I newOffset)
-    {
-        int srcX = Math.Max(0, Math.Min(x, Width));
-        int srcY = Math.Max(0, Math.Min(y, Height));
-    
-        int actualWidth = Math.Max(0, Math.Min(width, Width - srcX));
-        int actualHeight = Math.Max(0, Math.Min(height, Height - srcY));
-
-        if (actualWidth <= 0 || actualHeight <= 0)
-            return new Image(1, 1, ImageType, newOffset, Namespace);
-
-        uint[] newPixels = new uint[actualWidth * actualHeight];
-        ushort[]? newIndices = m_indices.Length > 0 ? new ushort[actualWidth * actualHeight] : null;
-
-        for (int row = 0; row < actualHeight; row++)
-        {
-            int srcRowOffset = (srcY + row) * Width + srcX;
-            int dstRowOffset = row * actualWidth;
-        
-            Array.Copy(m_pixels, srcRowOffset, newPixels, dstRowOffset, actualWidth);
-
-            if (newIndices == null) continue;
-            
-            for (int col = 0; col < actualWidth; col++)
-            {
-                newIndices[dstRowOffset + col] = m_indices[srcRowOffset + col];
-            }
-        }
-
-        return new Image(newPixels, (actualWidth, actualHeight), ImageType, newOffset, Namespace, newIndices);
-    }
-
     public static Image PaletteToArgb(PaletteImage image, Palette palette, bool[] fullBright, bool storeIndices, bool clearBlackPixels, byte[]? colorTranslation = null)
     {
         uint[] pixels = new uint[image.Indices.Length];

--- a/Core/Layer/Worlds/StatusBar/StatusBarRenderer.cs
+++ b/Core/Layer/Worlds/StatusBar/StatusBarRenderer.cs
@@ -75,7 +75,12 @@ public class StatusBarRenderer
     private readonly Dictionary<string, StatusBarNumberFontDef> m_fontNumberLookup = [];
     private readonly Dictionary<string, StatusBarHudFontDef> m_hudFontLookup = [];
     private readonly SpanString m_fmtSpan = new();
-    private readonly SpanString m_lookupKeySpan = new(64);
+    private readonly SpanString m_lookupKeySpan = new(128); 
+    
+    private readonly Dictionary<string, (IRenderableTextureHandle Handle, string Name)> m_croppedHandleCache = new(StringComparer.OrdinalIgnoreCase);
+    private string m_lastFacePatch = string.Empty;
+    private string m_lastFaceCropName = string.Empty;
+    private IRenderableTextureHandle? m_lastFaceHandle;
 
     private bool m_texturesResolved;
 
@@ -198,31 +203,39 @@ public class StatusBarRenderer
 
     private void EnsureTexturesResolved(IHudRenderContext hud, StatusBarLayoutDef layout)
     {
-        for (int i = 0; i < layout.Children.Count; i++)
+        foreach (var t in layout.Children)
         {
-            ResolveElementTextures(hud, layout.Children[i]);
+            ResolveElementTextures(hud, t);
         }
     }
 
     private void ResolveElementTextures(IHudRenderContext hud, StatusBarElementWrapper wrapper)
     {
+        StatusBarBaseDef? baseDef = null;
+
         if (wrapper.Graphic != null)
         {
+            baseDef = wrapper.Graphic;
             wrapper.Graphic.ResolvedPatchName = ResolvePatchName(wrapper.Graphic.Patch);
-            if (hud.Textures.TryGet(wrapper.Graphic.ResolvedPatchName, out var handle))
-            {
+            if (hud.Textures.TryGet(wrapper.Graphic.ResolvedPatchName, out var handle, ResourceNamespace.Global))
                 wrapper.Graphic.Handle = handle;
-                wrapper.Graphic.ResolvedHeight = handle.Dimension.Height;
-            }
             else if (hud.Textures.TryGet(wrapper.Graphic.ResolvedPatchName, out handle, ResourceNamespace.Sprites))
-            {
                 wrapper.Graphic.Handle = handle;
-                wrapper.Graphic.ResolvedHeight = handle.Dimension.Height;
-            }
-        }
 
-        if (wrapper.Animation != null)
+            if (wrapper.Graphic.Crop != null && !string.IsNullOrEmpty(wrapper.Graphic.ResolvedPatchName))
+            {
+                var cropped = GetCroppedHandle(hud, wrapper.Graphic.ResolvedPatchName, wrapper.Graphic.Crop);
+                if (cropped.HasValue)
+                {
+                    wrapper.Graphic.Handle = cropped.Value.Handle;
+                    wrapper.Graphic.ResolvedPatchName = cropped.Value.Name;
+                }
+            }
+            if (wrapper.Graphic.Handle != null) wrapper.Graphic.ResolvedHeight = wrapper.Graphic.Handle.Dimension.Height;
+        }
+        else if (wrapper.Animation != null)
         {
+            baseDef = wrapper.Animation;
             for (int i = 0; i < wrapper.Animation.Frames.Count; i++)
             {
                 var frame = wrapper.Animation.Frames[i];
@@ -231,64 +244,59 @@ public class StatusBarRenderer
                     frame.Handle = handle;
                 else if (hud.Textures.TryGet(frame.ResolvedPatchName, out handle, ResourceNamespace.Sprites))
                     frame.Handle = handle;
-                
                 wrapper.Animation.Frames[i] = frame; 
             }
         }
-
-        if (wrapper.String != null)
+        else if (wrapper.String != null)
         {
+            baseDef = wrapper.String;
             m_hudFontLookup.TryGetValue(wrapper.String.Font, out var f);
             if (f != null)
             {
                 string zeroPatch = GetHudFontPatch(f, '0');
-                if (hud.Textures.TryGet(zeroPatch, out var h)) wrapper.String.ResolvedHeight = h.Dimension.Height;
-                else wrapper.String.ResolvedHeight = hud.GetFontMaxHeight(f.Stem);
+                wrapper.String.ResolvedHeight = hud.Textures.TryGet(zeroPatch, out var h) ? h.Dimension.Height : hud.GetFontMaxHeight(f.Stem);
             }
             else wrapper.String.ResolvedHeight = 8;
         }
         else if (wrapper.Number != null || wrapper.Percent != null)
         {
-            var num = (StatusBarBaseDef?)wrapper.Number ?? wrapper.Percent;
+            baseDef = (StatusBarBaseDef?)wrapper.Number ?? wrapper.Percent;
             m_fontNumberLookup.TryGetValue(wrapper.Number?.Font ?? wrapper.Percent?.Font ?? string.Empty, out var nf);
             if (nf != null)
             {
                 string zeroPatch = GetFontPatch(hud, nf, '0');
-                if (hud.Textures.TryGet(zeroPatch, out var h)) num!.ResolvedHeight = h.Dimension.Height;
-                else num!.ResolvedHeight = 8;
+                baseDef!.ResolvedHeight = hud.Textures.TryGet(zeroPatch, out var h) ? h.Dimension.Height : 8;
             }
-            else num!.ResolvedHeight = 8;
+            else baseDef!.ResolvedHeight = 8;
         }
-        else if (wrapper.Face != null || wrapper.FaceBackground != null)
+        else if (wrapper.Face != null)
         {
-            var face = (StatusBarBaseDef?)wrapper.Face ?? wrapper.FaceBackground;
-            if (hud.Textures.TryGet("STFST00", out var h)) face!.ResolvedHeight = h.Dimension.Height;
-            else face!.ResolvedHeight = 32;
+            baseDef = wrapper.Face;
+            baseDef!.ResolvedHeight = hud.Textures.TryGet("STFST00", out var h) ? h.Dimension.Height : 32;
         }
-
-        if (wrapper.FaceBackground != null)
+        else if (wrapper.FaceBackground != null)
         {
+            baseDef = wrapper.FaceBackground;
             if (hud.Textures.TryGet("STFB0", out var handle))
+            {
                 wrapper.FaceBackground.Handle = handle;
+                if (wrapper.FaceBackground.Crop != null)
+                {
+                    var cropped = GetCroppedHandle(hud, "STFB0", wrapper.FaceBackground.Crop);
+                    if (cropped.HasValue) wrapper.FaceBackground.Handle = cropped.Value.Handle;
+                }
+            }
+            if (wrapper.FaceBackground.Handle != null) wrapper.FaceBackground.ResolvedHeight = wrapper.FaceBackground.Handle.Dimension.Height;
         }
-
-        StatusBarBaseDef? baseDef = null;
-        if (wrapper.Canvas != null) baseDef = wrapper.Canvas;
+        else if (wrapper.Canvas != null) baseDef = wrapper.Canvas;
         else if (wrapper.List != null) baseDef = wrapper.List;
-        else if (wrapper.Graphic != null) baseDef = wrapper.Graphic;
-        else if (wrapper.Face != null) baseDef = wrapper.Face;
-        else if (wrapper.Animation != null) baseDef = wrapper.Animation;
-        else if (wrapper.Carousel != null) baseDef = wrapper.Carousel;
-        else if (wrapper.Number != null) baseDef = wrapper.Number;
-        else if (wrapper.Percent != null) baseDef = wrapper.Percent;
-        else if (wrapper.String != null) baseDef = wrapper.String;
         else if (wrapper.Component != null) baseDef = wrapper.Component;
-        else if (wrapper.FaceBackground != null) baseDef = wrapper.FaceBackground;
+        else if (wrapper.Carousel != null) baseDef = wrapper.Carousel;
 
         if (baseDef?.Children != null)
         {
-            for (int i = 0; i < baseDef.Children.Count; i++)
-                ResolveElementTextures(hud, baseDef.Children[i]);
+            foreach (var t in baseDef.Children)
+                ResolveElementTextures(hud, t);
         }
     }
 
@@ -429,8 +437,9 @@ public class StatusBarRenderer
             if (graphic.MidOffset != 0) currentPos.X += graphic.MidOffset;
 
             float alpha = graphic.Translucency ? 0.5f : 1.0f;
+        
             DrawSBarTexture(hud, graphic.ResolvedPatchName ?? graphic.Patch, graphic.Handle, currentPos, align,
-                graphic.Alignment, graphic.Translation, alpha, graphic.Crop);
+                graphic.Alignment, graphic.Translation, alpha);
         }
 
         DrawChildren(hud, graphic, currentPos, containerHeight, context, widescreenOffset, (0, 0));
@@ -449,8 +458,28 @@ public class StatusBarRenderer
         {
             Align align = ConvertAlignment(face.Alignment);
             float alpha = face.Translucency ? 0.5f : 1.0f;
-            DrawSBarTexture(hud, patch, null, currentPos, align,
-                face.Alignment, face.Translation, alpha, face.Crop);
+        
+            string drawName = patch;
+            IRenderableTextureHandle? handle = null;
+
+            if (face.Crop != null)
+            {
+                if (patch != m_lastFacePatch)
+                {
+                    var cropped = GetCroppedHandle(hud, patch, face.Crop, ResourceNamespace.Sprites);
+                    if (cropped.HasValue)
+                    {
+                        m_lastFacePatch = patch;
+                        m_lastFaceCropName = cropped.Value.Name;
+                        m_lastFaceHandle = cropped.Value.Handle;
+                    }
+                }
+                drawName = m_lastFaceCropName;
+                handle = m_lastFaceHandle;
+            }
+
+            DrawSBarTexture(hud, drawName, handle, currentPos, align,
+                face.Alignment, face.Translation, alpha);
         }
 
         DrawChildren(hud, face, currentPos, containerHeight, context, widescreenOffset, (0, 0));
@@ -468,8 +497,9 @@ public class StatusBarRenderer
         {
             Align align = ConvertAlignment(faceBg.Alignment);
             float alpha = faceBg.Translucency ? 0.5f : 1.0f;
+        
             DrawSBarTexture(hud, "STFB0", faceBg.Handle, currentPos, align,
-                faceBg.Alignment, faceBg.Translation, alpha, faceBg.Crop);
+                faceBg.Alignment, faceBg.Translation, alpha);
         }
 
         DrawChildren(hud, faceBg, currentPos, containerHeight, context, widescreenOffset, (0, 0));
@@ -826,11 +856,11 @@ public class StatusBarRenderer
     }
 
     private static void DrawSBarTexture(IHudRenderContext hud, string patch, IRenderableTextureHandle? handle, Vec2I pos, Align align,
-        StatusBarAlignment sbarAlign, string? translation = null, float alpha = 1.0f, StatusBarCropDef? crop = null)
+        StatusBarAlignment sbarAlign, string? translation = null, float alpha = 1.0f)
     {
         string pName = handle == null ? ResolvePatchName(patch) : patch;
         ResourceNamespace ns = ResourceNamespace.Global;
-        
+    
         if (handle == null)
         {
             if (!hud.Textures.TryGet(pName, out handle))
@@ -854,8 +884,6 @@ public class StatusBarRenderer
             if (StandardTextColors.TryGetValue(translation, out var c))
                 drawColor = c;
         }
-
-        if (crop != null) { /* Future Implementation */ }
 
         hud.Image(pName, drawPos, anchor: align, resourceNamespace: ns, alpha: alpha, color: drawColor);
     }
@@ -1081,7 +1109,7 @@ public class StatusBarRenderer
 
     private Vec2I MeasureElement(IHudRenderContext hud, StatusBarElementWrapper wrapper, StatusBarContext context)
     {
-        if (wrapper.Graphic != null) return MeasureGraphic(hud, wrapper.Graphic);
+        if (wrapper.Graphic != null) return MeasureGraphic(wrapper.Graphic);
         if (wrapper.Number != null) return MeasureNumber(hud, wrapper.Number, context, false);
         if (wrapper.Percent != null) return MeasureNumber(hud, wrapper.Percent, context, true);
         if (wrapper.Face != null) return MeasureFace(hud, wrapper.Face, context);
@@ -1092,9 +1120,8 @@ public class StatusBarRenderer
         return Vec2I.Zero;
     }
 
-    private static Vec2I MeasureGraphic(IHudRenderContext hud, StatusBarGraphicDef def)
+    private static Vec2I MeasureGraphic(StatusBarGraphicDef def)
     {
-        _ = hud;
         var handle = def.Handle;
         if (handle == null) return Vec2I.Zero;
 
@@ -1122,7 +1149,7 @@ public class StatusBarRenderer
         return ApplyAlignment(new Vec2I(width, height), def.X, def.Y, def.Alignment);
     }
 
-    private Vec2I MeasureFace(IHudRenderContext hud, StatusBarFaceDef def, StatusBarContext context)
+    private static Vec2I MeasureFace(IHudRenderContext hud, StatusBarFaceDef def, StatusBarContext context)
     {
         string p = context.Player.StatusBar.GetFacePatch();
         if (!hud.Textures.TryGet(p, out var h)) return Vec2I.Zero;
@@ -1154,9 +1181,9 @@ public class StatusBarRenderer
     {
         if (def.Children == null) return Vec2I.Zero;
         int maxX = 0, maxY = 0;
-        for (int i = 0; i < def.Children.Count; i++)
+        foreach (var t in def.Children)
         {
-            var cSize = MeasureElement(hud, def.Children[i], context);
+            var cSize = MeasureElement(hud, t, context);
             if (cSize.X > maxX) maxX = cSize.X;
             if (cSize.Y > maxY) maxY = cSize.Y;
         }
@@ -1171,9 +1198,8 @@ public class StatusBarRenderer
         int totalH = 0;
         int count = 0;
 
-        for (int i = 0; i < def.Children.Count; i++)
+        foreach (var child in def.Children)
         {
-            var child = def.Children[i];
             if (!EvaluateWrapperConditions(child, context))
                 continue;
 
@@ -1198,15 +1224,7 @@ public class StatusBarRenderer
 
     private static Vec2I ApplyAlignment(Vec2I size, int posX, int posY, StatusBarAlignment alignment)
     {
-        int x = posX;
-        int y = posY;
-
-        if ((alignment & StatusBarAlignment.HCenter) != 0) x -= size.X >> 1;
-        else if ((alignment & StatusBarAlignment.Right) != 0) x -= size.X;
-
-        if ((alignment & StatusBarAlignment.VCenter) != 0) y -= size.Y >> 1;
-        else if ((alignment & StatusBarAlignment.Bottom) != 0) y -= size.Y;
-
+        _ = alignment;
         return new Vec2I(size.X + Math.Max(0, posX), size.Y + Math.Max(0, posY));
     }
 
@@ -1417,5 +1435,53 @@ public class StatusBarRenderer
         if (bottom) return hCenter ? Align.BottomMiddle : (right ? Align.BottomRight : Align.BottomLeft);
         if (vCenter) return hCenter ? Align.Center : (right ? Align.MiddleRight : Align.MiddleLeft);
         return hCenter ? Align.TopMiddle : (right ? Align.TopRight : Align.TopLeft);
+    }
+    
+    private (IRenderableTextureHandle Handle, string Name)? GetCroppedHandle(IHudRenderContext hud, string originalPatch, StatusBarCropDef crop, ResourceNamespace ns = ResourceNamespace.Global)
+    {
+        if (string.IsNullOrEmpty(originalPatch)) return null;
+
+        m_lookupKeySpan.Clear();
+        m_lookupKeySpan.Append(originalPatch);
+        m_lookupKeySpan.Append("_c_");
+        m_lookupKeySpan.Append(crop.Left);
+        m_lookupKeySpan.Append('_');
+        m_lookupKeySpan.Append(crop.Top);
+        m_lookupKeySpan.Append('_');
+        m_lookupKeySpan.Append(crop.Width);
+        m_lookupKeySpan.Append('_');
+        m_lookupKeySpan.Append(crop.Height);
+        m_lookupKeySpan.Append('_');
+        m_lookupKeySpan.Append(crop.Center ? '1' : '0');
+    
+        var lookup = m_croppedHandleCache.GetAlternateLookup<ReadOnlySpan<char>>();
+        if (lookup.TryGetValue(m_lookupKeySpan.AsSpan(), out var cached))
+        {
+            return cached;
+        }
+
+        var rawImage = m_archiveCollection.ImageRetriever.Get(originalPatch, ns);
+        if (rawImage == null) return null;
+
+        int srcX = crop.Left;
+        int srcY = crop.Top;
+        if (crop.Center)
+        {
+            srcX += rawImage.Width / 2;
+            srcY += rawImage.Height / 2;
+        }
+
+        int width = crop.Width > 0 ? crop.Width : (rawImage.Width - srcX);
+        int height = crop.Height > 0 ? crop.Height : (rawImage.Height - srcY);
+
+        Vec2I newOffset = rawImage.Offset;
+
+        var croppedImage = rawImage.CloneCrop(srcX, srcY, width, height, newOffset);
+        string cropName = m_lookupKeySpan.ToString();
+        var newHandle = hud.Textures.CreateOrReplaceTexture(cropName, ns, croppedImage);
+    
+        var result = (newHandle, cropName);
+        m_croppedHandleCache[cropName] = result;
+        return result;
     }
 }

--- a/Core/Layer/Worlds/StatusBar/StatusBarRenderer.cs
+++ b/Core/Layer/Worlds/StatusBar/StatusBarRenderer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using Helion.Geometry.Vectors;
 using Helion.Graphics;
+using Helion.Graphics.Geometry;
 using Helion.Render.Common;
 using Helion.Render.Common.Enums;
 using Helion.Render.Common.Renderers;
@@ -76,11 +77,6 @@ public class StatusBarRenderer
     private readonly Dictionary<string, StatusBarHudFontDef> m_hudFontLookup = [];
     private readonly SpanString m_fmtSpan = new();
     private readonly SpanString m_lookupKeySpan = new(128); 
-    
-    private readonly Dictionary<string, (IRenderableTextureHandle Handle, string Name)> m_croppedHandleCache = new(StringComparer.OrdinalIgnoreCase);
-    private string m_lastFacePatch = string.Empty;
-    private string m_lastFaceCropName = string.Empty;
-    private IRenderableTextureHandle? m_lastFaceHandle;
 
     private bool m_texturesResolved;
 
@@ -211,45 +207,37 @@ public class StatusBarRenderer
 
     private void ResolveElementTextures(IHudRenderContext hud, StatusBarElementWrapper wrapper)
     {
-        StatusBarBaseDef? baseDef = null;
-
         if (wrapper.Graphic != null)
         {
-            baseDef = wrapper.Graphic;
             wrapper.Graphic.ResolvedPatchName = ResolvePatchName(wrapper.Graphic.Patch);
-            if (hud.Textures.TryGet(wrapper.Graphic.ResolvedPatchName, out var handle, ResourceNamespace.Global))
-                wrapper.Graphic.Handle = handle;
-            else if (hud.Textures.TryGet(wrapper.Graphic.ResolvedPatchName, out handle, ResourceNamespace.Sprites))
-                wrapper.Graphic.Handle = handle;
-
-            if (wrapper.Graphic.Crop != null && !string.IsNullOrEmpty(wrapper.Graphic.ResolvedPatchName))
+            
+            if (hud.Textures.TryGet(wrapper.Graphic.ResolvedPatchName, out var handle) || 
+                hud.Textures.TryGet(wrapper.Graphic.ResolvedPatchName, out handle, ResourceNamespace.Sprites))
             {
-                var cropped = GetCroppedHandle(hud, wrapper.Graphic.ResolvedPatchName, wrapper.Graphic.Crop);
-                if (cropped.HasValue)
-                {
-                    wrapper.Graphic.Handle = cropped.Value.Handle;
-                    wrapper.Graphic.ResolvedPatchName = cropped.Value.Name;
-                }
+                wrapper.Graphic.Handle = handle;
+                wrapper.Graphic.ResolvedHeight = handle.Dimension.Height;
             }
-            if (wrapper.Graphic.Handle != null) wrapper.Graphic.ResolvedHeight = wrapper.Graphic.Handle.Dimension.Height;
         }
-        else if (wrapper.Animation != null)
+
+        if (wrapper.Animation != null)
         {
-            baseDef = wrapper.Animation;
             for (int i = 0; i < wrapper.Animation.Frames.Count; i++)
             {
                 var frame = wrapper.Animation.Frames[i];
                 frame.ResolvedPatchName = ResolvePatchName(frame.Lump);
-                if (hud.Textures.TryGet(frame.ResolvedPatchName, out var handle))
+                
+                if (hud.Textures.TryGet(frame.ResolvedPatchName, out var handle) || 
+                    hud.Textures.TryGet(frame.ResolvedPatchName, out handle, ResourceNamespace.Sprites))
+                {
                     frame.Handle = handle;
-                else if (hud.Textures.TryGet(frame.ResolvedPatchName, out handle, ResourceNamespace.Sprites))
-                    frame.Handle = handle;
+                }
+                
                 wrapper.Animation.Frames[i] = frame; 
             }
         }
-        else if (wrapper.String != null)
+
+        if (wrapper.String != null)
         {
-            baseDef = wrapper.String;
             m_hudFontLookup.TryGetValue(wrapper.String.Font, out var f);
             if (f != null)
             {
@@ -260,44 +248,55 @@ public class StatusBarRenderer
         }
         else if (wrapper.Number != null || wrapper.Percent != null)
         {
-            baseDef = (StatusBarBaseDef?)wrapper.Number ?? wrapper.Percent;
+            var num = (StatusBarBaseDef?)wrapper.Number ?? wrapper.Percent;
             m_fontNumberLookup.TryGetValue(wrapper.Number?.Font ?? wrapper.Percent?.Font ?? string.Empty, out var nf);
             if (nf != null)
             {
                 string zeroPatch = GetFontPatch(hud, nf, '0');
-                baseDef!.ResolvedHeight = hud.Textures.TryGet(zeroPatch, out var h) ? h.Dimension.Height : 8;
+                num!.ResolvedHeight = hud.Textures.TryGet(zeroPatch, out var h) ? h.Dimension.Height : 8;
             }
-            else baseDef!.ResolvedHeight = 8;
+            else num!.ResolvedHeight = 8;
         }
-        else if (wrapper.Face != null)
+        else if (wrapper.Face != null || wrapper.FaceBackground != null)
         {
-            baseDef = wrapper.Face;
-            baseDef!.ResolvedHeight = hud.Textures.TryGet("STFST00", out var h) ? h.Dimension.Height : 32;
+            var face = (StatusBarBaseDef?)wrapper.Face ?? wrapper.FaceBackground;
+            
+            if (hud.Textures.TryGet("STFST00", out var h) || 
+                hud.Textures.TryGet("STFST00", out h, ResourceNamespace.Sprites))
+            {
+                face!.ResolvedHeight = h.Dimension.Height;
+            }
+            else
+            {
+                face!.ResolvedHeight = 32;
+            }
         }
-        else if (wrapper.FaceBackground != null)
+
+        if (wrapper.FaceBackground != null)
         {
-            baseDef = wrapper.FaceBackground;
-            if (hud.Textures.TryGet("STFB0", out var handle))
+            if (hud.Textures.TryGet("STFB0", out var handle) || 
+                hud.Textures.TryGet("STFB0", out handle, ResourceNamespace.Sprites))
             {
                 wrapper.FaceBackground.Handle = handle;
-                if (wrapper.FaceBackground.Crop != null)
-                {
-                    var cropped = GetCroppedHandle(hud, "STFB0", wrapper.FaceBackground.Crop);
-                    if (cropped.HasValue) wrapper.FaceBackground.Handle = cropped.Value.Handle;
-                }
             }
-            if (wrapper.FaceBackground.Handle != null) wrapper.FaceBackground.ResolvedHeight = wrapper.FaceBackground.Handle.Dimension.Height;
         }
-        else if (wrapper.Canvas != null) baseDef = wrapper.Canvas;
-        else if (wrapper.List != null) baseDef = wrapper.List;
-        else if (wrapper.Component != null) baseDef = wrapper.Component;
-        else if (wrapper.Carousel != null) baseDef = wrapper.Carousel;
 
-        if (baseDef?.Children != null)
-        {
-            foreach (var t in baseDef.Children)
-                ResolveElementTextures(hud, t);
-        }
+        StatusBarBaseDef? baseDef = null;
+        if (wrapper.Canvas != null) baseDef = wrapper.Canvas;
+        else if (wrapper.List != null) baseDef = wrapper.List;
+        else if (wrapper.Graphic != null) baseDef = wrapper.Graphic;
+        else if (wrapper.Face != null) baseDef = wrapper.Face;
+        else if (wrapper.Animation != null) baseDef = wrapper.Animation;
+        else if (wrapper.Carousel != null) baseDef = wrapper.Carousel;
+        else if (wrapper.Number != null) baseDef = wrapper.Number;
+        else if (wrapper.Percent != null) baseDef = wrapper.Percent;
+        else if (wrapper.String != null) baseDef = wrapper.String;
+        else if (wrapper.Component != null) baseDef = wrapper.Component;
+        else if (wrapper.FaceBackground != null) baseDef = wrapper.FaceBackground;
+
+        if (baseDef?.Children == null) return;
+        foreach (var t in baseDef.Children)
+            ResolveElementTextures(hud, t);
     }
 
     private void DrawElementWrapper(IHudRenderContext hud, StatusBarElementWrapper wrapper, Vec2I parentPos,
@@ -439,7 +438,7 @@ public class StatusBarRenderer
             float alpha = graphic.Translucency ? 0.5f : 1.0f;
         
             DrawSBarTexture(hud, graphic.ResolvedPatchName ?? graphic.Patch, graphic.Handle, currentPos, align,
-                graphic.Alignment, graphic.Translation, alpha);
+                graphic.Alignment, graphic.Translation, alpha, graphic.Crop);
         }
 
         DrawChildren(hud, graphic, currentPos, containerHeight, context, widescreenOffset, (0, 0));
@@ -458,28 +457,9 @@ public class StatusBarRenderer
         {
             Align align = ConvertAlignment(face.Alignment);
             float alpha = face.Translucency ? 0.5f : 1.0f;
-        
-            string drawName = patch;
-            IRenderableTextureHandle? handle = null;
-
-            if (face.Crop != null)
-            {
-                if (patch != m_lastFacePatch)
-                {
-                    var cropped = GetCroppedHandle(hud, patch, face.Crop, ResourceNamespace.Sprites);
-                    if (cropped.HasValue)
-                    {
-                        m_lastFacePatch = patch;
-                        m_lastFaceCropName = cropped.Value.Name;
-                        m_lastFaceHandle = cropped.Value.Handle;
-                    }
-                }
-                drawName = m_lastFaceCropName;
-                handle = m_lastFaceHandle;
-            }
-
-            DrawSBarTexture(hud, drawName, handle, currentPos, align,
-                face.Alignment, face.Translation, alpha);
+            
+            DrawSBarTexture(hud, patch, null, currentPos, align,
+                face.Alignment, face.Translation, alpha, face.Crop);
         }
 
         DrawChildren(hud, face, currentPos, containerHeight, context, widescreenOffset, (0, 0));
@@ -855,12 +835,13 @@ public class StatusBarRenderer
         DrawChildren(hud, carousel, pos, containerHeight, context, widescreenOffset, rootPos);
     }
 
+        
     private static void DrawSBarTexture(IHudRenderContext hud, string patch, IRenderableTextureHandle? handle, Vec2I pos, Align align,
-        StatusBarAlignment sbarAlign, string? translation = null, float alpha = 1.0f)
+        StatusBarAlignment sbarAlign, string? translation = null, float alpha = 1.0f, StatusBarCropDef? cropDef = null)
     {
         string pName = handle == null ? ResolvePatchName(patch) : patch;
         ResourceNamespace ns = ResourceNamespace.Global;
-    
+        
         if (handle == null)
         {
             if (!hud.Textures.TryGet(pName, out handle))
@@ -870,6 +851,8 @@ public class StatusBarRenderer
                     return;
             }
         }
+
+        ImageBox2I? cropArea = GetCropArea(handle, cropDef);
 
         bool ignoreX = (sbarAlign & StatusBarAlignment.IgnoreLeftOffset) != 0;
         bool ignoreY = (sbarAlign & StatusBarAlignment.IgnoreTopOffset) != 0;
@@ -885,7 +868,7 @@ public class StatusBarRenderer
                 drawColor = c;
         }
 
-        hud.Image(pName, drawPos, anchor: align, resourceNamespace: ns, alpha: alpha, color: drawColor);
+        hud.Image(pName, drawPos, anchor: align, resourceNamespace: ns, alpha: alpha, color: drawColor, crop: cropArea);
     }
 
     private void DrawNumber(IHudRenderContext hud, StatusBarNumberDef number, Vec2I parentPos,
@@ -1437,51 +1420,22 @@ public class StatusBarRenderer
         return hCenter ? Align.TopMiddle : (right ? Align.TopRight : Align.TopLeft);
     }
     
-    private (IRenderableTextureHandle Handle, string Name)? GetCroppedHandle(IHudRenderContext hud, string originalPatch, StatusBarCropDef crop, ResourceNamespace ns = ResourceNamespace.Global)
+    private static ImageBox2I? GetCropArea(IRenderableTextureHandle handle, StatusBarCropDef? cropDef)
     {
-        if (string.IsNullOrEmpty(originalPatch)) return null;
+        if (cropDef == null) return null;
 
-        m_lookupKeySpan.Clear();
-        m_lookupKeySpan.Append(originalPatch);
-        m_lookupKeySpan.Append("_c_");
-        m_lookupKeySpan.Append(crop.Left);
-        m_lookupKeySpan.Append('_');
-        m_lookupKeySpan.Append(crop.Top);
-        m_lookupKeySpan.Append('_');
-        m_lookupKeySpan.Append(crop.Width);
-        m_lookupKeySpan.Append('_');
-        m_lookupKeySpan.Append(crop.Height);
-        m_lookupKeySpan.Append('_');
-        m_lookupKeySpan.Append(crop.Center ? '1' : '0');
-    
-        var lookup = m_croppedHandleCache.GetAlternateLookup<ReadOnlySpan<char>>();
-        if (lookup.TryGetValue(m_lookupKeySpan.AsSpan(), out var cached))
+        int cx = cropDef.Left;
+        int cy = cropDef.Top;
+        
+        if (cropDef.Center)
         {
-            return cached;
+            cx += handle.Dimension.Width / 2;
+            cy += handle.Dimension.Height / 2;
         }
 
-        var rawImage = m_archiveCollection.ImageRetriever.Get(originalPatch, ns);
-        if (rawImage == null) return null;
+        int cw = cropDef.Width > 0 ? cropDef.Width : (handle.Dimension.Width - cx);
+        int ch = cropDef.Height > 0 ? cropDef.Height : (handle.Dimension.Height - cy);
 
-        int srcX = crop.Left;
-        int srcY = crop.Top;
-        if (crop.Center)
-        {
-            srcX += rawImage.Width / 2;
-            srcY += rawImage.Height / 2;
-        }
-
-        int width = crop.Width > 0 ? crop.Width : (rawImage.Width - srcX);
-        int height = crop.Height > 0 ? crop.Height : (rawImage.Height - srcY);
-
-        Vec2I newOffset = rawImage.Offset;
-
-        var croppedImage = rawImage.CloneCrop(srcX, srcY, width, height, newOffset);
-        string cropName = m_lookupKeySpan.ToString();
-        var newHandle = hud.Textures.CreateOrReplaceTexture(cropName, ns, croppedImage);
-    
-        var result = (newHandle, cropName);
-        m_croppedHandleCache[cropName] = result;
-        return result;
+        return new ImageBox2I(cx, cy, cx + cw, cy + ch);
     }
 }

--- a/Core/Layer/Worlds/StatusBar/StatusBarRenderer.cs
+++ b/Core/Layer/Worlds/StatusBar/StatusBarRenderer.cs
@@ -138,7 +138,7 @@ public class StatusBarRenderer
     {
         if (!m_texturesResolved)
         {
-            EnsureTexturesResolved(hud.Textures, layout);
+            EnsureTexturesResolved(hud, layout);
             m_texturesResolved = true;
         }
 
@@ -196,23 +196,29 @@ public class StatusBarRenderer
         hud.PopVirtualDimension();
     }
 
-    private static void EnsureTexturesResolved(IRendererTextureManager textures, StatusBarLayoutDef layout)
+    private void EnsureTexturesResolved(IHudRenderContext hud, StatusBarLayoutDef layout)
     {
-        foreach (var child in layout.Children)
+        for (int i = 0; i < layout.Children.Count; i++)
         {
-            ResolveElementTextures(textures, child);
+            ResolveElementTextures(hud, layout.Children[i]);
         }
     }
-    
-    private static void ResolveElementTextures(IRendererTextureManager textures, StatusBarElementWrapper wrapper)
+
+    private void ResolveElementTextures(IHudRenderContext hud, StatusBarElementWrapper wrapper)
     {
         if (wrapper.Graphic != null)
         {
             wrapper.Graphic.ResolvedPatchName = ResolvePatchName(wrapper.Graphic.Patch);
-            if (textures.TryGet(wrapper.Graphic.ResolvedPatchName, out var handle))
+            if (hud.Textures.TryGet(wrapper.Graphic.ResolvedPatchName, out var handle))
+            {
                 wrapper.Graphic.Handle = handle;
-            else if (textures.TryGet(wrapper.Graphic.ResolvedPatchName, out handle, ResourceNamespace.Sprites))
+                wrapper.Graphic.ResolvedHeight = handle.Dimension.Height;
+            }
+            else if (hud.Textures.TryGet(wrapper.Graphic.ResolvedPatchName, out handle, ResourceNamespace.Sprites))
+            {
                 wrapper.Graphic.Handle = handle;
+                wrapper.Graphic.ResolvedHeight = handle.Dimension.Height;
+            }
         }
 
         if (wrapper.Animation != null)
@@ -221,17 +227,48 @@ public class StatusBarRenderer
             {
                 var frame = wrapper.Animation.Frames[i];
                 frame.ResolvedPatchName = ResolvePatchName(frame.Lump);
-                if (textures.TryGet(frame.ResolvedPatchName, out var handle))
+                if (hud.Textures.TryGet(frame.ResolvedPatchName, out var handle))
                     frame.Handle = handle;
-                else if (textures.TryGet(frame.ResolvedPatchName, out handle, ResourceNamespace.Sprites))
+                else if (hud.Textures.TryGet(frame.ResolvedPatchName, out handle, ResourceNamespace.Sprites))
                     frame.Handle = handle;
-                wrapper.Animation.Frames[i] = frame;
+                
+                wrapper.Animation.Frames[i] = frame; 
             }
         }
-        
+
+        if (wrapper.String != null)
+        {
+            m_hudFontLookup.TryGetValue(wrapper.String.Font, out var f);
+            if (f != null)
+            {
+                string zeroPatch = GetHudFontPatch(f, '0');
+                if (hud.Textures.TryGet(zeroPatch, out var h)) wrapper.String.ResolvedHeight = h.Dimension.Height;
+                else wrapper.String.ResolvedHeight = hud.GetFontMaxHeight(f.Stem);
+            }
+            else wrapper.String.ResolvedHeight = 8;
+        }
+        else if (wrapper.Number != null || wrapper.Percent != null)
+        {
+            var num = (StatusBarBaseDef?)wrapper.Number ?? wrapper.Percent;
+            m_fontNumberLookup.TryGetValue(wrapper.Number?.Font ?? wrapper.Percent?.Font ?? string.Empty, out var nf);
+            if (nf != null)
+            {
+                string zeroPatch = GetFontPatch(hud, nf, '0');
+                if (hud.Textures.TryGet(zeroPatch, out var h)) num!.ResolvedHeight = h.Dimension.Height;
+                else num!.ResolvedHeight = 8;
+            }
+            else num!.ResolvedHeight = 8;
+        }
+        else if (wrapper.Face != null || wrapper.FaceBackground != null)
+        {
+            var face = (StatusBarBaseDef?)wrapper.Face ?? wrapper.FaceBackground;
+            if (hud.Textures.TryGet("STFST00", out var h)) face!.ResolvedHeight = h.Dimension.Height;
+            else face!.ResolvedHeight = 32;
+        }
+
         if (wrapper.FaceBackground != null)
         {
-            if (textures.TryGet("STFB0", out var handle))
+            if (hud.Textures.TryGet("STFB0", out var handle))
                 wrapper.FaceBackground.Handle = handle;
         }
 
@@ -250,8 +287,8 @@ public class StatusBarRenderer
 
         if (baseDef?.Children != null)
         {
-            foreach (var child in baseDef.Children)
-                ResolveElementTextures(textures, child);
+            for (int i = 0; i < baseDef.Children.Count; i++)
+                ResolveElementTextures(hud, baseDef.Children[i]);
         }
     }
 
@@ -1079,11 +1116,13 @@ public class StatusBarRenderer
         m_fmtSpan.Append(ResolveNumberValue(context.Player, def.Type, def.Param));
         if (isPercent) m_fmtSpan.Append('%');
         
-        Vec2I size = new(MeasureSpan(hud, m_fmtSpan.AsSpan(), null, null, 1.0f), 8);
-        return ApplyAlignment(size, def.X, def.Y, def.Alignment);
+        int width = MeasureSpan(hud, m_fmtSpan.AsSpan(), null, null, 1.0f);
+        int height = def.ResolvedHeight > 0 ? def.ResolvedHeight : 8;
+
+        return ApplyAlignment(new Vec2I(width, height), def.X, def.Y, def.Alignment);
     }
 
-    private static Vec2I MeasureFace(IHudRenderContext hud, StatusBarFaceDef def, StatusBarContext context)
+    private Vec2I MeasureFace(IHudRenderContext hud, StatusBarFaceDef def, StatusBarContext context)
     {
         string p = context.Player.StatusBar.GetFacePatch();
         if (!hud.Textures.TryGet(p, out var h)) return Vec2I.Zero;
@@ -1104,19 +1143,22 @@ public class StatusBarRenderer
     {
         var text = GetStringValue(def);
         m_hudFontLookup.TryGetValue(def.Font, out var f);
-        Vec2I size = new(MeasureSpan(hud, text, null, f, 1.0f), 8);
-        return ApplyAlignment(size, def.X, def.Y, def.Alignment);
+        
+        int width = MeasureSpan(hud, text, null, f, 1.0f);
+        int height = def.ResolvedHeight > 0 ? def.ResolvedHeight : 8;
+
+        return ApplyAlignment(new Vec2I(width, height), def.X, def.Y, def.Alignment);
     }
 
     private Vec2I MeasureCanvas(IHudRenderContext hud, StatusBarCanvasDef def, StatusBarContext context)
     {
         if (def.Children == null) return Vec2I.Zero;
         int maxX = 0, maxY = 0;
-        foreach (var child in def.Children)
+        for (int i = 0; i < def.Children.Count; i++)
         {
-            var cSize = MeasureElement(hud, child, context);
-            maxX = Math.Max(maxX, cSize.X);
-            maxY = Math.Max(maxY, cSize.Y);
+            var cSize = MeasureElement(hud, def.Children[i], context);
+            if (cSize.X > maxX) maxX = cSize.X;
+            if (cSize.Y > maxY) maxY = cSize.Y;
         }
         return ApplyAlignment(new Vec2I(maxX, maxY), def.X, def.Y, def.Alignment);
     }
@@ -1124,32 +1166,48 @@ public class StatusBarRenderer
     private Vec2I MeasureList(IHudRenderContext hud, StatusBarListDef def, StatusBarContext context)
     {
         if (def.Children == null) return Vec2I.Zero;
-        int totalW = 0, totalH = 0;
-        foreach (var child in def.Children)
+
+        int totalW = 0;
+        int totalH = 0;
+        int count = 0;
+
+        for (int i = 0; i < def.Children.Count; i++)
         {
-            var lSize = MeasureElement(hud, child, context);
+            var child = def.Children[i];
+            if (!EvaluateWrapperConditions(child, context))
+                continue;
+
+            var size = MeasureElement(hud, child, context);
             if (def.Horizontal)
             {
-                totalW += lSize.X + def.Spacing;
-                totalH = Math.Max(totalH, lSize.Y);
+                totalW += size.X;
+                if (count > 0) totalW += def.Spacing;
+                if (size.Y > totalH) totalH = size.Y;
             }
             else
             {
-                totalH += lSize.Y + def.Spacing;
-                totalW = Math.Max(totalW, lSize.X);
+                totalH += size.Y;
+                if (count > 0) totalH += def.Spacing;
+                if (size.X > totalW) totalW = size.X;
             }
+            count++;
         }
+
         return ApplyAlignment(new Vec2I(totalW, totalH), def.X, def.Y, def.Alignment);
     }
 
     private static Vec2I ApplyAlignment(Vec2I size, int posX, int posY, StatusBarAlignment alignment)
     {
-        if ((alignment & StatusBarAlignment.HCenter) != 0) posX -= size.X / 2;
-        else if ((alignment & StatusBarAlignment.Right) != 0) posX -= size.X;
-        if ((alignment & StatusBarAlignment.VCenter) != 0) posY -= size.Y / 2;
-        else if ((alignment & StatusBarAlignment.Bottom) != 0) posY -= size.Y;
+        int x = posX;
+        int y = posY;
 
-        return new Vec2I(Math.Max(0, posX + size.X), Math.Max(0, posY + size.Y));
+        if ((alignment & StatusBarAlignment.HCenter) != 0) x -= size.X >> 1;
+        else if ((alignment & StatusBarAlignment.Right) != 0) x -= size.X;
+
+        if ((alignment & StatusBarAlignment.VCenter) != 0) y -= size.Y >> 1;
+        else if ((alignment & StatusBarAlignment.Bottom) != 0) y -= size.Y;
+
+        return new Vec2I(size.X + Math.Max(0, posX), size.Y + Math.Max(0, posY));
     }
 
     private static string ResolvePatchName(string patch)
@@ -1323,6 +1381,14 @@ public class StatusBarRenderer
                     5 => PowerupType.LightAmp,
                     _ => PowerupType.None
                 };
+
+                if (pt == PowerupType.None) return 0;
+
+                if (pt == PowerupType.Strength || pt == PowerupType.ComputerAreaMap)
+                {
+                    return player.Inventory.IsPowerupActive(pt) ? 1 : 0;
+                }
+
                 return (player.Inventory.GetPowerup(pt)?.Ticks ?? 0) / (int)Constants.TicksPerSecond;
             default: return 0;
         }

--- a/Core/Render/Common/Commands/RenderCommands.cs
+++ b/Core/Render/Common/Commands/RenderCommands.cs
@@ -117,10 +117,11 @@ public class RenderCommands
     }
 
     public void DrawImage(string textureName, ResourceNamespace ns, int left, int top, int width, int height, Color color,
-        float alpha = 1.0f, bool drawColorMap = false, bool drawFuzz = false, bool drawPalette = true, int colorMapIndex = 0, string? brightmapName = null)
+        float alpha = 1.0f, bool drawColorMap = false, bool drawFuzz = false, bool drawPalette = true, int colorMapIndex = 0,
+        string? brightmapName = null, ImageBox2I? crop = null)
     {
         ImageBox2I drawArea = TranslateDoomImageDimensions(left, top, width, height);
-        DrawImageCommand cmd = new(textureName, ns, drawArea, color, alpha * m_alpha, drawColorMap, drawFuzz, drawPalette, colorMapIndex, brightmapName);
+        DrawImageCommand cmd = new(textureName, ns, drawArea, color, alpha * m_alpha, drawColorMap, drawFuzz, drawPalette, colorMapIndex, brightmapName, crop);
         Commands.Add(new RenderCommand(RenderCommandType.Image, ImageCommands.Count));
         ImageCommands.Add(cmd);
     }

--- a/Core/Render/Common/Commands/Types/DrawImageCommand.cs
+++ b/Core/Render/Common/Commands/Types/DrawImageCommand.cs
@@ -8,15 +8,17 @@ namespace Helion.Render.OpenGL.Commands.Types;
 [StructLayout(LayoutKind.Sequential)]
 public readonly struct DrawImageCommand(string textureName, ResourceNamespace ns, ImageBox2I drawArea, Color multiplyColor,
     float alpha = 1.0f, bool drawColorMap = false, bool drawFuzz = false, bool drawPalette = true, int colorMapIndex = 0,
-    string? brightmapName = null)
+    string? brightmapName = null, ImageBox2I? cropArea = null)
 {
     public readonly ImageBox2I DrawArea = drawArea;
+    public readonly ImageBox2I CropArea = cropArea ?? default;
     public readonly float Alpha = alpha;
     public readonly Color MultiplyColor = multiplyColor;
     public readonly bool AreaIsTextureDimension = false;
     public readonly bool DrawColorMap = drawColorMap;
     public readonly bool DrawFuzz = drawFuzz;
     public readonly bool DrawPalette = drawPalette;
+    public readonly bool HasCrop = cropArea.HasValue;
     public readonly string TextureName = textureName;
     public readonly ResourceNamespace ResourceNamespace = ns;
     public readonly int ColorMapIndex = colorMapIndex;

--- a/Core/Render/Common/Renderers/IHudRenderContext.cs
+++ b/Core/Render/Common/Renderers/IHudRenderContext.cs
@@ -3,6 +3,7 @@ using Helion.Geometry;
 using Helion.Geometry.Segments;
 using Helion.Geometry.Vectors;
 using Helion.Graphics;
+using Helion.Graphics.Geometry;
 using Helion.Render.Common.Enums;
 using Helion.Render.Common.Textures;
 using Helion.Render.OpenGL.Texture.Fonts;
@@ -61,27 +62,29 @@ public interface IHudRenderContext : IDisposable
 
     void Image(string texture, Vec2I origin, Align window = Align.TopLeft, Align anchor = Align.TopLeft,
         Align? both = null, ResourceNamespace resourceNamespace = ResourceNamespace.Undefined, Color? color = null,
-        float scale = 1.0f, float alpha = 1.0f, int colorMapIndex = 0, int upscalingFactor = 1, string? brightmapName = null)
+        float scale = 1.0f, float alpha = 1.0f, int colorMapIndex = 0, int upscalingFactor = 1, string? brightmapName = null,
+        ImageBox2I? crop = null)
     {
-        Image(texture, origin, out _, window, anchor, both, resourceNamespace, color, scale, alpha, colorMapIndex, upscalingFactor, brightmapName);
+        Image(texture, origin, out _, window, anchor, both, resourceNamespace, color, scale, alpha, colorMapIndex, upscalingFactor, brightmapName, crop);
     }
 
     void Image(string texture, HudBox area, Align window = Align.TopLeft, Align anchor = Align.TopLeft,
         Align? both = null, ResourceNamespace resourceNamespace = ResourceNamespace.Undefined, Color? color = null,
-        float scale = 1.0f, float alpha = 1.0f, int colorMapIndex = 0, int upscalingFactor = 1, string? brightmapName = null)
+        float scale = 1.0f, float alpha = 1.0f, int colorMapIndex = 0, int upscalingFactor = 1, string? brightmapName = null,
+        ImageBox2I? crop = null)
     {
-        Image(texture, area, out _, window, anchor, both, resourceNamespace, color, scale, alpha, colorMapIndex, upscalingFactor, brightmapName);
+        Image(texture, area, out _, window, anchor, both, resourceNamespace, color, scale, alpha, colorMapIndex, upscalingFactor, brightmapName, crop);
     }
 
     void Image(string texture, HudBox area, out HudBox drawArea, Align window = Align.TopLeft,
         Align anchor = Align.TopLeft, Align? both = null, ResourceNamespace resourceNamespace = ResourceNamespace.Undefined,
         Color? color = null, float scale = 1.0f, float alpha = 1.0f, int colorMapIndex = 0, int upscalingFactor = 1,
-        string? brightmapName = null);
+        string? brightmapName = null, ImageBox2I? crop = null);
 
     void Image(string texture, Vec2I origin, out HudBox drawArea, Align window = Align.TopLeft,
         Align anchor = Align.TopLeft, Align? both = null, ResourceNamespace resourceNamespace = ResourceNamespace.Undefined,
         Color? color = null, float scale = 1.0f, float alpha = 1.0f, int colorMapIndex = 0, int upscalingFactor = 1,
-        string? brightmapName = null);
+        string? brightmapName = null, ImageBox2I? crop = null);
 
     void Text(RenderableString str, Vec2I origin, Align window = Align.TopLeft, Align anchor = Align.TopLeft,
         Align? both = null, float alpha = 1);

--- a/Core/Render/OpenGL/GLHudRenderContext.cs
+++ b/Core/Render/OpenGL/GLHudRenderContext.cs
@@ -114,25 +114,25 @@ public class GLHudRenderContext : IHudRenderContext
 
     public void Image(string texture, HudBox area, out HudBox drawArea, Align window = Align.TopLeft,
         Align anchor = Align.TopLeft, Align? both = null, ResourceNamespace resourceNamespace = ResourceNamespace.Global,
-         Color? color = null, float scale = 1.0f, float alpha = 1.0f, int colorMapIndex = 0, int upscalingFactor = 1,
-         string? brightmapName = null)
+        Color? color = null, float scale = 1.0f, float alpha = 1.0f, int colorMapIndex = 0, int upscalingFactor = 1,
+        string? brightmapName = null, ImageBox2I? crop = null)
     {
-        Image(texture, out drawArea, area, null, window, anchor, both, resourceNamespace, color, scale, alpha, false, colorMapIndex, upscalingFactor, brightmapName);
+        Image(texture, out drawArea, area, null, window, anchor, both, resourceNamespace, color, scale, alpha, false, colorMapIndex, upscalingFactor, brightmapName, crop);
     }
 
     public void Image(string texture, Vec2I origin, out HudBox drawArea, Align window = Align.TopLeft,
         Align anchor = Align.TopLeft, Align? both = null, ResourceNamespace resourceNamespace = ResourceNamespace.Global,
         Color? color = null, float scale = 1.0f, float alpha = 1.0f, int colorMapIndex = 0, int upscalingFactor = 1,
-        string? brightmapName = null)
+        string? brightmapName = null, ImageBox2I? crop = null)
     {
-        Image(texture, out drawArea, null, origin, window, anchor, both, resourceNamespace, color, scale, alpha, false, colorMapIndex, upscalingFactor, brightmapName);
+        Image(texture, out drawArea, null, origin, window, anchor, both, resourceNamespace, color, scale, alpha, false, colorMapIndex, upscalingFactor, brightmapName, crop);
     }
 
     private void Image(string texture, out HudBox drawArea, HudBox? area = null, Vec2I? origin = null,
         Align window = Align.TopLeft, Align anchor = Align.TopLeft, Align? both = null,
         ResourceNamespace resourceNamespace = ResourceNamespace.Global, Color? color = null,
         float scale = 1.0f, float alpha = 1.0f, bool drawFuzz = false, int colorMapIndex = 0, int upscalingFactor = 1,
-        string? brightmapName = null)
+        string? brightmapName = null, ImageBox2I? crop = null)
     {
         drawArea = default;
 
@@ -144,10 +144,19 @@ public class GLHudRenderContext : IHudRenderContext
 
         Vec2I location = (origin?.X ?? area?.Left ?? 0, origin?.Y ?? area?.Top ?? 0);
         Dimension drawDim = (0, 0);
+        
         if (area != null)
+        {
             drawDim = area.Value.Dimension;
+        }
+        else if (crop != null)
+        {
+            drawDim = new Dimension(crop.Value.Width, crop.Value.Height);
+        }
         else if (Textures.TryGet(texture, out var handle, resourceNamespace, upscalingFactor))
+        {
             drawDim = handle.Dimension;
+        }
 
         drawDim.Scale(scale / upscalingFactor);
 
@@ -155,7 +164,7 @@ public class GLHudRenderContext : IHudRenderContext
             window, anchor);
 
         m_commands.DrawImage(texture, resourceNamespace, pos.X, pos.Y, drawDim.Width, drawDim.Height,
-            color ?? Color.White, alpha, m_context.DrawColorMap, m_context.DrawFuzz, m_context.DrawPalette, colorMapIndex, brightmapName);
+            color ?? Color.White, alpha, m_context.DrawColorMap, m_context.DrawFuzz, m_context.DrawPalette, colorMapIndex, brightmapName, crop);
 
         drawArea = (location, location + drawDim.Vector);
     }

--- a/Core/Render/OpenGL/Renderers/HudRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/HudRenderer.cs
@@ -13,8 +13,8 @@ public abstract class HudRenderer : IDisposable
 {
     public abstract void Clear();
     public abstract void Dispose();
-    public abstract void DrawImage(string textureName, ResourceNamespace ns, Vec2I topLeft, Color multiplyColor, float alpha, bool drawInvul, bool drawFuzz, bool drawColorMap, int colorMapIndex, string? brightmapName = null);
-    public abstract void DrawImage(string textureName, ResourceNamespace ns, ImageBox2I drawArea, Color multiplyColor, float alpha, bool drawInvul, bool drawFuzz, bool drawColorMap, int colorMapIndex, string? brightmapName = null);
+    public abstract void DrawImage(string textureName, ResourceNamespace ns, Vec2I topLeft, Color multiplyColor, float alpha, bool drawInvul, bool drawFuzz, bool drawColorMap, int colorMapIndex, string? brightmapName = null, ImageBox2I? crop = null);
+    public abstract void DrawImage(string textureName, ResourceNamespace ns, ImageBox2I drawArea, Color multiplyColor, float alpha, bool drawInvul, bool drawFuzz, bool drawColorMap, int colorMapIndex, string? brightmapName = null, ImageBox2I? crop = null);
     public abstract void DrawShape(ImageBox2I area, Color color, float alpha);
     public abstract void DrawText(RenderableString text, ImageBox2I drawArea, float alpha, bool drawColorMap);
     public abstract void Render(Rectangle viewport, Dimension framebufferDimension, ShaderUniforms uniforms);

--- a/Core/Render/OpenGL/Renderers/Legacy/Hud/LegacyHudRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/Hud/LegacyHudRenderer.cs
@@ -57,7 +57,7 @@ public class LegacyHudRenderer : HudRenderer
     }
 
     public override void DrawImage(string textureName, ResourceNamespace ns, ImageBox2I drawArea, Color multiplyColor,
-        float alpha, bool drawColorMap, bool drawFuzz, bool drawPalette, int colorMapIndex, string? brightmapName = null)
+        float alpha, bool drawColorMap, bool drawFuzz, bool drawPalette, int colorMapIndex, string? brightmapName = null, ImageBox2I? crop = null)
     {
         m_textureManager.TryGet(textureName, ns, out GLLegacyTexture texture);
 
@@ -65,21 +65,24 @@ public class LegacyHudRenderer : HudRenderer
         if (brightmapName != null && m_textureManager.TryGet(brightmapName, ResourceNamespace.Brightmaps, out GLLegacyTexture val))
             brightmapTexture = val;
 
-        AddImage(texture, drawArea, multiplyColor, alpha, drawColorMap, drawFuzz, drawPalette, colorMapIndex, brightmapTexture);
+        AddImage(texture, drawArea, multiplyColor, alpha, drawColorMap, drawFuzz, drawPalette, colorMapIndex, brightmapTexture, crop);
     }
 
     public override void DrawImage(string textureName, ResourceNamespace ns, Vec2I topLeft, Color multiplyColor,
-        float alpha, bool drawColorMap, bool drawFuzz, bool drawPalette, int colorMapIndex, string? brightmapName = null)
+        float alpha, bool drawColorMap, bool drawFuzz, bool drawPalette, int colorMapIndex, string? brightmapName = null, ImageBox2I? crop = null)
     {
         m_textureManager.TryGet(textureName, ns, out GLLegacyTexture texture);
-        (int width, int height) = texture.Dimension;
+        
+        int width = crop?.Width ?? texture.Dimension.Width;
+        int height = crop?.Height ?? texture.Dimension.Height;
+        
         ImageBox2I drawArea = new(topLeft.X, topLeft.Y, topLeft.X + width, topLeft.Y + height);
 
         GLLegacyTexture? brightmapTexture = null;
         if (brightmapName != null && m_textureManager.TryGet(brightmapName, ResourceNamespace.Brightmaps, out GLLegacyTexture val))
             brightmapTexture = val;
 
-        AddImage(texture, drawArea, multiplyColor, alpha, drawColorMap, drawFuzz, drawPalette, colorMapIndex, brightmapTexture);
+        AddImage(texture, drawArea, multiplyColor, alpha, drawColorMap, drawFuzz, drawPalette, colorMapIndex, brightmapTexture, crop);
     }
 
     public override void DrawShape(ImageBox2I drawArea, Color color, float alpha)
@@ -213,14 +216,49 @@ public class LegacyHudRenderer : HudRenderer
     }
 
     private void AddImage(GLLegacyTexture texture, ImageBox2I drawArea, Color multiplyColor,
-        float alpha, bool drawColorMap, bool drawFuzz, bool drawPalette, int colorMapIndex, GLLegacyTexture? brightmapTexture = null)
+        float alpha, bool drawColorMap, bool drawFuzz, bool drawPalette, int colorMapIndex, 
+        GLLegacyTexture? brightmapTexture = null, ImageBox2I? crop = null)
     {
-        // Remember that we are drawing along the Z for visual depth now.
-        var topLeft = new HudVertex(drawArea.Left, drawArea.Top, DrawDepth, 0.0f, 0.0f, multiplyColor.R, multiplyColor.G, multiplyColor.B, multiplyColor.A, alpha, drawColorMap, drawFuzz, drawPalette, colorMapIndex);
-        var topRight = new HudVertex(drawArea.Right, drawArea.Top, DrawDepth, 1.0f, 0.0f, multiplyColor.R, multiplyColor.G, multiplyColor.B, multiplyColor.A, alpha, drawColorMap, drawFuzz, drawPalette, colorMapIndex);
-        var bottomLeft = new HudVertex(drawArea.Left, drawArea.Bottom, DrawDepth, 0.0f, 1.0f, multiplyColor.R, multiplyColor.G, multiplyColor.B, multiplyColor.A, alpha, drawColorMap, drawFuzz, drawPalette, colorMapIndex);
-        var bottomRight = new HudVertex(drawArea.Right, drawArea.Bottom, DrawDepth, 1.0f, 1.0f, multiplyColor.R, multiplyColor.G, multiplyColor.B, multiplyColor.A, alpha, drawColorMap, drawFuzz, drawPalette, colorMapIndex);
+        float u0 = 0.0f;
+        float v0 = 0.0f;
+        float u1 = 1.0f;
+        float v1 = 1.0f;
 
+        if (crop.HasValue)
+        {
+            var c = crop.Value;
+            
+            u0 = c.Min.X / (float)texture.Dimension.Width;
+            v0 = c.Min.Y / (float)texture.Dimension.Height;
+            u1 = c.Max.X / (float)texture.Dimension.Width;
+            v1 = c.Max.Y / (float)texture.Dimension.Height;
+        }
+
+        // Remember that we are drawing along the Z for visual depth now.
+        var topLeft = new HudVertex(
+            drawArea.Left, drawArea.Top, DrawDepth, 
+            u0, v0, 
+            multiplyColor.R, multiplyColor.G, multiplyColor.B, multiplyColor.A, 
+            alpha, drawColorMap, drawFuzz, drawPalette, colorMapIndex);
+
+        var topRight = new HudVertex(
+            drawArea.Right, drawArea.Top, DrawDepth, 
+            u1, v0, 
+            multiplyColor.R, multiplyColor.G, multiplyColor.B, multiplyColor.A, 
+            alpha, drawColorMap, drawFuzz, drawPalette, colorMapIndex);
+
+        var bottomLeft = new HudVertex(
+            drawArea.Left, drawArea.Bottom, DrawDepth, 
+            u0, v1, 
+            multiplyColor.R, multiplyColor.G, multiplyColor.B, multiplyColor.A, 
+            alpha, drawColorMap, drawFuzz, drawPalette, colorMapIndex);
+
+        var bottomRight = new HudVertex(
+            drawArea.Right, drawArea.Bottom, DrawDepth, 
+            u1, v1, 
+            multiplyColor.R, multiplyColor.G, multiplyColor.B, multiplyColor.A, 
+            alpha, drawColorMap, drawFuzz, drawPalette, colorMapIndex);
+        
         var quad = new HudQuad(topLeft, topRight, bottomLeft, bottomRight);
         m_drawBuffer.Add(texture, quad, brightmapTexture);
 

--- a/Core/Render/Renderer.cs
+++ b/Core/Render/Renderer.cs
@@ -29,6 +29,7 @@ using Helion.World.Geometry.Sectors;
 using NLog;
 using OpenTK.Graphics.OpenGL;
 using System;
+using Helion.Graphics.Geometry;
 using static Helion.Util.Assertion.Assert;
 
 namespace Helion.Render;
@@ -622,13 +623,39 @@ public partial class Renderer : IDisposable
 
     private void HandleDrawImage(DrawImageCommand cmd)
     {
+        ImageBox2I? crop = cmd.HasCrop ? cmd.CropArea : null;
+
         if (cmd.AreaIsTextureDimension)
         {
             Vec2I topLeft = (cmd.DrawArea.Top, cmd.DrawArea.Left);
-            m_hudRenderer.DrawImage(cmd.TextureName, cmd.ResourceNamespace, topLeft, cmd.MultiplyColor, cmd.Alpha, cmd.DrawColorMap, cmd.DrawFuzz, cmd.DrawPalette, cmd.ColorMapIndex, cmd.BrightmapName);
+            m_hudRenderer.DrawImage(
+                cmd.TextureName, 
+                cmd.ResourceNamespace, 
+                topLeft, 
+                cmd.MultiplyColor, 
+                cmd.Alpha, 
+                cmd.DrawColorMap, 
+                cmd.DrawFuzz, 
+                cmd.DrawPalette, 
+                cmd.ColorMapIndex, 
+                cmd.BrightmapName, 
+                crop);
         }
         else
-            m_hudRenderer.DrawImage(cmd.TextureName, cmd.ResourceNamespace, cmd.DrawArea, cmd.MultiplyColor, cmd.Alpha, cmd.DrawColorMap, cmd.DrawFuzz, cmd.DrawPalette, cmd.ColorMapIndex, cmd.BrightmapName);
+        {
+            m_hudRenderer.DrawImage(
+                cmd.TextureName, 
+                cmd.ResourceNamespace, 
+                cmd.DrawArea, 
+                cmd.MultiplyColor, 
+                cmd.Alpha, 
+                cmd.DrawColorMap, 
+                cmd.DrawFuzz, 
+                cmd.DrawPalette, 
+                cmd.ColorMapIndex, 
+                cmd.BrightmapName, 
+                crop);
+        }
     }
 
     private void HandleDrawShape(DrawShapeCommand cmd)

--- a/Core/Resources/Definitions/StatusBar/StatusBarElementDef.cs
+++ b/Core/Resources/Definitions/StatusBar/StatusBarElementDef.cs
@@ -81,6 +81,9 @@ public abstract class StatusBarBaseDef
 
     [JsonPropertyName("children")]
     public List<StatusBarElementWrapper>? Children { get; set; }
+    
+    [JsonIgnore]
+    public int ResolvedHeight { get; set; }
 }
 
 public class StatusBarCanvasDef : StatusBarBaseDef { }

--- a/Core/World/StatusBar/StatusBarConditionResolver.cs
+++ b/Core/World/StatusBar/StatusBarConditionResolver.cs
@@ -114,10 +114,10 @@ public static class StatusBarConditionResolver
             StatusBarConditionType.ItemsPercentGe => CheckStatPercent(world.LevelStats.ItemCount, world.LevelStats.TotalItems, c.Param, true),
             StatusBarConditionType.SecretsPercentLt => CheckStatPercent(world.LevelStats.SecretCount, world.LevelStats.TotalSecrets, c.Param, false),
             StatusBarConditionType.SecretsPercentGe => CheckStatPercent(world.LevelStats.SecretCount, world.LevelStats.TotalSecrets, c.Param, true),
-            StatusBarConditionType.PowerupDurationLt => CheckPowerupDuration(player, (PowerupType)c.Param2, c.Param, false),
-            StatusBarConditionType.PowerupDurationGe => CheckPowerupDuration(player, (PowerupType)c.Param2, c.Param, true),
-            StatusBarConditionType.PowerupDurationPercentLt => CheckPowerupPercent(player, (PowerupType)c.Param2, c.Param, false),
-            StatusBarConditionType.PowerupDurationPercentGe => CheckPowerupPercent(player, (PowerupType)c.Param2, c.Param, true),
+            StatusBarConditionType.PowerupDurationLt => CheckPowerupDuration(player, MapSbarPowerup(c.Param2), c.Param, false),
+            StatusBarConditionType.PowerupDurationGe => CheckPowerupDuration(player, MapSbarPowerup(c.Param2), c.Param, true),
+            StatusBarConditionType.PowerupDurationPercentLt => CheckPowerupPercent(player, MapSbarPowerup(c.Param2), c.Param, false),
+            StatusBarConditionType.PowerupDurationPercentGe => CheckPowerupPercent(player, MapSbarPowerup(c.Param2), c.Param, true),
 
             _ => false
         };
@@ -169,10 +169,10 @@ public static class StatusBarConditionResolver
             
             if (definition == null)
             {
-                if (entityName == "ComputerAreaMap") 
-                    definition = composer.GetByName("AllMap");
-                else if (entityName == "InvulnerabilitySphere") 
-                    definition = composer.GetByName("Invulnerability");
+                if (entityName == "ComputerAreaMap") definition = composer.GetByName("AllMap");
+                else if (entityName == "InvulnerabilitySphere") definition = composer.GetByName("Invulnerability");
+                else if (entityName == "LightAmp") definition = composer.GetByName("LiteAmp");
+                else if (entityName == "RadSuit") definition = composer.GetByName("IronFeet");
             }
 
             Id24PickupLookup[pickupItemType] = definition;
@@ -259,7 +259,27 @@ public static class StatusBarConditionResolver
 
     private static bool CheckItemOwned(Player player, int param, EntityDefinitionComposer composer)
     {
-        if (!TryGetId24PickupType(composer, param, out var def)) return false;
+        PowerupType? pType = param switch
+        {
+            16 => PowerupType.ComputerAreaMap,
+            17 => PowerupType.LightAmp,
+            18 => PowerupType.Strength,
+            19 => PowerupType.Invisibility,
+            20 => PowerupType.IronFeet,
+            21 => PowerupType.Invulnerable,
+            _ => null
+        };
+
+        if (pType.HasValue)
+        {
+            return player.Inventory.IsPowerupActive(pType.Value);
+        }
+
+        if (!TryGetId24PickupType(composer, param, out var def))
+        {
+            return false;
+        }
+
         if (player.Inventory.HasItem(def.Name)) return true;
         if (player.ArmorDefinition != null && player.ArmorDefinition == def) return true;
         if (player.Weapon != null && player.Weapon.Definition == def) return true;
@@ -441,6 +461,14 @@ public static class StatusBarConditionResolver
 
     private static bool CheckPowerupDuration(Player player, PowerupType type, int seconds, bool ge)
     {
+        if (type == PowerupType.None) return false;
+
+        if (type == PowerupType.Strength || type == PowerupType.ComputerAreaMap)
+        {
+            int val = player.Inventory.IsPowerupActive(type) ? 1 : 0;
+            return ge ? val >= seconds : val < seconds;
+        }
+
         var p = player.Inventory.GetPowerup(type);
         int currentTicks = p?.Ticks ?? 0;
         int targetTicks = seconds * 35;
@@ -449,17 +477,28 @@ public static class StatusBarConditionResolver
 
     private static bool CheckPowerupPercent(Player player, PowerupType type, int targetPct, bool ge)
     {
+        if (type == PowerupType.None) return false;
+
+        if (type == PowerupType.Strength || type == PowerupType.ComputerAreaMap)
+        {
+            int binaryPct = player.Inventory.IsPowerupActive(type) ? 100 : 0;
+            return ge ? binaryPct >= targetPct : binaryPct < targetPct;
+        }
+
         var p = player.Inventory.GetPowerup(type);
         if (p == null) return ge ? 0 >= targetPct : 0 < targetPct;
 
-        int maxTicks = type switch {
-            PowerupType.Invulnerable => 700,
-            PowerupType.Strength => 700,
-            _ => 2100
+        int maxTicks = type switch 
+        {
+            PowerupType.Invulnerable => 1050,
+            PowerupType.Invisibility => 2100,
+            PowerupType.IronFeet => 2100,
+            PowerupType.LightAmp => 4200,
+            _ => 1050
         };
 
-        int pct = (p.Ticks * 100) / maxTicks;
-        return ge ? pct >= targetPct : pct < targetPct;
+        int durationPct = (int)((p.Ticks * 100L) / maxTicks);
+        return ge ? durationPct >= targetPct : durationPct < targetPct;
     }
 
     private static int GetMaxAmount(EntityDefinition def, bool hasBackPack)
@@ -476,5 +515,19 @@ public static class StatusBarConditionResolver
             max = def.Properties.Ammo.BackpackMaxAmount;
         }
         return max;
+    }
+    
+    private static PowerupType MapSbarPowerup(int sbarIndex)
+    {
+        return sbarIndex switch
+        {
+            0 => PowerupType.Invulnerable,
+            1 => PowerupType.Strength,
+            2 => PowerupType.Invisibility,
+            3 => PowerupType.IronFeet,
+            4 => PowerupType.ComputerAreaMap,
+            5 => PowerupType.LightAmp,
+            _ => PowerupType.None
+        };
     }
 }


### PR DESCRIPTION
Test case:
<img width="640" height="480" alt="CropAndPowerupDurationsTest" src="https://github.com/user-attachments/assets/62a62c96-8ae9-4c10-8f0d-e52b0a4f5415" />

In Helion:
<img width="1024" height="768" alt="helion_20260104_18 05 47 6967" src="https://github.com/user-attachments/assets/5e6474d8-f732-45b1-9dcd-5674bc64b9b2" />

Test Case here:
[CropAndPowerupDurationsTest.zip](https://github.com/user-attachments/files/24425470/CropAndPowerupDurationsTest.zip)

