### PR TITLE
Fix alignment for fullscreen CWILV## Intermission -> Entering MAP screens.

### DIFF
--- a/Core/Layer/Intermission/IntermissionLayer.Render.cs
+++ b/Core/Layer/Intermission/IntermissionLayer.Render.cs
@@ -140,13 +140,32 @@ public partial class IntermissionLayer
 
         if (IntermissionState >= IntermissionState.NextMap && NextMapInfo != null)
         {
+            bool isFullscreen = IsFullscreenPatch(hud, NextMapInfo.TitlePatch, m_textUpscalingFactor);
+
+            if (!isFullscreen)
+            {
+                hud.Image(NowEnteringImage,
+                    (0, offsetY) + GetPatchOffset(hud, NowEnteringImage, m_textUpscalingFactor),
+                    out HudBox drawArea,
+                    both: Align.TopMiddle,
+                    upscalingFactor: m_textUpscalingFactor);
+                offsetY += (5 * drawArea.Height) / 4;
+            }
+
             DrawMapTitle(hud, NextMapInfo, ref offsetY, m_textUpscalingFactor);
-            hud.Image(NowEnteringImage, (0, offsetY) + GetPatchOffset(hud, NowEnteringImage, m_textUpscalingFactor), both: Align.TopMiddle, upscalingFactor: m_textUpscalingFactor);
         }
         else
         {
+            bool isFullscreen = IsFullscreenPatch(hud, CurrentMapInfo.TitlePatch, m_textUpscalingFactor);
             DrawMapTitle(hud, CurrentMapInfo, ref offsetY, m_textUpscalingFactor);
-            hud.Image(FinishedImage, (0, offsetY) + GetPatchOffset(hud, FinishedImage, m_textUpscalingFactor), both: Align.TopMiddle, upscalingFactor: m_textUpscalingFactor);
+
+            if (!isFullscreen)
+            {
+                hud.Image(FinishedImage,
+                    (0, offsetY) + GetPatchOffset(hud, FinishedImage, m_textUpscalingFactor),
+                    both: Align.TopMiddle,
+                    upscalingFactor: m_textUpscalingFactor);
+            }
         }
     }
 
@@ -154,10 +173,20 @@ public partial class IntermissionLayer
     {
         if (!string.IsNullOrEmpty(mapInfo.TitlePatch))
         {
-            hud.Image(mapInfo.TitlePatch, (0, offsetY) + GetPatchOffset(hud, mapInfo.TitlePatch, m_textUpscalingFactor),
-                out HudBox drawArea, both: Align.TopMiddle, upscalingFactor: textUpscalingFactor);
-            offsetY += (5 * drawArea.Height) / 4;
-            return;
+            if (hud.Textures.TryGet(mapInfo.TitlePatch, out var handle, upscalingFactor: textUpscalingFactor))
+            {
+                bool isFullscreen = handle.Dimension.Width >= 320 || handle.Dimension.Height >= 200;
+                int drawY = isFullscreen ? 0 : offsetY;
+
+                hud.Image(mapInfo.TitlePatch,
+                    (0, drawY) + TranslateDoomOffset(handle.Offset),
+                    out HudBox drawArea,
+                    both: Align.TopMiddle,
+                    upscalingFactor: textUpscalingFactor);
+
+                if (!isFullscreen) offsetY += 5 * drawArea.Height / 4;
+                return;
+            }
         }
 
         // TODO would look nicer if there was a large font for the level text
@@ -179,6 +208,15 @@ public partial class IntermissionLayer
         if (hud.Textures.TryGet(name, out var text, upscalingFactor: upscalingFactor))
             return TranslateDoomOffset(text.Offset);
         return Vec2I.Zero;
+    }
+
+    private static bool IsFullscreenPatch(IHudRenderContext hud, string patchName, int upscalingFactor)
+    {
+        if (string.IsNullOrEmpty(patchName)) return false;
+
+        if (hud.Textures.TryGet(patchName, out var handle, upscalingFactor: upscalingFactor))
+            return handle.Dimension.Width >= 320 || handle.Dimension.Height >= 200;
+        return false;
     }
 
     private void DrawStatistics(IHudRenderContext hud)

