### PR TITLE
Show incompatible saves in load/save menus

### DIFF
--- a/Client/Client.Commands.cs
+++ b/Client/Client.Commands.cs
@@ -1126,7 +1126,7 @@ public partial class Client
 
     private WorldModel? LoadNewestSave()
     {
-        var save = m_saveGameManager.GetSaveGames().FirstOrDefault();
+        var save = m_saveGameManager.GetSaveGames(compatibleOnly: true).FirstOrDefault();
         if (save != null)
             return save.ReadWorldModel();
         return null;

--- a/Core/Layer/Menus/MenuLayer.Render.cs
+++ b/Core/Layer/Menus/MenuLayer.Render.cs
@@ -240,11 +240,11 @@ public partial class MenuLayer
     private void DrawSaveRow(IHudRenderContext hud, SaveMenu saveMenu, MenuSaveRowComponent saveRowComponent, bool isSelected,
         bool wasPreviouslySelected, ref int offsetY, bool detailsEnabled, out Box2I drawArea)
     {
-        const string FontName = Constants.Fonts.Small;
-        int fontSize = hud.GetFontMaxHeight(FontName) - 2;
+        string fontName = saveRowComponent.IsCompatible ? Constants.Fonts.Small : Constants.Fonts.SmallGray;
+        int fontSize = hud.GetFontMaxHeight(fontName) - 2;
         int menuRowWidth = GetSaveRowWidth(detailsEnabled);
 
-        var textDimension = hud.MeasureText("_", FontName, fontSize);
+        var textDimension = hud.MeasureText("_", fontName, fontSize);
         var textHeight = textDimension.Height; 
 
         string saveText;
@@ -255,11 +255,11 @@ public partial class MenuLayer
             //Account for cursor flashing
             if (!saveRowComponent.Text.EndsWith('_'))
                 typedTextRowWidth -= textDimension.Width;
-            saveText = hud.GetTypedText(saveRowComponent.Text, FontName, fontSize, typedTextRowWidth);
+            saveText = hud.GetTypedText(saveRowComponent.Text, fontName, fontSize, typedTextRowWidth);
         }
         else
         {
-            saveText = hud.GetEllipsesText(saveRowComponent.Text, FontName, fontSize, textRowWidth);
+            saveText = hud.GetEllipsesText(saveRowComponent.Text, fontName, fontSize, textRowWidth);
         }
         
         var rowHeight = textHeight + 3;
@@ -275,7 +275,7 @@ public partial class MenuLayer
             hud.PopAlpha();
         }
 
-        hud.Text(saveText, FontName, fontSize, (1, offsetY + 2));
+        hud.Text(saveText, fontName, fontSize, (1, offsetY + 2));
         offsetY += rowHeight;
 
         if (isSelected && detailsEnabled && !wasPreviouslySelected)
@@ -323,17 +323,17 @@ public partial class MenuLayer
         if (m_saveGameSummary == null)
             return;
 
-        const string Font = Constants.Fonts.Small;
+        string fontName = m_saveGameSummary.IsCompatible ? Constants.Fonts.Small : Constants.Fonts.SmallGray;
         const float ImageAspect = 4 / 3f;
 
         bool wideScreen = SaveMenuWide(hud);
         int textSize = wideScreen ? 6 : 4;
         int boxWidth = wideScreen ? 128 : 80;
         int thumbnailHeight = (int)(boxWidth / ImageAspect * 0.8f);
-        int boxHeight = thumbnailHeight + 5 * textSize + 3;
+        int boxHeight = thumbnailHeight + textSize * (m_saveGameSummary.IsCompatible ? 5 : 7) + 3;
 
         var centerOffset = GetSaveMenuOffset(hud);
