### PR TITLE
SBARDEF [1.2.0 / Community Extended]: Add resolution agnostic native scaling.

### DIFF
--- a/Core/Layer/Worlds/StatusBar/StatusBarRenderer.cs
+++ b/Core/Layer/Worlds/StatusBar/StatusBarRenderer.cs
@@ -40,11 +40,12 @@ public enum StatusBarCoverage
 
 public class StatusBarRenderer
 {
-    // Caches
+// Caches
     private static readonly Dictionary<string, int> Type1WidthCache = new(StringComparer.OrdinalIgnoreCase);
     private static readonly Dictionary<string, int> HudType1WidthCache = new(StringComparer.OrdinalIgnoreCase);
     private static readonly Dictionary<string, string> FontPatchCache = new(StringComparer.OrdinalIgnoreCase);
     private static readonly Dictionary<string, string> HudFontPatchCache = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly Dictionary<string, string> PatchNameCache = new(StringComparer.OrdinalIgnoreCase);
 
     // Mapping SBARDEF stems to Helion Internal Fonts to enable grayscale tinting and better rendering
     private static readonly Dictionary<string, string> StemToHelionFontMap = new(StringComparer.OrdinalIgnoreCase)
@@ -74,16 +75,17 @@ public class StatusBarRenderer
     };
 
     private readonly ArchiveCollection m_archiveCollection;
-    private readonly List<CoordData> m_coordPartsCache = [];
+    private readonly List<CoordData> m_coordPartsCache = new(16);
     private readonly SpanString m_fmtSpan = new();
     private readonly Dictionary<string, StatusBarNumberFontDef> m_fontNumberLookup = [];
-    private readonly List<RenderGlyph> m_glyphCache = [];
+    private readonly List<RenderGlyph> m_glyphCache = new(256);
     private readonly Dictionary<string, StatusBarHudFontDef> m_hudFontLookup = [];
     private readonly SpanString m_lookupKeySpan = new(128);
 
     private readonly IWorld m_world;
     private float m_currentScale;
     private float m_hOffset;
+    private Vec2F m_scale = Vec2F.One;
 
     private bool m_texturesResolved;
     private float m_userScale;
@@ -94,9 +96,6 @@ public class StatusBarRenderer
         m_world = world;
         m_archiveCollection = world.ArchiveCollection;
         StatusBarDefinition sbarDef = world.ArchiveCollection.Definitions.StatusBarDefinition;
-
-        m_glyphCache.Capacity = 256;
-        m_coordPartsCache.Capacity = 16;
 
         foreach (StatusBarNumberFontDef f in sbarDef.NumberFonts)
             m_fontNumberLookup[f.Name] = f;
@@ -177,6 +176,7 @@ public class StatusBarRenderer
         float scaleY = windowHeight / 200f;
         m_currentScale = Math.Min(scaleX, scaleY);
         m_userScale = (float)m_world.Config.Hud.Scale.Value;
+        m_scale = Vec2F.One;
 
         m_hOffset = (windowWidth / m_currentScale - 320f) / 2f;
         m_vOffset = (windowHeight / m_currentScale - 200f) / 2f;
@@ -202,7 +202,7 @@ public class StatusBarRenderer
         }
 
         foreach (StatusBarElementWrapper child in layout.Children)
-            DrawElementWrapper(hud, child, rootPos, layout.Height, context, m_hOffset, rootPos, false);
+            DrawElementWrapper(hud, child, rootPos, layout.Height, context, m_hOffset, rootPos);
 
         hud.PopVirtualDimension();
     }
@@ -307,38 +307,39 @@ public class StatusBarRenderer
         int containerHeight,
         StatusBarContext context,
         float widescreenOffset,
-        Vec2I rootPos,
-        bool isNative)
+        Vec2I rootPos)
     {
         Vec2I effectiveParentPos = parentPos;
         bool isHudWidget = wrapper.Component != null || wrapper.Carousel != null;
+        bool isStandardMode = m_scale.IsApprox(Vec2F.One);
 
-        if (isHudWidget && parentPos == rootPos && !isNative) effectiveParentPos = (0, 0);
+        if (isHudWidget && parentPos == rootPos && isStandardMode)
+            effectiveParentPos = (0, 0);
 
         if (wrapper.Canvas != null)
-            DrawBase(hud, wrapper.Canvas, parentPos, containerHeight, context, widescreenOffset, rootPos, isNative);
+            DrawBase(hud, wrapper.Canvas, parentPos, containerHeight, context, widescreenOffset, rootPos);
         else if (wrapper.Native != null)
             DrawNative(hud, wrapper.Native, parentPos, containerHeight, context);
         else if (wrapper.List != null)
-            DrawList(hud, wrapper.List, parentPos, containerHeight, context, widescreenOffset, rootPos, isNative);
+            DrawList(hud, wrapper.List, parentPos, containerHeight, context, widescreenOffset, rootPos);
         else if (wrapper.Graphic != null)
-            DrawGraphic(hud, wrapper.Graphic, parentPos, containerHeight, context, widescreenOffset, isNative);
+            DrawGraphic(hud, wrapper.Graphic, parentPos, containerHeight, context, widescreenOffset);
         else if (wrapper.Number != null)
-            DrawNumber(hud, wrapper.Number, parentPos, containerHeight, context, false, widescreenOffset, isNative);
+            DrawNumber(hud, wrapper.Number, parentPos, containerHeight, context, false, widescreenOffset);
         else if (wrapper.Percent != null)
-            DrawNumber(hud, wrapper.Percent, parentPos, containerHeight, context, true, widescreenOffset, isNative);
+            DrawNumber(hud, wrapper.Percent, parentPos, containerHeight, context, true, widescreenOffset);
         else if (wrapper.String != null)
-            DrawString(hud, wrapper.String, parentPos, containerHeight, context, widescreenOffset, isNative);
+            DrawString(hud, wrapper.String, parentPos, containerHeight, context, widescreenOffset);
         else if (wrapper.Face != null)
-            DrawFace(hud, wrapper.Face, parentPos, containerHeight, context, widescreenOffset, isNative);
+            DrawFace(hud, wrapper.Face, parentPos, containerHeight, context, widescreenOffset);
         else if (wrapper.FaceBackground != null)
-            DrawFaceBackground(hud, wrapper.FaceBackground, parentPos, containerHeight, context, widescreenOffset, isNative);
+            DrawFaceBackground(hud, wrapper.FaceBackground, parentPos, containerHeight, context, widescreenOffset);
         else if (wrapper.Animation != null)
-            DrawAnimation(hud, wrapper.Animation, parentPos, containerHeight, context, widescreenOffset, isNative);
+            DrawAnimation(hud, wrapper.Animation, parentPos, containerHeight, context, widescreenOffset);
         else if (wrapper.Component != null)
-            DrawComponent(hud, wrapper.Component, effectiveParentPos, containerHeight, context, widescreenOffset, rootPos, isNative);
+            DrawComponent(hud, wrapper.Component, effectiveParentPos, containerHeight, context, widescreenOffset, rootPos);
         else if (wrapper.Carousel != null)
-            DrawCarousel(hud, wrapper.Carousel, effectiveParentPos, containerHeight, context, widescreenOffset, rootPos, isNative);
+            DrawCarousel(hud, wrapper.Carousel, effectiveParentPos, containerHeight, context, widescreenOffset, rootPos);
     }
 
     private void DrawBase(IHudRenderContext hud,
@@ -347,14 +348,13 @@ public class StatusBarRenderer
         int containerHeight,
         StatusBarContext context,
         float widescreenOffset,
-        Vec2I rootPos,
-        bool isNative)
+        Vec2I rootPos)
     {
         if (!StatusBarConditionResolver.Evaluate(context, def.Conditions))
             return;
 
-        Vec2I currentPos = ResolvePosition(def, parentPos, isNative, isNative ? m_userScale : 1.0f);
-        DrawChildren(hud, def, currentPos, containerHeight, context, widescreenOffset, rootPos, isNative);
+        Vec2I currentPos = ResolvePosition(def, parentPos);
+        DrawChildren(hud, def, currentPos, containerHeight, context, widescreenOffset, rootPos);
     }
 
     private void DrawList(IHudRenderContext hud,
@@ -363,14 +363,10 @@ public class StatusBarRenderer
         int containerHeight,
         StatusBarContext context,
         float widescreenOffset,
-        Vec2I rootPos,
-        bool isNative)
+        Vec2I rootPos)
     {
         if (!StatusBarConditionResolver.Evaluate(context, def.Conditions) || def.Children == null)
             return;
-
-        float scaleX = isNative ? m_userScale : 1.0f;
-        float scaleY = isNative ? m_userScale * 1.2f : 1.0f;
 
         int childCount = def.Children.Count;
         Span<Vec2I> sizes = stackalloc Vec2I[childCount];
@@ -378,13 +374,13 @@ public class StatusBarRenderer
         int totalWidth = 0;
         int totalHeight = 0;
 
-        int spacing = isNative ? (int)(def.Spacing * m_userScale) : def.Spacing;
+        int spacing = (int)(def.Spacing * m_scale.X);
 
         foreach (StatusBarElementWrapper child in def.Children)
         {
             if (!EvaluateWrapperConditions(child, context)) continue;
 
-            ElementBounds bounds = MeasureElement(hud, child, context, isNative, scaleX, scaleY);
+            ElementBounds bounds = MeasureElement(hud, child, context, m_scale.X, m_scale.Y);
             Vec2I size = new(bounds.Width, bounds.Height);
             sizes[activeCount] = size;
 
@@ -406,7 +402,7 @@ public class StatusBarRenderer
 
         if (activeCount == 0) return;
 
-        Vec2I listPos = ResolvePosition(def, parentPos, isNative, scaleX);
+        Vec2I listPos = ResolvePosition(def, parentPos);
 
         if ((def.Alignment & StatusBarAlignment.HCenter) != 0) listPos.X -= totalWidth / 2;
         else if ((def.Alignment & StatusBarAlignment.Right) != 0) listPos.X -= totalWidth;
@@ -430,7 +426,7 @@ public class StatusBarRenderer
                 else if ((def.Alignment & StatusBarAlignment.VCenter) != 0)
                     childPos.Y += (totalHeight - size.Y) / 2;
 
-                DrawElementWrapper(hud, child, childPos, containerHeight, context, widescreenOffset, rootPos, isNative);
+                DrawElementWrapper(hud, child, childPos, containerHeight, context, widescreenOffset, rootPos);
                 cursor.X += size.X + spacing;
             }
             else
@@ -440,7 +436,7 @@ public class StatusBarRenderer
                 else if ((def.Alignment & StatusBarAlignment.HCenter) != 0)
                     childPos.X += (totalWidth - size.X) / 2;
 
-                DrawElementWrapper(hud, child, childPos, containerHeight, context, widescreenOffset, rootPos, isNative);
+                DrawElementWrapper(hud, child, childPos, containerHeight, context, widescreenOffset, rootPos);
                 cursor.Y += size.Y + spacing;
             }
 
@@ -453,20 +449,22 @@ public class StatusBarRenderer
         if (!StatusBarConditionResolver.Evaluate(context, def.Conditions))
             return;
 
-        Vec2I vPos = ResolvePosition(def, parentPos, false, 1.0f);
+        Vec2I vPos = parentPos;
+        vPos.X += def.X;
+        vPos.Y += def.Y;
 
-        float scaleX = m_userScale;
-        float scaleY = m_userScale * 1.2f;
+        float nScaleX = m_userScale;
+        float nScaleY = m_userScale * 1.2f;
 
         ElementBounds bounds = ElementBounds.Empty;
         if (def.Children != null)
             foreach (StatusBarElementWrapper child in def.Children)
             {
                 if (!EvaluateWrapperConditions(child, context)) continue;
-                bounds = ElementBounds.Union(bounds, MeasureElement(hud, child, context, true, scaleX, scaleY));
+                bounds = ElementBounds.Union(bounds, MeasureElement(hud, child, context, nScaleX, nScaleY));
             }
 
-        if (bounds.X1 == int.MaxValue) return;
+        if (bounds.X1 == int.MaxValue) bounds = new ElementBounds(0, 0, 0, 0);
 
         int pivotX = (bounds.X1 + bounds.X2) / 2;
         int pivotY = (bounds.Y1 + bounds.Y2) / 2;
@@ -474,40 +472,40 @@ public class StatusBarRenderer
         int nativeX = (int)Math.Floor((vPos.X + m_hOffset) * m_currentScale);
         int nativeY = (int)Math.Floor((vPos.Y + m_vOffset) * m_currentScale);
 
-        bool isHCenter = (def.Alignment & StatusBarAlignment.HCenter) != 0;
-        bool isVCenter = (def.Alignment & StatusBarAlignment.VCenter) != 0;
-
         int hShift = (int)Math.Ceiling(m_hOffset * m_currentScale);
         int vShift = (int)Math.Ceiling(m_vOffset * m_currentScale);
 
-        if (!isHCenter)
+        if ((def.Alignment & StatusBarAlignment.HCenter) == 0)
         {
-            if ((def.Alignment & StatusBarAlignment.Right) != 0)
-                nativeX += hShift;
-            else
-                nativeX -= hShift;
+            if ((def.Alignment & StatusBarAlignment.Right) != 0) nativeX += hShift;
+            else nativeX -= hShift;
         }
 
-        if (!isVCenter)
+        if ((def.Alignment & StatusBarAlignment.VCenter) == 0)
         {
-            if ((def.Alignment & StatusBarAlignment.Bottom) != 0)
-                nativeY += vShift;
-            else
-                nativeY -= vShift;
+            if ((def.Alignment & StatusBarAlignment.Bottom) != 0) nativeY += vShift;
+            else nativeY -= vShift;
         }
 
-        if (isHCenter) nativeX -= pivotX;
+        if ((def.Alignment & StatusBarAlignment.HCenter) != 0) nativeX -= pivotX;
         else if ((def.Alignment & StatusBarAlignment.Right) != 0) nativeX -= bounds.X2;
         else nativeX -= bounds.X1;
 
-        if (isVCenter) nativeY -= pivotY;
+        if ((def.Alignment & StatusBarAlignment.VCenter) != 0) nativeY -= pivotY;
         else if ((def.Alignment & StatusBarAlignment.Bottom) != 0) nativeY -= bounds.Y2;
         else nativeY -= bounds.Y1;
 
         Vec2I nativeRoot = (nativeX, nativeY);
 
         hud.PopVirtualDimension();
-        DrawChildren(hud, def, nativeRoot, containerHeight, context, 0, nativeRoot, true);
+
+        Vec2F prevScale = m_scale;
+        m_scale = (nScaleX, nScaleY);
+
+        DrawChildren(hud, def, nativeRoot, containerHeight, context, 0, nativeRoot);
+
+        m_scale = prevScale;
+
         hud.PushVirtualDimension((320, 200), ResolutionScale.Center, Constants.DoomVirtualAspectRatio);
     }
 
@@ -516,18 +514,17 @@ public class StatusBarRenderer
         Vec2I parentPos,
         int containerHeight,
         StatusBarContext context,
-        float widescreenOffset,
-        bool isNative)
+        float widescreenOffset)
     {
         if (!StatusBarConditionResolver.Evaluate(context, graphic.Conditions))
             return;
 
-        Vec2I currentPos = ResolvePosition(graphic, parentPos, isNative, isNative ? m_userScale : 1.0f);
+        Vec2I currentPos = ResolvePosition(graphic, parentPos);
 
         if (graphic.Handle != null || !string.IsNullOrEmpty(graphic.Patch))
         {
             Align align = ConvertAlignment(graphic.Alignment);
-            if (graphic.MidOffset != 0) currentPos.X += (int)(graphic.MidOffset * (isNative ? m_userScale : 1.0f));
+            if (graphic.MidOffset != 0) currentPos.X += (int)(graphic.MidOffset * m_scale.X);
 
             float alpha = graphic.Translucency ? 0.5f : 1.0f;
 
@@ -539,11 +536,10 @@ public class StatusBarRenderer
                 graphic.Alignment,
                 graphic.Translation,
                 alpha,
-                graphic.Crop,
-                isNative);
+                graphic.Crop);
         }
 
-        DrawChildren(hud, graphic, currentPos, containerHeight, context, widescreenOffset, (0, 0), isNative);
+        DrawChildren(hud, graphic, currentPos, containerHeight, context, widescreenOffset, (0, 0));
     }
 
     private void DrawFace(IHudRenderContext hud,
@@ -551,13 +547,12 @@ public class StatusBarRenderer
         Vec2I parentPos,
         int containerHeight,
         StatusBarContext context,
-        float widescreenOffset,
-        bool isNative)
+        float widescreenOffset)
     {
         if (!StatusBarConditionResolver.Evaluate(context, face.Conditions))
             return;
 
-        Vec2I currentPos = ResolvePosition(face, parentPos, isNative, isNative ? m_userScale : 1.0f);
+        Vec2I currentPos = ResolvePosition(face, parentPos);
         string patch = context.Player.StatusBar.GetFacePatch();
 
         if (!string.IsNullOrEmpty(patch))
@@ -565,10 +560,10 @@ public class StatusBarRenderer
             Align align = ConvertAlignment(face.Alignment);
             float alpha = face.Translucency ? 0.5f : 1.0f;
 
-            DrawSBarTexture(hud, patch, null, currentPos, align, face.Alignment, face.Translation, alpha, face.Crop, isNative);
+            DrawSBarTexture(hud, patch, null, currentPos, align, face.Alignment, face.Translation, alpha, face.Crop);
         }
 
-        DrawChildren(hud, face, currentPos, containerHeight, context, widescreenOffset, (0, 0), isNative);
+        DrawChildren(hud, face, currentPos, containerHeight, context, widescreenOffset, (0, 0));
     }
 
     private void DrawFaceBackground(IHudRenderContext hud,
@@ -576,31 +571,22 @@ public class StatusBarRenderer
         Vec2I parentPos,
         int containerHeight,
         StatusBarContext context,
-        float widescreenOffset,
-        bool isNative)
+        float widescreenOffset)
     {
         if (!StatusBarConditionResolver.Evaluate(context, faceBg.Conditions))
             return;
 
-        Vec2I currentPos = ResolvePosition(faceBg, parentPos, isNative, isNative ? m_userScale : 1.0f);
+        Vec2I currentPos = ResolvePosition(faceBg, parentPos);
 
         if (faceBg.Handle != null)
         {
             Align align = ConvertAlignment(faceBg.Alignment);
             float alpha = faceBg.Translucency ? 0.5f : 1.0f;
 
-            DrawSBarTexture(hud,
-                "STFB0",
-                faceBg.Handle,
-                currentPos,
-                align,
-                faceBg.Alignment,
-                faceBg.Translation,
-                alpha,
-                isNative: isNative);
+            DrawSBarTexture(hud, "STFB0", faceBg.Handle, currentPos, align, faceBg.Alignment, faceBg.Translation, alpha);
         }
 
-        DrawChildren(hud, faceBg, currentPos, containerHeight, context, widescreenOffset, (0, 0), isNative);
+        DrawChildren(hud, faceBg, currentPos, containerHeight, context, widescreenOffset, (0, 0));
     }
 
     private void DrawAnimation(IHudRenderContext hud,
@@ -608,13 +594,12 @@ public class StatusBarRenderer
         Vec2I parentPos,
         int containerHeight,
         StatusBarContext context,
-        float widescreenOffset,
-        bool isNative)
+        float widescreenOffset)
     {
         if (!StatusBarConditionResolver.Evaluate(context, anim.Conditions))
             return;
 
-        Vec2I currentPos = ResolvePosition(anim, parentPos, isNative, isNative ? m_userScale : 1.0f);
+        Vec2I currentPos = ResolvePosition(anim, parentPos);
 
         if (anim.Frames.Count > 0)
         {
@@ -646,12 +631,11 @@ public class StatusBarRenderer
                     currentPos,
                     align,
                     anim.Alignment,
-                    anim.Translation,
-                    isNative: isNative);
+                    anim.Translation);
             }
         }
 
