### PR TITLE
Fix letterbox clear margins and true color overlays

### DIFF
--- a/Core/Layer/Worlds/WorldLayer.Render.Hud.cs
+++ b/Core/Layer/Worlds/WorldLayer.Render.Hud.cs
@@ -16,8 +16,10 @@ using Helion.Render.OpenGL.Util;
 using Helion.Resources;
 using Helion.Resources.Definitions.Decorate.States;
 using Helion.Resources.Definitions.MapInfo;
+using Helion.Resources.Definitions.StatusBar;
 using Helion.Strings;
 using Helion.Util;
+using Helion.Util.Configs;
 using Helion.Util.Configs.Components;
 using Helion.Util.Configs.Extensions;
 using Helion.Util.Consoles;
@@ -33,7 +35,6 @@ using Helion.World.StatusBar;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Helion.Resources.Definitions.StatusBar;
 using static Helion.Render.Common.RenderDimensions;
 
 namespace Helion.Layer.Worlds;
@@ -344,11 +345,20 @@ public partial class WorldLayer
         return str;
     }
 
+    private Box2I GetNativeDrawBox()
+    {
+        if (Renderer.GetNativeLetterBoxes(m_config, m_viewport, out var left, out var right))
+            return new Box2I(new Vec2I(left.Max.X, left.Min.Y), new Vec2I(right.Min.X, right.Max.Y));
+
+        return new Box2I(new Vec2I(0, 0), new Vec2I(m_viewport.Width, m_viewport.Height));
+    }
+
     private void DrawHudEffects(IHudRenderContext hud)
     {
         if (!WorldStatic.World.DrawHud || (ShaderVars.PaletteColorMode && !m_config.Window.PaletteTrueColorOverlay))
             return;
 
+        var box = GetNativeDrawBox();
         IPowerup? powerup = Player.Inventory.PowerupEffectColor;
         if (powerup?.DrawColor != null && powerup.DrawPowerupEffect)
         {
@@ -356,7 +366,7 @@ public partial class WorldLayer
             if (powerup.PowerupType == PowerupType.Strength)
                 alpha *= (float)m_config.Game.BerserkIntensity;
 
-            hud.Clear(powerup.DrawColor.Value, alpha);
+            hud.Clear(box, powerup.DrawColor.Value, alpha);
         }
 
         if (Player.BonusCount > 0)
@@ -364,7 +374,7 @@ public partial class WorldLayer
             const float PickupScaleAmount = 3f;
             var pickupScale = (Player.BonusCount + 7) / PickupScaleAmount;
             pickupScale *= 1 / PickupScaleAmount;
-            hud.Clear(PickupColor, Math.Min(pickupScale, 0.2f));
+            hud.Clear(box, PickupColor, Math.Min(pickupScale, 0.2f));
         }
 
         if (Player.DamageCount > 0)
@@ -372,7 +382,7 @@ public partial class WorldLayer
             const float DamageScaleAmount = 8f;
             var damageScale = Math.Min(Player.DamageCount + 7, 100) / DamageScaleAmount;
             damageScale *= 1 / DamageScaleAmount;
-            hud.Clear(DamageColor, Math.Min(damageScale, 0.89f) * (float)m_config.Game.PainIntensity);
+            hud.Clear(box, DamageColor, Math.Min(damageScale, 0.89f) * (float)m_config.Game.PainIntensity);
         }
     }
 

--- a/Core/Render/Common/Commands/RenderCommands.cs
+++ b/Core/Render/Common/Commands/RenderCommands.cs
@@ -1,10 +1,8 @@
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
 using Helion.Geometry;
+using Helion.Geometry.Boxes;
 using Helion.Geometry.Vectors;
 using Helion.Graphics;
 using Helion.Graphics.Geometry;
-using Helion.Layer.Transition;
 using Helion.Render.Common.Enums;
 using Helion.Render.OpenGL.Commands.Types;
 using Helion.Render.OpenGL.Shared;
@@ -14,6 +12,8 @@ using Helion.Util.Configs;
 using Helion.Util.Timing;
 using Helion.World;
 using Helion.World.Entities;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
 
 namespace Helion.Render.OpenGL.Commands;
 
@@ -29,6 +29,7 @@ public enum RenderCommandType
     Automap,
     Hud,
     Transition,
+    Scissor
 }
 
 [StructLayout(LayoutKind.Sequential)]
@@ -64,6 +65,7 @@ public class RenderCommands
     public List<DrawTextCommand> TextCommands = new();
     public List<DrawShapeCommand> ShapeCommands = new();
     public List<TransitionCommand> TransitionCommands = new();
+    public List<ScissorCommand> ScissorCommands = new();
 
     public Dimension RenderDimension => m_renderDimensions;
     public Dimension WindowDimension => m_windowDimensions;
@@ -98,6 +100,7 @@ public class RenderCommands
         ShapeCommands.Clear();
         AutomapCommands.Clear();
         TransitionCommands.Clear();
