### PR TITLE
Add clear screen option and clean up unnecessary clear calls

### DIFF
--- a/Core/Layer/GameLayerManager.cs
+++ b/Core/Layer/GameLayerManager.cs
@@ -836,8 +836,13 @@ public class GameLayerManager : IGameLayerManager
         m_hudRenderCtx.DrawHud();
         if (LoadingLayer?.HasImage == true)
             TransitionLayer?.GrabFramebufferIfNeeded(m_ctx);
-        TransitionLayer?.Render(m_ctx);
         m_ctx.ClearDepth();
+        if (TransitionLayer != null)
+        {
+            TransitionLayer.Render(m_ctx);
+            // Clear depth doesn't appear to be required on all GPUs. Required on old AMD 3.3 GPU.
+            m_ctx.ClearDepth();
+        }
 
         if (MenuLayer != null)
             RenderWithAlpha(hudCtx, MenuLayer.Animation, RenderMenu);

--- a/Core/Layer/GameLayerManager.cs
+++ b/Core/Layer/GameLayerManager.cs
@@ -767,7 +767,9 @@ public class GameLayerManager : IGameLayerManager
         m_hudContext.Dimension = m_renderer.RenderDimension;
         m_hudContext.DrawPalette = true;
         ctx.Viewport(m_renderer.RenderDimension.Box);
-        ctx.Clear(GetClearColor(), true, true);
+
+        if (m_config.Window.ClearScreen)
+            ctx.Clear(GetClearColor(), true, true);
 
         if (WorldLayer != null && WorldLayer.ShouldRender && (m_config.Hud.AutoMap.Overlay || !WorldLayer.DrawAutomap))
         {

--- a/Core/Layer/Worlds/WorldLayer.Render.cs
+++ b/Core/Layer/Worlds/WorldLayer.Render.cs
@@ -75,6 +75,8 @@ public partial class WorldLayer
             ctx.Clear(color, true, true);
         }
 
+        // Clear depth doesn't appear to be required on all GPUs. Required on old AMD 3.3 GPU.
+        ctx.ClearDepth();
         ctx.Automap(m_worldContext, m_renderAutomapAction);
     }
 

--- a/Core/Render/OpenGL/Framebuffer/OitFrameBuffer.cs
+++ b/Core/Render/OpenGL/Framebuffer/OitFrameBuffer.cs
@@ -8,6 +8,7 @@ namespace Helion.Render.OpenGL.Framebuffer;
 
 public class OitFrameBuffer
 {
+    private readonly DrawBuffersEnum[] DrawBuffers = [DrawBuffersEnum.ColorAttachment0, DrawBuffersEnum.ColorAttachment1, DrawBuffersEnum.ColorAttachment2];
     private uint m_oitFramebuffer;
     private uint m_accumTexture;
     private uint m_accumCountTexture;
@@ -62,7 +63,7 @@ public class OitFrameBuffer
         GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment2, TextureTarget.Texture2D, m_fuzzTexture, 0);
         GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.DepthStencilAttachment, TextureTarget.Texture2D, opaqueDepthTexture.Name, 0);
 
-        GL.DrawBuffers(3, [DrawBuffersEnum.ColorAttachment0, DrawBuffersEnum.ColorAttachment1, DrawBuffersEnum.ColorAttachment2]);
+        GL.DrawBuffers(DrawBuffers.Length, DrawBuffers);
 
         if (GL.CheckFramebufferStatus(FramebufferTarget.Framebuffer) != FramebufferErrorCode.FramebufferComplete)
             throw new Exception("Failed to complete oit framebuffer");
@@ -70,13 +71,10 @@ public class OitFrameBuffer
 
     public unsafe void StartRender()
     {
-        var zero = stackalloc float[4] { 0f, 0f, 0f, 0f };
         BindFrameBuffer();
-
-        GL.ClearBuffer(ClearBuffer.Color, 0, zero);
-        GL.ClearBuffer(ClearBuffer.Color, 1, zero);
-        GL.ClearBuffer(ClearBuffer.Color, 2, zero);
-
+        GL.DrawBuffers(DrawBuffers.Length, DrawBuffers);
+        GL.ClearColor(0f, 0f, 0f, 0f);
+        GL.Clear(ClearBufferMask.ColorBufferBit);
         SetBlendEquations();
     }
 

--- a/Core/Render/OpenGL/Renderers/FramebufferRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/FramebufferRenderer.cs
@@ -100,14 +100,6 @@ public class FramebufferRenderer : IDisposable
         m_vbo.Unbind();
     }
 