-        hud.LineWrap(m_saveGameSummary.MapName, Font, textSize, boxWidth - 4, m_lineWrapLines, 
+        hud.LineWrap(m_saveGameSummary.MapName, fontName, textSize, boxWidth - 4, m_lineWrapLines, 
             out var requiredHeight);
         boxHeight += requiredHeight;
 
@@ -351,8 +351,8 @@ public partial class MenuLayer
         if (m_saveGameTexture == null)
         {
             hud.PushOffset(boxUpperLeft);
-            var size = hud.MeasureText("No Image", Font, textSize);
-            hud.Text("No Image", Font, textSize, (boxWidth / 2 - size.Width / 2, thumbnailHeight / 2 - size.Height / 2), textAlign: TextAlign.Center);
+            var size = hud.MeasureText("No Image", fontName, textSize);
+            hud.Text("No Image", fontName, textSize, (boxWidth / 2 - size.Width / 2, thumbnailHeight / 2 - size.Height / 2), textAlign: TextAlign.Center);
             hud.PopOffset();
         }
         else
@@ -365,17 +365,23 @@ public partial class MenuLayer
 
         for (int i = 0; i < m_lineWrapLines.Count; i++)
         {
-            hud.Text(m_lineWrapLines[i].AsSpan(), Font, textSize, offset, out var drawArea);
+            hud.Text(m_lineWrapLines[i].AsSpan(), fontName, textSize, offset, out var drawArea);
             offset += (0, drawArea.Height);
         }
 
-        hud.Text(m_saveGameSummary.Date, Font, textSize, offset, out var area);
+        hud.Text(m_saveGameSummary.Date, fontName, textSize, offset, out var area);
         offset += (0, area.Height);
         offset += (0, area.Height);
 
-        foreach (string str in m_saveGameSummary?.Stats ?? [])
+        foreach (string str in m_saveGameSummary.Stats ?? [])
         {
-            hud.Text(str, Constants.Fonts.Small, textSize, offset, out area);
+            hud.Text(str, fontName, textSize, offset, out area);
+            offset += (0, area.Height);
+        }
+        if (!m_saveGameSummary.IsCompatible)
+        {
+            offset += (0, area.Height);
+            hud.Text("WADS differ", fontName, textSize, offset, out area);
             offset += (0, area.Height);
         }
     }

--- a/Core/Layer/Menus/MenuLayer.Render.cs
+++ b/Core/Layer/Menus/MenuLayer.Render.cs
@@ -240,16 +240,18 @@ public partial class MenuLayer
     private void DrawSaveRow(IHudRenderContext hud, SaveMenu saveMenu, MenuSaveRowComponent saveRowComponent, bool isSelected,
         bool wasPreviouslySelected, ref int offsetY, bool detailsEnabled, out Box2I drawArea)
     {
-        string fontName = saveRowComponent.IsCompatible ? Constants.Fonts.Small : Constants.Fonts.SmallGray;
+        bool isTypingTarget = isSelected && saveMenu.IsTypingName;
+
+        string fontName = (saveRowComponent.IsCompatible || isTypingTarget) ? Constants.Fonts.Small : Constants.Fonts.SmallGray;
         int fontSize = hud.GetFontMaxHeight(fontName) - 2;
         int menuRowWidth = GetSaveRowWidth(detailsEnabled);
 
         var textDimension = hud.MeasureText("_", fontName, fontSize);
-        var textHeight = textDimension.Height; 
+        var textHeight = textDimension.Height;
 
         string saveText;
         var textRowWidth = menuRowWidth - 8;
-        if (isSelected && saveMenu.IsTypingName)
+        if (isTypingTarget)
         {
             var typedTextRowWidth = textRowWidth;
             //Account for cursor flashing
@@ -382,7 +384,6 @@ public partial class MenuLayer
         {
             offset += (0, area.Height);
             hud.Text("WADS differ", fontName, textSize, offset, out area);
-            offset += (0, area.Height);
         }
     }
 }

--- a/Core/Menus/Base/MenuSaveRowComponent.cs
+++ b/Core/Menus/Base/MenuSaveRowComponent.cs
@@ -3,23 +3,20 @@ using System;
 
 namespace Helion.Menus.Base;
 
-public class MenuSaveRowComponent : IMenuComponent
+public class MenuSaveRowComponent(
+    string text,
+    string mapName,
+    bool isAutoOrQuickSave,
+    bool isCompatible,
+    Func<Menu?>? action = null,
+    Func<Menu?>? deleteAction = null,
+    SaveGame? saveGame = null) : IMenuComponent
 {
-    public string Text { get; set; }
-    public string MapName { get; set; }
-    public Func<Menu?>? Action { get; set; }
-    public Func<Menu?>? DeleteAction { get; }
-    public SaveGame? SaveGame { get; }
-    public bool IsAutoOrQuickSave { get; }
-
-    public MenuSaveRowComponent(string text, string mapName, bool isAutoOrQuickSave, Func<Menu?>? action = null,
-        Func<Menu?>? deleteAction = null, SaveGame? saveGame = null)
-    {
-        Text = text;
-        MapName = mapName;
-        Action = action;
-        DeleteAction = deleteAction;
-        SaveGame = saveGame;
-        IsAutoOrQuickSave = isAutoOrQuickSave;
-    }
+    public string Text { get; set; } = text;
+    public string MapName { get; set; } = mapName;
+    public Func<Menu?>? Action { get; set; } = action;
+    public Func<Menu?>? DeleteAction { get; } = deleteAction;
+    public SaveGame? SaveGame { get; } = saveGame;
+    public bool IsAutoOrQuickSave { get; } = isAutoOrQuickSave;
+    public bool IsCompatible { get; } = isCompatible;
 }

