### PR TITLE
fix project heights calculation to remove pixel gap correction from t…

### DIFF
--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/CoverWallUtil.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/CoverWallUtil.cs
@@ -1,7 +1,6 @@
 ﻿using Helion.World;
 using Helion.World.Geometry.Sides;
 using Helion.World.Geometry.Walls;
-using Helion.World.Physics;
 
 namespace Helion.Render.OpenGL.Renderers.Legacy.World.Geometry;
 
@@ -75,10 +74,11 @@ public class CoverWallUtil
 
         // Do not add to upper portion of lower textures, or upper portion of lower textures
         // Adjust cover wall offsets to not block extra pixels from the the backside
-        return new Heights
-        (
-            location == WallLocation.Lower ? -(float)WorldStatic.LineVertexGap : ProjectHeight,
-            location == WallLocation.Upper ? (float)WorldStatic.LineVertexGap : ProjectHeight
-        );
+        return location switch
+        {
+            WallLocation.Upper => new Heights(ProjectHeight, -(float)WorldStatic.LineVertexGap),
+            WallLocation.Lower => new Heights(-(float)WorldStatic.LineVertexGap, ProjectHeight),
+            _ => new(ProjectHeight, ProjectHeight),
+        };
     }
 }

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -11,6 +11,7 @@
 - Fix vertical alignment for fullscreen CWILV## graphics in Intermissions (like in Eviternity.WAD)
 - Fix ZDoom-style message centering when using SBARDEF
 - Fix intermission exitpic from MAPINFO not being set on transition. Fixes Eviternity II.
+- Fix software emulation discarding extra sprite pixels on the backside of upper textures.
 
 ## Misc:
 - Added option to disable stats showing in automap


### PR DESCRIPTION
Fix project heights calculation to remove pixel gap correction from the bottom of upper textures

fixes #1519 