--- a/Core/Layer/Intermission/IntermissionLayer.Render.cs
+++ b/Core/Layer/Intermission/IntermissionLayer.Render.cs
@@ -140,9 +140,8 @@ public partial class IntermissionLayer
 
         if (IntermissionState >= IntermissionState.NextMap && NextMapInfo != null)
         {
-            hud.Image(NowEnteringImage, (0, offsetY) + GetPatchOffset(hud, NowEnteringImage, m_textUpscalingFactor), out HudBox drawArea, both: Align.TopMiddle, upscalingFactor: m_textUpscalingFactor);
-            offsetY += (5 * drawArea.Height) / 4;
             DrawMapTitle(hud, NextMapInfo, ref offsetY, m_textUpscalingFactor);
+            hud.Image(NowEnteringImage, (0, offsetY) + GetPatchOffset(hud, NowEnteringImage, m_textUpscalingFactor), both: Align.TopMiddle, upscalingFactor: m_textUpscalingFactor);
         }
         else
         {

--- a/Core/Layer/Intermission/IntermissionLayer.Render.cs
+++ b/Core/Layer/Intermission/IntermissionLayer.Render.cs
@@ -142,15 +142,10 @@ public partial class IntermissionLayer
         {
             bool isFullscreen = IsFullscreenPatch(hud, NextMapInfo.TitlePatch, m_textUpscalingFactor);
 
-            if (!isFullscreen)
-            {
-                hud.Image(NowEnteringImage,
-                    (0, offsetY) + GetPatchOffset(hud, NowEnteringImage, m_textUpscalingFactor),
-                    out HudBox drawArea,
-                    both: Align.TopMiddle,
-                    upscalingFactor: m_textUpscalingFactor);
-                offsetY += (5 * drawArea.Height) / 4;
-            }
+            hud.Image(NowEnteringImage, (0, offsetY) + GetPatchOffset(hud, NowEnteringImage, m_textUpscalingFactor), 
+                out HudBox drawArea, both: Align.TopMiddle, upscalingFactor: m_textUpscalingFactor);
+
+            if (!isFullscreen) offsetY += 5 * drawArea.Height / 4;
 
             DrawMapTitle(hud, NextMapInfo, ref offsetY, m_textUpscalingFactor);
         }
@@ -161,10 +156,8 @@ public partial class IntermissionLayer
 
             if (!isFullscreen)
             {
-                hud.Image(FinishedImage,
-                    (0, offsetY) + GetPatchOffset(hud, FinishedImage, m_textUpscalingFactor),
-                    both: Align.TopMiddle,
-                    upscalingFactor: m_textUpscalingFactor);
+                hud.Image(FinishedImage, (0, offsetY) + GetPatchOffset(hud, FinishedImage, m_textUpscalingFactor), 
+                    both: Align.TopMiddle, upscalingFactor: m_textUpscalingFactor);
             }
         }
     }
@@ -178,15 +171,13 @@ public partial class IntermissionLayer
                 bool isFullscreen = handle.Dimension.Width >= 320 || handle.Dimension.Height >= 200;
                 int drawY = isFullscreen ? 0 : offsetY;
 
-                hud.Image(mapInfo.TitlePatch,
-                    (0, drawY) + TranslateDoomOffset(handle.Offset),
-                    out HudBox drawArea,
-                    both: Align.TopMiddle,
-                    upscalingFactor: textUpscalingFactor);
+                hud.Image(mapInfo.TitlePatch, (0, drawY) + TranslateDoomOffset(handle.Offset),
+                    out HudBox drawArea, both: Align.TopMiddle, upscalingFactor: textUpscalingFactor);
 
                 if (!isFullscreen) offsetY += 5 * drawArea.Height / 4;
-                return;
             }
+            
+            return; 
         }
 
         // TODO would look nicer if there was a large font for the level text


### PR DESCRIPTION
Fixes #1501.

# Fullscreen `CWILV##`s, Eviternity:

## Before:

<img width="1024" height="768" alt="helion_20260226_00 21 55 1681" src="https://github.com/user-attachments/assets/225aca62-1641-4da8-b799-241d4d228b01" />

## After:

<img width="1024" height="768" alt="helion_20260226_00 14 15 8692" src="https://github.com/user-attachments/assets/ad61d75c-6423-43a7-9945-420122d0cc88" />
<img width="1024" height="768" alt="helion_20260226_00 14 18 4355" src="https://github.com/user-attachments/assets/5583d5d0-154e-4f8d-b22b-ca404eaffeaa" />

# No regressions on IWADs:

<img width="1024" height="768" alt="helion_20260226_00 19 31 1145" src="https://github.com/user-attachments/assets/ec57cbb2-6ed8-4173-936e-895f0759a22b" />
<img width="1024" height="768" alt="helion_20260226_01 08 49 2356" src="https://github.com/user-attachments/assets/b2bfec99-19d7-4940-b49c-3d8630b99993" />


<img width="1024" height="768" alt="helion_20260226_00 13 41 87" src="https://github.com/user-attachments/assets/38ee9e57-e520-4ba4-8415-8583804bf1c1" />
<img width="1024" height="768" alt="helion_20260226_01 02 44 2569" src="https://github.com/user-attachments/assets/4b2551e6-2e93-4296-bfc7-5c05a77cfa1c" />
