### PR TITLE
move sbardef viewport handling to use original full size status bar viewport handling

### DIFF
--- a/Core/Layer/GameLayerManager.cs
+++ b/Core/Layer/GameLayerManager.cs
@@ -770,7 +770,7 @@ public class GameLayerManager : IGameLayerManager
 
         if (WorldLayer != null && WorldLayer.ShouldRender && (m_config.Hud.AutoMap.Overlay || !WorldLayer.DrawAutomap))
         {
-            var offset = HudView.GetViewPortOffset(m_config.Hud.StatusBarSize, ctx.Surface.Dimension);
+            var offset = HudView.GetViewPortOffset(m_config.Hud.StatusBarSize, ctx.Surface.Dimension, WorldLayer.GetActiveStatusBarLayout());
             if (WorldLayer.World.DrawHud && (offset.X != 0 || offset.Y != 0))
             {
                 var box = new Box2I((offset.X, offset.Y), (ctx.Surface.Dimension.Width + offset.X, ctx.Surface.Dimension.Height + offset.Y));

--- a/Core/Layer/Worlds/WorldLayer.Render.Hud.cs
+++ b/Core/Layer/Worlds/WorldLayer.Render.Hud.cs
@@ -172,9 +172,10 @@ public partial class WorldLayer
         }
     }
     
-    private StatusBarLayoutDef? GetActiveStatusBarLayout()
+    public StatusBarLayoutDef? GetActiveStatusBarLayout()
     {
-        if (!WorldStatic.World.DrawHud) return null;
+        if (!WorldStatic.World.DrawHud)
+            return null;
         
         m_statusBarSizeType = m_config.Hud.StatusBarSize.Value;
         
@@ -499,7 +500,7 @@ public partial class WorldLayer
                 hudContext.DrawFuzz = true;
 
             // Push the gun sprite up based on the status bar height
-            int yOffset = HudView.GetWeaponOffset(m_config.Hud.StatusBarSize.Value, sbarHeight);
+            int yOffset = HudView.GetWeaponOffset(m_config.Hud.StatusBarSize.Value, GetActiveStatusBarLayout());
             DrawHudWeapon(hud, Player.AnimationWeapon.FrameState, yOffset, flash: false);
             if (Player.AnimationWeapon.FlashState.Frame.BranchType != ActorStateBranch.Stop)
                 DrawHudWeapon(hud, Player.AnimationWeapon.FlashState, yOffset, flash: true);
@@ -676,7 +677,7 @@ public partial class WorldLayer
             totalCrosshairLength += 1;
 
         Vec2I center = m_viewport.Vector / 2;
-        center -= HudView.GetViewPortOffset(m_config.Hud.StatusBarSize.Value, m_viewport, sbarHeight);
+        center -= HudView.GetViewPortOffset(m_config.Hud.StatusBarSize.Value, m_viewport, GetActiveStatusBarLayout());
 
         Vec2I horizontal = center - new Vec2I(crosshairLength, HalfWidth);
         Vec2I vertical = center - new Vec2I(HalfWidth, crosshairLength);

--- a/Core/Layer/Worlds/WorldLayer.Render.cs
+++ b/Core/Layer/Worlds/WorldLayer.Render.cs
@@ -1,11 +1,8 @@
-using Helion.Geometry.Boxes;
 using Helion.Geometry.Vectors;
 using Helion.Graphics;
 using Helion.Render.Common.Context;
 using Helion.Render.Common.Renderers;
 using Helion.Render.Common.World;
-using Helion.Resources.Definitions.StatusBar;
-using Helion.World.StatusBar;
 using System;
 
 namespace Helion.Layer.Worlds;
@@ -20,8 +17,6 @@ public partial class WorldLayer
     private Action<IHudRenderContext> m_drawHudAction;
     private readonly Action<IWorldRenderContext> m_renderWorldAction;
     private readonly Action<IWorldRenderContext> m_renderAutomapAction;
-    private readonly Action m_renderWorldViewportAction;
-    private IRenderableSurfaceContext? m_renderableWorldSurfaceContext;
 
     private RenderHudOptions m_renderHudOptions;
 
@@ -33,28 +28,7 @@ public partial class WorldLayer
         ctx.ClearStencil();
 
         SetWorldContextVars();
-
-        StatusBarLayoutDef? activeSbar = GetActiveStatusBarLayout();
-        int sbarHeight = activeSbar != null
-            ? (activeSbar.FullscreenRender ? 0 : activeSbar.Height)
-            : (m_config.Hud.StatusBarSize.Value == StatusBarSizeType.Full ? 32 : 0);
-
-        int nativeWidth = ctx.Surface.Dimension.Width;
-        int nativeHeight = ctx.Surface.Dimension.Height;
-
-        int nativeBarHeight = (int)(nativeHeight / 200.0 * sbarHeight);
-
-        int viewportBottom = nativeBarHeight;
-        int viewportHeight = nativeHeight - viewportBottom;
-        Box2I viewportArea = new((0, viewportBottom), (nativeWidth, nativeHeight));
-
-        m_worldContext.Viewport = (nativeWidth, viewportHeight);
-
-        m_renderableWorldSurfaceContext = ctx;
-        ctx.Viewport(viewportArea, m_renderWorldViewportAction);
-        m_renderableWorldSurfaceContext = null;
-
-        m_worldContext.Viewport = ctx.Surface.Dimension;
+        ctx.World(m_worldContext, m_renderWorldAction);
 
         m_profiler.Render.World.Stop();
     }
