### PR TITLE
Log Git SHA on startup; mainly helpful on Linux

### DIFF
--- a/Client/AppInfo.cs
+++ b/Client/AppInfo.cs
@@ -14,12 +14,14 @@ public class AppInfo
         if (assemblyName.Version != null)
             ApplicationVersion = assemblyName.Version.ToString();
 
+        GitSHA = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion[6..] ?? "Unknown";
         ApplicationDirectory = AppContext.BaseDirectory;
         ApplicationExe = AppDomain.CurrentDomain.FriendlyName + ".exe";
     }
 
     public string ApplicationName { get; set; } = "Helion";
     public string ApplicationVersion { get; set; } = "Version Unknown";
+    public string GitSHA { get; set; }
     public string ApplicationDirectory { get; set; }
     public string ApplicationExe { get; set; }
 }

--- a/Client/Client.cs
+++ b/Client/Client.cs
@@ -602,7 +602,7 @@ public partial class Client : IDisposable, IInputManagement
 
     private static void LogClientInfo()
     {
-        Log.Info("{0} v{1}", AppInfo.ApplicationName, AppInfo.ApplicationVersion);
+        Log.Info("{0} v{1}, Git SHA {2}", AppInfo.ApplicationName, AppInfo.ApplicationVersion, AppInfo.GitSHA);
         Log.Info("Processor: {0} {1}", Environment.GetEnvironmentVariable("PROCESSOR_IDENTIFIER"), RuntimeInformation.OSArchitecture);
         Log.Info("Processors: {0}", Environment.ProcessorCount);
         Log.Info("OS: {0} {1} (running {2})", Environment.OSVersion, Environment.Is64BitOperatingSystem ? "x64" : "x86", Environment.Is64BitProcess ? "x64" : "x86");


### PR DESCRIPTION
If users want to report bugs against nightly builds, we should give them the means to tell us what build they are using.

In Windows, you can just right-click an EXE and see the extended information in one of the tabs in File Properties.  On Linux, this isn't really a thing.  So log the SHA on startup too.