-    public static void ClearWithViewport(Dimension dimension)
-    {
-        (float a, float r, float g, float b) = Color.Black.Normalized;
-        GL.Viewport(0, 0, dimension.Width, dimension.Height);
-        GL.ClearColor(r, g, b, a);
-        GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit | ClearBufferMask.StencilBufferBit);
-    }
-
     public void Render(GLFramebuffer buffer, mat4 mvp)
     {
         m_program.Bind();

--- a/Core/Render/Renderer.cs
+++ b/Core/Render/Renderer.cs
@@ -872,6 +872,7 @@ public partial class Renderer : IDisposable
 
         m_mainFramebuffer.BindDraw();
         UpdateVirtualTextureFilter(m_virtualFramebuffer);
+        GL.Clear(ClearBufferMask.DepthBufferBit);
         m_framebufferRenderer.Render(m_virtualFramebuffer, CalculateVirtualMvp(m_virtualFramebuffer, GetVirtualDimension()));
     }
 

--- a/Core/Render/Renderer.cs
+++ b/Core/Render/Renderer.cs
@@ -811,9 +811,7 @@ public partial class Renderer : IDisposable
             GL.ClipControl(ClipOrigin.LowerLeft, ClipDepthMode.ZeroToOne);
             GL.DepthFunc(DepthFunction.Greater);
             GL.Enable(EnableCap.DepthTest);
-
             GL.ClearDepth(0.0);
-            GL.Clear(ClearBufferMask.DepthBufferBit);
         }
 
         m_lastDrawWorldCmd = cmd;
@@ -874,7 +872,6 @@ public partial class Renderer : IDisposable
 
         m_mainFramebuffer.BindDraw();
         UpdateVirtualTextureFilter(m_virtualFramebuffer);
-        FramebufferRenderer.ClearWithViewport(Window.ClientDimension);
         m_framebufferRenderer.Render(m_virtualFramebuffer, CalculateVirtualMvp(m_virtualFramebuffer, GetVirtualDimension()));
     }
 

--- a/Core/Util/Configs/Components/ConfigWindow.cs
+++ b/Core/Util/Configs/Components/ConfigWindow.cs
@@ -108,6 +108,10 @@ public class ConfigWindow: ConfigElement<ConfigWindow>
     [OptionMenu(OptionSectionType.Video, "True Color Overlay")]
     public readonly ConfigValue<bool> PaletteTrueColorOverlay = new(true);
 
+    [ConfigInfo("Clear screen buffer before drawing. Off emulates Doom's hall of mirrors effect.")]
+    [OptionMenu(OptionSectionType.Video, "Clear Screen")]
+    public readonly ConfigValue<bool> ClearScreen = new(false);
+
     [ConfigInfo("Changes which laptop GPU is used. Computer restart required.", restartRequired: true)]
     [OptionMenu(OptionSectionType.Video, "Laptop GPU", spacer: true, allowReset: false, windowsPlatform: true)]
     public readonly ConfigValue<LaptopGpuMode> LaptopGpu = new(LaptopGpuMode.HighPerformance);

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -6,6 +6,7 @@
 - Add ZDoom-styled centered HUD key notifications.
 - Add SpawnMulti and SpawnMultiCoopOnly.
 - Add support for new UMAPINFO keys 'jumping', 'crouching', and 'freeaim'.
+- Add clear screen option in video options to emulate hall of mirrors effect where pixels are not draw.
 
 ## Bug Fixes:
 - Fix not cooperative flag check for solo-net.
@@ -17,3 +18,4 @@
 - Add compatibility for Eviternity II Annihilate Me skill level to swap incorrect usage of SpawnMulti to SpawnMultiCoopOnly.
 - Implemented custom frame limiter. Reduces CPU/power usage and yields better results since the OpenTK 4.9.4 upgrade in Helion 0.9.8.0 that was causing FPS drops on certain machines.
 - Removed intermediate buffer copy per frame. Increases performance with integrated GPUs at higher resolutions caused by bandwidth bottleneck.
+- Removed unecessary OpenGL clear calls. Small performance improvement with integrated GPUs.

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -18,4 +18,4 @@
 - Add compatibility for Eviternity II Annihilate Me skill level to swap incorrect usage of SpawnMulti to SpawnMultiCoopOnly.
 - Implemented custom frame limiter. Reduces CPU/power usage and yields better results since the OpenTK 4.9.4 upgrade in Helion 0.9.8.0 that was causing FPS drops on certain machines.
 - Removed intermediate buffer copy per frame. Increases performance with integrated GPUs at higher resolutions caused by bandwidth bottleneck.
-- Removed unecessary OpenGL clear calls. Small performance improvement with integrated GPUs.
+- Removed unnecessary OpenGL clear calls. Small performance improvement with integrated GPUs.


### PR DESCRIPTION
Add option to toggle clearing the screen to emulate doom's hall of mirrors effect when nothing is drawn.

Use DrawBuffers to clear all three color attachments with one command in OIT framebuffer.

Clean up some unnecessary GL clear calls