### PR TITLE
Make gamepad 'a' behave like 'enter' in save menu

### DIFF
--- a/Core/Menus/Impl/SaveMenu.cs
+++ b/Core/Menus/Impl/SaveMenu.cs
@@ -216,7 +216,7 @@ public class SaveMenu : Menu
                     // We're already in "name edit mode"
                     EditRow(savedGameRow, input);
                 }
-                else if (input.ConsumeKeyPressed(Key.Enter) || input.ConsumeKeyPressed(Key.MouseLeft))
+                else if (input.ConsumeKeyPressed(Key.Enter) || input.ConsumeKeyPressed(Key.MouseLeft) || input.ConsumeKeyPressed(Key.ButtonA))
                 {
                     if (savedGameRow.IsAutoOrQuickSave)
                     {
@@ -298,7 +298,7 @@ public class SaveMenu : Menu
             m_tickStopwatch.Stop();
             SoundManager.PlayStaticSound(Constants.MenuSounds.Backup);
         }
-        else if (input.ConsumeKeyPressed(Key.Enter) || input.ConsumeKeyPressed(Key.MouseLeft))
+        else if (input.ConsumeKeyPressed(Key.Enter) || input.ConsumeKeyPressed(Key.MouseLeft) || input.ConsumeKeyPressed(Key.ButtonA))
         {
             // If there's any text in the field, use that as the name, else force the defualt.
             savedGameRow.Text = m_customNameBuilder.Length > 0


### PR DESCRIPTION
This brings the behaviour of the primary button on gamepads in line with the 'Enter' key or left mouse in the save menu.

By default, pressing 'Enter' on an empty save slot adds the level name to the save and puts you in edit mode. A second press confirms the name and finishes.

Gamepads currently only perform the confirm action, so manual saves are left with  
'EMPTY SLOT' as the name, or the old level name if you were overwriting.