### PR TITLE
fix MoveEnemy returning true when a monster can't move when they have velocity

### DIFF
--- a/Core/World/Entities/Enemy.cs
+++ b/Core/World/Entities/Enemy.cs
@@ -362,8 +362,10 @@ public partial class Entity
 
         bool isMoving = speedX != 0 || speedY != 0;
         bool setZ = true;
+        var posX = Position.X;
+        var posY = Position.Y;
         Flags.SetMonsterMove();
-        tryMove = WorldStatic.World.PhysicsManager.TryMoveXY(this, Position.X + speedX, Position.Y + speedY);
+        tryMove = WorldStatic.World.PhysicsManager.TryMoveXY(this, posX + speedX, posY + speedY);
         Flags.ClearMonsterMove();
 
         if (Flags.Teleported())
@@ -372,8 +374,8 @@ public partial class Entity
         if (tryMove.Success && moveFactor.Friction > Constants.DefaultFriction)
         {
             moveFactor.Factor *= Constants.DefaultFriction / 4;
-            Position.X = PrevPosition.X;
-            Position.Y = PrevPosition.Y;
+            Position.X = posX;
+            Position.Y = posY;
             Velocity.X += speedX * moveFactor.Factor;
             Velocity.Y += speedY * moveFactor.Factor;
             setZ = false;
@@ -398,7 +400,7 @@ public partial class Entity
 
         // With increased speeds using the TickMultiplier TryMove will iterate and can have partial successes.
         // A partial success needs be considered true in this case.
-        return Position.X != PrevPosition.X || Position.Y != PrevPosition.Y || tryMove.Success;
+        return tryMove.Success || tryMove.SubMoveSuccess;
     }
 
     public void TurnTowardsMovementDirection()

--- a/Core/World/Physics/PhysicsManager.cs
+++ b/Core/World/Physics/PhysicsManager.cs
@@ -1151,7 +1151,6 @@ doneLinkToSectors:
         }
 
         bool success = true;
-        bool successfulSubmove = false;
         Vec3D saveVelocity = entity.Velocity;
         int slideBlockLineId = -1;
         Entity? slideBlockEntity = null;
@@ -1166,7 +1165,7 @@ doneLinkToSectors:
             double nextY = entity.Position.Y + stepDelta.Y;
             if (IsPositionValid(entity, nextX, nextY, TryMoveData) && entity.CheckDropOff(TryMoveData))
             {
-                successfulSubmove = true;
+                TryMoveData.SubMoveSuccess = true;
                 entity.MoveLinked = true;
                 MoveTo(entity, nextX, nextY, TryMoveData);
                 if (entity.Flags.Teleported())
@@ -1217,7 +1216,7 @@ doneLinkToSectors:
         }
 
         // Only required for ripper entities
-        if (successfulSubmove && entity.Flags.Ripper())
+        if (TryMoveData.SubMoveSuccess && entity.Flags.Ripper())
             m_world.HandleFinalizeEntityIntersections(entity, TryMoveData);
 
         if (!success)

--- a/Core/World/Physics/TryMoveData.cs
+++ b/Core/World/Physics/TryMoveData.cs
@@ -9,6 +9,7 @@ namespace Helion.World.Physics;
 public class TryMoveData
 {
     public bool Success;
+    public bool SubMoveSuccess;
     public bool CanFloat;
     public bool BlockedLineClearsVelocity;
     public bool HasTouchy;
@@ -45,6 +46,7 @@ public class TryMoveData
         DropOffEntity = null;
         Subsector = null;
         BlockingEntity = null;
+        SubMoveSuccess = false;
     }
 
     public void SetIntersectionData(LineOpening opening)

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,32 +1,9 @@
-# 0.9.9.1 (Pre-release)
+# 0.9.9.2 (Pre-release)
 
 ## Features:
-- Add SBARDEF.
-- Add stacked message counts.
-- Add ZDoom-styled centered HUD key notifications.
-- Add SpawnMulti and SpawnMultiCoopOnly.
-- Add support for new UMAPINFO keys 'jumping', 'crouching', and 'freeaim'.
-- Add clear screen option in video options to emulate hall of mirrors effect where pixels are not draw.
+
 
 ## Bug Fixes:
