### PR TITLE
fix physics crash in EntityFallCheck

### DIFF
--- a/Core/World/Physics/PhysicsManager.cs
+++ b/Core/World/Physics/PhysicsManager.cs
@@ -151,17 +151,17 @@ public sealed class PhysicsManager
     {
         for (int i = entities.Length - 1; i >= 0; i--)
         {
-            var entity = entities[i];
+            var entity = entities.Data[i];
+            if (entity == null || entity.IsDisposed)
+                continue;
+
             var onEntity = entity.OnEntity();
-            bool hasOnEntity = onEntity != null;
-            if (!hasOnEntity && entity.HadOnEntity)
+            if ((onEntity == null && entity.HadOnEntity) ||
+                (onEntity != null && (onEntity.Position.Z + onEntity.Height < entity.Position.Z || !onEntity.Overlaps2D(entity))))
             {
                 ClampBetweenFloorAndCeiling(entity, entity.IntersectSectors, smoothZ: false, clampToLinkedSectors: true);
                 continue;
             }
-
-            if (onEntity!.Position.Z + onEntity.Height < entity.Position.Z || !onEntity.Overlaps2D(entity))
-                ClampBetweenFloorAndCeiling(entity, entity.IntersectSectors, smoothZ: false, clampToLinkedSectors: true);
         }
     }
 


### PR DESCRIPTION
Add safety checks for null and IsDisposed

Simplify check to guard for null and remove null forgive operator

Seems to be a rare occurrence but happened during gameplay.

Crash log logged this line as the crash:
if (!hasOnEntity && entity.HadOnEntity)

but was likely a crash on this line because of inlining in release:
var onEntity = entity.OnEntity(); 