### PR TITLE
Return PaletteIndex.Normal when the calculated palette is <= 0.

### DIFF
--- a/Core/Graphics/Palettes/PaletteUtil.cs
+++ b/Core/Graphics/Palettes/PaletteUtil.cs
@@ -79,6 +79,8 @@ public static class PaletteUtil
         const int StartRedPals = 1;
         int palette = (damageCount + 7) >> 3;
         palette = (int)(palette * damgeIntensity);
+        if (palette <= 0)
+            return PaletteIndex.Normal;
         if (palette >= RedPals)
             palette = RedPals - 1;
         palette += StartRedPals;


### PR DESCRIPTION
This will not show paletted berserk in the case where we're not doing truecolor overlays and the intensity is set low or off.

Config to test:
```
window.colormode == Palette
window.palettetruecoloroverlay == False
game.berserkintensity == 0.0
```

Fixes #1500.