-        DrawChildren(hud, anim, currentPos, containerHeight, context, widescreenOffset, (0, 0), isNative);
+        DrawChildren(hud, anim, currentPos, containerHeight, context, widescreenOffset, (0, 0));
     }
 
     private void DrawString(IHudRenderContext hud,
@@ -659,13 +643,12 @@ public class StatusBarRenderer
         Vec2I parentPos,
         int containerHeight,
         StatusBarContext context,
-        float widescreenOffset,
-        bool isNative)
+        float widescreenOffset)
     {
         if (!StatusBarConditionResolver.Evaluate(context, def.Conditions))
             return;
 
-        Vec2I pos = ResolvePosition(def, parentPos, isNative, isNative ? m_userScale : 1.0f);
+        Vec2I pos = ResolvePosition(def, parentPos);
         ReadOnlySpan<char> text = GetStringValue(def);
         if (text.IsEmpty) return;
 
@@ -674,8 +657,8 @@ public class StatusBarRenderer
         if (fontHeight <= 0) fontHeight = 8;
         float alpha = def.Translucency ? 0.5f : 1.0f;
 
-        RenderLines(hud, text, pos, fontDef, fontHeight, def.Alignment, def.Translation, alpha, isNative);
-        DrawChildren(hud, def, pos, containerHeight, context, widescreenOffset, (0, 0), isNative);
+        RenderLines(hud, text, pos, fontDef, fontHeight, def.Alignment, def.Translation, alpha);
+        DrawChildren(hud, def, pos, containerHeight, context, widescreenOffset, (0, 0));
     }
 
     private void DrawComponent(IHudRenderContext hud,
@@ -684,13 +667,12 @@ public class StatusBarRenderer
         int containerHeight,
         StatusBarContext context,
         float widescreenOffset,
-        Vec2I rootPos,
-        bool isNative)
+        Vec2I rootPos)
     {
         if (!StatusBarConditionResolver.Evaluate(context, comp.Conditions))
             return;
 
-        Vec2I pos = ResolvePosition(comp, parentPos, isNative, isNative ? m_userScale : 1.0f);
+        Vec2I pos = ResolvePosition(comp, parentPos);
         ConfigHud config = m_world.Config.Hud;
         float alpha = comp.Translucency ? 0.5f : 1.0f;
         StatusBarAlignment alignment = comp.Alignment;
@@ -707,7 +689,7 @@ public class StatusBarRenderer
         {
             case StatusBarComponentType.StatTotals:
                 if (!config.ShowStats.Value) return;
-                DrawStatTotals(hud, comp, pos, fontDef, fontHeight, alpha, isNative);
+                DrawStatTotals(hud, comp, pos, fontDef, fontHeight, alpha);
                 break;
 
             case StatusBarComponentType.Time:
@@ -718,24 +700,24 @@ public class StatusBarRenderer
                 m_fmtSpan.Append(t.Minutes, 2);
                 m_fmtSpan.Append(':');
                 m_fmtSpan.Append(t.Seconds, 2);
-                RenderLines(hud, m_fmtSpan.AsSpan(), pos, fontDef, fontHeight, alignment, comp.Translation, alpha, isNative);
+                RenderLines(hud, m_fmtSpan.AsSpan(), pos, fontDef, fontHeight, alignment, comp.Translation, alpha);
                 break;
             case StatusBarComponentType.Coordinates:
-                DrawCoordinates(hud, comp, pos, fontDef, fontHeight, alpha, context, isNative);
+                DrawCoordinates(hud, comp, pos, fontDef, fontHeight, alpha, context);
                 break;
             case StatusBarComponentType.Speedometer:
                 string speedText = GetSpeedometerText(context.Player);
-                RenderLines(hud, speedText.AsSpan(), pos, fontDef, fontHeight, alignment, comp.Translation, alpha, isNative);
+                RenderLines(hud, speedText.AsSpan(), pos, fontDef, fontHeight, alignment, comp.Translation, alpha);
                 break;
             case StatusBarComponentType.LevelTitle:
                 string levelTitle = m_world.MapInfo.GetDisplayNameWithPrefix(m_archiveCollection.Language);
-                RenderLines(hud, levelTitle.AsSpan(), pos, fontDef, fontHeight, alignment, comp.Translation, alpha, isNative);
+                RenderLines(hud, levelTitle.AsSpan(), pos, fontDef, fontHeight, alignment, comp.Translation, alpha);
                 break;
             case StatusBarComponentType.FpsCounter:
                 if (!config.ShowFPS.Value) return;
                 m_fmtSpan.Clear();
                 m_fmtSpan.Append(context.Fps);
-                RenderLines(hud, m_fmtSpan.AsSpan(), pos, fontDef, fontHeight, alignment, comp.Translation, alpha, isNative);
+                RenderLines(hud, m_fmtSpan.AsSpan(), pos, fontDef, fontHeight, alignment, comp.Translation, alpha);
                 break;
             case StatusBarComponentType.Message:
                 string msg = context.ConsoleMessage ?? string.Empty;
@@ -745,7 +727,7 @@ public class StatusBarRenderer
                     alignment = StatusBarAlignment.HCenter;
                 }
 
-                RenderLines(hud, msg.AsSpan(), pos, fontDef, fontHeight, alignment, comp.Translation, alpha, isNative);
+                RenderLines(hud, msg.AsSpan(), pos, fontDef, fontHeight, alignment, comp.Translation, alpha);
                 break;
             case StatusBarComponentType.AnnounceLevelTitle:
                 double duration = comp.Duration > 0 ? comp.Duration : 2.5;
@@ -767,17 +749,20 @@ public class StatusBarRenderer
                 }
 
                 string annTitle = m_world.MapInfo.GetDisplayNameWithPrefix(m_archiveCollection.Language);
-                RenderLines(hud, annTitle.AsSpan(), pos, fontDef, fontHeight, alignment, comp.Translation, alpha, isNative);
+                RenderLines(hud, annTitle.AsSpan(), pos, fontDef, fontHeight, alignment, comp.Translation, alpha);
                 break;
+
             case StatusBarComponentType.Unknown:
             case StatusBarComponentType.RenderStats:
             case StatusBarComponentType.CommandHistory:
             case StatusBarComponentType.Chat:
-            default:
                 break;
+
+            default:
+                return;
         }
 
-        DrawChildren(hud, comp, pos, containerHeight, context, widescreenOffset, rootPos, isNative);
+        DrawChildren(hud, comp, pos, containerHeight, context, widescreenOffset, rootPos);
     }
 
     private void RenderLines(IHudRenderContext hud,
@@ -787,28 +772,26 @@ public class StatusBarRenderer
         int fontHeight,
         StatusBarAlignment alignment,
         string? translation,
-        float alpha,
-        bool isNative)
+        float alpha)
     {
         if (text.IsEmpty) return;
 
         Vec2I drawPos = pos;
         int lineStart = 0;
-        float scaleY = isNative ? m_userScale * 1.2f : 1.0f;
 
         for (int i = 0; i < text.Length; i++)
         {
             if (text[i] != '\n') continue;
             ReadOnlySpan<char> line = text[lineStart..i];
-            DrawSingleLine(hud, line, drawPos, fontDef, alignment, translation, alpha, isNative);
-            drawPos.Y += (int)(fontHeight * scaleY);
+            DrawSingleLine(hud, line, drawPos, fontDef, alignment, translation, alpha);
+            drawPos.Y += (int)(fontHeight * m_scale.Y);
             lineStart = i + 1;
         }
 
         if (lineStart >= text.Length) return;
         {
             ReadOnlySpan<char> line = text[lineStart..];
-            DrawSingleLine(hud, line, drawPos, fontDef, alignment, translation, alpha, isNative);
+            DrawSingleLine(hud, line, drawPos, fontDef, alignment, translation, alpha);
         }
     }
 
@@ -818,18 +801,16 @@ public class StatusBarRenderer
         StatusBarHudFontDef? fontDef,
         StatusBarAlignment alignment,
         string? translation,
-        float alpha,
-        bool isNative)
+        float alpha)
     {
         if (line.IsEmpty) return;
 
         int drawnWidth = 0;
-        if (fontDef != null) drawnWidth = DrawHudText(hud, line, fontDef, drawPos, alignment, translation, alpha, isNative);
+        if (fontDef != null) drawnWidth = DrawHudText(hud, line, fontDef, drawPos, alignment, translation, alpha);
 
         if (drawnWidth != 0) return;
         Align align = ConvertAlignment(alignment);
-        float textScale = isNative ? m_userScale : 1.0f;
-        hud.Text(line, Constants.Fonts.Small, 8, drawPos, both: align, alpha: alpha, scale: textScale);
+        hud.Text(line, Constants.Fonts.Small, 8, drawPos, TextAlign.Left, Align.TopLeft, align, alpha: alpha, scale: m_scale.X);
     }
 
     private int DrawHudText(IHudRenderContext hud,
@@ -839,23 +820,20 @@ public class StatusBarRenderer
         StatusBarAlignment alignment,
         string? translation,
         float alpha,
-        bool isNative,
         bool draw = true)
     {
         Color? drawColor = null;
         if (!string.IsNullOrEmpty(translation) && StandardTextColors.TryGetValue(translation, out Color colorValue))
             drawColor = colorValue;
 
-        float scaleX = isNative ? m_userScale : 1.0f;
-        float scaleY = isNative ? m_userScale * 1.2f : 1.0f;
-
         if (StemToHelionFontMap.TryGetValue(fontDef.Stem, out string? helionFont))
         {
-            if (!draw) return (int)(hud.MeasureText(text, helionFont, 8).Width * scaleX);
-            Align anchor = ConvertAlignment(alignment);
-            hud.Text(text, helionFont, 8, pos, TextAlign.Left, Align.TopLeft, anchor, color: drawColor, alpha: alpha, scale: scaleX);
+            if (!draw) return (int)(hud.MeasureText(text, helionFont, 8).Width * m_scale.X);
 
-            return (int)(hud.MeasureText(text, helionFont, 8).Width * scaleX);
+            Align anchor = ConvertAlignment(alignment);
+            hud.Text(text, helionFont, 8, pos, TextAlign.Left, Align.TopLeft, anchor, color: drawColor, alpha: alpha, scale: m_scale.X);
+
+            return (int)(hud.MeasureText(text, helionFont, 8).Width * m_scale.X);
         }
 
         int totalWidth = 0;
@@ -927,7 +905,7 @@ public class StatusBarRenderer
 
             if (monoWidth > 0) width = monoWidth;
 
-            int scaledWidth = (int)(width * scaleX);
+            int scaledWidth = (int)(width * m_scale.X);
             m_glyphCache.Add(new RenderGlyph(patch, scaledWidth, 0));
             totalWidth += scaledWidth;
         }
@@ -941,14 +919,14 @@ public class StatusBarRenderer
         if ((alignment & StatusBarAlignment.HCenter) != 0) drawX -= totalWidth / 2;
         else if ((alignment & StatusBarAlignment.Right) != 0) drawX -= totalWidth;
 
-        int scaledMaxHeight = (int)(maxHeight * scaleY);
+        int scaledMaxHeight = (int)(maxHeight * m_scale.Y);
         if ((alignment & StatusBarAlignment.Bottom) != 0) drawY -= scaledMaxHeight;
         else if ((alignment & StatusBarAlignment.VCenter) != 0) drawY -= scaledMaxHeight / 2;
 
         foreach (RenderGlyph g in m_glyphCache)
         {
             if (!string.IsNullOrEmpty(g.Patch))
-                DrawSBarTexture(hud, g.Patch, null, (drawX, drawY), Align.TopLeft, alignment, translation, alpha, isNative: isNative);
+                DrawSBarTexture(hud, g.Patch, null, (drawX, drawY), Align.TopLeft, alignment, translation, alpha);
             drawX += g.Width;
         }
 
@@ -961,13 +939,12 @@ public class StatusBarRenderer
         int containerHeight,
         StatusBarContext context,
         float widescreenOffset,
-        Vec2I rootPos,
-        bool isNative)
+        Vec2I rootPos)
     {
         if (!StatusBarConditionResolver.Evaluate(context, carousel.Conditions))
             return;
 
-        Vec2I pos = ResolvePosition(carousel, parentPos, isNative, isNative ? m_userScale : 1.0f);
+        Vec2I pos = ResolvePosition(carousel, parentPos);
         pos.X = 160;
 
         if (context.Player.Weapon != null)
@@ -977,11 +954,11 @@ public class StatusBarRenderer
             {
                 Align align = ConvertAlignment(carousel.Alignment);
                 float alpha = carousel.Translucency ? 0.5f : 1.0f;
-                DrawSBarTexture(hud, icon, null, pos, align, carousel.Alignment, carousel.Translation, alpha, isNative: isNative);
+                DrawSBarTexture(hud, icon, null, pos, align, carousel.Alignment, carousel.Translation, alpha);
             }
         }
 
-        DrawChildren(hud, carousel, pos, containerHeight, context, widescreenOffset, rootPos, isNative);
+        DrawChildren(hud, carousel, pos, containerHeight, context, widescreenOffset, rootPos);
     }
 
 
@@ -993,67 +970,33 @@ public class StatusBarRenderer
         StatusBarAlignment sbarAlign,
         string? translation = null,
         float alpha = 1.0f,
-        StatusBarCropDef? cropDef = null,
-        bool isNative = false)
+        StatusBarCropDef? cropDef = null)
     {
         string pName = handle == null ? ResolvePatchName(patch) : patch;
         if (handle == null && !hud.Textures.TryGet(pName, out handle) &&
             !hud.Textures.TryGet(pName, out handle, ResourceNamespace.Sprites)) return;
 
         ImageBox2I? cropArea = GetCropArea(handle, cropDef);
-        float scaleX = isNative ? m_userScale : 1.0f;
-        float scaleY = isNative ? m_userScale * 1.2f : 1.0f;
 
-        Vec2I drawPos = pos;
+        int w = (int)(handle.Dimension.Width * m_scale.X);
+        int h = (int)(handle.Dimension.Height * m_scale.Y);
+
         Vec2I translatedOffset = RenderDimensions.TranslateDoomOffset(handle.Offset);
+        int offsetX = (sbarAlign & StatusBarAlignment.IgnoreLeftOffset) == 0 ? (int)(translatedOffset.X * m_scale.X) : 0;
+        int offsetY = (sbarAlign & StatusBarAlignment.IgnoreTopOffset) == 0 ? (int)(translatedOffset.Y * m_scale.Y) : 0;
 
-        if ((sbarAlign & StatusBarAlignment.IgnoreLeftOffset) == 0)
-            drawPos.X += (int)(translatedOffset.X * scaleX);
+        Vec2I pivotOffset = align.AnchorDelta((w, h));
 
-        if ((sbarAlign & StatusBarAlignment.IgnoreTopOffset) == 0)
-            drawPos.Y += (int)(translatedOffset.Y * scaleY);
+        int finalX = pos.X + offsetX + pivotOffset.X;
+        int finalY = pos.Y + offsetY + pivotOffset.Y;
+        HudBox destBox = new(new Vec2I(finalX, finalY), new Vec2I(finalX + w, finalY + h));
 
         Color? drawColor = null;
         if (!string.IsNullOrEmpty(translation) && StandardTextColors.TryGetValue(translation, out Color colorValue))
             drawColor = colorValue;
 
-        int w = (int)(handle.Dimension.Width * scaleX);
-        int h = (int)(handle.Dimension.Height * scaleY);
-        int x = drawPos.X;
-        int y = drawPos.Y;
-
-        switch (align)
-        {
-            case Align.TopMiddle:
-            case Align.Center:
-            case Align.BottomMiddle: x -= w / 2; break;
-            case Align.TopRight:
-            case Align.MiddleRight:
-            case Align.BottomRight: x -= w; break;
-            case Align.TopLeft:
-            case Align.MiddleLeft:
-            case Align.BottomLeft:
-            default:
-                break;
-        }
-
-        switch (align)
-        {
-            case Align.MiddleLeft:
-            case Align.Center:
-            case Align.MiddleRight: y -= h / 2; break;
-            case Align.BottomLeft:
-            case Align.BottomMiddle:
-            case Align.BottomRight: y -= h; break;
-            case Align.TopLeft:
-            case Align.TopMiddle:
-            case Align.TopRight:
-            default:
-                break;
-        }
-
         hud.Image(pName,
-            new HudBox((x, y), (x + w, y + h)),
+            destBox,
             out _,
             Align.TopLeft,
             Align.TopLeft,
@@ -1074,8 +1017,7 @@ public class StatusBarRenderer
         int containerHeight,
         StatusBarContext context,
         bool isPercent,
-        float widescreenOffset,
-        bool isNative)
+        float widescreenOffset)
     {
         if (!StatusBarConditionResolver.Evaluate(context, number.Conditions))
             return;
@@ -1098,9 +1040,8 @@ public class StatusBarRenderer
         if (isPercent) m_fmtSpan.Append('%');
 
         ReadOnlySpan<char> text = m_fmtSpan.AsSpan();
-        float scaleX = isNative ? m_userScale : 1.0f;
 
-        Vec2I pos = ResolvePosition(number, parentPos, isNative, scaleX);
+        Vec2I pos = ResolvePosition(number, parentPos);
 
         float alpha = number.Translucency ? 0.5f : 1.0f;
         int totalWidth = 0;
@@ -1154,8 +1095,8 @@ public class StatusBarRenderer
                     width = monoWidth;
                 }
 
-            int scaledWidth = (int)(width * scaleX);
-            m_glyphCache.Add(new RenderGlyph(patch, scaledWidth, (int)(xOffset * scaleX), handle));
+            int scaledWidth = (int)(width * m_scale.X);
+            m_glyphCache.Add(new RenderGlyph(patch, scaledWidth, (int)(xOffset * m_scale.X), handle));
             totalWidth += scaledWidth;
         }
 
@@ -1170,11 +1111,11 @@ public class StatusBarRenderer
         foreach (RenderGlyph g in m_glyphCache)
         {
             Vec2I drawPos = (drawX + g.Offset, drawY);
-            DrawSBarTexture(hud, g.Patch, g.Handle, drawPos, yAnchor, number.Alignment, number.Translation, alpha, isNative: isNative);
+            DrawSBarTexture(hud, g.Patch, g.Handle, drawPos, yAnchor, number.Alignment, number.Translation, alpha);
             drawX += g.Width;
         }
 
-        DrawChildren(hud, number, pos, containerHeight, context, widescreenOffset, (0, 0), isNative);
+        DrawChildren(hud, number, pos, containerHeight, context, widescreenOffset, (0, 0));
     }
 
     private void DrawStatTotals(IHudRenderContext hud,
@@ -1182,14 +1123,13 @@ public class StatusBarRenderer
         Vec2I pos,
         StatusBarHudFontDef? fontDef,
         int fontHeight,
-        float alpha,
-        bool isNative)
+        float alpha)
     {
         LevelStats stats = m_world.LevelStats;
         Vec2I cur = pos;
-        DrawStatPart(hud, "K: ", stats.KillCount, stats.TotalMonsters, ref cur, comp, fontDef, fontHeight, alpha, isNative);
-        DrawStatPart(hud, "I: ", stats.ItemCount, stats.TotalItems, ref cur, comp, fontDef, fontHeight, alpha, isNative);
-        DrawStatPart(hud, "S: ", stats.SecretCount, stats.TotalSecrets, ref cur, comp, fontDef, fontHeight, alpha, isNative);
+        DrawStatPart(hud, "K: ", stats.KillCount, stats.TotalMonsters, ref cur, comp, fontDef, fontHeight, alpha);
+        DrawStatPart(hud, "I: ", stats.ItemCount, stats.TotalItems, ref cur, comp, fontDef, fontHeight, alpha);
+        DrawStatPart(hud, "S: ", stats.SecretCount, stats.TotalSecrets, ref cur, comp, fontDef, fontHeight, alpha);
     }
 
     private void DrawStatPart(IHudRenderContext hud,
@@ -1200,15 +1140,14 @@ public class StatusBarRenderer
         StatusBarComponentDef comp,
         StatusBarHudFontDef? fontDef,
         int fontHeight,
-        float alpha,
-        bool isNative)
+        float alpha)
     {
         string? defaultColor = comp.Translation;
         string? valueColor = defaultColor;
 
         if (total != int.MinValue && total > 0 && count >= total) valueColor = "CRGREEN";
 
-        int labelWidth = DrawTextPart(hud, label.AsSpan(), cursor, defaultColor, comp.Alignment, fontDef, alpha, isNative);
+        int labelWidth = DrawTextPart(hud, label.AsSpan(), cursor, defaultColor, comp.Alignment, fontDef, alpha);
         Vec2I valuePos = cursor;
         valuePos.X += labelWidth;
 
@@ -1217,11 +1156,10 @@ public class StatusBarRenderer
         m_fmtSpan.Append('/');
         m_fmtSpan.Append(total);
 
-        int valueWidth = DrawTextPart(hud, m_fmtSpan.AsSpan(), valuePos, valueColor, comp.Alignment, fontDef, alpha, isNative);
+        int valueWidth = DrawTextPart(hud, m_fmtSpan.AsSpan(), valuePos, valueColor, comp.Alignment, fontDef, alpha);
 
-        float scale = isNative ? m_userScale : 1.0f;
-        if (comp.Vertical) cursor.Y += (int)(fontHeight * (isNative ? m_userScale * 1.2f : 1.0f));
-        else cursor.X += labelWidth + valueWidth + (int)(8 * scale);
+        if (comp.Vertical) cursor.Y += (int)(fontHeight * m_scale.Y);
+        else cursor.X += labelWidth + valueWidth + (int)(8 * m_scale.X);
     }
 
     private void DrawCoordinates(IHudRenderContext hud,
@@ -1230,8 +1168,7 @@ public class StatusBarRenderer
         StatusBarHudFontDef? fontDef,
         int fontHeight,
         float alpha,
-        StatusBarContext context,
-        bool isNative)
+        StatusBarContext context)
     {
         Vec3D playerPos = context.Player.Position;
         m_coordPartsCache.Clear();
@@ -1239,18 +1176,17 @@ public class StatusBarRenderer
         m_coordPartsCache.Add(new CoordData("Y: ", (int)playerPos.Y, 0, 0));
         m_coordPartsCache.Add(new CoordData("Z: ", (int)playerPos.Z, 0, 0));
 
-        float scale = isNative ? m_userScale : 1.0f;
         int totalHorizontalWidth = 0;
         for (int i = 0; i < m_coordPartsCache.Count; i++)
         {
             CoordData data = m_coordPartsCache[i];
-            int lw = MeasureSpan(hud, data.Label.AsSpan(), "CRGREEN", fontDef, alpha, isNative);
+            int lw = MeasureSpan(hud, data.Label.AsSpan(), "CRGREEN", fontDef, alpha);
             m_fmtSpan.Clear();
             m_fmtSpan.Append(data.Value);
-            int vw = MeasureSpan(hud, m_fmtSpan.AsSpan(), comp.Translation, fontDef, alpha, isNative);
+            int vw = MeasureSpan(hud, m_fmtSpan.AsSpan(), comp.Translation, fontDef, alpha);
             m_coordPartsCache[i] = data with { LabelWidth = lw, ValWidth = vw };
             totalHorizontalWidth += lw + vw;
-            if (i < m_coordPartsCache.Count - 1) totalHorizontalWidth += (int)(8 * scale);
+            if (i < m_coordPartsCache.Count - 1) totalHorizontalWidth += (int)(8 * m_scale.X);
         }
 
         Vec2I cursor = pos;
@@ -1268,7 +1204,7 @@ public class StatusBarRenderer
                 if ((comp.Alignment & StatusBarAlignment.Right) != 0) lineX -= lineWidth;
                 else if ((comp.Alignment & StatusBarAlignment.HCenter) != 0) lineX -= lineWidth / 2;
 
-                _ = DrawTextPart(hud, data.Label.AsSpan(), (lineX, cursor.Y), "CRGREEN", StatusBarAlignment.Left, fontDef, alpha, isNative);
+                _ = DrawTextPart(hud, data.Label.AsSpan(), (lineX, cursor.Y), "CRGREEN", StatusBarAlignment.Left, fontDef, alpha);
 
                 m_fmtSpan.Clear();
                 m_fmtSpan.Append(data.Value);
@@ -1279,43 +1215,28 @@ public class StatusBarRenderer
                     comp.Translation,
                     StatusBarAlignment.Left,
                     fontDef,
-                    alpha,
-                    isNative);
+                    alpha);
 
