### PR TITLE
fix potential crash with A_HealChase

### DIFF
--- a/Core/World/Entities/Definition/States/FrameState.cs
+++ b/Core/World/Entities/Definition/States/FrameState.cs
@@ -5,6 +5,7 @@ using NLog;
 using static Helion.Util.Assertion.Assert;
 using System.Collections.Generic;
 using System;
+using System.Runtime.CompilerServices;
 
 namespace Helion.World.Entities.Definition.States;
 
@@ -133,6 +134,7 @@ public struct FrameState
         return false;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void SetState(Entity entity, EntityFrame entityFrame) =>
         SetFrameIndexInternal(entity, entityFrame.MasterFrameIndex);
 

--- a/Core/World/WorldBase.cs
+++ b/Core/World/WorldBase.cs
@@ -3181,7 +3181,7 @@ public abstract partial class WorldBase : IWorld
         healChaseEntity.SetTarget(entity);
         EntityActionFunctions.A_FaceTarget(healChaseEntity);
         healChaseEntity.SetTarget(saveTarget);
-        healChaseEntity.FrameState.SetState(entity, m_healChaseData.HealState);
+        healChaseEntity.FrameState.SetState(healChaseEntity, m_healChaseData.HealState);
 
         if (m_healChaseData.HealSound.Length > 0)
             WorldStatic.SoundManager.CreateSoundOn(entity, m_healChaseData.HealSound, new SoundParams(entity));

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -16,6 +16,7 @@
 - Fix A_JumpIfFlagsSet always evaluating to true if Args3 is set for MBF21 flags.
 - Fix movement/ticking processing order so that movement is handled first. Fixes Dominus Diabolicus 2 Cybermancubus acid puddles not doing damage.
 - Add validation for custom monster look logic in monster closets. Fixes Wraith Dominus Diabolicus 2 in monster closet.
+- Fix crash that can happen from A_HealChase. FIxes Skulltiverse II MAP24 boss.
 
 ## Misc:
 - Add compatibility for Eviternity II Annihilate Me skill level to swap incorrect usage of SpawnMulti to SpawnMultiCoopOnly.


### PR DESCRIPTION
Pass correct entity to SetState for heal chase. fixes crash with boss in Skulltiverse II MAP24. This was exposed because the boss calls A_JumpIfFlagsSet which attempts to set the state on the healed entity instead of the boss entity disposing it which crashes.