### PR TITLE
Monster closet custom check

### DIFF
--- a/Core/World/Entities/Definition/Composer/DefinitionStateApplier.cs
+++ b/Core/World/Entities/Definition/Composer/DefinitionStateApplier.cs
@@ -113,8 +113,30 @@ public class DefinitionStateApplier
         definition.PainState = GetEntityFrame(entityFrameTable, definition, Constants.FrameStates.Pain);
         definition.HealState = GetEntityFrame(entityFrameTable, definition, Constants.FrameStates.Heal);
 
+        if (definition.SpawnState.HasValue)
+            ValidateSpawnStateForMonsterCloset(entityFrameTable.Frames[definition.SpawnState.Value], definition);
+
         if (definition.HealState.HasValue && definition.HealState.Value < entityFrameTable.Frames.Count)
             definition.HealFrame = entityFrameTable.Frames[definition.HealState.Value];
+    }
+
+    private static void ValidateSpawnStateForMonsterCloset(EntityFrame entityFrame, EntityDefinition definition)
+    {
+        // If the monster does anything other than A_Look then set invalid for using A_ClosetLook.
+        var frame = entityFrame;
+        int count = 0;
+        while (count++ < 20)
+        {
+            if (frame.ActionFunction != null && frame.ActionFunction != A_Look)
+                return;
+
+            frame = frame.NextFrame;
+            if (frame == entityFrame)
+            {
+                definition.ValidForMonsterCloset = true;
+                return;
+            }
+        }
     }
 
     private static void ApplyAllLabels(EntityFrameTable entityFrameTable, EntityDefinition definition, Dictionary<string, FrameLabel> masterLabelTable)

--- a/Core/World/Entities/Definition/EntityDefinition.cs
+++ b/Core/World/Entities/Definition/EntityDefinition.cs
@@ -43,6 +43,7 @@ public class EntityDefinition
     public string DehackedName = string.Empty;
     public bool DefinitionSet;
     public bool IgnoreVanillaSpriteLookup;
+    public bool ValidForMonsterCloset;
 
     public EntityFrame? HealFrame;
 

--- a/Core/World/Entities/Definition/States/EntityActionFunctions.cs
+++ b/Core/World/Entities/Definition/States/EntityActionFunctions.cs
@@ -1589,7 +1589,7 @@ public static class EntityActionFunctions
 
     public static void A_Look(Entity entity)
     {
-        if ((entity.ClosetFlags & ClosetFlags.MonsterCloset) != 0)
+        if ((entity.ClosetFlags & ClosetFlags.MonsterCloset) != 0 && entity.Definition.ValidForMonsterCloset)
         {
             entity.SetClosetLook();
             return;

--- a/Core/World/Geometry/Islands/ClosetClassifier.cs
+++ b/Core/World/Geometry/Islands/ClosetClassifier.cs
@@ -91,10 +91,6 @@ public static class ClosetClassifier
     private static void SetCloset(Island island, WorldBase world, List<Entity> entities,
         Dictionary<int, BspSubsector> entityToSubsector)
     {
-        // Monster closets are simple, should not have a ton of lines.
-        if (island.LineIds.Count > 300)
-            return;
-
         bool monsterCloset = true;
         bool voodooCloset = true;
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -15,6 +15,7 @@
 - Fix boom generalized sector damage not working.
 - Fix A_JumpIfFlagsSet always evaluating to true if Args3 is set for MBF21 flags.
 - Fix movement/ticking processing order so that movement is handled first. Fixes Dominus Diabolicus 2 Cybermancubus acid puddles not doing damage.
+- Add validation for custom monster look logic in monster closets. Fixes Wraith Dominus Diabolicus 2 in monster closet.
 
 ## Misc:
 - Add compatibility for Eviternity II Annihilate Me skill level to swap incorrect usage of SpawnMulti to SpawnMultiCoopOnly.


### PR DESCRIPTION
Scan frames and set invalid for monster closet if the definition contains frames that don't call A_Look.

Fixes Wraith Dominus Diabolicus 2 in MAP23.

https://www.doomworld.com/forum/post/3004468