-                cursor.Y += (int)(fontHeight * (isNative ? m_userScale * 1.2f : 1.0f));
+                cursor.Y += (int)(fontHeight * m_scale.Y);
             }
             else
             {
-                cursor.X += DrawTextPart(hud, data.Label.AsSpan(), cursor, "CRGREEN", StatusBarAlignment.Left, fontDef, alpha, isNative);
+                cursor.X += DrawTextPart(hud, data.Label.AsSpan(), cursor, "CRGREEN", StatusBarAlignment.Left, fontDef, alpha);
 
                 m_fmtSpan.Clear();
                 m_fmtSpan.Append(data.Value);
 
-                cursor.X += DrawTextPart(hud,
-                    m_fmtSpan.AsSpan(),
-                    cursor,
-                    comp.Translation,
-                    StatusBarAlignment.Left,
-                    fontDef,
-                    alpha,
-                    isNative);
+                cursor.X += DrawTextPart(hud, m_fmtSpan.AsSpan(), cursor, comp.Translation, StatusBarAlignment.Left, fontDef, alpha);
 
-                cursor.X += (int)(8 * scale);
+                cursor.X += (int)(8 * m_scale.X);
             }
     }
 
-    private int MeasureSpan(IHudRenderContext hud,
-        ReadOnlySpan<char> t,
-        string? trans,
-        StatusBarHudFontDef? fontDef,
-        float alpha,
-        bool isNative)
+    private int MeasureSpan(IHudRenderContext hud, ReadOnlySpan<char> t, string? trans, StatusBarHudFontDef? fontDef, float alpha)
     {
-        if (fontDef != null)
-            return DrawHudText(hud, t, fontDef, (0, 0), StatusBarAlignment.Left, trans, alpha, isNative, false);
-
-        float textScale = isNative ? m_userScale : 1.0f;
-        return (int)(hud.MeasureText(t, Constants.Fonts.Small, 8).Width * textScale);
+        return fontDef != null
+            ? DrawHudText(hud, t, fontDef, (0, 0), StatusBarAlignment.Left, trans, alpha, false)
+            : (int)(hud.MeasureText(t, Constants.Fonts.Small, 8).Width * m_scale.X);
     }
 
     private int DrawTextPart(IHudRenderContext hud,
@@ -1324,18 +1245,16 @@ public class StatusBarRenderer
         string? translation,
         StatusBarAlignment alignment,
         StatusBarHudFontDef? fontDef,
-        float alpha,
-        bool isNative)
+        float alpha)
     {
         if (fontDef != null)
-            return DrawHudText(hud, text, fontDef, position, alignment, translation, alpha, isNative);
+            return DrawHudText(hud, text, fontDef, position, alignment, translation, alpha);
 
         Align align = ConvertAlignment(alignment);
         Color? color = !string.IsNullOrEmpty(translation) && StandardTextColors.TryGetValue(translation, out Color c) ? c : null;
-        float textScale = isNative ? m_userScale : 1.0f;
 
-        hud.Text(text, Constants.Fonts.Small, 8, position, both: align, alpha: alpha, color: color, scale: textScale);
-        return (int)(hud.MeasureText(text, Constants.Fonts.Small, 8).Width * textScale);
+        hud.Text(text, Constants.Fonts.Small, 8, position, both: align, alpha: alpha, color: color, scale: m_scale.X);
+        return (int)(hud.MeasureText(text, Constants.Fonts.Small, 8).Width * m_scale.X);
     }
 
     private void DrawChildren(IHudRenderContext hud,
@@ -1344,8 +1263,7 @@ public class StatusBarRenderer
         int containerHeight,
         StatusBarContext context,
         float widescreenOffset,
-        Vec2I rootPos,
-        bool isNative)
+        Vec2I rootPos)
     {
         if (def.Children == null) return;
 
@@ -1354,33 +1272,33 @@ public class StatusBarRenderer
             if (!EvaluateWrapperConditions(child, context))
                 continue;
 
-            DrawElementWrapper(hud, child, pos, containerHeight, context, widescreenOffset, rootPos, isNative);
+            DrawElementWrapper(hud, child, pos, containerHeight, context, widescreenOffset, rootPos);
         }
     }
 
     private ElementBounds MeasureElement(IHudRenderContext hud,
         StatusBarElementWrapper wrapper,
         StatusBarContext context,
-        bool isNative,
         float sX = 1.0f,
         float sY = 1.0f)
     {
-        float scaleX = isNative ? sX : 1.0f;
-        float scaleY = isNative ? sY : 1.0f;
-
-        if (wrapper.Graphic != null) return MeasureGraphic(wrapper.Graphic, scaleX, scaleY);
-        if (wrapper.Number != null) return MeasureNumber(hud, wrapper.Number, context, false, isNative, scaleX, scaleY);
-        if (wrapper.Percent != null) return MeasureNumber(hud, wrapper.Percent, context, true, isNative, scaleX, scaleY);
-        if (wrapper.Face != null) return MeasureFace(hud, wrapper.Face, context, scaleX, scaleY);
-        if (wrapper.String != null) return MeasureString(hud, wrapper.String, isNative, scaleX, scaleY);
-        if (wrapper.Canvas != null) return MeasureBase(hud, wrapper.Canvas, context, isNative, scaleX, scaleY);
-        if (wrapper.List != null) return MeasureList(hud, wrapper.List, context, isNative, scaleX, scaleY);
-        if (wrapper.Component != null) return MeasureComponent(hud, wrapper.Component, isNative, scaleX, scaleY);
-        if (wrapper.Carousel != null) return MeasureCarousel(hud, wrapper.Carousel, context, scaleX, scaleY);
+        if (wrapper.Graphic != null) return MeasureGraphic(wrapper.Graphic, sX, sY);
+        if (wrapper.Number != null) return MeasureNumber(hud, wrapper.Number, context, false, sX, sY);
+        if (wrapper.Percent != null) return MeasureNumber(hud, wrapper.Percent, context, true, sX, sY);
+        if (wrapper.Face != null) return MeasureFace(hud, wrapper.Face, context, sX, sY);
+        if (wrapper.String != null) return MeasureString(hud, wrapper.String, sX, sY);
+        if (wrapper.Canvas != null) return MeasureBase(hud, wrapper.Canvas, context, sX, sY);
+        if (wrapper.List != null) return MeasureList(hud, wrapper.List, context, sX, sY);
+        if (wrapper.Component != null) return MeasureComponent(hud, wrapper.Component, sX, sY);
+        if (wrapper.Carousel != null) return MeasureCarousel(hud, wrapper.Carousel, context, sX, sY);
 
         if (wrapper.Native == null) return ElementBounds.Empty;
-        ElementBounds bounds = MeasureBase(hud, wrapper.Native, context, true, m_userScale, m_userScale * 1.2f);
-        return !isNative && m_currentScale > 0
+
+        float nX = m_userScale;
+        float nY = m_userScale * 1.2f;
+        ElementBounds bounds = MeasureBase(hud, wrapper.Native, context, nX, nY);
+
+        return m_currentScale > 0
             ? new ElementBounds((int)(bounds.X1 / m_currentScale),
                 (int)(bounds.Y1 / m_currentScale),
                 (int)(bounds.X2 / m_currentScale),
@@ -1388,12 +1306,7 @@ public class StatusBarRenderer
             : bounds;
     }
 
-    private ElementBounds MeasureBase(IHudRenderContext hud,
-        StatusBarBaseDef def,
-        StatusBarContext context,
-        bool isNative,
-        float sX,
-        float sY)
+    private ElementBounds MeasureBase(IHudRenderContext hud, StatusBarBaseDef def, StatusBarContext context, float sX, float sY)
     {
         if (def.Children == null || def.Children.Count == 0) return ElementBounds.Empty;
 
@@ -1401,7 +1314,7 @@ public class StatusBarRenderer
         foreach (StatusBarElementWrapper t in def.Children)
         {
             if (!EvaluateWrapperConditions(t, context)) continue;
-            contentBounds = ElementBounds.Union(contentBounds, MeasureElement(hud, t, context, isNative, sX, sY));
+            contentBounds = ElementBounds.Union(contentBounds, MeasureElement(hud, t, context, sX, sY));
         }
 
         if (contentBounds.X1 == int.MaxValue) return ElementBounds.Empty;
@@ -1440,19 +1353,22 @@ public class StatusBarRenderer
         StatusBarNumberDef def,
         StatusBarContext context,
         bool isPercent,
-        bool isNative,
-        float scaleX,
-        float scaleY)
+        float sX,
+        float sY)
     {
         m_fmtSpan.Clear();
         m_fmtSpan.Append(ResolveNumberValue(context.Player, def.Type, def.Param));
         if (isPercent) m_fmtSpan.Append('%');
 
-        int width = MeasureSpan(hud, m_fmtSpan.AsSpan(), null, null, 1.0f, isNative);
-        int height = (int)((def.ResolvedHeight > 0 ? def.ResolvedHeight : 8) * scaleY);
+        Vec2F oldScale = m_scale;
+        m_scale = (sX, sY);
+        int width = MeasureSpan(hud, m_fmtSpan.AsSpan(), null, null, 1.0f);
+        m_scale = oldScale;
 
-        int posX = (int)(def.X * scaleX);
-        int posY = (int)(def.Y * scaleY);
+        int height = (int)((def.ResolvedHeight > 0 ? def.ResolvedHeight : 8) * sY);
+
+        int posX = (int)(def.X * sX);
+        int posY = (int)(def.Y * sY);
         return ApplyAlignment(new Vec2I(width, height), posX, posY, def.Alignment);
     }
 
@@ -1480,26 +1396,24 @@ public class StatusBarRenderer
         return ApplyAlignment(size, posX, posY, def.Alignment);
     }
 
-    private ElementBounds MeasureString(IHudRenderContext hud, StatusBarStringDef def, bool isNative, float scaleX, float scaleY)
+    private ElementBounds MeasureString(IHudRenderContext hud, StatusBarStringDef def, float sX, float sY)
     {
         ReadOnlySpan<char> text = GetStringValue(def);
-
         _ = m_hudFontLookup.TryGetValue(def.Font, out StatusBarHudFontDef? f);
 
-        int width = MeasureSpan(hud, text, null, f, 1.0f, isNative);
-        int height = (int)((def.ResolvedHeight > 0 ? def.ResolvedHeight : 8) * scaleY);
+        Vec2F oldScale = m_scale;
+        m_scale = (sX, sY);
+        int width = MeasureSpan(hud, text, null, f, 1.0f);
+        m_scale = oldScale;
 
-        int posX = (int)(def.X * scaleX);
-        int posY = (int)(def.Y * scaleY);
+        int height = (int)((def.ResolvedHeight > 0 ? def.ResolvedHeight : 8) * sY);
+
+        int posX = (int)(def.X * sX);
+        int posY = (int)(def.Y * sY);
         return ApplyAlignment(new Vec2I(width, height), posX, posY, def.Alignment);
     }
 
-    private ElementBounds MeasureList(IHudRenderContext hud,
-        StatusBarListDef def,
-        StatusBarContext context,
-        bool isNative,
-        float scaleX,
-        float scaleY)
+    private ElementBounds MeasureList(IHudRenderContext hud, StatusBarListDef def, StatusBarContext context, float sX, float sY)
     {
         if (def.Children == null) return ElementBounds.Empty;
 
@@ -1507,13 +1421,13 @@ public class StatusBarRenderer
         int totalH = 0;
         int count = 0;
 
-        int spacing = (int)(def.Spacing * (isNative ? m_userScale : 1.0f));
+        int spacing = (int)(def.Spacing * sX);
 
         foreach (StatusBarElementWrapper child in def.Children)
         {
             if (!EvaluateWrapperConditions(child, context)) continue;
 
-            ElementBounds size = MeasureElement(hud, child, context, isNative, scaleX, scaleY);
+            ElementBounds size = MeasureElement(hud, child, context, sX, sY);
             if (def.Horizontal)
             {
                 totalW += size.Width;
@@ -1530,13 +1444,13 @@ public class StatusBarRenderer
             count++;
         }
 
-        int posX = (int)(def.X * scaleX);
-        int posY = (int)(def.Y * scaleY);
+        int posX = (int)(def.X * sX);
+        int posY = (int)(def.Y * sY);
 
         return ApplyAlignment(new Vec2I(totalW, totalH), posX, posY, def.Alignment);
     }
 
-    private ElementBounds MeasureComponent(IHudRenderContext hud, StatusBarComponentDef comp, bool isNative, float scaleX, float scaleY)
+    private ElementBounds MeasureComponent(IHudRenderContext hud, StatusBarComponentDef comp, float sX, float sY)
     {
         int fontHeight = 8;
         if (m_hudFontLookup.TryGetValue(comp.Font, out StatusBarHudFontDef? fontDef) &&
@@ -1547,6 +1461,8 @@ public class StatusBarRenderer
         }
 
         Vec2I size = Vec2I.Zero;
+        Vec2F oldScale = m_scale;
+        m_scale = (sX, sY);
 
         switch (comp.ComponentType)
         {
@@ -1554,43 +1470,51 @@ public class StatusBarRenderer
                 if (m_world.Config.Hud.ShowStats.Value)
                 {
                     const string Dummy = "K: 000/000 I: 000/000 S: 000/000";
-                    int w = MeasureSpan(hud, Dummy.AsSpan(), null, fontDef, 1.0f, isNative);
-                    size = comp.Vertical ? (w / 3, (int)(fontHeight * 3 * scaleY)) : (w, (int)(fontHeight * scaleY));
+                    int w = MeasureSpan(hud, Dummy.AsSpan(), null, fontDef, 1.0f);
+                    size = comp.Vertical ? (w / 3, (int)(fontHeight * 3 * sY)) : (w, (int)(fontHeight * sY));
                 }
 
                 break;
 
             case StatusBarComponentType.Time:
-                size = (MeasureSpan(hud, "00:00:00".AsSpan(), null, fontDef, 1.0f, isNative), (int)(fontHeight * scaleY));
+                size = (MeasureSpan(hud, "00:00:00".AsSpan(), null, fontDef, 1.0f), (int)(fontHeight * sY));
+                break;
+
+            case StatusBarComponentType.Coordinates:
+                int cw = MeasureSpan(hud, "X: -00000 Y: -00000 Z: -00000".AsSpan(), null, fontDef, 1.0f);
+                size = comp.Vertical ? (cw / 3, (int)(fontHeight * 3 * sY)) : (cw, (int)(fontHeight * sY));
+                break;
+
+            case StatusBarComponentType.Speedometer:
+                size = (MeasureSpan(hud, "000.00".AsSpan(), null, fontDef, 1.0f), (int)(fontHeight * sY));
                 break;
 
             case StatusBarComponentType.LevelTitle:
             case StatusBarComponentType.AnnounceLevelTitle:
                 string title = m_world.MapInfo.GetDisplayNameWithPrefix(m_archiveCollection.Language);
-                size = (MeasureSpan(hud, title.AsSpan(), null, fontDef, 1.0f, isNative), (int)(fontHeight * scaleY));
+                size = (MeasureSpan(hud, title.AsSpan(), null, fontDef, 1.0f), (int)(fontHeight * sY));
                 break;
 
             case StatusBarComponentType.FpsCounter:
                 if (m_world.Config.Hud.ShowFPS.Value)
-                    size = (MeasureSpan(hud, "000".AsSpan(), null, fontDef, 1.0f, isNative), (int)(fontHeight * scaleY));
-                break;
-
-            case StatusBarComponentType.Message:
-                size = Vec2I.Zero;
+                    size = (MeasureSpan(hud, "000".AsSpan(), null, fontDef, 1.0f), (int)(fontHeight * sY));
                 break;
 
             case StatusBarComponentType.Unknown:
-            case StatusBarComponentType.Coordinates:
-            case StatusBarComponentType.Speedometer:
+            case StatusBarComponentType.Message:
             case StatusBarComponentType.RenderStats:
             case StatusBarComponentType.CommandHistory:
             case StatusBarComponentType.Chat:
+                break;
+
             default:
+                size = Vec2I.Zero;
                 break;
         }
 
-        int posX = (int)(comp.X * scaleX);
-        int posY = (int)(comp.Y * scaleY);
+        m_scale = oldScale;
+        int posX = (int)(comp.X * sX);
+        int posY = (int)(comp.Y * sY);
 
         return ApplyAlignment(size, posX, posY, comp.Alignment);
     }
@@ -1631,8 +1555,13 @@ public class StatusBarRenderer
 
     private static string ResolvePatchName(string patch)
     {
-        if (string.IsNullOrEmpty(patch) || (!patch.Contains('/') && !patch.Contains('.')))
-            return patch;
+        if (string.IsNullOrEmpty(patch)) return string.Empty;
+
+        Dictionary<string, string>.AlternateLookup<ReadOnlySpan<char>> lookup = PatchNameCache.GetAlternateLookup<ReadOnlySpan<char>>();
+        ReadOnlySpan<char> patchSpan = patch.AsSpan();
+
+        if (lookup.TryGetValue(patchSpan, out string? cached))
+            return cached;
 
         int lastSlash = patch.LastIndexOf('/') + 1;
         int lastDot = patch.LastIndexOf('.');
@@ -1640,7 +1569,15 @@ public class StatusBarRenderer
         if (lastDot < lastSlash)
             lastDot = patch.Length;
 
-        return patch[lastSlash..lastDot];
+        if (lastSlash == 0 && lastDot == patch.Length)
+        {
+            PatchNameCache[patch] = patch;
+            return patch;
+        }
+
+        string result = patch[lastSlash..lastDot];
+        PatchNameCache[patch] = result;
+        return result;
     }
 
     private ReadOnlySpan<char> GetStringValue(StatusBarStringDef def)
@@ -1673,15 +1610,12 @@ public class StatusBarRenderer
         };
     }
 
-    private static Vec2I ResolvePosition(StatusBarBaseDef def, Vec2I parentPos, bool isNative, float scale)
+    private Vec2I ResolvePosition(StatusBarBaseDef def, Vec2I parentPos)
     {
         Vec2I pos = parentPos;
 
-        int x = (int)(def.X * scale);
-        int y = (int)(def.Y * (isNative ? scale * 1.2f : scale));
-
-        pos.X += x;
-        pos.Y += y;
+        pos.X += (int)(def.X * m_scale.X);
+        pos.Y += (int)(def.Y * m_scale.Y);
 
         return pos;
     }

--- a/Core/Layer/Worlds/StatusBar/StatusBarRenderer.cs
+++ b/Core/Layer/Worlds/StatusBar/StatusBarRenderer.cs
@@ -9,17 +9,21 @@ using Helion.Render.Common.Enums;
 using Helion.Render.Common.Renderers;
 using Helion.Render.Common.Textures;
 using Helion.Resources;
+using Helion.Resources.Archives.Collection;
+using Helion.Resources.Definitions.MapInfo;
 using Helion.Resources.Definitions.StatusBar;
 using Helion.Resources.Definitions.StatusBar.Enums;
-using Helion.Resources.Definitions.MapInfo;
 using Helion.Strings;
 using Helion.Util;
-using Helion.World.Entities.Inventories;
-using Helion.World.Entities.Players;
-using Helion.World.StatusBar;
-using Helion.Resources.Archives.Collection;
+using Helion.Util.Configs.Components;
 using Helion.World;
+using Helion.World.Entities.Definition;
+using Helion.World.Entities.Definition.Composer;
+using Helion.World.Entities.Inventories;
 using Helion.World.Entities.Inventories.Powerups;
+using Helion.World.Entities.Players;
+using Helion.World.Stats;
+using Helion.World.StatusBar;
 
 namespace Helion.Layer.Worlds.StatusBar;
 
@@ -27,11 +31,11 @@ namespace Helion.Layer.Worlds.StatusBar;
 public enum StatusBarCoverage
 {
     None = 0,
-    Stats = 1 << 0,      // for stat_totals
-    Time = 1 << 1,       // for time
-    Messages = 1 << 2,   // for message
-    MapTitle = 1 << 3,   // for level_title
-    FPS = 1 << 4         // for fps_counter
+    Stats = 1 << 0, // for stat_totals
+    Time = 1 << 1, // for time
+    Messages = 1 << 2, // for message
+    MapTitle = 1 << 3, // for level_title
+    FPS = 1 << 4 // for fps_counter
 }
 
 public class StatusBarRenderer
@@ -69,42 +73,47 @@ public class StatusBarRenderer
         { "CRUNTRANSLATED", Color.White }
     };
 
-    private readonly IWorld m_world;
     private readonly ArchiveCollection m_archiveCollection;
-    private readonly List<RenderGlyph> m_glyphCache = [];
     private readonly List<CoordData> m_coordPartsCache = [];
-    private readonly Dictionary<string, StatusBarNumberFontDef> m_fontNumberLookup = [];
-    private readonly Dictionary<string, StatusBarHudFontDef> m_hudFontLookup = [];
     private readonly SpanString m_fmtSpan = new();
-    private readonly SpanString m_lookupKeySpan = new(128); 
+    private readonly Dictionary<string, StatusBarNumberFontDef> m_fontNumberLookup = [];
+    private readonly List<RenderGlyph> m_glyphCache = [];
+    private readonly Dictionary<string, StatusBarHudFontDef> m_hudFontLookup = [];
+    private readonly SpanString m_lookupKeySpan = new(128);
+
+    private readonly IWorld m_world;
+    private float m_currentScale;
+    private float m_hOffset;
 
     private bool m_texturesResolved;