--- a/Core/Menus/Impl/SaveGameSummary.cs
+++ b/Core/Menus/Impl/SaveGameSummary.cs
@@ -21,6 +21,7 @@ public class SaveGameSummary(SaveGame saveGame)
                 $"Secrets: {saveGame.Model.SaveGameStats.SecretCount} / {saveGame.Model.SaveGameStats.TotalSecrets}",
                 $"Elapsed: {TimeSpan.FromSeconds(saveGame.Model.SaveGameStats.LevelTime / 35)}"
             ];
+    public readonly bool IsCompatible = saveGame.IsCompatible == true;
     private readonly Image? m_saveGameImage = saveGame.GetSaveGameImage();
 
     public IRenderableTextureHandle? UpdateSaveGameTexture(IHudRenderContext hud)

--- a/Core/Menus/Impl/SaveMenu.cs
+++ b/Core/Menus/Impl/SaveMenu.cs
@@ -63,7 +63,7 @@ public class SaveMenu : Menu
         m_canSave = canSave;
         IsSaveMenu = isSave;
         m_screenshotGenerator = screenshotGenerator;
-        SaveHeader = new(isSave ? "SAVE GAME" : "LOAD GAME");        
+        SaveHeader = new(isSave ? "SAVE GAME" : "LOAD GAME");
 
         m_saveGames = saveManager.GetSaveGames();
         UpdateMenuComponents(setTop: true);

