### PR TITLE
Console Messages in SBARDEF as original color, not greyscale.

### DIFF
--- a/Core/Layer/Worlds/StatusBar/StatusBarRenderer.cs
+++ b/Core/Layer/Worlds/StatusBar/StatusBarRenderer.cs
@@ -51,7 +51,7 @@ public class StatusBarRenderer
     // Mapping SBARDEF stems to Helion Internal Fonts to enable grayscale tinting and better rendering
     private static readonly Dictionary<string, string> StemToHelionFontMap = new(StringComparer.OrdinalIgnoreCase)
     {
-        { "STCFN", Constants.Fonts.SmallGray },
+        { "STCFN", Constants.Fonts.Small },
         { "STT", Constants.Fonts.LargeHud },
         { "STG", Constants.Fonts.SmallGrayFixedWidthNumbers },
         { "STYS", "HudYellowNumbers" }


### PR DESCRIPTION
This, along with an updated [NightKicker (EA.V5)](https://github.com/user-attachments/files/25536510/Nightkicker-Native-EarlyAccess5.zip) (which puts the console font in a native container), will allow for massive scaling without message scale getting out of hand.

Pictured, `hud.scale == 6`:

<img width="1920" height="1080" alt="helion_20260224_21 32 02 4926" src="https://github.com/user-attachments/assets/bbb098be-ce11-4406-9963-4c6f217fd9ca" />
<img width="1920" height="1080" alt="helion_20260224_21 30 09 3927" src="https://github.com/user-attachments/assets/a33b0d04-c6c6-4c3a-98ac-d9e3737e4a8c" />
