### PR TITLE
Better flood fill overlap handling

### DIFF
--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
@@ -113,21 +113,6 @@ public class GeometryRenderer : IDisposable
         ReleaseUnmanagedResources();
     }
 
-    private static void PushSeg(Line line, Side facingSide)
-    {
-        if (WorldStatic.LineVertexGap == 0)
-            return;
-
-        // Push it out to prevent potential z-fighting. Default pushes out from the sector.
-        var angle = facingSide == line.Front ? line.GetAngle() : line.GetAngle() + MathHelper.Pi;
-        angle += MathHelper.Pi;
-
-        // ReversedZ allows for a much smaller push amount. Always set to LineVertexGap to close the middle texture with extended inside wall.
-        var pushUnit = Vec2D.UnitCircle(angle + MathHelper.HalfPi) * WorldStatic.LineVertexGap;
-        line.RenderSegStart += pushUnit;
-        line.RenderSegEnd += pushUnit;
-    }
-
     public void UpdateTo(IWorld world)
     {
         m_world = world;
@@ -1209,20 +1194,12 @@ public class GeometryRenderer : IDisposable
 
         if (facingSide.OffsetChanged || m_sectorChangedLine || data == null)
         {
-            // Push forward to cover flood fill side and prevent z-fighting (ex Doom2 MAP25 bloodfall)
             var saveStart = line.RenderSegStart;
             var saveEnd = line.RenderSegEnd;
 
-            // Restore the original position for alpha walls. Touching walls look bad with the overlap and it's not necessary.
-            if (m_pixelGapCorrection && alpha < 1)
-            {
-                line.RenderSegStart = line.Segment.Start;
-                line.RenderSegEnd = line.Segment.End;
-            }
-
-            // Don't push with flood plane. This is different from flood fill side and are already pushed.
-            if (!facingSector.Flood)
-                PushSeg(line, facingSide);
+            // Restore original position for two-sided middle walls. Touching walls look bad with the overlap and it's not necessary.
+            line.RenderSegStart = line.Segment.Start;
+            line.RenderSegEnd = line.Segment.End;
 
             var opening = GetMidTexOpening(TextureManager, facingSide, facingSector, otherSector, false);
             var prevOpening = GetMidTexOpening(TextureManager, facingSide, facingSector, otherSector, true);

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillProgram.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillProgram.cs
@@ -27,6 +27,7 @@ public class FloodFillProgram : RenderProgram
     private readonly int m_lightModeLocation;
     private readonly int m_gammaCorrectionLocation;
     private readonly int m_useBrightmapsLocation;
+    private readonly int m_cameraDirection;
 
     public FloodFillProgram(string name) : base($"FloodFill - {name}")
     {
@@ -48,6 +49,7 @@ public class FloodFillProgram : RenderProgram
         m_lightModeLocation = Uniforms.GetLocation("lightMode");
         m_gammaCorrectionLocation = Uniforms.GetLocation("gammaCorrection");
         m_useBrightmapsLocation = Uniforms.GetLocation("useBrightmaps");
+        m_cameraDirection = Uniforms.GetLocation("cameraDirection");
     }
 
     public void BoundTexture(TextureUnit unit) => ProgramUniforms.Set(unit, m_boundTextureLocation);
@@ -55,6 +57,7 @@ public class FloodFillProgram : RenderProgram
     public void ColormapTexture(TextureUnit unit) => ProgramUniforms.Set(unit, m_colormapTextureLocation);
     public void SectorColormapTexture(TextureUnit unit) => ProgramUniforms.Set(unit, m_sectorColormapTextureLocation);
 
+    public void CameraDirection(Vec3F dir) => ProgramUniforms.Set(dir, m_cameraDirection);
     public void Camera(Vec3F camera) => ProgramUniforms.Set(camera, m_cameraLocation);
     public void Mvp(mat4 mvp) => ProgramUniforms.Set(mvp, m_mvpLocation);
     public void TimeFrac(float frac) => ProgramUniforms.Set(frac, m_timeFracLocation);
@@ -101,6 +104,7 @@ public class FloodFillProgram : RenderProgram
 
         uniform mat4 mvp;
         uniform vec3 camera;
+        uniform vec3 cameraDirection;
         uniform float timeFrac;
 
         void main()
@@ -119,11 +123,12 @@ public class FloodFillProgram : RenderProgram
             ${VertexLightBuffer}
             ${SectorColorMapVertexFunction}
 
-            if (camera.z <= minViewZ || camera.z >= maxViewZ)
-                gl_Position = vec4(0, 0, 0, 1);
-            else
-                gl_Position = mvp * vec4(vertexPosFrag, 1.0);
-            
+            // Match doom behavior to not render flood view when camera is above/below ceiling/floor
+            vec3 worldPos = mix(vertexPosFrag + cameraDirection * 0.001,
+                vec3(0.0, 0.0, 0.0), 
+                float(camera.z <= minViewZ || camera.z >= maxViewZ));
+
+            gl_Position = mvp * vec4(worldPos, 1.0);
             depthFrag = gl_Position.${Depth};
         }
     "

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillRenderer.cs
@@ -342,6 +342,7 @@ public class FloodFillRenderer(LegacyGLTextureManager glTextureManager, FloodFil
         program.ColormapTexture(BindTextures.Colormap);
         program.SectorColormapTexture(BindTextures.SectorColormap);
         program.Camera(renderInfo.Camera.PositionInterpolated);
+        program.CameraDirection(renderInfo.Camera.Direction);
         program.Mvp(renderInfo.Uniforms.Mvp);
         program.TimeFrac(renderInfo.TickFraction);
         program.HasInvulnerability(renderInfo.Uniforms.DrawInvulnerability);

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
@@ -302,16 +302,17 @@ public class StaticCacheGeometryRenderer : IDisposable
         if (side.PartnerSide != null && side.Sector == side.PartnerSide.Sector)
             return;
 
+        var textureManager = m_world.ArchiveCollection.TextureManager;
         bool floodFloor = (flood && !sector.Floor.MidTextureHack) || side.MidTextureFlood != SectorPlanes.None;
         bool floodCeiling = (flood && !sector.Ceiling.MidTextureHack) || side.MidTextureFlood != SectorPlanes.None;
 
         bool skyHack = false;
         if (side.PartnerSide != null)
-            GeometryRenderer.UpperOrSkySideIsVisible(m_world.ArchiveCollection.TextureManager, side, side.Sector, side.PartnerSide.Sector, out skyHack);
+            GeometryRenderer.UpperOrSkySideIsVisible(textureManager, side, side.Sector, side.PartnerSide.Sector, out skyHack);
 
         if (floodFloor && side.FloorFloodKey == 0)
         {
-            if (!m_world.ArchiveCollection.TextureManager.IsSkyTexture(sector.Floor.TextureHandle))
+            if (!textureManager.IsSkyTexture(sector.Floor.TextureHandle))
             {
                 m_geometryRenderer.Portals.AddFloodFillPlane(side, sector, SectorPlanes.Floor, SectorPlaneFace.Floor, isFrontSide, m_floodFillRenderer);
             }
@@ -324,8 +325,11 @@ public class StaticCacheGeometryRenderer : IDisposable
         }
 
         // Sky ceilings are handled differently
-        if (floodCeiling && !skyHack && side.CeilingFloodKey == 0 && !m_world.ArchiveCollection.TextureManager.IsSkyTexture(sector.Ceiling.TextureHandle))
+        if (floodCeiling && !skyHack && side.CeilingFloodKey == 0 && !textureManager.IsSkyTexture(sector.Ceiling.TextureHandle) &&
+            (side.PartnerSide == null || !textureManager.IsSkyTexture(side.PartnerSide.Sector.Ceiling.TextureHandle)))
+        {
             m_geometryRenderer.Portals.AddFloodFillPlane(side, sector, SectorPlanes.Ceiling, SectorPlaneFace.Ceiling, isFrontSide, m_floodFillRenderer);
+        }
     }
 
     private void AddTwoSided(Side side, bool isFrontSide, bool update)

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -379,9 +379,10 @@ public class LegacyWorldRenderer : WorldRenderer
     {
         // Doom would draw middle textures over flood fill.
         // Setting the factor using PolygonOffset will push them further away in depth so middle textures are closer and render over.
+        // Very tiny for reversed z. Flood fill is pushed in world coordinates in the shader.
         GL.Enable(EnableCap.PolygonOffsetFill);
         if (ShaderVars.ReversedZ)
-            GL.PolygonOffset(-0.005f, -0.1f);
+            GL.PolygonOffset(-0.005f, -0.002f);
         else
             GL.PolygonOffset(0.05f, 1f);
         m_geometryRenderer.RenderPortals(renderInfo);


### PR DESCRIPTION
Push flood fill vertex in world space in the flood fill shader. This removes messy CPU side pushing code and allows for a smaller push amount and helps prevent cracks from forming.

Uses a much smaller push amount with glPolygonOffset. This works on top of the shader push and is just needed to deal with pushing it a bit further when the camera is further away from the vertex.

This fix doesn't perfectly handle all the cases and is set to handle all the below cases the best it can. Very tiny cracks for the middle textures can still appear but they should be practically not noticeable even in this worst case scenario.

Fixes #1465 

Previous PR
#1437 

Other Relevant Issues
#1436 
#1348 