### PR TITLE
Option in Automap settings to hide stats.

### DIFF
--- a/Core/Graphics/Palettes/PaletteUtil.cs
+++ b/Core/Graphics/Palettes/PaletteUtil.cs
@@ -79,6 +79,8 @@ public static class PaletteUtil
         const int StartRedPals = 1;
         int palette = (damageCount + 7) >> 3;
         palette = (int)(palette * damgeIntensity);
+        if (palette <= 0)
+            return PaletteIndex.Normal;
         if (palette >= RedPals)
             palette = RedPals - 1;
         palette += StartRedPals;

--- a/Core/Layer/Worlds/WorldLayer.Render.Hud.cs
+++ b/Core/Layer/Worlds/WorldLayer.Render.Hud.cs
@@ -256,7 +256,7 @@ public partial class WorldLayer
     private void DrawStatInfo(IHudRenderContext hud, bool automapVisible, Vec2I start, ref int topRightY, 
         bool suppressStats = false, bool suppressTime = false)
     {
-        if (!m_config.Hud.ShowStats && !automapVisible)
+        if (!m_config.Hud.ShowStats && (!automapVisible || !m_config.Hud.AutoMap.ShowStats))
             return;
 
         start.X = -m_padding - m_hudPaddingX;

--- a/Core/Util/Configs/Components/ConfigHud.cs
+++ b/Core/Util/Configs/Components/ConfigHud.cs
@@ -61,6 +61,10 @@ public class ConfigHudAutoMap: ConfigElement<ConfigHudAutoMap>
     [ConfigInfo("Show map title on the automap.")]
     [OptionMenu(OptionSectionType.Automap, "Show Map Title")]
     public readonly ConfigValue<bool> MapTitle = new(true);
+
+    [ConfigInfo("Show stats (kills, items, secrets, time) on the automap.")]
+    [OptionMenu(OptionSectionType.Automap, "Show Stats")]
+    public readonly ConfigValue<bool> ShowStats = new(true);
     
     [ConfigInfo("Use average color from key icon image.")]
     [OptionMenu(OptionSectionType.Automap, "Key Image Color")]


### PR DESCRIPTION
Closes #1462.

<img width="652" height="281" alt="image" src="https://github.com/user-attachments/assets/ba035d16-4381-42e1-bd1c-ad8e82f1f81a" />

<img width="1023" height="767" alt="image" src="https://github.com/user-attachments/assets/55359533-e64a-45b5-827c-2bc18a9f7c22" />
