### PR TITLE
Fix ZDoom-style message centering when using SBARDEF.

### DIFF
--- a/Core/Layer/Worlds/WorldLayer.Render.Hud.cs
+++ b/Core/Layer/Worlds/WorldLayer.Render.Hud.cs
@@ -151,7 +151,27 @@ public partial class WorldLayer
             DrawHudEffects(hud);
             hud.DrawPalette(false);
 
-            if ((sbarCoverage & StatusBarCoverage.Messages) == 0)
+            bool hasCenteredMessage = false;
+            long currentNanos = Ticker.NanoTime();
+            lock (m_console.Messages)
+            {
+                var node = m_console.Messages.First;
+                while (node != null)
+                {
+                    var msg = node.Value;
+                    if (currentNanos - msg.TimeNanos > Constants.MaxMessageVisibleTimeNanos)
+                        break;
+                    if (msg.IsCentered)
+                    {
+                        hasCenteredMessage = true;
+                        break;
+                    }
+                    node = node.Next;
+                }
+            }
+
+            if (hasCenteredMessage) DrawCenterMessages(hud);
+            else if ((sbarCoverage & StatusBarCoverage.Messages) == 0)
             {
                 DrawRecentConsoleMessages(hud);
                 DrawCenterMessages(hud);
@@ -467,15 +487,18 @@ public partial class WorldLayer
                     {
                         isCentered = msg.IsCentered;
 
-                        if (msg.StackCount > 1)
+                        if (!isCentered)
                         {
-                            var worldMsg = new WorldMessage(msg.Message, 1.0f, msg.StackCount);
-                            var span = GetRenderMessageWithCount(worldMsg);
-                            consoleMsg = span.ToString(); 
-                        }
-                        else
-                        {
-                            consoleMsg = msg.Message;
+                            if (msg.StackCount > 1)
+                            {
+                                var worldMsg = new WorldMessage(msg.Message, 1.0f, msg.StackCount);
+                                var span = GetRenderMessageWithCount(worldMsg);
+                                consoleMsg = span.ToString(); 
+                            }
+                            else
+                            {
+                                consoleMsg = msg.Message;
+                            }
                         }
                     }
                 }

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -8,6 +8,8 @@
 - Fix berserk intensity not working when set to zero with true color overlays disabled
 - Fix message color for SBARDEF
 - Fix letterbox areas not clearing and pain/pickup overlays drawing over letterbox areas when using virtual resolution
+- Fix vertical alignment for fullscreen CWILV## graphics in Intermissions (like in Eviternity.WAD)
+- Fix ZDoom-style message centering when using SBARDEF
 
 ## Misc:
 - Added option to disable stats showing in automap


### PR DESCRIPTION
<img width="1024" height="768" alt="helion_20260226_12 39 30 8197" src="https://github.com/user-attachments/assets/2f3c38bc-eb10-494d-87ac-5d172ad12f42" />
<img width="1024" height="768" alt="helion_20260226_12 39 33 9768" src="https://github.com/user-attachments/assets/2d72e1fb-dc46-4c5d-bd88-e0f30bb3adac" />