-
-    private readonly record struct RenderGlyph(string Patch, int Width, int Offset, IRenderableTextureHandle? Handle = null);
-    private readonly record struct CoordData(string Label, int Value, int LabelWidth, int ValWidth);
+    private float m_userScale;
+    private float m_vOffset;
 
     public StatusBarRenderer(IWorld world)
     {
         m_world = world;
         m_archiveCollection = world.ArchiveCollection;
-        var sbarDef = world.ArchiveCollection.Definitions.StatusBarDefinition;
-        foreach (var f in sbarDef.NumberFonts)
+        StatusBarDefinition sbarDef = world.ArchiveCollection.Definitions.StatusBarDefinition;
+
+        m_glyphCache.Capacity = 256;
+        m_coordPartsCache.Capacity = 16;
+
+        foreach (StatusBarNumberFontDef f in sbarDef.NumberFonts)
             m_fontNumberLookup[f.Name] = f;
 
-        foreach (var f in sbarDef.HudFonts)
+        foreach (StatusBarHudFontDef f in sbarDef.HudFonts)
             m_hudFontLookup[f.Name] = f;
     }
 
     public static StatusBarCoverage GetCoverage(StatusBarLayoutDef layout)
     {
-        if (layout.Children.Count == 0) return StatusBarCoverage.None;
-        return ScanChildren(layout.Children);
+        return layout.Children.Count == 0 ? StatusBarCoverage.None : ScanChildren(layout.Children);
     }
 
     private static StatusBarCoverage ScanChildren(List<StatusBarElementWrapper> children)
     {
         StatusBarCoverage mask = StatusBarCoverage.None;
-        foreach (var child in children)
+        foreach (StatusBarElementWrapper child in children)
         {
             if (child.Component != null)
             {
@@ -115,6 +124,14 @@ public class StatusBarRenderer
                     case StatusBarComponentType.Message: mask |= StatusBarCoverage.Messages; break;
                     case StatusBarComponentType.LevelTitle: mask |= StatusBarCoverage.MapTitle; break;
                     case StatusBarComponentType.FpsCounter: mask |= StatusBarCoverage.FPS; break;
+                    case StatusBarComponentType.Unknown:
+                    case StatusBarComponentType.Coordinates:
+                    case StatusBarComponentType.Speedometer:
+                    case StatusBarComponentType.AnnounceLevelTitle:
+                    case StatusBarComponentType.RenderStats:
+                    case StatusBarComponentType.CommandHistory:
+                    case StatusBarComponentType.Chat:
+                    default: break;
                 }
 
                 if (child.Component.Children != null)
@@ -122,6 +139,7 @@ public class StatusBarRenderer
             }
 
             if (child.Canvas?.Children != null) mask |= ScanChildren(child.Canvas.Children);
+            if (child.Native?.Children != null) mask |= ScanChildren(child.Native.Children);
             if (child.List?.Children != null) mask |= ScanChildren(child.List.Children);
             if (child.Graphic?.Children != null) mask |= ScanChildren(child.Graphic.Children);
             if (child.Face?.Children != null) mask |= ScanChildren(child.Face.Children);
@@ -132,6 +150,7 @@ public class StatusBarRenderer
             if (child.Percent?.Children != null) mask |= ScanChildren(child.Percent.Children);
             if (child.String?.Children != null) mask |= ScanChildren(child.String.Children);
         }
+
         return mask;
     }
 
@@ -143,66 +162,54 @@ public class StatusBarRenderer
             m_texturesResolved = true;
         }
 
-        const int width = 320;
-        const int height = 200;
+        const int Width = 320;
+        const int Height = 200;
 
-        hud.PushVirtualDimension((width, height), ResolutionScale.Center, Constants.DoomVirtualAspectRatio);
+        hud.PushVirtualDimension((Width, Height), ResolutionScale.Center, Constants.DoomVirtualAspectRatio);
 
-        int yOffset = layout.FullscreenRender ? 0 : (200 - layout.Height);
+        int yOffset = layout.FullscreenRender ? 0 : 200 - layout.Height;
         Vec2I rootPos = (0, yOffset);
 
-        float windowAspect = (float)hud.WindowDimension.Width / hud.WindowDimension.Height;
-        const float virtualAspect = 320f / 200f;
+        float windowWidth = hud.WindowDimension.Width;
+        float windowHeight = hud.WindowDimension.Height;
 
-        float hOffset = 0;
-        float vOffset = 0;
+        float scaleX = windowWidth / 320f;
+        float scaleY = windowHeight / 200f;
+        m_currentScale = Math.Min(scaleX, scaleY);
+        m_userScale = (float)m_world.Config.Hud.Scale.Value;
 
-        if (windowAspect > virtualAspect)
-            hOffset = (200f * windowAspect - 320f) / 2f;
-        else if (windowAspect < virtualAspect)
-            vOffset = (320f / windowAspect - 200f) / 2f;
+        m_hOffset = (windowWidth / m_currentScale - 320f) / 2f;
+        m_vOffset = (windowHeight / m_currentScale - 200f) / 2f;
 
         if (!layout.FullscreenRender)
         {
-            string? fillFlat = layout.FillFlat;
-            if (string.IsNullOrEmpty(fillFlat))
-                fillFlat = m_world.GameInfo.BorderFlat;
+            string fillFlat = layout.FillFlat ?? m_world.GameInfo.BorderFlat;
 
-            if (!string.IsNullOrEmpty(fillFlat) && hud.Textures.TryGet(fillFlat, out var bgHandle))
+            if (!string.IsNullOrEmpty(fillFlat) && hud.Textures.TryGet(fillFlat, out IRenderableTextureHandle? bgHandle))
             {
                 int bgWidth = bgHandle.Dimension.Width;
                 int bgHeight = bgHandle.Dimension.Height;
                 if (bgHeight <= 0) bgHeight = 64;
 
-                int startX = (int)-Math.Ceiling(hOffset);
-                int endX = 320 + (int)Math.Ceiling(hOffset);
-                int startY = yOffset;
-                int endY = 200 + (int)Math.Ceiling(vOffset);
+                int startX = (int)-Math.Ceiling(m_hOffset);
+                int endX = 320 + (int)Math.Ceiling(m_hOffset);
+                int endY = 200 + (int)Math.Ceiling(m_vOffset);
 
                 for (int x = (startX / bgWidth - 1) * bgWidth; x < endX; x += bgWidth)
-                {
-                    for (int y = startY; y < endY; y += bgHeight)
-                    {
-                        hud.Image(fillFlat, (x, y), anchor: Align.TopLeft);
-                    }
-                }
+                for (int y = yOffset; y < endY; y += bgHeight)
+                    hud.Image(fillFlat, (x, y), anchor: Align.TopLeft);
             }
         }
 
-        foreach (var child in layout.Children)
-        {
-            DrawElementWrapper(hud, child, rootPos, layout.Height, context, hOffset, rootPos);
-        }
+        foreach (StatusBarElementWrapper child in layout.Children)
+            DrawElementWrapper(hud, child, rootPos, layout.Height, context, m_hOffset, rootPos, false);
 
         hud.PopVirtualDimension();
     }
 
     private void EnsureTexturesResolved(IHudRenderContext hud, StatusBarLayoutDef layout)
     {
-        foreach (var t in layout.Children)
-        {
-            ResolveElementTextures(hud, t);
-        }
+        foreach (StatusBarElementWrapper t in layout.Children) ResolveElementTextures(hud, t);
     }
 
     private void ResolveElementTextures(IHudRenderContext hud, StatusBarElementWrapper wrapper)
