### PR TITLE
Fix ripper flag creating sound/blood when not applying damage

### DIFF
--- a/Core/World/WorldBase.cs
+++ b/Core/World/WorldBase.cs
@@ -1904,10 +1904,11 @@ public abstract partial class WorldBase : IWorld
             damage = (int)(damage * WorldStatic.DamageApplyMultiplier);
         }
 
-        if (target.Damage(source, damage, setPainState, damageType) || target.IsInvulnerable)
+        var success = target.Damage(source, damage, setPainState, damageType);
+        if (success || target.IsInvulnerable)
             target.Velocity += thrustVelocity;
 
-        return true;
+        return success;
     }
 
     public virtual bool GiveItem(Player player, Entity item, EntityFlags? flags, out EntityDefinition definition, bool pickupFlash = true)

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -18,6 +18,7 @@
 - Add validation for custom monster look logic in monster closets. Fixes Wraith Dominus Diabolicus 2 in monster closet.
 - Fix crash that can happen from A_HealChase. FIxes Skulltiverse II MAP24 boss.
 - Fix missing tracer set in A_SpawnObject and A_Fire call from A_CireCrackle. Fixes Dominus Diabolicus 2 MAP21 boss.
+- Fix ripper flag creating sound/blood when not applying damage.
 
 ## Misc:
 - Add compatibility for Eviternity II Annihilate Me skill level to swap incorrect usage of SpawnMulti to SpawnMultiCoopOnly.


### PR DESCRIPTION
Correct bool return on DamageEntity to fix blood/sound being created when entity isn't actually damaged