+        ScissorCommands.Clear();
 
         ResolutionInfo = new ResolutionInfo { VirtualDimensions = RenderDimension };
         m_scale = Vec2D.One;
@@ -176,6 +179,12 @@ public class RenderCommands
     {
         Commands.Add(new RenderCommand(RenderCommandType.Transition, TransitionCommands.Count));
         TransitionCommands.Add(new TransitionCommand(type, progress, init));
+    }
+
+    public void Scissor(Box2I box, ScissorEnable enable)
+    {
+        Commands.Add(new RenderCommand(RenderCommandType.Scissor, ScissorCommands.Count));
+        ScissorCommands.Add(new(box, enable));
     }
 
     /// <summary>

--- a/Core/Render/Common/Commands/Types/ScissorCommand.cs
+++ b/Core/Render/Common/Commands/Types/ScissorCommand.cs
@@ -1,0 +1,13 @@
+﻿using Helion.Geometry.Boxes;
+
+namespace Helion.Render.OpenGL.Commands.Types;
+
+public enum ScissorEnable
+{
+    KeepState,
+    Disable,
+    Enable,
+}
+
+
+public record struct ScissorCommand(Box2I Box, ScissorEnable Enable);

--- a/Core/Render/Common/Renderers/IHudRenderContext.cs
+++ b/Core/Render/Common/Renderers/IHudRenderContext.cs
@@ -1,5 +1,6 @@
 using System;
 using Helion.Geometry;
+using Helion.Geometry.Boxes;
 using Helion.Geometry.Segments;
 using Helion.Geometry.Vectors;
 using Helion.Graphics;
@@ -43,6 +44,7 @@ public interface IHudRenderContext : IDisposable
     /// <param name="color">The color to fill with.</param>
     /// <param name="alpha">The alpha value for the color.</param>
     void Clear(Color color, float alpha = 1.0f);
+    void Clear(Box2I box, Color color, float alpha = 1.0f);
 
     void Point(Vec2I point, Color color, Align window = Align.TopLeft, float alpha = 1.0f);
 

--- a/Core/Render/Common/Renderers/IRenderableSurfaceContext.cs
+++ b/Core/Render/Common/Renderers/IRenderableSurfaceContext.cs
@@ -61,8 +61,8 @@ public interface IRenderableSurfaceContext
     /// restores back to the area before this call.
     /// </summary>
     /// <param name="area">The restricted scissor area.</param>
-    /// <param name="action">The actions to run with the new area.</param>
-    void Scissor(Box2I area, Action action);
+    /// <param name="enable">If scissor should be applied to the restricted area.</param>
+    void Scissor(Box2I area, bool enable);
 
     /// <summary>
     /// Begins hud rendering actions.

--- a/Core/Render/OpenGL/GLHudRenderContext.cs
+++ b/Core/Render/OpenGL/GLHudRenderContext.cs
@@ -1,4 +1,5 @@
 using Helion.Geometry;
+using Helion.Geometry.Boxes;
 using Helion.Geometry.Segments;
 using Helion.Geometry.Vectors;
 using Helion.Graphics;
@@ -62,6 +63,15 @@ public class GLHudRenderContext : IHudRenderContext
 
         Dimension dim = m_commands.WindowDimension;
         m_commands.FillRect(new((0, 0), (dim.Vector)), color, alpha);
+    }
+
+    public void Clear(Box2I box, Color color, float alpha)
+    {
+        if (m_context == null)
+            return;
+
+        var imageBox = new ImageBox2I(box.Min, box.Max);
+        m_commands.FillRect(imageBox, color, alpha);
     }
 
     public void Point(Vec2I point, Color color, Align window = Align.TopLeft, float alpha = 1.0f)

--- a/Core/Render/OpenGL/GLRenderableSurfaceContext.cs
+++ b/Core/Render/OpenGL/GLRenderableSurfaceContext.cs
@@ -4,6 +4,7 @@ using Helion.Graphics;
 using Helion.Render.Common.Context;
 using Helion.Render.Common.Renderers;
 using Helion.Render.OpenGL.Commands;
+using Helion.Render.OpenGL.Commands.Types;
 using Helion.Window;
 using Helion.World;
 
@@ -68,12 +69,12 @@ public class GLRenderableSurfaceContext : IRenderableSurfaceContext
 
     public void Scissor(Box2I area)
     {
-        // Not part of the old renderer.
+        Commands.Scissor(area, ScissorEnable.KeepState);
     }
 
-    public void Scissor(Box2I area, Action action)
+    public void Scissor(Box2I area, bool enable)
     {
-        // Not part of the old renderer.
+        Commands.Scissor(area, enable ? ScissorEnable.Enable : ScissorEnable.Disable);
     }
 
     public void DrawVirtualFrameBuffer()

