### PR TITLE
Fix minor ENDOOM issues

### DIFF
--- a/Core/Layer/Endoom/TextScreen.cs
+++ b/Core/Layer/Endoom/TextScreen.cs
@@ -108,8 +108,8 @@
                             ctx.FillPolygon(
                                 backgroundColor,
                                 new PointF(xOffset, yOffset),
-                                new PointF(xOffset + charWidth, yOffset),
-                                new PointF(xOffset + charWidth, yOffset + charHeight),
+                                new PointF(xOffset + charWidth + 1, yOffset),
+                                new PointF(xOffset + charWidth + 1, yOffset + charHeight),
                                 new PointF(xOffset, yOffset + charHeight));
 
                             if (!(characterBlinking && blinkOn))

--- a/Core/Layer/GameLayerManager.cs
+++ b/Core/Layer/GameLayerManager.cs
@@ -640,7 +640,6 @@ public class GameLayerManager : IGameLayerManager
 
     public void ShowEndoom(Action closeAction)
     {
-        m_soundManager.ClearSounds();
         Add(new EndoomLayer(closeAction, m_archiveCollection, m_window.ClientDimension.Height));
     }
 

--- a/Core/Layer/GameLayerManager.cs
+++ b/Core/Layer/GameLayerManager.cs
@@ -640,6 +640,7 @@ public class GameLayerManager : IGameLayerManager
 
     public void ShowEndoom(Action closeAction)
     {
+        WorldLayer?.Stop();
         Add(new EndoomLayer(closeAction, m_archiveCollection, m_window.ClientDimension.Height));
     }
 

--- a/Core/Layer/GameLayerManager.cs
+++ b/Core/Layer/GameLayerManager.cs
@@ -640,6 +640,7 @@ public class GameLayerManager : IGameLayerManager
 
     public void ShowEndoom(Action closeAction)
     {
+        m_soundManager.ClearSounds();
         Add(new EndoomLayer(closeAction, m_archiveCollection, m_window.ClientDimension.Height));
     }
 


### PR DESCRIPTION
1. Ever since we updated to a newer version of  SixLabors.ImageSharp.Drawing, there have been vertical stripes in ENDOOM.  _Part_ of this may just be attributable to the behavior of their antialiasing algorithm, so there may be a "better" way to do this, but for now I'm just going to fudge the width of the background tiles by 1px.
2. Fix issue where quitting during a running game may result in game SFX continuing while ENDOOM is displayed.