@@ -210,8 +217,8 @@ public class StatusBarRenderer
         if (wrapper.Graphic != null)
         {
             wrapper.Graphic.ResolvedPatchName = ResolvePatchName(wrapper.Graphic.Patch);
-            
-            if (hud.Textures.TryGet(wrapper.Graphic.ResolvedPatchName, out var handle) || 
+
+            if (hud.Textures.TryGet(wrapper.Graphic.ResolvedPatchName, out IRenderableTextureHandle? handle) ||
                 hud.Textures.TryGet(wrapper.Graphic.ResolvedPatchName, out handle, ResourceNamespace.Sprites))
             {
                 wrapper.Graphic.Handle = handle;
@@ -220,70 +227,65 @@ public class StatusBarRenderer
         }
 
         if (wrapper.Animation != null)
-        {
             for (int i = 0; i < wrapper.Animation.Frames.Count; i++)
             {
-                var frame = wrapper.Animation.Frames[i];
+                StatusBarFrameDef frame = wrapper.Animation.Frames[i];
                 frame.ResolvedPatchName = ResolvePatchName(frame.Lump);
-                
-                if (hud.Textures.TryGet(frame.ResolvedPatchName, out var handle) || 
+
+                if (hud.Textures.TryGet(frame.ResolvedPatchName, out IRenderableTextureHandle? handle) ||
                     hud.Textures.TryGet(frame.ResolvedPatchName, out handle, ResourceNamespace.Sprites))
-                {
                     frame.Handle = handle;
-                }
-                
-                wrapper.Animation.Frames[i] = frame; 
+
+                wrapper.Animation.Frames[i] = frame;
             }
-        }
 
         if (wrapper.String != null)
         {
-            m_hudFontLookup.TryGetValue(wrapper.String.Font, out var f);
-            if (f != null)
+            if (m_hudFontLookup.TryGetValue(wrapper.String.Font, out StatusBarHudFontDef? f))
             {
                 string zeroPatch = GetHudFontPatch(f, '0');
-                wrapper.String.ResolvedHeight = hud.Textures.TryGet(zeroPatch, out var h) ? h.Dimension.Height : hud.GetFontMaxHeight(f.Stem);
-            }
-            else wrapper.String.ResolvedHeight = 8;
-        }
-        else if (wrapper.Number != null || wrapper.Percent != null)
-        {
-            var num = (StatusBarBaseDef?)wrapper.Number ?? wrapper.Percent;
-            m_fontNumberLookup.TryGetValue(wrapper.Number?.Font ?? wrapper.Percent?.Font ?? string.Empty, out var nf);
-            if (nf != null)
-            {
-                string zeroPatch = GetFontPatch(hud, nf, '0');
-                num!.ResolvedHeight = hud.Textures.TryGet(zeroPatch, out var h) ? h.Dimension.Height : 8;
-            }
-            else num!.ResolvedHeight = 8;
-        }
-        else if (wrapper.Face != null || wrapper.FaceBackground != null)
-        {
-            var face = (StatusBarBaseDef?)wrapper.Face ?? wrapper.FaceBackground;
-            
-            if (hud.Textures.TryGet("STFST00", out var h) || 
-                hud.Textures.TryGet("STFST00", out h, ResourceNamespace.Sprites))
-            {
-                face!.ResolvedHeight = h.Dimension.Height;
+                wrapper.String.ResolvedHeight = hud.Textures.TryGet(zeroPatch, out IRenderableTextureHandle? h)
+                    ? h.Dimension.Height
+                    : hud.GetFontMaxHeight(f.Stem);
             }
             else
             {
-                face!.ResolvedHeight = 32;
+                wrapper.String.ResolvedHeight = 8;
             }
+        }
+        else if (wrapper.Number != null || wrapper.Percent != null)
+        {
+            StatusBarBaseDef? num = (StatusBarBaseDef?)wrapper.Number ?? wrapper.Percent;
+            if (m_fontNumberLookup.TryGetValue(wrapper.Number?.Font ?? wrapper.Percent?.Font ?? string.Empty,
+                    out StatusBarNumberFontDef? nf))
+            {
+                string zeroPatch = GetFontPatch(hud, nf, '0');
+                num!.ResolvedHeight = hud.Textures.TryGet(zeroPatch, out IRenderableTextureHandle? h) ? h.Dimension.Height : 8;
+            }
+            else
+            {
+                num!.ResolvedHeight = 8;
+            }
+        }
+        else if (wrapper.Face != null || wrapper.FaceBackground != null)
+        {
+            StatusBarBaseDef? face = (StatusBarBaseDef?)wrapper.Face ?? wrapper.FaceBackground;
+
+            face!.ResolvedHeight = hud.Textures.TryGet("STFST00", out IRenderableTextureHandle? h) ||
+                                   hud.Textures.TryGet("STFST00", out h, ResourceNamespace.Sprites)
+                ? h.Dimension.Height
+                : 32;
         }
 
         if (wrapper.FaceBackground != null)
-        {
-            if (hud.Textures.TryGet("STFB0", out var handle) || 
+            if (hud.Textures.TryGet("STFB0", out IRenderableTextureHandle? handle) ||
                 hud.Textures.TryGet("STFB0", out handle, ResourceNamespace.Sprites))
-            {
                 wrapper.FaceBackground.Handle = handle;
-            }
-        }
 
         StatusBarBaseDef? baseDef = null;
         if (wrapper.Canvas != null) baseDef = wrapper.Canvas;
         else if (wrapper.List != null) baseDef = wrapper.List;
+        else if (wrapper.Native != null) baseDef = wrapper.Native;
         else if (wrapper.Graphic != null) baseDef = wrapper.Graphic;
         else if (wrapper.Face != null) baseDef = wrapper.Face;
         else if (wrapper.Animation != null) baseDef = wrapper.Animation;
@@ -295,59 +297,80 @@ public class StatusBarRenderer
         else if (wrapper.FaceBackground != null) baseDef = wrapper.FaceBackground;
 
         if (baseDef?.Children == null) return;
-        foreach (var t in baseDef.Children)
+        foreach (StatusBarElementWrapper t in baseDef.Children)
             ResolveElementTextures(hud, t);
     }
 
-    private void DrawElementWrapper(IHudRenderContext hud, StatusBarElementWrapper wrapper, Vec2I parentPos,
-        int containerHeight, StatusBarContext context, float widescreenOffset, Vec2I rootPos)
+    private void DrawElementWrapper(IHudRenderContext hud,
+        StatusBarElementWrapper wrapper,
+        Vec2I parentPos,
+        int containerHeight,
+        StatusBarContext context,
+        float widescreenOffset,
+        Vec2I rootPos,
+        bool isNative)
     {
         Vec2I effectiveParentPos = parentPos;
         bool isHudWidget = wrapper.Component != null || wrapper.Carousel != null;
-        if (isHudWidget && parentPos == rootPos)
-        {
-            effectiveParentPos = (0, 0);
-        }
+
+        if (isHudWidget && parentPos == rootPos && !isNative) effectiveParentPos = (0, 0);
 
         if (wrapper.Canvas != null)
-            DrawBase(hud, wrapper.Canvas, parentPos, containerHeight, context, widescreenOffset, rootPos);
+            DrawBase(hud, wrapper.Canvas, parentPos, containerHeight, context, widescreenOffset, rootPos, isNative);
+        else if (wrapper.Native != null)
+            DrawNative(hud, wrapper.Native, parentPos, containerHeight, context);
         else if (wrapper.List != null)
-            DrawList(hud, wrapper.List, parentPos, containerHeight, context, widescreenOffset, rootPos);
+            DrawList(hud, wrapper.List, parentPos, containerHeight, context, widescreenOffset, rootPos, isNative);
         else if (wrapper.Graphic != null)
-            DrawGraphic(hud, wrapper.Graphic, parentPos, containerHeight, context, widescreenOffset);
+            DrawGraphic(hud, wrapper.Graphic, parentPos, containerHeight, context, widescreenOffset, isNative);
         else if (wrapper.Number != null)
-            DrawNumber(hud, wrapper.Number, parentPos, containerHeight, context, false, widescreenOffset);
+            DrawNumber(hud, wrapper.Number, parentPos, containerHeight, context, false, widescreenOffset, isNative);
         else if (wrapper.Percent != null)
-            DrawNumber(hud, wrapper.Percent, parentPos, containerHeight, context, true, widescreenOffset);
+            DrawNumber(hud, wrapper.Percent, parentPos, containerHeight, context, true, widescreenOffset, isNative);
         else if (wrapper.String != null)
-            DrawString(hud, wrapper.String, parentPos, containerHeight, context, widescreenOffset);
+            DrawString(hud, wrapper.String, parentPos, containerHeight, context, widescreenOffset, isNative);
         else if (wrapper.Face != null)
-            DrawFace(hud, wrapper.Face, parentPos, containerHeight, context, widescreenOffset);
+            DrawFace(hud, wrapper.Face, parentPos, containerHeight, context, widescreenOffset, isNative);
         else if (wrapper.FaceBackground != null)
-            DrawFaceBackground(hud, wrapper.FaceBackground, parentPos, containerHeight, context, widescreenOffset);
+            DrawFaceBackground(hud, wrapper.FaceBackground, parentPos, containerHeight, context, widescreenOffset, isNative);
         else if (wrapper.Animation != null)
-            DrawAnimation(hud, wrapper.Animation, parentPos, containerHeight, context, widescreenOffset);
+            DrawAnimation(hud, wrapper.Animation, parentPos, containerHeight, context, widescreenOffset, isNative);
         else if (wrapper.Component != null)
-            DrawComponent(hud, wrapper.Component, effectiveParentPos, containerHeight, context, widescreenOffset, rootPos);
+            DrawComponent(hud, wrapper.Component, effectiveParentPos, containerHeight, context, widescreenOffset, rootPos, isNative);
         else if (wrapper.Carousel != null)
-            DrawCarousel(hud, wrapper.Carousel, effectiveParentPos, containerHeight, context, widescreenOffset, rootPos);
+            DrawCarousel(hud, wrapper.Carousel, effectiveParentPos, containerHeight, context, widescreenOffset, rootPos, isNative);
     }
 
-    private void DrawBase(IHudRenderContext hud, StatusBarCanvasDef def, Vec2I parentPos, int containerHeight,
-        StatusBarContext context, float widescreenOffset, Vec2I rootPos)
+    private void DrawBase(IHudRenderContext hud,
+        StatusBarCanvasDef def,
+        Vec2I parentPos,
+        int containerHeight,
+        StatusBarContext context,
+        float widescreenOffset,
+        Vec2I rootPos,
+        bool isNative)
     {
         if (!StatusBarConditionResolver.Evaluate(context, def.Conditions))
             return;
 
-        Vec2I currentPos = ResolvePosition(def, parentPos, widescreenOffset);
-        DrawChildren(hud, def, currentPos, containerHeight, context, widescreenOffset, rootPos);
+        Vec2I currentPos = ResolvePosition(def, parentPos, isNative, isNative ? m_userScale : 1.0f);
+        DrawChildren(hud, def, currentPos, containerHeight, context, widescreenOffset, rootPos, isNative);
     }
 
-    private void DrawList(IHudRenderContext hud, StatusBarListDef def, Vec2I parentPos, int containerHeight,
-        StatusBarContext context, float widescreenOffset, Vec2I rootPos)
+    private void DrawList(IHudRenderContext hud,
+        StatusBarListDef def,
+        Vec2I parentPos,
+        int containerHeight,
+        StatusBarContext context,
+        float widescreenOffset,
+        Vec2I rootPos,
+        bool isNative)
     {
         if (!StatusBarConditionResolver.Evaluate(context, def.Conditions) || def.Children == null)
             return;
+
+        float scaleX = isNative ? m_userScale : 1.0f;
+        float scaleY = isNative ? m_userScale * 1.2f : 1.0f;
 
         int childCount = def.Children.Count;
         Span<Vec2I> sizes = stackalloc Vec2I[childCount];
@@ -355,32 +378,35 @@ public class StatusBarRenderer
         int totalWidth = 0;
         int totalHeight = 0;
 
-        foreach (var child in def.Children)
-        {
-            if (!EvaluateWrapperConditions(child, context))
-                continue;
+        int spacing = isNative ? (int)(def.Spacing * m_userScale) : def.Spacing;
 
-            Vec2I size = MeasureElement(hud, child, context);
+        foreach (StatusBarElementWrapper child in def.Children)
+        {
+            if (!EvaluateWrapperConditions(child, context)) continue;
+
+            ElementBounds bounds = MeasureElement(hud, child, context, isNative, scaleX, scaleY);
+            Vec2I size = new(bounds.Width, bounds.Height);
             sizes[activeCount] = size;
 
             if (def.Horizontal)
             {
                 totalWidth += size.X;
-                if (activeCount > 0) totalWidth += def.Spacing;
+                if (activeCount > 0) totalWidth += spacing;
                 totalHeight = Math.Max(totalHeight, size.Y);
             }
             else
             {
                 totalHeight += size.Y;
-                if (activeCount > 0) totalHeight += def.Spacing;
+                if (activeCount > 0) totalHeight += spacing;
                 totalWidth = Math.Max(totalWidth, size.X);
             }
+
             activeCount++;
         }
 
         if (activeCount == 0) return;
 
-        Vec2I listPos = ResolvePosition(def, parentPos, widescreenOffset);
+        Vec2I listPos = ResolvePosition(def, parentPos, isNative, scaleX);
 
         if ((def.Alignment & StatusBarAlignment.HCenter) != 0) listPos.X -= totalWidth / 2;
         else if ((def.Alignment & StatusBarAlignment.Right) != 0) listPos.X -= totalWidth;
@@ -390,10 +416,9 @@ public class StatusBarRenderer
 
         int currentIdx = 0;
         Vec2I cursor = listPos;
-        foreach (var child in def.Children)
+        foreach (StatusBarElementWrapper child in def.Children)
         {
-            if (!EvaluateWrapperConditions(child, context))
-                continue;
+            if (!EvaluateWrapperConditions(child, context)) continue;
 
             Vec2I size = sizes[currentIdx];
             Vec2I childPos = cursor;
@@ -401,102 +426,200 @@ public class StatusBarRenderer
             if (def.Horizontal)
             {
                 if ((def.Alignment & StatusBarAlignment.Bottom) != 0)
-                    childPos.Y += (totalHeight - size.Y);
+                    childPos.Y += totalHeight - size.Y;
                 else if ((def.Alignment & StatusBarAlignment.VCenter) != 0)
                     childPos.Y += (totalHeight - size.Y) / 2;
 
-                DrawElementWrapper(hud, child, childPos, containerHeight, context, widescreenOffset, rootPos);
-                cursor.X += size.X + def.Spacing;
+                DrawElementWrapper(hud, child, childPos, containerHeight, context, widescreenOffset, rootPos, isNative);
+                cursor.X += size.X + spacing;
             }
             else
             {
                 if ((def.Alignment & StatusBarAlignment.Right) != 0)
-                    childPos.X += (totalWidth - size.X);
+                    childPos.X += totalWidth - size.X;
                 else if ((def.Alignment & StatusBarAlignment.HCenter) != 0)
                     childPos.X += (totalWidth - size.X) / 2;
 
-                DrawElementWrapper(hud, child, childPos, containerHeight, context, widescreenOffset, rootPos);
-                cursor.Y += size.Y + def.Spacing;
+                DrawElementWrapper(hud, child, childPos, containerHeight, context, widescreenOffset, rootPos, isNative);
+                cursor.Y += size.Y + spacing;
             }
+
             currentIdx++;
         }
     }
 
-    private void DrawGraphic(IHudRenderContext hud, StatusBarGraphicDef graphic, Vec2I parentPos,
-        int containerHeight, StatusBarContext context, float widescreenOffset)
+    private void DrawNative(IHudRenderContext hud, StatusBarNativeDef def, Vec2I parentPos, int containerHeight, StatusBarContext context)
+    {
+        if (!StatusBarConditionResolver.Evaluate(context, def.Conditions))
+            return;
+
+        Vec2I vPos = ResolvePosition(def, parentPos, false, 1.0f);
+
+        float scaleX = m_userScale;
+        float scaleY = m_userScale * 1.2f;
+
+        ElementBounds bounds = ElementBounds.Empty;
+        if (def.Children != null)
+            foreach (StatusBarElementWrapper child in def.Children)
+            {
+                if (!EvaluateWrapperConditions(child, context)) continue;
+                bounds = ElementBounds.Union(bounds, MeasureElement(hud, child, context, true, scaleX, scaleY));
+            }
+
+        if (bounds.X1 == int.MaxValue) return;
+
+        int pivotX = (bounds.X1 + bounds.X2) / 2;
+        int pivotY = (bounds.Y1 + bounds.Y2) / 2;
+
+        int nativeX = (int)Math.Floor((vPos.X + m_hOffset) * m_currentScale);
+        int nativeY = (int)Math.Floor((vPos.Y + m_vOffset) * m_currentScale);
+
+        bool isHCenter = (def.Alignment & StatusBarAlignment.HCenter) != 0;
+        bool isVCenter = (def.Alignment & StatusBarAlignment.VCenter) != 0;
+
+        int hShift = (int)Math.Ceiling(m_hOffset * m_currentScale);
+        int vShift = (int)Math.Ceiling(m_vOffset * m_currentScale);
+
+        if (!isHCenter)
+        {
+            if ((def.Alignment & StatusBarAlignment.Right) != 0)
+                nativeX += hShift;
+            else
+                nativeX -= hShift;
+        }
+
+        if (!isVCenter)
+        {
+            if ((def.Alignment & StatusBarAlignment.Bottom) != 0)
+                nativeY += vShift;
+            else
+                nativeY -= vShift;
+        }
+
+        if (isHCenter) nativeX -= pivotX;
+        else if ((def.Alignment & StatusBarAlignment.Right) != 0) nativeX -= bounds.X2;
+        else nativeX -= bounds.X1;
+
+        if (isVCenter) nativeY -= pivotY;
+        else if ((def.Alignment & StatusBarAlignment.Bottom) != 0) nativeY -= bounds.Y2;
+        else nativeY -= bounds.Y1;
+
+        Vec2I nativeRoot = (nativeX, nativeY);
+
+        hud.PopVirtualDimension();
+        DrawChildren(hud, def, nativeRoot, containerHeight, context, 0, nativeRoot, true);
+        hud.PushVirtualDimension((320, 200), ResolutionScale.Center, Constants.DoomVirtualAspectRatio);
+    }
+
+    private void DrawGraphic(IHudRenderContext hud,
+        StatusBarGraphicDef graphic,
+        Vec2I parentPos,
+        int containerHeight,
+        StatusBarContext context,
+        float widescreenOffset,
+        bool isNative)
     {
         if (!StatusBarConditionResolver.Evaluate(context, graphic.Conditions))
             return;
 
-        Vec2I currentPos = ResolvePosition(graphic, parentPos, widescreenOffset);
+        Vec2I currentPos = ResolvePosition(graphic, parentPos, isNative, isNative ? m_userScale : 1.0f);
 
         if (graphic.Handle != null || !string.IsNullOrEmpty(graphic.Patch))
         {
             Align align = ConvertAlignment(graphic.Alignment);
-            if (graphic.MidOffset != 0) currentPos.X += graphic.MidOffset;
+            if (graphic.MidOffset != 0) currentPos.X += (int)(graphic.MidOffset * (isNative ? m_userScale : 1.0f));
 
             float alpha = graphic.Translucency ? 0.5f : 1.0f;
-        
-            DrawSBarTexture(hud, graphic.ResolvedPatchName ?? graphic.Patch, graphic.Handle, currentPos, align,
-                graphic.Alignment, graphic.Translation, alpha, graphic.Crop);
+
+            DrawSBarTexture(hud,
+                graphic.ResolvedPatchName ?? graphic.Patch,
+                graphic.Handle,
+                currentPos,
+                align,
+                graphic.Alignment,
+                graphic.Translation,
+                alpha,
+                graphic.Crop,
+                isNative);
         }
 
-        DrawChildren(hud, graphic, currentPos, containerHeight, context, widescreenOffset, (0, 0));
+        DrawChildren(hud, graphic, currentPos, containerHeight, context, widescreenOffset, (0, 0), isNative);
     }
 
-    private void DrawFace(IHudRenderContext hud, StatusBarFaceDef face, Vec2I parentPos,
-        int containerHeight, StatusBarContext context, float widescreenOffset)
+    private void DrawFace(IHudRenderContext hud,
+        StatusBarFaceDef face,
+        Vec2I parentPos,
+        int containerHeight,
+        StatusBarContext context,
+        float widescreenOffset,
+        bool isNative)
     {
         if (!StatusBarConditionResolver.Evaluate(context, face.Conditions))
             return;
 
-        Vec2I currentPos = ResolvePosition(face, parentPos, widescreenOffset);
+        Vec2I currentPos = ResolvePosition(face, parentPos, isNative, isNative ? m_userScale : 1.0f);
         string patch = context.Player.StatusBar.GetFacePatch();
 
         if (!string.IsNullOrEmpty(patch))
         {
             Align align = ConvertAlignment(face.Alignment);
             float alpha = face.Translucency ? 0.5f : 1.0f;
-            
-            DrawSBarTexture(hud, patch, null, currentPos, align,
-                face.Alignment, face.Translation, alpha, face.Crop);
+
+            DrawSBarTexture(hud, patch, null, currentPos, align, face.Alignment, face.Translation, alpha, face.Crop, isNative);
         }
 
-        DrawChildren(hud, face, currentPos, containerHeight, context, widescreenOffset, (0, 0));
+        DrawChildren(hud, face, currentPos, containerHeight, context, widescreenOffset, (0, 0), isNative);
     }
 
-    private void DrawFaceBackground(IHudRenderContext hud, StatusBarFaceDef faceBg, Vec2I parentPos,
-        int containerHeight, StatusBarContext context, float widescreenOffset)
+    private void DrawFaceBackground(IHudRenderContext hud,
+        StatusBarFaceDef faceBg,
+        Vec2I parentPos,
+        int containerHeight,
+        StatusBarContext context,
+        float widescreenOffset,
+        bool isNative)
     {
         if (!StatusBarConditionResolver.Evaluate(context, faceBg.Conditions))
             return;
 
-        Vec2I currentPos = ResolvePosition(faceBg, parentPos, widescreenOffset);
+        Vec2I currentPos = ResolvePosition(faceBg, parentPos, isNative, isNative ? m_userScale : 1.0f);
 
         if (faceBg.Handle != null)
         {
             Align align = ConvertAlignment(faceBg.Alignment);
             float alpha = faceBg.Translucency ? 0.5f : 1.0f;
-        
-            DrawSBarTexture(hud, "STFB0", faceBg.Handle, currentPos, align,
-                faceBg.Alignment, faceBg.Translation, alpha);
+
+            DrawSBarTexture(hud,
+                "STFB0",
+                faceBg.Handle,
+                currentPos,
+                align,
+                faceBg.Alignment,
+                faceBg.Translation,
+                alpha,
+                isNative: isNative);
         }
 
-        DrawChildren(hud, faceBg, currentPos, containerHeight, context, widescreenOffset, (0, 0));
+        DrawChildren(hud, faceBg, currentPos, containerHeight, context, widescreenOffset, (0, 0), isNative);
     }
 
-    private void DrawAnimation(IHudRenderContext hud, StatusBarAnimationDef anim, Vec2I parentPos,
-        int containerHeight, StatusBarContext context, float widescreenOffset)
+    private void DrawAnimation(IHudRenderContext hud,
+        StatusBarAnimationDef anim,
+        Vec2I parentPos,
+        int containerHeight,
+        StatusBarContext context,
+        float widescreenOffset,
+        bool isNative)
     {
         if (!StatusBarConditionResolver.Evaluate(context, anim.Conditions))
             return;
 
-        Vec2I currentPos = ResolvePosition(anim, parentPos, widescreenOffset);
+        Vec2I currentPos = ResolvePosition(anim, parentPos, isNative, isNative ? m_userScale : 1.0f);
 
         if (anim.Frames.Count > 0)
         {
             double totalDuration = 0;
-            foreach (var frame1 in anim.Frames)
+            foreach (StatusBarFrameDef frame1 in anim.Frames)
                 totalDuration += frame1.Duration;
 
             if (totalDuration > 0)
@@ -505,62 +628,76 @@ public class StatusBarRenderer
                 long currentTick = m_world.LevelTime;
                 double animTime = currentTick % timePerLoop;
 
-                var frame = anim.Frames[0];
+                StatusBarFrameDef frame = anim.Frames[0];
                 double timeAccumulator = 0;
 
-                foreach (var f in anim.Frames)
+                foreach (StatusBarFrameDef f in anim.Frames)
                 {
                     timeAccumulator += f.Duration * Constants.TicksPerSecond;
-                    if (animTime < timeAccumulator)
-                    {
-                        frame = f;
-                        break;
-                    }
+                    if (!(animTime < timeAccumulator)) continue;
+                    frame = f;
+                    break;
                 }
 
                 Align align = ConvertAlignment(anim.Alignment);
-                DrawSBarTexture(hud, frame.ResolvedPatchName ?? frame.Lump, frame.Handle, currentPos, align, anim.Alignment, anim.Translation);
+                DrawSBarTexture(hud,
+                    frame.ResolvedPatchName ?? frame.Lump,
+                    frame.Handle,
+                    currentPos,
+                    align,
+                    anim.Alignment,
+                    anim.Translation,
+                    isNative: isNative);
             }
         }
 
-        DrawChildren(hud, anim, currentPos, containerHeight, context, widescreenOffset, (0, 0));
+        DrawChildren(hud, anim, currentPos, containerHeight, context, widescreenOffset, (0, 0), isNative);
     }
 
-    private void DrawString(IHudRenderContext hud, StatusBarStringDef def, Vec2I parentPos,
-        int containerHeight, StatusBarContext context, float widescreenOffset)
+    private void DrawString(IHudRenderContext hud,
+        StatusBarStringDef def,
+        Vec2I parentPos,
+        int containerHeight,
+        StatusBarContext context,
+        float widescreenOffset,
+        bool isNative)
     {
         if (!StatusBarConditionResolver.Evaluate(context, def.Conditions))
             return;
 
-        Vec2I pos = ResolvePosition(def, parentPos, widescreenOffset);
+        Vec2I pos = ResolvePosition(def, parentPos, isNative, isNative ? m_userScale : 1.0f);
         ReadOnlySpan<char> text = GetStringValue(def);
         if (text.IsEmpty) return;
 
-        m_hudFontLookup.TryGetValue(def.Font, out var fontDef);
-        float alpha = def.Translucency ? 0.5f : 1.0f;
-        int fontHeight = fontDef != null ? hud.GetFontMaxHeight(fontDef.Stem) : 8;
-        if (fontHeight <= 0) fontHeight = 8;
+        int fontHeight = m_hudFontLookup.TryGetValue(def.Font, out StatusBarHudFontDef? fontDef) ? hud.GetFontMaxHeight(fontDef.Stem) : 8;
 
-        RenderLines(hud, text, pos, fontDef, fontHeight, def.Alignment, def.Translation, alpha);
-        DrawChildren(hud, def, pos, containerHeight, context, widescreenOffset, (0, 0));
+        if (fontHeight <= 0) fontHeight = 8;
+        float alpha = def.Translucency ? 0.5f : 1.0f;
+
+        RenderLines(hud, text, pos, fontDef, fontHeight, def.Alignment, def.Translation, alpha, isNative);
+        DrawChildren(hud, def, pos, containerHeight, context, widescreenOffset, (0, 0), isNative);
     }
 
-    private void DrawComponent(IHudRenderContext hud, StatusBarComponentDef comp, Vec2I parentPos,
-        int containerHeight, StatusBarContext context, float widescreenOffset, Vec2I rootPos)
+    private void DrawComponent(IHudRenderContext hud,
+        StatusBarComponentDef comp,
+        Vec2I parentPos,
+        int containerHeight,
+        StatusBarContext context,
+        float widescreenOffset,
+        Vec2I rootPos,
+        bool isNative)
     {
         if (!StatusBarConditionResolver.Evaluate(context, comp.Conditions))
             return;
 
-        Vec2I pos = ResolvePosition(comp, parentPos, widescreenOffset);
-        var config = m_world.Config.Hud;
-
+        Vec2I pos = ResolvePosition(comp, parentPos, isNative, isNative ? m_userScale : 1.0f);
+        ConfigHud config = m_world.Config.Hud;
         float alpha = comp.Translucency ? 0.5f : 1.0f;
         StatusBarAlignment alignment = comp.Alignment;
 
-        m_hudFontLookup.TryGetValue(comp.Font, out var fontDef);
-
         int fontHeight = 8;
-        if (fontDef != null && StemToHelionFontMap.TryGetValue(fontDef.Stem, out var helionFontName))
+        if (m_hudFontLookup.TryGetValue(comp.Font, out StatusBarHudFontDef? fontDef) &&
+            StemToHelionFontMap.TryGetValue(fontDef.Stem, out string? helionFontName))
         {
             int h = hud.GetFontMaxHeight(helionFontName);
             if (h > 0) fontHeight = h;
@@ -570,7 +707,7 @@ public class StatusBarRenderer
         {
             case StatusBarComponentType.StatTotals:
                 if (!config.ShowStats.Value) return;
-                DrawStatTotals(hud, comp, pos, fontDef, fontHeight, alpha);
+                DrawStatTotals(hud, comp, pos, fontDef, fontHeight, alpha, isNative);
                 break;
 
             case StatusBarComponentType.Time:
@@ -581,24 +718,24 @@ public class StatusBarRenderer
                 m_fmtSpan.Append(t.Minutes, 2);
                 m_fmtSpan.Append(':');
                 m_fmtSpan.Append(t.Seconds, 2);
-                RenderLines(hud, m_fmtSpan.AsSpan(), pos, fontDef, fontHeight, alignment, comp.Translation, alpha);
+                RenderLines(hud, m_fmtSpan.AsSpan(), pos, fontDef, fontHeight, alignment, comp.Translation, alpha, isNative);
                 break;
             case StatusBarComponentType.Coordinates:
-                DrawCoordinates(hud, comp, pos, fontDef, fontHeight, alpha, context);
+                DrawCoordinates(hud, comp, pos, fontDef, fontHeight, alpha, context, isNative);
                 break;
             case StatusBarComponentType.Speedometer:
                 string speedText = GetSpeedometerText(context.Player);
-                RenderLines(hud, speedText.AsSpan(), pos, fontDef, fontHeight, alignment, comp.Translation, alpha);
+                RenderLines(hud, speedText.AsSpan(), pos, fontDef, fontHeight, alignment, comp.Translation, alpha, isNative);
                 break;
             case StatusBarComponentType.LevelTitle:
                 string levelTitle = m_world.MapInfo.GetDisplayNameWithPrefix(m_archiveCollection.Language);
-                RenderLines(hud, levelTitle.AsSpan(), pos, fontDef, fontHeight, alignment, comp.Translation, alpha);
+                RenderLines(hud, levelTitle.AsSpan(), pos, fontDef, fontHeight, alignment, comp.Translation, alpha, isNative);
                 break;
             case StatusBarComponentType.FpsCounter:
                 if (!config.ShowFPS.Value) return;
                 m_fmtSpan.Clear();
                 m_fmtSpan.Append(context.Fps);
-                RenderLines(hud, m_fmtSpan.AsSpan(), pos, fontDef, fontHeight, alignment, comp.Translation, alpha);
+                RenderLines(hud, m_fmtSpan.AsSpan(), pos, fontDef, fontHeight, alignment, comp.Translation, alpha, isNative);
                 break;
             case StatusBarComponentType.Message:
                 string msg = context.ConsoleMessage ?? string.Empty;
@@ -607,119 +744,118 @@ public class StatusBarRenderer
                     pos = (160, 66);
                     alignment = StatusBarAlignment.HCenter;
                 }
-                RenderLines(hud, msg.AsSpan(), pos, fontDef, fontHeight, alignment, comp.Translation, alpha);
+
+                RenderLines(hud, msg.AsSpan(), pos, fontDef, fontHeight, alignment, comp.Translation, alpha, isNative);
                 break;
             case StatusBarComponentType.AnnounceLevelTitle:
                 double duration = comp.Duration > 0 ? comp.Duration : 2.5;
-                const double fadeInTime = 0.25;
-                const double fadeOutTime = 1.0;
+                const double FadeInTime = 0.25;
+                const double FadeOutTime = 1.0;
                 double timeSinceStart = m_world.LevelTime / Constants.TicksPerSecond;
 
-                if (timeSinceStart > duration + fadeOutTime)
+                if (timeSinceStart > duration + FadeOutTime)
                     return;
 
-                if (timeSinceStart < fadeInTime) alpha *= (float)(timeSinceStart / fadeInTime);
+                if (timeSinceStart < FadeInTime)
+                {
+                    alpha *= (float)(timeSinceStart / FadeInTime);
+                }
                 else if (timeSinceStart > duration)
                 {
-                    double progress = (timeSinceStart - duration) / fadeOutTime;
+                    double progress = (timeSinceStart - duration) / FadeOutTime;
                     alpha *= (float)(1.0 - progress);
                 }
 
                 string annTitle = m_world.MapInfo.GetDisplayNameWithPrefix(m_archiveCollection.Language);
-                RenderLines(hud, annTitle.AsSpan(), pos, fontDef, fontHeight, alignment, comp.Translation, alpha);
+                RenderLines(hud, annTitle.AsSpan(), pos, fontDef, fontHeight, alignment, comp.Translation, alpha, isNative);
+                break;
+            case StatusBarComponentType.Unknown:
+            case StatusBarComponentType.RenderStats:
+            case StatusBarComponentType.CommandHistory:
+            case StatusBarComponentType.Chat:
+            default:
                 break;
         }
 
-        DrawChildren(hud, comp, pos, containerHeight, context, widescreenOffset, rootPos);
+        DrawChildren(hud, comp, pos, containerHeight, context, widescreenOffset, rootPos, isNative);
     }
 
-    private void RenderLines(IHudRenderContext hud, ReadOnlySpan<char> text, Vec2I pos,
-        StatusBarHudFontDef? fontDef, int fontHeight, StatusBarAlignment alignment, string? translation, float alpha)
+    private void RenderLines(IHudRenderContext hud,
+        ReadOnlySpan<char> text,
+        Vec2I pos,
+        StatusBarHudFontDef? fontDef,
+        int fontHeight,
+        StatusBarAlignment alignment,
+        string? translation,
+        float alpha,
+        bool isNative)
     {
         if (text.IsEmpty) return;
 
         Vec2I drawPos = pos;
         int lineStart = 0;
+        float scaleY = isNative ? m_userScale * 1.2f : 1.0f;
 
         for (int i = 0; i < text.Length; i++)
         {
-            if (text[i] == '\n')
-            {
-                var line = text.Slice(lineStart, i - lineStart);
-                DrawSingleLine(hud, line, drawPos, fontDef, alignment, translation, alpha);
-                drawPos.Y += fontHeight;
-                lineStart = i + 1;
-            }
+            if (text[i] != '\n') continue;
+            ReadOnlySpan<char> line = text[lineStart..i];
+            DrawSingleLine(hud, line, drawPos, fontDef, alignment, translation, alpha, isNative);
+            drawPos.Y += (int)(fontHeight * scaleY);
+            lineStart = i + 1;
         }
 
-        if (lineStart < text.Length)
+        if (lineStart >= text.Length) return;
         {
-            var line = text.Slice(lineStart);
-            DrawSingleLine(hud, line, drawPos, fontDef, alignment, translation, alpha);
+            ReadOnlySpan<char> line = text[lineStart..];
+            DrawSingleLine(hud, line, drawPos, fontDef, alignment, translation, alpha, isNative);
         }
     }
 
-    private void DrawSingleLine(IHudRenderContext hud, ReadOnlySpan<char> line, Vec2I drawPos,
-        StatusBarHudFontDef? fontDef, StatusBarAlignment alignment, string? translation, float alpha)
+    private void DrawSingleLine(IHudRenderContext hud,
+        ReadOnlySpan<char> line,
+        Vec2I drawPos,
+        StatusBarHudFontDef? fontDef,
+        StatusBarAlignment alignment,
+        string? translation,
+        float alpha,
+        bool isNative)
     {
         if (line.IsEmpty) return;
 
         int drawnWidth = 0;
-        if (fontDef != null)
-        {
-            drawnWidth = DrawHudText(hud, line, fontDef, drawPos, alignment, translation, alpha);
-        }
+        if (fontDef != null) drawnWidth = DrawHudText(hud, line, fontDef, drawPos, alignment, translation, alpha, isNative);
 
-        if (drawnWidth == 0)
-        {
-            Align align = ConvertAlignment(alignment);
-            hud.Text(line, Constants.Fonts.Small, 8, drawPos, both: align, alpha: alpha);
-        }
+        if (drawnWidth != 0) return;
+        Align align = ConvertAlignment(alignment);
+        float textScale = isNative ? m_userScale : 1.0f;
+        hud.Text(line, Constants.Fonts.Small, 8, drawPos, both: align, alpha: alpha, scale: textScale);
     }
 
-    private int DrawHudText(IHudRenderContext hud, ReadOnlySpan<char> text, StatusBarHudFontDef fontDef,
-        Vec2I pos, StatusBarAlignment alignment, string? translation, float alpha, bool draw = true)
+    private int DrawHudText(IHudRenderContext hud,
+        ReadOnlySpan<char> text,
+        StatusBarHudFontDef fontDef,
+        Vec2I pos,
+        StatusBarAlignment alignment,
+        string? translation,
+        float alpha,
+        bool isNative,
+        bool draw = true)
     {
         Color? drawColor = null;
-        if (!string.IsNullOrEmpty(translation))
-        {
-            if (StandardTextColors.TryGetValue(translation, out var c))
-                drawColor = c;
-        }
+        if (!string.IsNullOrEmpty(translation) && StandardTextColors.TryGetValue(translation, out Color colorValue))
+            drawColor = colorValue;
+
+        float scaleX = isNative ? m_userScale : 1.0f;
+        float scaleY = isNative ? m_userScale * 1.2f : 1.0f;
 
         if (StemToHelionFontMap.TryGetValue(fontDef.Stem, out string? helionFont))
         {
-            if (draw)
-            {
-                Align anchor;
-                TextAlign textAlign = TextAlign.Left;
+            if (!draw) return (int)(hud.MeasureText(text, helionFont, 8).Width * scaleX);
+            Align anchor = ConvertAlignment(alignment);
+            hud.Text(text, helionFont, 8, pos, TextAlign.Left, Align.TopLeft, anchor, color: drawColor, alpha: alpha, scale: scaleX);
 
-                bool hCenter = (alignment & StatusBarAlignment.HCenter) != 0;
-                bool right = (alignment & StatusBarAlignment.Right) != 0;
-                bool vCenter = (alignment & StatusBarAlignment.VCenter) != 0;
-                bool bottom = (alignment & StatusBarAlignment.Bottom) != 0;
-
-                if (hCenter)
-                {
-                    anchor = bottom ? Align.BottomMiddle : (vCenter ? Align.Center : Align.TopMiddle);
-                    textAlign = TextAlign.Center;
-                }
-                else if (right)
-                {
-                    anchor = bottom ? Align.BottomRight : (vCenter ? Align.MiddleRight : Align.TopRight);
-                    textAlign = TextAlign.Right;
-                }
-                else
-                {
-                    anchor = bottom ? Align.BottomLeft : (vCenter ? Align.MiddleLeft : Align.TopLeft);
-                }
-
-                hud.Text(text, helionFont, 8, pos, textAlign: textAlign,
-                    window: Align.TopLeft, anchor: anchor,
-                    color: drawColor, alpha: alpha);
-            }
-
-            return hud.MeasureText(text, helionFont, 8).Width;
+            return (int)(hud.MeasureText(text, helionFont, 8).Width * scaleX);
         }
 
         int totalWidth = 0;
@@ -728,27 +864,34 @@ public class StatusBarRenderer
         m_glyphCache.Clear();
 
         int monoWidth = 0;
-        if (fontDef.Type == 1)
+        switch (fontDef.Type)
         {
-            if (!HudType1WidthCache.TryGetValue(fontDef.Stem, out monoWidth))
+            case 1:
             {
-                monoWidth = 0;
-                for (char c1 = '!'; c1 <= '_'; c1++)
+                if (!HudType1WidthCache.TryGetValue(fontDef.Stem, out monoWidth))
                 {
-                    string patch1 = GetHudFontPatch(fontDef, c1);
-                    if (ResolveGlyph(hud, patch1, out int w, out _))
-                        monoWidth = Math.Max(monoWidth, w);
+                    monoWidth = 0;
+                    for (char c1 = '!'; c1 <= '_'; c1++)
+                    {
+                        string patch1 = GetHudFontPatch(fontDef, c1);
+                        if (ResolveGlyph(hud, patch1, out int w, out _))
+                            monoWidth = Math.Max(monoWidth, w);
+                    }
+
+                    HudType1WidthCache[fontDef.Stem] = monoWidth;
                 }
-                HudType1WidthCache[fontDef.Stem] = monoWidth;
+
+                break;
+            }
+            case 0:
+            {
+                string zero = GetHudFontPatch(fontDef, '0');
+                if (hud.Textures.TryGet(zero, out IRenderableTextureHandle? zh)) monoWidth = zh.Dimension.Width;
+                break;
             }
         }
-        else if (fontDef.Type == 0)
-        {
-            string zero = GetHudFontPatch(fontDef, '0');
-            if (hud.Textures.TryGet(zero, out var zh)) monoWidth = zh.Dimension.Width;
-        }
 
-        foreach (var originalChar in text)
+        foreach (char originalChar in text)
         {
             int width;
             string patch = string.Empty;
@@ -757,7 +900,7 @@ public class StatusBarRenderer
             if (c == ' ')
             {
                 string bang = GetHudFontPatch(fontDef, '!');
-                width = hud.Textures.TryGet(bang, out var h) ? h.Dimension.Width : 4;
+                width = hud.Textures.TryGet(bang, out IRenderableTextureHandle? h) ? h.Dimension.Width : 4;
             }
             else
             {
@@ -784,8 +927,9 @@ public class StatusBarRenderer
 
             if (monoWidth > 0) width = monoWidth;
 
-            m_glyphCache.Add(new RenderGlyph(patch, width, 0));
-            totalWidth += width;
+            int scaledWidth = (int)(width * scaleX);
+            m_glyphCache.Add(new RenderGlyph(patch, scaledWidth, 0));
+            totalWidth += scaledWidth;
         }
 
         if (m_glyphCache.Count == 0 && text.Length > 0) return 0;
@@ -797,28 +941,33 @@ public class StatusBarRenderer
         if ((alignment & StatusBarAlignment.HCenter) != 0) drawX -= totalWidth / 2;
         else if ((alignment & StatusBarAlignment.Right) != 0) drawX -= totalWidth;
 
-        if ((alignment & StatusBarAlignment.Bottom) != 0) drawY -= maxHeight;
-        else if ((alignment & StatusBarAlignment.VCenter) != 0) drawY -= maxHeight / 2;
+        int scaledMaxHeight = (int)(maxHeight * scaleY);
+        if ((alignment & StatusBarAlignment.Bottom) != 0) drawY -= scaledMaxHeight;
+        else if ((alignment & StatusBarAlignment.VCenter) != 0) drawY -= scaledMaxHeight / 2;
 
-        foreach (var g in m_glyphCache)
+        foreach (RenderGlyph g in m_glyphCache)
         {
             if (!string.IsNullOrEmpty(g.Patch))
-            {
-                DrawSBarTexture(hud, g.Patch, null, (drawX, drawY), Align.TopLeft, alignment, translation, alpha);
-            }
+                DrawSBarTexture(hud, g.Patch, null, (drawX, drawY), Align.TopLeft, alignment, translation, alpha, isNative: isNative);
             drawX += g.Width;
         }
 
         return totalWidth;
     }
 
-    private void DrawCarousel(IHudRenderContext hud, StatusBarCarouselDef carousel, Vec2I parentPos,
-        int containerHeight, StatusBarContext context, float widescreenOffset, Vec2I rootPos)
+    private void DrawCarousel(IHudRenderContext hud,
+        StatusBarCarouselDef carousel,
+        Vec2I parentPos,
+        int containerHeight,
+        StatusBarContext context,
+        float widescreenOffset,
+        Vec2I rootPos,
+        bool isNative)
     {
         if (!StatusBarConditionResolver.Evaluate(context, carousel.Conditions))
             return;
 
-        Vec2I pos = ResolvePosition(carousel, parentPos, widescreenOffset);
+        Vec2I pos = ResolvePosition(carousel, parentPos, isNative, isNative ? m_userScale : 1.0f);
         pos.X = 160;
 
         if (context.Player.Weapon != null)
@@ -828,51 +977,105 @@ public class StatusBarRenderer
             {
                 Align align = ConvertAlignment(carousel.Alignment);
                 float alpha = carousel.Translucency ? 0.5f : 1.0f;
-                DrawSBarTexture(hud, icon, null, pos, align, carousel.Alignment, carousel.Translation, alpha);
+                DrawSBarTexture(hud, icon, null, pos, align, carousel.Alignment, carousel.Translation, alpha, isNative: isNative);
             }
         }
 
-        DrawChildren(hud, carousel, pos, containerHeight, context, widescreenOffset, rootPos);
+        DrawChildren(hud, carousel, pos, containerHeight, context, widescreenOffset, rootPos, isNative);
     }
 
-        
-    private static void DrawSBarTexture(IHudRenderContext hud, string patch, IRenderableTextureHandle? handle, Vec2I pos, Align align,
-        StatusBarAlignment sbarAlign, string? translation = null, float alpha = 1.0f, StatusBarCropDef? cropDef = null)
+
+    private void DrawSBarTexture(IHudRenderContext hud,
+        string patch,
+        IRenderableTextureHandle? handle,
+        Vec2I pos,
+        Align align,
+        StatusBarAlignment sbarAlign,
+        string? translation = null,
+        float alpha = 1.0f,
+        StatusBarCropDef? cropDef = null,
+        bool isNative = false)
     {
         string pName = handle == null ? ResolvePatchName(patch) : patch;
-        ResourceNamespace ns = ResourceNamespace.Global;
-        
-        if (handle == null)
-        {
-            if (!hud.Textures.TryGet(pName, out handle))
-            {
-                ns = ResourceNamespace.Sprites;
-                if (!hud.Textures.TryGet(pName, out handle, ns))
-                    return;
-            }
-        }
+        if (handle == null && !hud.Textures.TryGet(pName, out handle) &&
+            !hud.Textures.TryGet(pName, out handle, ResourceNamespace.Sprites)) return;
 
         ImageBox2I? cropArea = GetCropArea(handle, cropDef);
-
-        bool ignoreX = (sbarAlign & StatusBarAlignment.IgnoreLeftOffset) != 0;
-        bool ignoreY = (sbarAlign & StatusBarAlignment.IgnoreTopOffset) != 0;
+        float scaleX = isNative ? m_userScale : 1.0f;
+        float scaleY = isNative ? m_userScale * 1.2f : 1.0f;
 
         Vec2I drawPos = pos;
-        if (!ignoreX) drawPos.X += RenderDimensions.TranslateDoomOffset(handle.Offset).X;
-        if (!ignoreY) drawPos.Y += RenderDimensions.TranslateDoomOffset(handle.Offset).Y;
+        Vec2I translatedOffset = RenderDimensions.TranslateDoomOffset(handle.Offset);
+
+        if ((sbarAlign & StatusBarAlignment.IgnoreLeftOffset) == 0)
+            drawPos.X += (int)(translatedOffset.X * scaleX);
+
+        if ((sbarAlign & StatusBarAlignment.IgnoreTopOffset) == 0)
+            drawPos.Y += (int)(translatedOffset.Y * scaleY);
 
         Color? drawColor = null;
-        if (!string.IsNullOrEmpty(translation))
+        if (!string.IsNullOrEmpty(translation) && StandardTextColors.TryGetValue(translation, out Color colorValue))
+            drawColor = colorValue;
+
+        int w = (int)(handle.Dimension.Width * scaleX);
+        int h = (int)(handle.Dimension.Height * scaleY);
+        int x = drawPos.X;
+        int y = drawPos.Y;
+
+        switch (align)
         {
-            if (StandardTextColors.TryGetValue(translation, out var c))
-                drawColor = c;
+            case Align.TopMiddle:
+            case Align.Center:
+            case Align.BottomMiddle: x -= w / 2; break;
+            case Align.TopRight:
+            case Align.MiddleRight:
+            case Align.BottomRight: x -= w; break;
+            case Align.TopLeft:
+            case Align.MiddleLeft:
+            case Align.BottomLeft:
+            default:
+                break;
         }
 
-        hud.Image(pName, drawPos, anchor: align, resourceNamespace: ns, alpha: alpha, color: drawColor, crop: cropArea);
+        switch (align)
+        {
+            case Align.MiddleLeft:
+            case Align.Center:
+            case Align.MiddleRight: y -= h / 2; break;
+            case Align.BottomLeft:
+            case Align.BottomMiddle:
+            case Align.BottomRight: y -= h; break;
+            case Align.TopLeft:
+            case Align.TopMiddle:
+            case Align.TopRight:
+            default:
+                break;
+        }
+
+        hud.Image(pName,
+            new HudBox((x, y), (x + w, y + h)),
+            out _,
+            Align.TopLeft,
+            Align.TopLeft,
+            null,
+            ResourceNamespace.Undefined,
+            drawColor,
+            1.0f,
+            alpha,
+            0,
+            1,
+            null,
+            cropArea);
     }
 
-    private void DrawNumber(IHudRenderContext hud, StatusBarNumberDef number, Vec2I parentPos,
-        int containerHeight, StatusBarContext context, bool isPercent, float widescreenOffset)
+    private void DrawNumber(IHudRenderContext hud,
+        StatusBarNumberDef number,
+        Vec2I parentPos,
+        int containerHeight,
+        StatusBarContext context,
+        bool isPercent,
+        float widescreenOffset,
+        bool isNative)
     {
         if (!StatusBarConditionResolver.Evaluate(context, number.Conditions))
             return;
@@ -887,7 +1090,7 @@ public class StatusBarRenderer
             if (value < minVal) value = minVal;
         }
 
-        if (!m_fontNumberLookup.TryGetValue(number.Font, out var fontDef))
+        if (!m_fontNumberLookup.TryGetValue(number.Font, out StatusBarNumberFontDef? fontDef))
             return;
 
         m_fmtSpan.Clear();
@@ -895,56 +1098,65 @@ public class StatusBarRenderer
         if (isPercent) m_fmtSpan.Append('%');
 
         ReadOnlySpan<char> text = m_fmtSpan.AsSpan();
-        Vec2I pos = ResolvePosition(number, parentPos, widescreenOffset);
+        float scaleX = isNative ? m_userScale : 1.0f;
+
+        Vec2I pos = ResolvePosition(number, parentPos, isNative, scaleX);
 
         float alpha = number.Translucency ? 0.5f : 1.0f;
         int totalWidth = 0;
         int monoWidth = 0;
 
-        if (fontDef.Type == 0)
+        switch (fontDef.Type)
         {
-            string zeroPatch = GetFontPatch(hud, fontDef, '0');
-            if (hud.Textures.TryGet(zeroPatch, out var zeroHandle))
-                monoWidth = zeroHandle.Dimension.Width;
-        }
-        else if (fontDef.Type == 1)
-        {
-            if (!Type1WidthCache.TryGetValue(fontDef.Stem, out monoWidth))
+            case 0:
             {
-                monoWidth = 0;
-                for (char d = '0'; d <= '9'; d++)
+                string zeroPatch = GetFontPatch(hud, fontDef, '0');
+                if (hud.Textures.TryGet(zeroPatch, out IRenderableTextureHandle? zeroHandle))
+                    monoWidth = zeroHandle.Dimension.Width;
+                break;
+            }
+            case 1:
+            {
+                if (!Type1WidthCache.TryGetValue(fontDef.Stem, out monoWidth))
                 {
-                    string dPatch = GetFontPatch(hud, fontDef, d);
-                    if (hud.Textures.TryGet(dPatch, out var dHandle))
-                        monoWidth = Math.Max(monoWidth, dHandle.Dimension.Width);
+                    monoWidth = 0;
+                    for (char d = '0'; d <= '9'; d++)
+                    {
+                        string dPatch = GetFontPatch(hud, fontDef, d);
+                        if (hud.Textures.TryGet(dPatch, out IRenderableTextureHandle? dHandle))
+                            monoWidth = Math.Max(monoWidth, dHandle.Dimension.Width);
+                    }
+
+                    Type1WidthCache[fontDef.Stem] = monoWidth;
                 }
-                Type1WidthCache[fontDef.Stem] = monoWidth;
+
+                break;
             }
         }
 
         m_glyphCache.Clear();
 
-        foreach (var c in text)
+        foreach (char c in text)
         {
             string patch = GetFontPatch(hud, fontDef, c);
             int width;
             int xOffset = 0;
 
-            if (hud.Textures.TryGet(patch, out var handle)) width = handle.Dimension.Width;
-            else if (hud.Textures.TryGet(patch, out handle, ResourceNamespace.Sprites)) width = handle.Dimension.Width;
-            else continue;
+            if (hud.Textures.TryGet(patch, out IRenderableTextureHandle? handle) ||
+                hud.Textures.TryGet(patch, out handle, ResourceNamespace.Sprites)) width = handle.Dimension.Width;
+            else
+                continue;
 
-            if (fontDef.Type == 0 || fontDef.Type == 1)
-            {
+            if (fontDef.Type is 0 or 1)
                 if (monoWidth > 0)
                 {
                     if (width < monoWidth) xOffset = (monoWidth - width) / 2;
                     width = monoWidth;
                 }
-            }
 
-            m_glyphCache.Add(new RenderGlyph(patch, width, xOffset, handle));
-            totalWidth += width;
+            int scaledWidth = (int)(width * scaleX);
+            m_glyphCache.Add(new RenderGlyph(patch, scaledWidth, (int)(xOffset * scaleX), handle));
+            totalWidth += scaledWidth;
         }
 
         int drawX = pos.X;
@@ -955,34 +1167,48 @@ public class StatusBarRenderer
 
         Align yAnchor = (number.Alignment & StatusBarAlignment.Bottom) != 0 ? Align.BottomLeft : Align.TopLeft;
 
-        foreach (var g in m_glyphCache)
+        foreach (RenderGlyph g in m_glyphCache)
         {
             Vec2I drawPos = (drawX + g.Offset, drawY);
-            DrawSBarTexture(hud, g.Patch, g.Handle, drawPos, yAnchor, number.Alignment, number.Translation, alpha);
+            DrawSBarTexture(hud, g.Patch, g.Handle, drawPos, yAnchor, number.Alignment, number.Translation, alpha, isNative: isNative);
             drawX += g.Width;
         }
 
-        DrawChildren(hud, number, pos, containerHeight, context, widescreenOffset, (0, 0));
+        DrawChildren(hud, number, pos, containerHeight, context, widescreenOffset, (0, 0), isNative);
     }
 
-    private void DrawStatTotals(IHudRenderContext hud, StatusBarComponentDef comp, Vec2I pos,
-        StatusBarHudFontDef? fontDef, int fontHeight, float alpha)
+    private void DrawStatTotals(IHudRenderContext hud,
+        StatusBarComponentDef comp,
+        Vec2I pos,
+        StatusBarHudFontDef? fontDef,
+        int fontHeight,
+        float alpha,
+        bool isNative)
     {
-        var stats = m_world.LevelStats;
-        DrawStatPart(hud, "K: ", stats.KillCount, stats.TotalMonsters, ref pos, comp, fontDef, fontHeight, alpha);
-        DrawStatPart(hud, "I: ", stats.ItemCount, stats.TotalItems, ref pos, comp, fontDef, fontHeight, alpha);
-        DrawStatPart(hud, "S: ", stats.SecretCount, stats.TotalSecrets, ref pos, comp, fontDef, fontHeight, alpha);
+        LevelStats stats = m_world.LevelStats;
+        Vec2I cur = pos;
+        DrawStatPart(hud, "K: ", stats.KillCount, stats.TotalMonsters, ref cur, comp, fontDef, fontHeight, alpha, isNative);
+        DrawStatPart(hud, "I: ", stats.ItemCount, stats.TotalItems, ref cur, comp, fontDef, fontHeight, alpha, isNative);
+        DrawStatPart(hud, "S: ", stats.SecretCount, stats.TotalSecrets, ref cur, comp, fontDef, fontHeight, alpha, isNative);
     }
 
-    private void DrawStatPart(IHudRenderContext hud, string label, int count, int total, ref Vec2I cursor,
-        StatusBarComponentDef comp, StatusBarHudFontDef? fontDef, int fontHeight, float alpha)
+    private void DrawStatPart(IHudRenderContext hud,
+        string label,
+        int count,
+        int total,
+        ref Vec2I cursor,
+        StatusBarComponentDef comp,
+        StatusBarHudFontDef? fontDef,
+        int fontHeight,
+        float alpha,
+        bool isNative)
     {
         string? defaultColor = comp.Translation;
         string? valueColor = defaultColor;
 
         if (total != int.MinValue && total > 0 && count >= total) valueColor = "CRGREEN";
 
-        int labelWidth = DrawTextPart(hud, label.AsSpan(), cursor, defaultColor, comp.Alignment, fontDef, alpha);
+        int labelWidth = DrawTextPart(hud, label.AsSpan(), cursor, defaultColor, comp.Alignment, fontDef, alpha, isNative);
         Vec2I valuePos = cursor;
         valuePos.X += labelWidth;
 
@@ -991,32 +1217,40 @@ public class StatusBarRenderer
         m_fmtSpan.Append('/');
         m_fmtSpan.Append(total);
 
-        int valueWidth = DrawTextPart(hud, m_fmtSpan.AsSpan(), valuePos, valueColor, comp.Alignment, fontDef, alpha);
+        int valueWidth = DrawTextPart(hud, m_fmtSpan.AsSpan(), valuePos, valueColor, comp.Alignment, fontDef, alpha, isNative);
 
-        if (comp.Vertical) cursor.Y += fontHeight;
-        else cursor.X += labelWidth + valueWidth + 8;
+        float scale = isNative ? m_userScale : 1.0f;
+        if (comp.Vertical) cursor.Y += (int)(fontHeight * (isNative ? m_userScale * 1.2f : 1.0f));
+        else cursor.X += labelWidth + valueWidth + (int)(8 * scale);
     }
 
-    private void DrawCoordinates(IHudRenderContext hud, StatusBarComponentDef comp, Vec2I pos,
-        StatusBarHudFontDef? fontDef, int fontHeight, float alpha, StatusBarContext context)
+    private void DrawCoordinates(IHudRenderContext hud,
+        StatusBarComponentDef comp,
+        Vec2I pos,
+        StatusBarHudFontDef? fontDef,
+        int fontHeight,
+        float alpha,
+        StatusBarContext context,
+        bool isNative)
     {
-        var playerPos = context.Player.Position;
+        Vec3D playerPos = context.Player.Position;
         m_coordPartsCache.Clear();
         m_coordPartsCache.Add(new CoordData("X: ", (int)playerPos.X, 0, 0));
         m_coordPartsCache.Add(new CoordData("Y: ", (int)playerPos.Y, 0, 0));
         m_coordPartsCache.Add(new CoordData("Z: ", (int)playerPos.Z, 0, 0));
 
+        float scale = isNative ? m_userScale : 1.0f;
         int totalHorizontalWidth = 0;
         for (int i = 0; i < m_coordPartsCache.Count; i++)
         {
-            var data = m_coordPartsCache[i];
-            int lw = MeasureSpan(hud, data.Label.AsSpan(), "CRGREEN", fontDef, alpha);
+            CoordData data = m_coordPartsCache[i];
+            int lw = MeasureSpan(hud, data.Label.AsSpan(), "CRGREEN", fontDef, alpha, isNative);
             m_fmtSpan.Clear();
             m_fmtSpan.Append(data.Value);
-            int vw = MeasureSpan(hud, m_fmtSpan.AsSpan(), comp.Translation, fontDef, alpha);
+            int vw = MeasureSpan(hud, m_fmtSpan.AsSpan(), comp.Translation, fontDef, alpha, isNative);
             m_coordPartsCache[i] = data with { LabelWidth = lw, ValWidth = vw };
             totalHorizontalWidth += lw + vw;
-            if (i < m_coordPartsCache.Count - 1) totalHorizontalWidth += 8;
+            if (i < m_coordPartsCache.Count - 1) totalHorizontalWidth += (int)(8 * scale);
         }
 
         Vec2I cursor = pos;
@@ -1026,8 +1260,7 @@ public class StatusBarRenderer
             else if ((comp.Alignment & StatusBarAlignment.HCenter) != 0) cursor.X -= totalHorizontalWidth / 2;
         }
 
-        foreach (var data in m_coordPartsCache)
-        {
+        foreach (CoordData data in m_coordPartsCache)
             if (comp.Vertical)
             {
                 int lineWidth = data.LabelWidth + data.ValWidth;
@@ -1035,246 +1268,434 @@ public class StatusBarRenderer
                 if ((comp.Alignment & StatusBarAlignment.Right) != 0) lineX -= lineWidth;
                 else if ((comp.Alignment & StatusBarAlignment.HCenter) != 0) lineX -= lineWidth / 2;
 
-                DrawTextPart(hud, data.Label.AsSpan(), (lineX, cursor.Y), "CRGREEN",
-                    StatusBarAlignment.Left, fontDef, alpha);
+                _ = DrawTextPart(hud, data.Label.AsSpan(), (lineX, cursor.Y), "CRGREEN", StatusBarAlignment.Left, fontDef, alpha, isNative);
+
                 m_fmtSpan.Clear();
                 m_fmtSpan.Append(data.Value);
-                DrawTextPart(hud, m_fmtSpan.AsSpan(), (lineX + data.LabelWidth, cursor.Y),
-                    comp.Translation, StatusBarAlignment.Left, fontDef, alpha);
-                cursor.Y += fontHeight;
+
+                _ = DrawTextPart(hud,
+                    m_fmtSpan.AsSpan(),
+                    (lineX + data.LabelWidth, cursor.Y),
+                    comp.Translation,
+                    StatusBarAlignment.Left,
+                    fontDef,
+                    alpha,
+                    isNative);
+
+                cursor.Y += (int)(fontHeight * (isNative ? m_userScale * 1.2f : 1.0f));
             }
             else
             {
-                DrawTextPart(hud, data.Label.AsSpan(), cursor, "CRGREEN",
-                    StatusBarAlignment.Left, fontDef, alpha);
-                cursor.X += data.LabelWidth;
+                cursor.X += DrawTextPart(hud, data.Label.AsSpan(), cursor, "CRGREEN", StatusBarAlignment.Left, fontDef, alpha, isNative);
+
                 m_fmtSpan.Clear();
                 m_fmtSpan.Append(data.Value);
-                DrawTextPart(hud, m_fmtSpan.AsSpan(), cursor,
-                    comp.Translation, StatusBarAlignment.Left, fontDef, alpha);
-                cursor.X += data.ValWidth + 8;
+
+                cursor.X += DrawTextPart(hud,
+                    m_fmtSpan.AsSpan(),
+                    cursor,
+                    comp.Translation,
+                    StatusBarAlignment.Left,
+                    fontDef,
+                    alpha,
+                    isNative);
+
+                cursor.X += (int)(8 * scale);
             }
-        }
     }
 
-    private int MeasureSpan(IHudRenderContext hud, ReadOnlySpan<char> t, string? trans, StatusBarHudFontDef? fontDef, float alpha)
+    private int MeasureSpan(IHudRenderContext hud,
+        ReadOnlySpan<char> t,
+        string? trans,
+        StatusBarHudFontDef? fontDef,
+        float alpha,
+        bool isNative)
     {
         if (fontDef != null)
-            return DrawHudText(hud, t, fontDef, (0, 0), StatusBarAlignment.Left, trans, alpha, false);
-        return hud.MeasureText(t, Constants.Fonts.Small, 8).Width;
+            return DrawHudText(hud, t, fontDef, (0, 0), StatusBarAlignment.Left, trans, alpha, isNative, false);
+
+        float textScale = isNative ? m_userScale : 1.0f;
+        return (int)(hud.MeasureText(t, Constants.Fonts.Small, 8).Width * textScale);
     }
 
-    private int DrawTextPart(IHudRenderContext hud, ReadOnlySpan<char> text, Vec2I position, string? translation,
-        StatusBarAlignment alignment, StatusBarHudFontDef? fontDef, float alpha)
+    private int DrawTextPart(IHudRenderContext hud,
+        ReadOnlySpan<char> text,
+        Vec2I position,
+        string? translation,
+        StatusBarAlignment alignment,
+        StatusBarHudFontDef? fontDef,
+        float alpha,
+        bool isNative)
     {
         if (fontDef != null)
-            return DrawHudText(hud, text, fontDef, position, alignment, translation, alpha);
+            return DrawHudText(hud, text, fontDef, position, alignment, translation, alpha, isNative);
 
         Align align = ConvertAlignment(alignment);
-        Color? color = !string.IsNullOrEmpty(translation) && StandardTextColors.TryGetValue(translation, out var c) ? c : null;
-        hud.Text(text, Constants.Fonts.Small, 8, position, both: align, alpha: alpha, color: color);
-        return hud.MeasureText(text, Constants.Fonts.Small, 8).Width;
+        Color? color = !string.IsNullOrEmpty(translation) && StandardTextColors.TryGetValue(translation, out Color c) ? c : null;
+        float textScale = isNative ? m_userScale : 1.0f;
+
+        hud.Text(text, Constants.Fonts.Small, 8, position, both: align, alpha: alpha, color: color, scale: textScale);
+        return (int)(hud.MeasureText(text, Constants.Fonts.Small, 8).Width * textScale);
     }
 
-    private void DrawChildren(IHudRenderContext hud, StatusBarBaseDef def, Vec2I pos, int containerHeight,
-        StatusBarContext context, float widescreenOffset, Vec2I rootPos)
+    private void DrawChildren(IHudRenderContext hud,
+        StatusBarBaseDef def,
+        Vec2I pos,
+        int containerHeight,
+        StatusBarContext context,
+        float widescreenOffset,
+        Vec2I rootPos,
+        bool isNative)
     {
         if (def.Children == null) return;
 
-        foreach (var child in def.Children)
+        foreach (StatusBarElementWrapper child in def.Children)
         {
             if (!EvaluateWrapperConditions(child, context))
                 continue;
 
-            DrawElementWrapper(hud, child, pos, containerHeight, context, widescreenOffset, rootPos);
+            DrawElementWrapper(hud, child, pos, containerHeight, context, widescreenOffset, rootPos, isNative);
         }
     }
 
-    private Vec2I MeasureElement(IHudRenderContext hud, StatusBarElementWrapper wrapper, StatusBarContext context)
+    private ElementBounds MeasureElement(IHudRenderContext hud,
+        StatusBarElementWrapper wrapper,
+        StatusBarContext context,
+        bool isNative,
+        float sX = 1.0f,
+        float sY = 1.0f)
     {
-        if (wrapper.Graphic != null) return MeasureGraphic(wrapper.Graphic);
-        if (wrapper.Number != null) return MeasureNumber(hud, wrapper.Number, context, false);
-        if (wrapper.Percent != null) return MeasureNumber(hud, wrapper.Percent, context, true);
-        if (wrapper.Face != null) return MeasureFace(hud, wrapper.Face, context);
-        if (wrapper.String != null) return MeasureString(hud, wrapper.String);
-        if (wrapper.Canvas != null) return MeasureCanvas(hud, wrapper.Canvas, context);
-        if (wrapper.List != null) return MeasureList(hud, wrapper.List, context);
+        float scaleX = isNative ? sX : 1.0f;
+        float scaleY = isNative ? sY : 1.0f;
 
-        return Vec2I.Zero;
+        if (wrapper.Graphic != null) return MeasureGraphic(wrapper.Graphic, scaleX, scaleY);
+        if (wrapper.Number != null) return MeasureNumber(hud, wrapper.Number, context, false, isNative, scaleX, scaleY);
+        if (wrapper.Percent != null) return MeasureNumber(hud, wrapper.Percent, context, true, isNative, scaleX, scaleY);
+        if (wrapper.Face != null) return MeasureFace(hud, wrapper.Face, context, scaleX, scaleY);
+        if (wrapper.String != null) return MeasureString(hud, wrapper.String, isNative, scaleX, scaleY);
+        if (wrapper.Canvas != null) return MeasureBase(hud, wrapper.Canvas, context, isNative, scaleX, scaleY);
+        if (wrapper.List != null) return MeasureList(hud, wrapper.List, context, isNative, scaleX, scaleY);
+        if (wrapper.Component != null) return MeasureComponent(hud, wrapper.Component, isNative, scaleX, scaleY);
+        if (wrapper.Carousel != null) return MeasureCarousel(hud, wrapper.Carousel, context, scaleX, scaleY);
+
+        if (wrapper.Native == null) return ElementBounds.Empty;
+        ElementBounds bounds = MeasureBase(hud, wrapper.Native, context, true, m_userScale, m_userScale * 1.2f);
+        return !isNative && m_currentScale > 0
+            ? new ElementBounds((int)(bounds.X1 / m_currentScale),
+                (int)(bounds.Y1 / m_currentScale),
+                (int)(bounds.X2 / m_currentScale),
+                (int)(bounds.Y2 / m_currentScale))
+            : bounds;
     }
 
-    private static Vec2I MeasureGraphic(StatusBarGraphicDef def)
+    private ElementBounds MeasureBase(IHudRenderContext hud,
+        StatusBarBaseDef def,
+        StatusBarContext context,
+        bool isNative,
+        float sX,
+        float sY)
     {
-        var handle = def.Handle;
-        if (handle == null) return Vec2I.Zero;
+        if (def.Children == null || def.Children.Count == 0) return ElementBounds.Empty;
 
-        Vec2I size = handle.Dimension.Vector;
-        int posX = def.X;
-        int posY = def.Y;
+        ElementBounds contentBounds = ElementBounds.Empty;
+        foreach (StatusBarElementWrapper t in def.Children)
+        {
+            if (!EvaluateWrapperConditions(t, context)) continue;
+            contentBounds = ElementBounds.Union(contentBounds, MeasureElement(hud, t, context, isNative, sX, sY));
+        }
+
+        if (contentBounds.X1 == int.MaxValue) return ElementBounds.Empty;
+
+        int posX = (int)(def.X * sX);
+        int posY = (int)(def.Y * sY);
+        ElementBounds containerPos = ApplyAlignment(new Vec2I(contentBounds.Width, contentBounds.Height), posX, posY, def.Alignment);
+
+        return new ElementBounds(containerPos.X1 + contentBounds.X1,
+            containerPos.Y1 + contentBounds.Y1,
+            containerPos.X1 + contentBounds.X2,
+            containerPos.Y1 + contentBounds.Y2);
+    }
+
+    private static ElementBounds MeasureGraphic(StatusBarGraphicDef def, float scaleX, float scaleY)
+    {
+        IRenderableTextureHandle? handle = def.Handle;
+        if (handle == null) return ElementBounds.Empty;
+
+        Vec2I size = new((int)(handle.Dimension.Width * scaleX), (int)(handle.Dimension.Height * scaleY));
+        int posX = (int)(def.X * scaleX);
+        int posY = (int)(def.Y * scaleY);
+
+        Vec2I translatedOffset = RenderDimensions.TranslateDoomOffset(handle.Offset);
 
         if ((def.Alignment & StatusBarAlignment.IgnoreLeftOffset) == 0)
-            posX += RenderDimensions.TranslateDoomOffset(handle.Offset).X;
+            posX += (int)(translatedOffset.X * scaleX);
+
         if ((def.Alignment & StatusBarAlignment.IgnoreTopOffset) == 0)
-            posY += RenderDimensions.TranslateDoomOffset(handle.Offset).Y;
+            posY += (int)(translatedOffset.Y * scaleY);
 
         return ApplyAlignment(size, posX, posY, def.Alignment);
     }
 
-    private Vec2I MeasureNumber(IHudRenderContext hud, StatusBarNumberDef def, StatusBarContext context, bool isPercent)
+    private ElementBounds MeasureNumber(IHudRenderContext hud,
+        StatusBarNumberDef def,
+        StatusBarContext context,
+        bool isPercent,
+        bool isNative,
+        float scaleX,
+        float scaleY)
     {
         m_fmtSpan.Clear();
         m_fmtSpan.Append(ResolveNumberValue(context.Player, def.Type, def.Param));
         if (isPercent) m_fmtSpan.Append('%');
-        
-        int width = MeasureSpan(hud, m_fmtSpan.AsSpan(), null, null, 1.0f);
-        int height = def.ResolvedHeight > 0 ? def.ResolvedHeight : 8;
 
-        return ApplyAlignment(new Vec2I(width, height), def.X, def.Y, def.Alignment);
+        int width = MeasureSpan(hud, m_fmtSpan.AsSpan(), null, null, 1.0f, isNative);
+        int height = (int)((def.ResolvedHeight > 0 ? def.ResolvedHeight : 8) * scaleY);
+
+        int posX = (int)(def.X * scaleX);
+        int posY = (int)(def.Y * scaleY);
+        return ApplyAlignment(new Vec2I(width, height), posX, posY, def.Alignment);
     }
 
-    private static Vec2I MeasureFace(IHudRenderContext hud, StatusBarFaceDef def, StatusBarContext context)
+    private static ElementBounds MeasureFace(IHudRenderContext hud,
+        StatusBarFaceDef def,
+        StatusBarContext context,
+        float scaleX,
+        float scaleY)
     {
         string p = context.Player.StatusBar.GetFacePatch();
-        if (!hud.Textures.TryGet(p, out var h)) return Vec2I.Zero;
+        if (!hud.Textures.TryGet(p, out IRenderableTextureHandle? h)) return ElementBounds.Empty;
 
-        Vec2I size = h.Dimension.Vector;
-        int posX = def.X;
-        int posY = def.Y;
+        Vec2I size = new((int)(h.Dimension.Width * scaleX), (int)(h.Dimension.Height * scaleY));
+        int posX = (int)(def.X * scaleX);
+        int posY = (int)(def.Y * scaleY);
+
+        Vec2I translatedOffset = RenderDimensions.TranslateDoomOffset(h.Offset);
 
         if ((def.Alignment & StatusBarAlignment.IgnoreLeftOffset) == 0)
-            posX += RenderDimensions.TranslateDoomOffset(h.Offset).X;
+            posX += (int)(translatedOffset.X * scaleX);
+
         if ((def.Alignment & StatusBarAlignment.IgnoreTopOffset) == 0)
-            posY += RenderDimensions.TranslateDoomOffset(h.Offset).Y;
+            posY += (int)(translatedOffset.Y * scaleY);
 
         return ApplyAlignment(size, posX, posY, def.Alignment);
     }
 
-    private Vec2I MeasureString(IHudRenderContext hud, StatusBarStringDef def)
+    private ElementBounds MeasureString(IHudRenderContext hud, StatusBarStringDef def, bool isNative, float scaleX, float scaleY)
     {
-        var text = GetStringValue(def);
-        m_hudFontLookup.TryGetValue(def.Font, out var f);
-        
-        int width = MeasureSpan(hud, text, null, f, 1.0f);
-        int height = def.ResolvedHeight > 0 ? def.ResolvedHeight : 8;
+        ReadOnlySpan<char> text = GetStringValue(def);
 
-        return ApplyAlignment(new Vec2I(width, height), def.X, def.Y, def.Alignment);
+        _ = m_hudFontLookup.TryGetValue(def.Font, out StatusBarHudFontDef? f);
+
+        int width = MeasureSpan(hud, text, null, f, 1.0f, isNative);
+        int height = (int)((def.ResolvedHeight > 0 ? def.ResolvedHeight : 8) * scaleY);
+
+        int posX = (int)(def.X * scaleX);
+        int posY = (int)(def.Y * scaleY);
+        return ApplyAlignment(new Vec2I(width, height), posX, posY, def.Alignment);
     }
 
-    private Vec2I MeasureCanvas(IHudRenderContext hud, StatusBarCanvasDef def, StatusBarContext context)
+    private ElementBounds MeasureList(IHudRenderContext hud,
+        StatusBarListDef def,
+        StatusBarContext context,
+        bool isNative,
+        float scaleX,
+        float scaleY)
     {
-        if (def.Children == null) return Vec2I.Zero;
-        int maxX = 0, maxY = 0;
-        foreach (var t in def.Children)
-        {
-            var cSize = MeasureElement(hud, t, context);
-            if (cSize.X > maxX) maxX = cSize.X;
-            if (cSize.Y > maxY) maxY = cSize.Y;
-        }
-        return ApplyAlignment(new Vec2I(maxX, maxY), def.X, def.Y, def.Alignment);
-    }
-
-    private Vec2I MeasureList(IHudRenderContext hud, StatusBarListDef def, StatusBarContext context)
-    {
-        if (def.Children == null) return Vec2I.Zero;
+        if (def.Children == null) return ElementBounds.Empty;
 
         int totalW = 0;
         int totalH = 0;
         int count = 0;
 
-        foreach (var child in def.Children)
-        {
-            if (!EvaluateWrapperConditions(child, context))
-                continue;
+        int spacing = (int)(def.Spacing * (isNative ? m_userScale : 1.0f));
 
-            var size = MeasureElement(hud, child, context);
+        foreach (StatusBarElementWrapper child in def.Children)
+        {
+            if (!EvaluateWrapperConditions(child, context)) continue;
+
+            ElementBounds size = MeasureElement(hud, child, context, isNative, scaleX, scaleY);
             if (def.Horizontal)
             {
-                totalW += size.X;
-                if (count > 0) totalW += def.Spacing;
-                if (size.Y > totalH) totalH = size.Y;
+                totalW += size.Width;
+                if (count > 0) totalW += spacing;
+                totalH = Math.Max(totalH, size.Height);
             }
             else
             {
-                totalH += size.Y;
-                if (count > 0) totalH += def.Spacing;
-                if (size.X > totalW) totalW = size.X;
+                totalH += size.Height;
+                if (count > 0) totalH += spacing;
+                totalW = Math.Max(totalW, size.Width);
             }
+
             count++;
         }
 
-        return ApplyAlignment(new Vec2I(totalW, totalH), def.X, def.Y, def.Alignment);
+        int posX = (int)(def.X * scaleX);
+        int posY = (int)(def.Y * scaleY);
+
+        return ApplyAlignment(new Vec2I(totalW, totalH), posX, posY, def.Alignment);
     }
 
-    private static Vec2I ApplyAlignment(Vec2I size, int posX, int posY, StatusBarAlignment alignment)
+    private ElementBounds MeasureComponent(IHudRenderContext hud, StatusBarComponentDef comp, bool isNative, float scaleX, float scaleY)
     {
-        _ = alignment;
-        return new Vec2I(size.X + Math.Max(0, posX), size.Y + Math.Max(0, posY));
+        int fontHeight = 8;
+        if (m_hudFontLookup.TryGetValue(comp.Font, out StatusBarHudFontDef? fontDef) &&
+            StemToHelionFontMap.TryGetValue(fontDef.Stem, out string? helionFontName))
+        {
+            int h = hud.GetFontMaxHeight(helionFontName);
+            if (h > 0) fontHeight = h;
+        }
+
+        Vec2I size = Vec2I.Zero;
+
+        switch (comp.ComponentType)
+        {
+            case StatusBarComponentType.StatTotals:
+                if (m_world.Config.Hud.ShowStats.Value)
+                {
+                    const string Dummy = "K: 000/000 I: 000/000 S: 000/000";
+                    int w = MeasureSpan(hud, Dummy.AsSpan(), null, fontDef, 1.0f, isNative);
+                    size = comp.Vertical ? (w / 3, (int)(fontHeight * 3 * scaleY)) : (w, (int)(fontHeight * scaleY));
+                }
+
+                break;
+
+            case StatusBarComponentType.Time:
+                size = (MeasureSpan(hud, "00:00:00".AsSpan(), null, fontDef, 1.0f, isNative), (int)(fontHeight * scaleY));
+                break;
+
+            case StatusBarComponentType.LevelTitle:
+            case StatusBarComponentType.AnnounceLevelTitle:
+                string title = m_world.MapInfo.GetDisplayNameWithPrefix(m_archiveCollection.Language);
+                size = (MeasureSpan(hud, title.AsSpan(), null, fontDef, 1.0f, isNative), (int)(fontHeight * scaleY));
+                break;
+
+            case StatusBarComponentType.FpsCounter:
+                if (m_world.Config.Hud.ShowFPS.Value)
+                    size = (MeasureSpan(hud, "000".AsSpan(), null, fontDef, 1.0f, isNative), (int)(fontHeight * scaleY));
+                break;
+
+            case StatusBarComponentType.Message:
+                size = Vec2I.Zero;
+                break;
+
+            case StatusBarComponentType.Unknown:
+            case StatusBarComponentType.Coordinates:
+            case StatusBarComponentType.Speedometer:
+            case StatusBarComponentType.RenderStats:
+            case StatusBarComponentType.CommandHistory:
+            case StatusBarComponentType.Chat:
+            default:
+                break;
+        }
+
+        int posX = (int)(comp.X * scaleX);
+        int posY = (int)(comp.Y * scaleY);
+
+        return ApplyAlignment(size, posX, posY, comp.Alignment);
+    }
+
+    private static ElementBounds MeasureCarousel(IHudRenderContext hud,
+        StatusBarCarouselDef carousel,
+        StatusBarContext context,
+        float scaleX,
+        float scaleY)
+    {
+        Vec2I size = Vec2I.Zero;
+        if (context.Player.Weapon != null)
+        {
+            string icon = context.Player.Weapon.Definition.Properties.Inventory.Icon;
+            if (!string.IsNullOrEmpty(icon) && hud.Textures.TryGet(icon, out IRenderableTextureHandle? handle))
+                size = new Vec2I((int)(handle.Dimension.Width * scaleX), (int)(handle.Dimension.Height * scaleY));
+        }
+
+        int posX = (int)(carousel.X * scaleX);
+        int posY = (int)(carousel.Y * scaleY);
+
+        return ApplyAlignment(size, posX, posY, carousel.Alignment);
+    }
+
+    private static ElementBounds ApplyAlignment(Vec2I size, int posX, int posY, StatusBarAlignment alignment)
+    {
+        int x1 = posX;
+        int y1 = posY;
+
+        if ((alignment & StatusBarAlignment.HCenter) != 0) x1 -= size.X / 2;
+        else if ((alignment & StatusBarAlignment.Right) != 0) x1 -= size.X;
+
+        if ((alignment & StatusBarAlignment.VCenter) != 0) y1 -= size.Y / 2;
+        else if ((alignment & StatusBarAlignment.Bottom) != 0) y1 -= size.Y;
+
+        return new ElementBounds(x1, y1, x1 + size.X, y1 + size.Y);
     }
 
     private static string ResolvePatchName(string patch)
     {
-        if (string.IsNullOrEmpty(patch)) return patch;
-        if (patch.Contains('/') || patch.Contains('.'))
-        {
-            int lastSlash = patch.LastIndexOf('/') + 1;
-            int lastDot = patch.LastIndexOf('.');
-            if (lastDot < lastSlash) lastDot = patch.Length;
-            return patch.Substring(lastSlash, lastDot - lastSlash);
-        }
-        return patch;
+        if (string.IsNullOrEmpty(patch) || (!patch.Contains('/') && !patch.Contains('.')))
+            return patch;
+
+        int lastSlash = patch.LastIndexOf('/') + 1;
+        int lastDot = patch.LastIndexOf('.');
+
+        if (lastDot < lastSlash)
+            lastDot = patch.Length;
+
+        return patch[lastSlash..lastDot];
     }
 
     private ReadOnlySpan<char> GetStringValue(StatusBarStringDef def)
     {
-        switch (def.Type)
+        return def.Type switch
         {
-            case 0: return def.Data.AsSpan();
-            case 1: return m_world.MapInfo.GetDisplayNameWithPrefix(m_archiveCollection.Language).AsSpan();
-            case 2: return m_world.MapInfo.Label.AsSpan();
-            case 3: return m_world.MapInfo.Author.AsSpan();
-            default: return ReadOnlySpan<char>.Empty;
-        }
+            0 => def.Data.AsSpan(),
+            1 => m_world.MapInfo.GetDisplayNameWithPrefix(m_archiveCollection.Language).AsSpan(),
+            2 => m_world.MapInfo.Label.AsSpan(),
+            3 => m_world.MapInfo.Author.AsSpan(),
+            _ => []
+        };
     }
 
     private static bool EvaluateWrapperConditions(StatusBarElementWrapper wrapper, StatusBarContext context)
     {
-        if (wrapper.Canvas != null) return StatusBarConditionResolver.Evaluate(context, wrapper.Canvas.Conditions);
-        if (wrapper.Graphic != null) return StatusBarConditionResolver.Evaluate(context, wrapper.Graphic.Conditions);
-        if (wrapper.Number != null) return StatusBarConditionResolver.Evaluate(context, wrapper.Number.Conditions);
-        if (wrapper.Percent != null) return StatusBarConditionResolver.Evaluate(context, wrapper.Percent.Conditions);
-        if (wrapper.Face != null) return StatusBarConditionResolver.Evaluate(context, wrapper.Face.Conditions);
-        if (wrapper.Animation != null) return StatusBarConditionResolver.Evaluate(context, wrapper.Animation.Conditions);
-        if (wrapper.Component != null) return StatusBarConditionResolver.Evaluate(context, wrapper.Component.Conditions);
-        if (wrapper.Carousel != null) return StatusBarConditionResolver.Evaluate(context, wrapper.Carousel.Conditions);
-        if (wrapper.List != null) return StatusBarConditionResolver.Evaluate(context, wrapper.List.Conditions);
-        if (wrapper.String != null) return StatusBarConditionResolver.Evaluate(context, wrapper.String.Conditions);
-        return true;
+        return wrapper switch
+        {
+            { Canvas: not null } => StatusBarConditionResolver.Evaluate(context, wrapper.Canvas.Conditions),
+            { Graphic: not null } => StatusBarConditionResolver.Evaluate(context, wrapper.Graphic.Conditions),
+            { Number: not null } => StatusBarConditionResolver.Evaluate(context, wrapper.Number.Conditions),
+            { Percent: not null } => StatusBarConditionResolver.Evaluate(context, wrapper.Percent.Conditions),
+            { Face: not null } => StatusBarConditionResolver.Evaluate(context, wrapper.Face.Conditions),
+            { Animation: not null } => StatusBarConditionResolver.Evaluate(context, wrapper.Animation.Conditions),
+            { Component: not null } => StatusBarConditionResolver.Evaluate(context, wrapper.Component.Conditions),
+            { Carousel: not null } => StatusBarConditionResolver.Evaluate(context, wrapper.Carousel.Conditions),
+            { List: not null } => StatusBarConditionResolver.Evaluate(context, wrapper.List.Conditions),
+            { String: not null } => StatusBarConditionResolver.Evaluate(context, wrapper.String.Conditions),
+            _ => true
+        };
     }
 
-    private static Vec2I ResolvePosition(StatusBarBaseDef def, Vec2I parentPos, float widescreenOffset)
+    private static Vec2I ResolvePosition(StatusBarBaseDef def, Vec2I parentPos, bool isNative, float scale)
     {
         Vec2I pos = parentPos;
-        pos.X += def.X;
-        pos.Y += def.Y;
 
-        if (widescreenOffset > 0)
-        {
-            int offset = (int)Math.Ceiling(widescreenOffset);
-            if ((def.Alignment & StatusBarAlignment.WidescreenLeft) != 0) pos.X -= offset;
-            else if ((def.Alignment & StatusBarAlignment.WidescreenRight) != 0) pos.X += offset;
-        }
+        int x = (int)(def.X * scale);
+        int y = (int)(def.Y * (isNative ? scale * 1.2f : scale));
+
+        pos.X += x;
+        pos.Y += y;
+
         return pos;
     }
 
     private static bool ResolveGlyph(IHudRenderContext hud, string patch, out int width, out int height)
     {
         string p = ResolvePatchName(patch);
-        if (hud.Textures.TryGet(p, out var handle) || hud.Textures.TryGet(p, out handle, ResourceNamespace.Sprites))
+        if (hud.Textures.TryGet(p, out IRenderableTextureHandle? handle) || hud.Textures.TryGet(p, out handle, ResourceNamespace.Sprites))
         {
             width = handle.Dimension.Width;
             height = handle.Dimension.Height;
             return true;
         }
+
         width = height = 0;
         return false;
     }
@@ -1285,8 +1706,8 @@ public class StatusBarRenderer
         m_lookupKeySpan.Append(font.Stem);
         m_lookupKeySpan.Append(c);
 
-        var lookup = HudFontPatchCache.GetAlternateLookup<ReadOnlySpan<char>>();
-        if (lookup.TryGetValue(m_lookupKeySpan.AsSpan(), out var cached)) return cached;
+        Dictionary<string, string>.AlternateLookup<ReadOnlySpan<char>> lookup = HudFontPatchCache.GetAlternateLookup<ReadOnlySpan<char>>();
+        if (lookup.TryGetValue(m_lookupKeySpan.AsSpan(), out string? cached)) return cached;
 
         string result = font.Stem + ((int)c).ToString("D3", CultureInfo.InvariantCulture);
         HudFontPatchCache[font.Stem + c] = result;
@@ -1298,28 +1719,21 @@ public class StatusBarRenderer
         m_lookupKeySpan.Clear();
         m_lookupKeySpan.Append(font.Stem);
         m_lookupKeySpan.Append(c);
-        var lookup = FontPatchCache.GetAlternateLookup<ReadOnlySpan<char>>();
-        if (lookup.TryGetValue(m_lookupKeySpan.AsSpan(), out var cached)) return cached;
+        Dictionary<string, string>.AlternateLookup<ReadOnlySpan<char>> lookup = FontPatchCache.GetAlternateLookup<ReadOnlySpan<char>>();
+        if (lookup.TryGetValue(m_lookupKeySpan.AsSpan(), out string? cached)) return cached;
 
-        string result;
-        if (c == '-')
+        string result = c switch
         {
-            string p = font.Stem + "MINUS";
-            result = hud.Textures.HasImage(p) ? p : font.Stem + "-";
-        }
-        else if (c == '%')
-        {
-            string p = font.Stem + "PRCNT";
-            if (!hud.Textures.HasImage(p)) p = font.Stem + "PRCN";
-            if (!hud.Textures.HasImage(p)) p = font.Stem + "PERCENT";
-            result = hud.Textures.HasImage(p) ? p : font.Stem + "%";
-        }
-        else if (char.IsDigit(c))
-        {
-            string p = font.Stem + "NUM" + c;
-            result = hud.Textures.HasImage(p) ? p : font.Stem + c;
-        }
-        else result = font.Stem + c;
+            '-' => hud.Textures.HasImage(font.Stem + "MINUS") ? font.Stem + "MINUS" : font.Stem + "-",
+
+            '%' => hud.Textures.HasImage(font.Stem + "PRCNT") ? font.Stem + "PRCNT" :
+                hud.Textures.HasImage(font.Stem + "PRCN") ? font.Stem + "PRCN" :
+                hud.Textures.HasImage(font.Stem + "PERCENT") ? font.Stem + "PERCENT" : font.Stem + "%",
+
+            _ when char.IsDigit(c) => hud.Textures.HasImage(font.Stem + "NUM" + c) ? font.Stem + "NUM" + c : font.Stem + c,
+
+            _ => font.Stem + c
+        };
 
         FontPatchCache[font.Stem + c] = result;
         return result;
