### PR TITLE
Update OpenGL version test

### DIFF
--- a/Client/Client.cs
+++ b/Client/Client.cs
@@ -110,6 +110,9 @@ public partial class Client : IDisposable, IInputManagement
         m_config.Render.PixelGapCorrection.OnChanged += PixelGapCorrection_OnChanged;
         m_config.Hud.Scale.OnChanged += Scale_OnChanged;
 
+        GLFWProvider.EnsureInitialized();
+        GLFWProvider.SetErrorCallback(GLFWErrorCallback);
+
         if (commandLineArgs.GlVersion.HasValue)
         {
             GlVersion.Major = commandLineArgs.GlVersion.Value / 10;
@@ -120,8 +123,6 @@ public partial class Client : IDisposable, IInputManagement
             SetOpenGLVersion(config);
         }
 
-        GLFWProvider.EnsureInitialized();
-        GLFWProvider.SetErrorCallback(GLFWErrorCallback);
         GLFW.WindowHint(WindowHintString.WaylandAppID, "Helion");
         m_window = new Window(AppInfo.ApplicationName, config, archiveCollection, m_fpsTracker, this, GlVersion.Major, GlVersion.Minor, GlVersion.Flags, CheckOpenGLSupport);
         m_screenshotGenerator = new(m_window.Renderer);
@@ -212,7 +213,9 @@ public partial class Client : IDisposable, IInputManagement
 
     private static void GLFWErrorCallback(ErrorCode error, string description)
     {
-        Log.Error($"GLFW error: {error}: {description}");
+        // Don't log version error since higher versions are tested for lower version support
+        if (error != ErrorCode.VersionUnavailable)
+            Log.Error($"GLFW error: {error}: {description}");
     }
 
     private void PixelGapCorrection_OnChanged(object? sender, bool e)
@@ -223,7 +226,7 @@ public partial class Client : IDisposable, IInputManagement
 
     private void Rng_OnChanged(object? sender, RngMethod e) =>  m_invalidateRng = true;
 
-    private static void SetOpenGLVersion(IConfig config)
+    private void SetOpenGLVersion(IConfig config)
     {
         // MacOS is opposite from Windows/Linux. Request 3.3 with ForwardCompatible and MacOS will return the highest available (The M series appears to return 4.1).
         // Running the tests below appears to generate a hard crash so just force it here.

--- a/Client/GlVersionTest.cs
+++ b/Client/GlVersionTest.cs
@@ -27,7 +27,7 @@ public class GlVersionTest
                     GLFW.WindowHint(WindowHintClientApi.ClientApi, ClientApi.OpenGlApi);
                     break;
                 default:
-                    throw new ArgumentOutOfRangeException();
+                    throw new ArgumentOutOfRangeException(nameof(settings));
             }
 
             bool forwardCompatible = (GlVersion.Flags & GLContextFlags.ForwardCompatible) != 0;
@@ -39,6 +39,9 @@ public class GlVersionTest
             GLFW.WindowHint(WindowHintBool.Visible, false);
 
             OpenTK.Windowing.GraphicsLibraryFramework.Window* windowPtr = GLFW.CreateWindow(640, 480, "", null, (OpenTK.Windowing.GraphicsLibraryFramework.Window*)(void*)IntPtr.Zero);
+            if (windowPtr == null)
+                return false;
+
             GLFW.MakeContextCurrent(windowPtr);
 
             LoadBindingsES11();

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -19,3 +19,4 @@
 - Implemented custom frame limiter. Reduces CPU/power usage and yields better results since the OpenTK 4.9.4 upgrade in Helion 0.9.8.0 that was causing FPS drops on certain machines.
 - Removed intermediate buffer copy per frame. Increases performance with integrated GPUs at higher resolutions caused by bandwidth bottleneck.
 - Removed unnecessary OpenGL clear calls. Small performance improvement with integrated GPUs.
+- Added better OpenGL version testing that would previously cause hard crashes on some Linux setups.


### PR DESCRIPTION
don't rely on exception since it may not be thrown on linux

move error callback register so the app doesn't hard crash on version test failure

fixes #1441 