@@ -79,11 +53,6 @@ public partial class WorldLayer
     void RenderWorld(IWorldRenderContext context)
     {
         context.Draw(World);
-    }
-    
-    private void RenderWorldViewportContext()
-    {
-        m_renderableWorldSurfaceContext?.World(m_worldContext, m_renderWorldAction);
     }
 
     public void RenderHud(IRenderableSurfaceContext ctx, RenderHudOptions options)

--- a/Core/Layer/Worlds/WorldLayer.cs
+++ b/Core/Layer/Worlds/WorldLayer.cs
@@ -101,7 +101,6 @@ public partial class WorldLayer : IGameLayerParent
         m_drawHudAction = new(DrawHudContext);
         m_renderWorldAction = new(RenderWorld);
         m_renderAutomapAction = new(RenderAutomap);
-        m_renderWorldViewportAction = new(RenderWorldViewportContext);
         m_virtualDrawFullStatusBarAction = new(VirtualDrawFullStatusBar);
         m_virtualStatusBarBackgroundAction = new(VirtualStatusBarBackground);
         m_virtualDrawPauseAction = new(VirtualDrawPause);

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -285,7 +285,7 @@ public class LegacyWorldRenderer : WorldRenderer
         if (framebuffer.DepthTexture == null)
             throw new Exception("Framebuffer must have a depth texture.");
 
-        var dimension = framebuffer.Dimension; 
+        var dimension = new Dimension(renderInfo.Viewport.Width, renderInfo.Viewport.Height);
         m_oitFrameBuffer.CreateOrUpdate(dimension, framebuffer.DepthTexture);
 
         var prevDownscale = m_downscaleVanillaBuffer;

--- a/Core/Util/Configs/Components/ConfigHud.cs
+++ b/Core/Util/Configs/Components/ConfigHud.cs
@@ -5,20 +5,17 @@ using Helion.Util.Configs.Impl;
 using Helion.Util.Configs.Options;
 using Helion.Util.Configs.Values;
 using Helion.World.StatusBar;