@@ -1327,50 +1741,56 @@ public class StatusBarRenderer
 
     private int ResolveNumberValue(Player player, StatusBarNumberType type, int param)
     {
-        var composer = m_archiveCollection.EntityDefinitionComposer;
-        var stats = m_world.LevelStats;
+        EntityDefinitionComposer composer = m_archiveCollection.EntityDefinitionComposer;
+        LevelStats stats = m_world.LevelStats;
 
         switch (type)
         {
             case StatusBarNumberType.Health: return Math.Max(0, player.Health);
             case StatusBarNumberType.Armor: return player.Armor;
+            case StatusBarNumberType.Frags: return 0;
             case StatusBarNumberType.Ammo:
-                return StatusBarConditionResolver.TryGetId24AmmoType(composer, param, out var ammoDef)
-                    ? player.Inventory.Amount(ammoDef.Name) : 0;
+                return StatusBarConditionResolver.TryGetId24AmmoType(composer, param, out EntityDefinition? ammoDef)
+                    ? player.Inventory.Amount(ammoDef.Name)
+                    : 0;
+
             case StatusBarNumberType.AmmoSelected:
-                string? a = player.AnimationWeapon?.Definition.Properties.Weapons.AmmoType;
-                return !string.IsNullOrEmpty(a) ? player.Inventory.Amount(a) : 0;
+                return player.AnimationWeapon?.Definition.Properties.Weapons.AmmoType is { } a && !string.IsNullOrEmpty(a)
+                    ? player.Inventory.Amount(a)
+                    : 0;
+
             case StatusBarNumberType.MaxAmmo:
-                return StatusBarConditionResolver.TryGetId24AmmoType(composer, param, out var maxAmmoDef)
-                    ? GetMaxAmount(player, maxAmmoDef.Name) : 0;
+                return StatusBarConditionResolver.TryGetId24AmmoType(composer, param, out EntityDefinition? maxAmmoDef)
+                    ? GetMaxAmount(player, maxAmmoDef.Name)
+                    : 0;
+
             case StatusBarNumberType.AmmoWeapon:
-                var deh = m_archiveCollection.Definitions.DehackedDefinition;
-                if (deh != null && deh.TryGetId24PickupType(composer, param, out var wDef))
-                {
-                    string weaponAmmo = wDef.Properties.Weapons.AmmoType;
-                    return !string.IsNullOrEmpty(weaponAmmo) ? player.Inventory.Amount(weaponAmmo) : 0;
-                }
-                return 0;
+                return m_archiveCollection.Definitions.DehackedDefinition is { } deh &&
+                       deh.TryGetId24PickupType(composer, param, out EntityDefinition? wDef)
+                    ? player.Inventory.Amount(wDef.Properties.Weapons.AmmoType)
+                    : 0;
+
             case StatusBarNumberType.MaxAmmoWeapon:
-                var dehM = m_archiveCollection.Definitions.DehackedDefinition;
-                if (dehM != null && dehM.TryGetId24PickupType(composer, param, out var mwDef))
-                {
-                    string maxWeaponAmmo = mwDef.Properties.Weapons.AmmoType;
-                    return !string.IsNullOrEmpty(maxWeaponAmmo) ? GetMaxAmount(player, maxWeaponAmmo) : 0;
-                }
-                return 0;
+                return m_archiveCollection.Definitions.DehackedDefinition is { } dehM &&
+                       dehM.TryGetId24PickupType(composer, param, out EntityDefinition? mwDef)
+                    ? GetMaxAmount(player, mwDef.Properties.Weapons.AmmoType)
+                    : 0;
+
             case StatusBarNumberType.Kills: return stats.KillCount;
             case StatusBarNumberType.Items: return stats.ItemCount;
             case StatusBarNumberType.Secrets: return stats.SecretCount;
+
             case StatusBarNumberType.KillsPercent:
-                return stats.TotalMonsters > 0 ? (stats.KillCount * 100) / stats.TotalMonsters : 100;
+                return stats.TotalMonsters > 0 ? stats.KillCount * 100 / stats.TotalMonsters : 100;
             case StatusBarNumberType.ItemsPercent:
-                return stats.TotalItems > 0 ? (stats.ItemCount * 100) / stats.TotalItems : 100;
+                return stats.TotalItems > 0 ? stats.ItemCount * 100 / stats.TotalItems : 100;
             case StatusBarNumberType.SecretsPercent:
-                return stats.TotalSecrets > 0 ? (stats.SecretCount * 100) / stats.TotalSecrets : 100;
+                return stats.TotalSecrets > 0 ? stats.SecretCount * 100 / stats.TotalSecrets : 100;
+
             case StatusBarNumberType.MaxKills: return stats.TotalMonsters;
             case StatusBarNumberType.MaxItems: return stats.TotalItems;
             case StatusBarNumberType.MaxSecrets: return stats.TotalSecrets;
+
             case StatusBarNumberType.PowerupDuration:
                 PowerupType pt = param switch
                 {
@@ -1383,25 +1803,28 @@ public class StatusBarRenderer
                     _ => PowerupType.None
                 };
 
-                if (pt == PowerupType.None) return 0;
-
-                if (pt == PowerupType.Strength || pt == PowerupType.ComputerAreaMap)
+                return pt switch
                 {
-                    return player.Inventory.IsPowerupActive(pt) ? 1 : 0;
-                }
+                    PowerupType.None => 0,
+                    PowerupType.Strength or PowerupType.ComputerAreaMap => player.Inventory.IsPowerupActive(pt) ? 1 : 0,
+                    _ => (player.Inventory.GetPowerup(pt)?.Ticks ?? 0) / (int)Constants.TicksPerSecond
+                };
 
-                return (player.Inventory.GetPowerup(pt)?.Ticks ?? 0) / (int)Constants.TicksPerSecond;
             default: return 0;
         }
     }
 