-- Fix not cooperative flag check for solo-net.
-- Fix crash that can happen with hud string rendering.
-- Fix boom teleport line specials to match boom behavior for non-players. Fixes Remanence MAP01 cyber platforms not lowering.
-- Fix boom generalized sector damage not working.
-- Fix A_JumpIfFlagsSet always evaluating to true if Args3 is set for MBF21 flags.
-- Fix movement/ticking processing order so that movement is handled first. Fixes Dominus Diabolicus 2 Cybermancubus acid puddles not doing damage.
-- Add validation for custom monster look logic in monster closets. Fixes Wraith Dominus Diabolicus 2 in monster closet.
-- Fix crash that can happen from A_HealChase. FIxes Skulltiverse II MAP24 boss.
-- Fix missing tracer set in A_SpawnObject and A_Fire call from A_CireCrackle. Fixes Dominus Diabolicus 2 MAP21 boss.
-- Fix ripper flag creating sound/blood when not applying damage.
-- Fix missiles with NoBlockMap flag not being destroyed by crushers.
-- Fix levelstat and log file options not writing to the user's data folder when not in portable mode.
+- Fix issue where monsters would not move when they have velocity applied (e.g. from bullet hit or explosion damage)
 
 ## Misc:
-- Add compatibility for Eviternity II Annihilate Me skill level to swap incorrect usage of SpawnMulti to SpawnMultiCoopOnly.
-- Implemented custom frame limiter. Reduces CPU/power usage and yields better results since the OpenTK 4.9.4 upgrade in Helion 0.9.8.0 that was causing FPS drops on certain machines.
-- Removed intermediate buffer copy per frame. Increases performance with integrated GPUs at higher resolutions caused by bandwidth bottleneck.
-- Removed unnecessary OpenGL clear calls. Small performance improvement with integrated GPUs.
-- Added better OpenGL version testing that would previously cause hard crashes on some Linux setups.
-- Added -fast parameter to toggle fast monsters in addition to sv_fastmonsters.
-- Interpolation for scrolling SKYDEFS.

--- a/Tests/Unit/GameAction/Physics/Physics_TryMove.cs
+++ b/Tests/Unit/GameAction/Physics/Physics_TryMove.cs
@@ -28,6 +28,41 @@ public partial class Physics
         monster.Position.Z.Should().Be(0);
     }
 
+
+    [Fact(DisplayName = "Moving enemy success with velocity")]
+    public void EnemyMoveWithVelocitySuccess()
+    {
+        var monster = GameActions.CreateEntity(World, "BaronOfHell", new Vec3D(-1504, 216, int.MinValue), frozen: false, initSpawn: true);
+        monster.MonsterMovementSpeed = 8;
+        monster.Position.Z.Should().Be(0);
+        monster.SetEnemyDirection(Entity.MoveDir.North);
+        monster.Velocity.X = 0.1;
+        monster.Velocity.Y = 0.1;
+        monster.PrevPosition.Y = 208;
+        monster.MoveEnemy(out _).Should().Be(true);
+        monster.Position.X.Should().Be(-1504);
+        monster.Position.Y.Should().Be(224);
+        monster.Position.Z.Should().Be(0);
+    }
+
+    [Fact(DisplayName = "Moving enemy fails with velocity because of blocking thing")]
+    public void EnemyMoveWithVelocityFail()
+    {
+        var monster = GameActions.CreateEntity(World, "BaronOfHell", new Vec3D(-1504, 216, int.MinValue), frozen: false, initSpawn: true);
+        var blockMonster = GameActions.CreateEntity(World, "BaronOfHell", new Vec3D(-1504, 216 + monster.Radius + 1, int.MinValue), frozen: false, initSpawn: true);
+        monster.MonsterMovementSpeed = 8;
+        monster.Position.Z.Should().Be(0);
+        monster.SetEnemyDirection(Entity.MoveDir.North);
+        monster.Velocity.X = 0.1;
+        monster.Velocity.Y = 0.1;
+        monster.PrevPosition.Y = 208;
+        monster.MoveEnemy(out _).Should().Be(false);
+        monster.BlockingEntity.Should().Be(blockMonster);
+        monster.Position.X.Should().Be(-1504);
+        monster.Position.Y.Should().Be(216);
+        monster.Position.Z.Should().Be(0);
+    }
+
     [Fact(DisplayName = "Moving to a position where the bounding box lands exactly on a blocking line is successful")]
     public void TryMoveBoundingBoxOnLine()
     {


### PR DESCRIPTION
This removes using the PrevPosition to check for success. Because of the move/tick order swap the PrevPosition no longer equals the current Position. This caused this check to always return true even if the monster is blocked but has velocity applied from a bullet or explosion thrust. Added SubMoveSuccess to TryMove to correctly check for partial move success.