-using System;
 using static Helion.Util.Configs.Values.ConfigFilters;
 
 namespace Helion.Util.Configs.Components;
 
 public static class HudView
 {
-    const int FullSizeWeaponOffsetY = 16;
     const int FullSizeHudHeight = 32;
 
     public static int GetWeaponOffset(StatusBarSizeType statusBarSize, StatusBarLayoutDef? activeStatusBar)
     {
-        int statusBarHeight = GetStatusBarHeight(statusBarSize, activeStatusBar);
-        return Math.Max(statusBarHeight - FullSizeWeaponOffsetY, 0);
+        return GetStatusBarHeight(statusBarSize, activeStatusBar) / 2;
     }
 
     public static Vec2I GetViewPortOffset(StatusBarSizeType statusBarSize, Dimension viewport, StatusBarLayoutDef? activeStatusBar)

--- a/Core/Util/Configs/Components/ConfigHud.cs
+++ b/Core/Util/Configs/Components/ConfigHud.cs
@@ -1,33 +1,41 @@
 using Helion.Geometry;
 using Helion.Geometry.Vectors;
+using Helion.Resources.Definitions.StatusBar;
 using Helion.Util.Configs.Impl;
 using Helion.Util.Configs.Options;
 using Helion.Util.Configs.Values;
 using Helion.World.StatusBar;
+using System;
 using static Helion.Util.Configs.Values.ConfigFilters;
 
 namespace Helion.Util.Configs.Components;
 
 public static class HudView
 {
-    public const int FullSizeHudOffsetY = 16;
+    const int FullSizeWeaponOffsetY = 16;
+    const int FullSizeHudHeight = 32;
 
-    public static int GetWeaponOffset(StatusBarSizeType statusBarSize, int? customHeight = null)
+    public static int GetWeaponOffset(StatusBarSizeType statusBarSize, StatusBarLayoutDef? activeStatusBar)
     {
-        int height = customHeight ?? (statusBarSize == StatusBarSizeType.Full ? 32 : 0);
-        return height / 2;
+        int statusBarHeight = GetStatusBarHeight(statusBarSize, activeStatusBar);
+        return Math.Max(statusBarHeight - FullSizeWeaponOffsetY, 0);
     }
 
-    public static Vec2I GetViewPortOffset(StatusBarSizeType statusBarSize, Dimension viewport, int? customHeight = null)
+    public static Vec2I GetViewPortOffset(StatusBarSizeType statusBarSize, Dimension viewport, StatusBarLayoutDef? activeStatusBar)
     {
-        int height = customHeight ?? (statusBarSize == StatusBarSizeType.Full ? 32 : 0);
-        
-        if (height > 0)
-        {
-            return (0, (int)(viewport.Height / 200.0 * (height / 2.0)));
-        }
-        
-        return (0, 0);
+        var statusBarHeight = GetStatusBarHeight(statusBarSize, activeStatusBar);
+        if (statusBarHeight > 0)
+            return (0, (int)(viewport.Height / 200.0 * (statusBarHeight / 2.0)));
+
+        return Vec2I.Zero;
+    }
+
+    private static int GetStatusBarHeight(StatusBarSizeType statusBarSize, StatusBarLayoutDef? activeStatusBar)
+    {
+        if (activeStatusBar == null)
+            return statusBarSize == StatusBarSizeType.Full ? FullSizeHudHeight : 0;
+
+        return activeStatusBar.FullscreenRender ? 0 : activeStatusBar.Height;
     }
 }
 


### PR DESCRIPTION
Use original viewport logic for SBARDEF

190 Helion
<img width="1924" height="1127" alt="image" src="https://github.com/user-attachments/assets/86f980bb-63e1-4409-80cf-861df081745a" />

100 Helion
<img width="1924" height="1127" alt="image" src="https://github.com/user-attachments/assets/bac302e8-75a5-4884-88dd-a13d0e2f1e67" />


190 Kex
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/9c5d58dc-d6bc-4ce4-ba4e-73672faf67ea" />

100 Kex
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/fd4f94c0-0a73-48a7-911f-84e2739332d5" />