-    private static string GetSpeedometerText(Player player) { _ = player; return string.Empty; }
+    private static string GetSpeedometerText(Player player)
+    {
+        _ = player;
+        return string.Empty;
+    }
 
     private int GetMaxAmount(Player player, string name)
     {
-        var def = m_archiveCollection.EntityDefinitionComposer.GetByName(name);
+        EntityDefinition? def = m_archiveCollection.EntityDefinitionComposer.GetByName(name);
         if (def == null) return 0;
-        var baseDef = Inventory.GetBaseInventoryDefinition(def) ?? def;
+        EntityDefinition baseDef = Inventory.GetBaseInventoryDefinition(def) ?? def;
         int max = baseDef.Properties.Inventory.MaxAmount;
         if (player.Inventory.HasItemOfClass(Inventory.BackPackBaseClassName) && baseDef.IsType(Inventory.AmmoClassName))
             max = Math.Max(max, baseDef.Properties.Ammo.BackpackMaxAmount);
@@ -1415,27 +1838,44 @@ public class StatusBarRenderer
         bool vCenter = (sbarAlign & StatusBarAlignment.VCenter) != 0;
         bool bottom = (sbarAlign & StatusBarAlignment.Bottom) != 0;
 
-        if (bottom) return hCenter ? Align.BottomMiddle : (right ? Align.BottomRight : Align.BottomLeft);
-        if (vCenter) return hCenter ? Align.Center : (right ? Align.MiddleRight : Align.MiddleLeft);
-        return hCenter ? Align.TopMiddle : (right ? Align.TopRight : Align.TopLeft);
+        return bottom ? hCenter ? Align.BottomMiddle : right ? Align.BottomRight : Align.BottomLeft :
+            vCenter ? hCenter ? Align.Center : right ? Align.MiddleRight : Align.MiddleLeft :
+            hCenter ? Align.TopMiddle :
+            right ? Align.TopRight : Align.TopLeft;
     }