--- a/Core/Render/Renderer.cs
+++ b/Core/Render/Renderer.cs
@@ -1,5 +1,6 @@
 using GlmSharp;
 using Helion.Geometry;
+using Helion.Geometry.Boxes;
 using Helion.Geometry.Vectors;
 using Helion.Graphics;
 using Helion.Graphics.Geometry;
@@ -340,6 +341,26 @@ public partial class Renderer : IDisposable
             GetDownScaleAmount(config, renderInfo));
     }
 
+    public static bool GetNativeLetterBoxes(IConfig config, Dimension renderDimension, out Box2I left, out Box2I right)
+    {
+        if (!config.Window.Virtual.Enable || config.Window.Virtual.Stretch || config.Window.Virtual.Dimension == renderDimension)
+        {
+            left = default;
+            right = default;
+            return false;
+        }
+
+        var virtualDim = config.Window.Virtual.Dimension.Value;
+        var scale = Math.Min((float)renderDimension.Width / virtualDim.Width, (float)renderDimension.Height / virtualDim.Height);
+
+        var scaledWidth = (int)(virtualDim.Width * scale);
+        var offsetX = (renderDimension.Width - scaledWidth) / 2;
+
+        left = new Box2I(new Vec2I(0, 0), new Vec2I(offsetX, renderDimension.Height));
+        right = new Box2I(new Vec2I(renderDimension.Width - offsetX, 0), new Vec2I(renderDimension.Width, renderDimension.Height));
+        return true;
+    }
+
     private static float GetDownScaleAmount(IConfig config, RenderInfo renderInfo)
     {
         if (renderInfo.Viewport.Height <= 480)
@@ -538,6 +559,9 @@ public partial class Renderer : IDisposable
                     if (tranCmd.Progress.HasValue)
                         m_transitionRenderer.Render(m_mainFramebuffer, tranCmd.Progress.Value);
                     break;
+                case RenderCommandType.Scissor:
+                    HandleScissorCommand(renderCommands.ScissorCommands[cmd.Index]);
+                    break;
                 default:
                     Fail($"Unsupported render command type: {cmd.Type}");
                     break;
@@ -549,6 +573,19 @@ public partial class Renderer : IDisposable
 
         if (!virtualFrameBufferDraw)
             DrawVirtualFramebufferToMain();
+    }
+
+    private static void HandleScissorCommand(ScissorCommand cmd)
+    {
+        if (cmd.Enable != ScissorEnable.KeepState)
+        {
+            if (cmd.Enable == ScissorEnable.Enable)
+                GL.Enable(EnableCap.ScissorTest);
+            else
+                GL.Disable(EnableCap.ScissorTest);
+        }
+
+        GL.Scissor(cmd.Box.Min.X, cmd.Box.Min.Y, cmd.Box.Width, cmd.Box.Height);
     }
 
     private void BindColorMapBuffer()
@@ -872,7 +909,28 @@ public partial class Renderer : IDisposable
 
         m_mainFramebuffer.BindDraw();
         UpdateVirtualTextureFilter(m_virtualFramebuffer);
-        GL.Clear(ClearBufferMask.DepthBufferBit);
+
+        if (GetNativeLetterBoxes(m_config, Window.ClientDimension, out var left, out var right))
+        {
+            GL.Enable(EnableCap.ScissorTest);
+
+            GL.Scissor(left.Min.X, left.Min.Y, left.Width, left.Height);
+            GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit | ClearBufferMask.StencilBufferBit);
+
+            GL.Scissor(right.Min.X, right.Min.Y, right.Width, right.Height);
+            GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit | ClearBufferMask.StencilBufferBit);
+
+            var box = new Box2I(new Vec2I(left.Max.X, left.Min.Y), new Vec2I(right.Min.X, right.Max.Y));
+            GL.Scissor(box.Min.X, box.Min.Y, box.Width, box.Height);
+            GL.Clear(ClearBufferMask.DepthBufferBit);
+
+            GL.Disable(EnableCap.ScissorTest);
+        }
+        else
+        {
+            GL.Clear(ClearBufferMask.DepthBufferBit);
+        }
+
         m_framebufferRenderer.Render(m_virtualFramebuffer, CalculateVirtualMvp(m_virtualFramebuffer, GetVirtualDimension()));
     }
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -5,5 +5,9 @@
 
 ## Bug Fixes:
 - Fix issue where monsters would not move when they have velocity applied (e.g. from bullet hit or explosion damage)
+- Fix berserk intensity not working when set to zero with true color overlays disabled
+- Fix message color for SBARDEF
+- Fix letterbox areas not clearing and pain/pickup overlays drawing over letterbox areas when using virtual resolution
 
 ## Misc:
+- Added option to disable stats showing in automap


### PR DESCRIPTION
Clear letterbox areas when virtual resolution is used that requires it

Fix true color overlays to only apply to the render dimensions

fixes #1507 