--- a/Core/Menus/Impl/SaveMenu.cs
+++ b/Core/Menus/Impl/SaveMenu.cs
@@ -218,7 +218,7 @@ public class SaveMenu : Menu
                 }
                 else if (input.ConsumeKeyPressed(Key.Enter) || input.ConsumeKeyPressed(Key.MouseLeft))
                 {
-                    if (savedGameRow.IsAutoOrQuickSave || !savedGameRow.IsCompatible)
+                    if (savedGameRow.IsAutoOrQuickSave)
                     {
                         SoundManager.PlayStaticSound(Constants.MenuSounds.Invalid);
                     }

--- a/Core/Menus/Impl/SaveMenu.cs
+++ b/Core/Menus/Impl/SaveMenu.cs
@@ -148,7 +148,7 @@ public class SaveMenu : Menu
             // show empty slot on page 1
             if (m_currentPage == 1)
             {
-                MenuSaveRowComponent saveRowComponent = new(EmptySlotText, string.Empty, false);
+                MenuSaveRowComponent saveRowComponent = new(EmptySlotText, string.Empty, false, true);
                 saveRowComponent.Action = CreateNewSaveGame(() => saveRowComponent.Text);
                 newComponents.Add(saveRowComponent);
             }
@@ -156,7 +156,7 @@ public class SaveMenu : Menu
             {
                 string displayName = save.Model?.Text ?? UnknownSavedGameName;
                 string mapName = save.Model?.MapName ?? UnknownSavedGameName;
-                MenuSaveRowComponent saveRow = new(displayName, mapName, save.Type != SaveGameType.Default,
+                MenuSaveRowComponent saveRow = new(displayName, mapName, save.Type != SaveGameType.Default, save.IsCompatible == true,
                     null, CreateDeleteCommand(save), save);
                 saveRow.Action = new Func<Menu?>(UpdateSaveGame(save, new(() => saveRow.Text)));
                 return saveRow;
@@ -185,7 +185,7 @@ public class SaveMenu : Menu
             {
                 string displayName = save.Model?.Text ?? UnknownSavedGameName;
                 string fileName = System.IO.Path.GetFileName(save.FileName);
-                return new MenuSaveRowComponent(displayName, string.Empty, save.Type != SaveGameType.Default,
+                return new MenuSaveRowComponent(displayName, string.Empty, save.Type != SaveGameType.Default, save.IsCompatible == true,
                     CreateConsoleCommand($"load \"{fileName}\""), CreateDeleteCommand(save), save);
             });
             newComponents.AddRange(saveRowComponents);
@@ -218,7 +218,7 @@ public class SaveMenu : Menu
                 }
                 else if (input.ConsumeKeyPressed(Key.Enter) || input.ConsumeKeyPressed(Key.MouseLeft))
                 {
-                    if (savedGameRow.IsAutoOrQuickSave)
+                    if (savedGameRow.IsAutoOrQuickSave || !savedGameRow.IsCompatible)
                     {
                         SoundManager.PlayStaticSound(Constants.MenuSounds.Invalid);
                     }
@@ -257,7 +257,12 @@ public class SaveMenu : Menu
             else
             {
                 if (input.ConsumeKeyPressed(Key.Enter) || input.ConsumeKeyPressed(Key.MouseLeft)) // Load
-                    savedGameRow.Action?.Invoke();
+                {
+                    if (!savedGameRow.IsCompatible)
+                        SoundManager.PlayStaticSound(Constants.MenuSounds.Invalid);
+                    else
+                        savedGameRow.Action?.Invoke();
+                }
                 else
                     ConsumeAndHandlePageChange(input);
             }

--- a/Core/World/Save/SaveGame.cs
+++ b/Core/World/Save/SaveGame.cs
@@ -35,6 +35,11 @@ public class SaveGame
 
     public readonly SaveGameType Type;
 
+    /// <summary>
+    /// Whether the save is compatible with the currently loaded WADs.
+    /// </summary>
+    public bool? IsCompatible;
+
     public SaveGame(string saveDir, string filename, SaveGameModel model)
     {
         SaveDir = saveDir;

--- a/Core/World/Save/SaveGameManager.cs
+++ b/Core/World/Save/SaveGameManager.cs
@@ -91,9 +91,15 @@ public class SaveGameManager
     {
         if (m_currentSavesLoaded)
             return;
-        
-        m_currentSaves.AddRange(ReadSaveGameFiles());
-        m_matchingSaves.AddRange(GetMatchingSaveGames(m_currentSaves));
+
+        var saves = ReadSaveGameFiles();
+        foreach (var save in saves)
+        {
+            save.IsCompatible = CheckIfSaveModelCompatible(save.Model);
+            m_currentSaves.Add(save);
+            if (save.IsCompatible == true)
+                m_matchingSaves.Add(save);
+        }
         m_currentSavesLoaded = true;
     }
 
@@ -122,6 +128,7 @@ public class SaveGameManager
         m_saveArgs = new(world, worldModel, title, GetSaveDir(), filename, screenshotGenerator, image);
         var saveEvent = await Task.Run(m_saveFunc);
 
+        saveEvent.SaveGame.IsCompatible = true;
         AddOrUpdateSaveGame(saveEvent.SaveGame);
         GameSaved?.Invoke(this, saveEvent);
         m_saving = false;
@@ -134,7 +141,8 @@ public class SaveGameManager
     private void AddOrUpdateSaveGame(SaveGame newSaveGame)
     {
         AddOrUpdateSaveGame(newSaveGame, m_currentSaves);
-        AddOrUpdateSaveGame(newSaveGame, m_matchingSaves);
+        if (newSaveGame.IsCompatible == true)
+            AddOrUpdateSaveGame(newSaveGame, m_matchingSaves);
     }
 
     private static void AddOrUpdateSaveGame(SaveGame newSaveGame, List<SaveGame> saveList)
@@ -154,7 +162,7 @@ public class SaveGameManager
 
     private SaveGame? GetExistingSave(SaveGame? existingSave, SaveGameType type)
     {
-        var saveGames = GetSaveGames(sortByDate: false);
+        var saveGames = GetSaveGames(compatibleOnly: true, sortByDate: false);
 
         if (existingSave == null && type == SaveGameType.Auto && m_config.Game.RotatingAutoSaves > 0)
         {
@@ -173,18 +181,18 @@ public class SaveGameManager
         return existingSave;
     }
 
-    private IEnumerable<SaveGame> GetMatchingSaveGames(List<SaveGame> saveGames)
+    private bool CheckIfSaveModelCompatible(SaveGameModel? model)
     {
-        return saveGames.Where(x => x.Model != null &&
-            ModelVerification.VerifyModelFiles(x.Model.Files, m_archiveCollection, null));
+        return model != null && ModelVerification.VerifyModelFiles(model.Files, m_archiveCollection, null);
     }
 
-    public List<SaveGame> GetSaveGames(bool sortByDate = true)
+    public List<SaveGame> GetSaveGames(bool compatibleOnly = false, bool sortByDate = true)
     {
         LoadCurrentSaveFiles();
+        var saves = compatibleOnly ? m_matchingSaves : m_currentSaves;
         if (sortByDate)
-            m_matchingSaves.Sort(m_saveDateComparison);
-        return m_matchingSaves;
+            saves.Sort(m_saveDateComparison);
+        return saves;
     }
 
     private List<SaveGame> ReadSaveGameFiles()

--- a/Core/World/Save/SaveGameManager.cs
+++ b/Core/World/Save/SaveGameManager.cs
@@ -44,7 +44,7 @@ public class SaveGameManager
     private readonly string? m_saveDirCommandLineArg;
     private readonly List<SaveGame> m_currentSaves = [];
     private readonly List<SaveGame> m_matchingSaves = [];
-    private readonly Comparison<SaveGame> m_saveDateComparison = new(CompareSaveDates);
+    private readonly Comparison<SaveGame> m_saveComparison = new(CompareSaveCompatibilityAndDates);
     private readonly Func<SaveGameEvent> m_saveFunc;
     private bool m_currentSavesLoaded;
     private bool m_saving;
@@ -162,20 +162,20 @@ public class SaveGameManager
 
     private SaveGame? GetExistingSave(SaveGame? existingSave, SaveGameType type)
     {
-        var saveGames = GetSaveGames(compatibleOnly: true, sortByDate: false);
+        var saveGames = GetSaveGames(compatibleOnly: true);
 
         if (existingSave == null && type == SaveGameType.Auto && m_config.Game.RotatingAutoSaves > 0)
         {
-            var autoSaves = saveGames.Where(x => x.Type == SaveGameType.Auto).OrderBy(x => x.Model?.Date);
+            var autoSaves = saveGames.Where(x => x.Type == SaveGameType.Auto);
             if (autoSaves.Any() && autoSaves.Count() >= m_config.Game.RotatingAutoSaves)
-                existingSave = autoSaves.First();
+                existingSave = autoSaves.Last();
         }
 
         if (existingSave == null && type == SaveGameType.Quick && m_config.Game.RotatingQuickSaves > 0)
         {
-            var quickSaves = saveGames.Where(x => x.Type == SaveGameType.Quick).OrderBy(x => x.Model?.Date);
+            var quickSaves = saveGames.Where(x => x.Type == SaveGameType.Quick);
             if (quickSaves.Any() && quickSaves.Count() >= m_config.Game.RotatingQuickSaves)
-                existingSave = quickSaves.First();
+                existingSave = quickSaves.Last();
         }
 
         return existingSave;
@@ -186,12 +186,14 @@ public class SaveGameManager
         return model != null && ModelVerification.VerifyModelFiles(model.Files, m_archiveCollection, null);
     }
 
-    public List<SaveGame> GetSaveGames(bool compatibleOnly = false, bool sortByDate = true)
+    /// <summary>
+    /// Gets save games, ordered by compatible first, then newest first.
+    /// </summary>
+    public List<SaveGame> GetSaveGames(bool compatibleOnly = false)
     {
         LoadCurrentSaveFiles();
         var saves = compatibleOnly ? m_matchingSaves : m_currentSaves;
-        if (sortByDate)
-            saves.Sort(m_saveDateComparison);
+        saves.Sort(m_saveComparison);
         return saves;
     }
 
@@ -243,7 +245,7 @@ public class SaveGameManager
         };
     }
 
-    private static int CompareSaveDates(SaveGame x, SaveGame y)
+    private static int CompareSaveCompatibilityAndDates(SaveGame x, SaveGame y)
     {
         if (x.Model == null)
             return 1;
@@ -251,6 +253,12 @@ public class SaveGameManager
         if (y.Model == null)
             return -1;
 
+        // sort compatible saves first
+        if (x.IsCompatible != y.IsCompatible)
+            return x.IsCompatible == true ? -1 : 1;
+
+        // then by most recent first
         return y.Model.Date.CompareTo(x.Model.Date);
+
     }
 }


### PR DESCRIPTION
Implements #1439, minus the details on how the WAD lists differ. For incompatible saves, the text is greyed out and the details pane will say "WADS differ". Saves are sorted compatible first then newest first. Quick/autosaves will only overwrite compatible saves. Incompatible saves can be overwritten if selected in the save menu.

Since the separate lists of all saves and compatible saves were kept, a config option to not show these could be added if there's ever demand.

<img width="1600" height="1200" alt="incompatible" src="https://github.com/user-attachments/assets/b3d5b50e-3a3b-421b-85e6-581ed04f59b1" />