-    
+
     private static ImageBox2I? GetCropArea(IRenderableTextureHandle handle, StatusBarCropDef? cropDef)
     {
         if (cropDef == null) return null;
 
         int cx = cropDef.Left;
         int cy = cropDef.Top;
-        
+
         if (cropDef.Center)
         {
             cx += handle.Dimension.Width / 2;
             cy += handle.Dimension.Height / 2;
         }
 
-        int cw = cropDef.Width > 0 ? cropDef.Width : (handle.Dimension.Width - cx);
-        int ch = cropDef.Height > 0 ? cropDef.Height : (handle.Dimension.Height - cy);
+        int cw = cropDef.Width > 0 ? cropDef.Width : handle.Dimension.Width - cx;
+        int ch = cropDef.Height > 0 ? cropDef.Height : handle.Dimension.Height - cy;
 
         return new ImageBox2I(cx, cy, cx + cw, cy + ch);
+    }
+
+    private readonly record struct RenderGlyph(string Patch, int Width, int Offset, IRenderableTextureHandle? Handle = null);
+
+    private readonly record struct CoordData(string Label, int Value, int LabelWidth, int ValWidth);
+
+    private readonly record struct ElementBounds(int X1, int Y1, int X2, int Y2)
+    {
+        public int Width => X2 - X1;
+        public int Height => Y2 - Y1;
+        public static ElementBounds Empty => new(int.MaxValue, int.MaxValue, int.MinValue, int.MinValue);
+
+        public static ElementBounds Union(ElementBounds a, ElementBounds b)
+        {
+            return new ElementBounds(Math.Min(a.X1, b.X1), Math.Min(a.Y1, b.Y1), Math.Max(a.X2, b.X2), Math.Max(a.Y2, b.Y2));
+        }
     }
 }

--- a/Core/Resources/Definitions/StatusBar/StatusBarElementDef.cs
+++ b/Core/Resources/Definitions/StatusBar/StatusBarElementDef.cs
@@ -12,6 +12,9 @@ public class StatusBarElementWrapper
     
     [JsonPropertyName("list")]
     public StatusBarListDef? List { get; set; }
+    
+    [JsonPropertyName("native")]
+    public StatusBarNativeDef? Native { get; set; }
 
     [JsonPropertyName("graphic")]
     public StatusBarGraphicDef? Graphic { get; set; }
@@ -87,6 +90,8 @@ public abstract class StatusBarBaseDef
 }
 
 public class StatusBarCanvasDef : StatusBarBaseDef { }
+
+public class StatusBarNativeDef : StatusBarBaseDef { }
 
 public class StatusBarListDef : StatusBarBaseDef 
 {


### PR DESCRIPTION
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/af394710-ffd3-4ae5-ac4e-8b11c3b09586" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/103beede-a39c-464a-952d-c98a553de37a" />

<img width="1024" height="768" alt="image" src="https://github.com/user-attachments/assets/4b5022ea-9f0d-4576-8eb9-75a076c2f6c7" />

---

Even works with eccentric window sizes:

<img width="420" height="690" alt="image" src="https://github.com/user-attachments/assets/0cb85d64-9226-4a26-b623-78f85b8e1022" />

Download [NativeTrueTest.zip](https://github.com/user-attachments/files/24537847/NativeTrueTest.zip) and mess with the scaling. It's faster to open the console and use `hud.scale` and pass a float of your choice.

---


Additionally, one could try a stress-test of 20 HUDs rendered at once by loading [NativeStressTest.zip](https://github.com/user-attachments/files/24537852/NativeStressTest.zip) to see the system remains resilient despite a JSON file half the size of DOOM2.WAD:

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b1c0b6ac-1ccc-4e09-95aa-264f9e857948" />

