### PR TITLE
do not render both sides of two-sided middle coverwall

### DIFF
--- a/Core/Render/OpenGL/Renderers/Legacy/World/Data/RenderWorldDataManager.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Data/RenderWorldDataManager.cs
@@ -30,7 +30,7 @@ public sealed class RenderWorldDataManager : IDisposable
         return renderDataList.Add(texture, program, brightmapTexture);
     }
 
-    public void AddCoverWallVertices(Side side, Span<DynamicVertex> vertices, WallLocation location)
+    public void AddCoverWallVertices(Side side, Span<DynamicVertex> vertices, WallLocation location, bool oneSided)
     {
         if (m_coverWalls == null || !BufferCoverWalls)
             return;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
@@ -34,6 +34,8 @@ namespace Helion.Render.OpenGL.Renderers.Legacy.World.Geometry;
 
 public partial class GeometryRenderer : IDisposable
 {
+    public delegate void RenderCoverWallAction(Side side, Span<DynamicVertex> vertices, WallLocation location, bool oneSided);
+
     private const double MaxSky = 16384;
     private static readonly Sector DefaultSector = CreateDefault();
     private static readonly GLLegacyTexture TestTexture = new(0, "TEST", default, default, default, default, default);
@@ -53,7 +55,7 @@ public partial class GeometryRenderer : IDisposable
     private readonly MidTextureHack m_midTextureHack = new();
     private readonly SectorPlane m_fakeFloor = new(SectorPlaneFace.Floor, 0, 0, 0);
     private readonly SectorPlane m_fakeCeiling = new(SectorPlaneFace.Ceiling, 0, 0, 0);
-    private readonly Action<Side, Span<DynamicVertex>, WallLocation> m_renderCoverWallAction;
+    private readonly RenderCoverWallAction m_renderCoverWallAction;
     private double m_tickFraction;
     private bool m_floorChanged;
     private bool m_ceilingChanged;
@@ -771,7 +773,7 @@ public partial class GeometryRenderer : IDisposable
             var renderData = m_worldDataManager.GetRenderData(texture, m_program, geometryType, brightmapTexture);
             renderData.Vbo.Add(data);
             if (m_vanillaRender && baseType == GeometryType.Wall && style == RenderDataStyle.Normal)
-                m_worldDataManager.AddCoverWallVertices(side, data, side.Middle.Location);
+                m_worldDataManager.AddCoverWallVertices(side, data, side.Middle.Location, true);
         }
         vertices = data;
     }
@@ -902,8 +904,10 @@ public partial class GeometryRenderer : IDisposable
     }
 
     public void RenderMidTexCoverWalls(Side side, Sector facingSector, Sector otherSector, Span<DynamicVertex> midTexVertices,
-        SideTexture visibleTextures, Action<Side, Span<DynamicVertex>, WallLocation> render)
+        SideTexture visibleTextures, RenderCoverWallAction render)
     {
+        // Check if this middle wall should clip to floor/ceiling.
+        // If not then project the cover walls from the floor/ceiling to block sprites from rendering to match software behavior.
         var clipPlanes = GetMidTexClipPlanes(side, facingSector, otherSector, out var opening, out var prevOpening);
         if (
             ((visibleTextures & SideTexture.Lower) == 0 || (side.FloodTextures & SideTexture.Lower) != 0) &&
@@ -920,7 +924,7 @@ public partial class GeometryRenderer : IDisposable
             }
 
             CoverWallUtil.SetCoverWallVertices(side, m_wallVertices, 0, WallLocation.Lower);
-            render(side, m_wallVertices, WallLocation.Lower);
+            render(side, m_wallVertices, WallLocation.Lower, true);
         }
 
         if (
@@ -938,7 +942,7 @@ public partial class GeometryRenderer : IDisposable
             }
 
             CoverWallUtil.SetCoverWallVertices(side, m_wallVertices, 0, WallLocation.Upper);
-            render(side, m_wallVertices, WallLocation.Upper);
+            render(side, m_wallVertices, WallLocation.Upper, true);
         }
     }
 
@@ -1250,7 +1254,7 @@ public partial class GeometryRenderer : IDisposable
             return;
 
         var vertices = RenderTwoSidedUpperOrLowerRaw(location, facingSide, facingSector, otherSector, isFrontSide);
-        m_worldDataManager.AddCoverWallVertices(facingSide, vertices, location);
+        m_worldDataManager.AddCoverWallVertices(facingSide, vertices, location, location == WallLocation.Middle);
     }
 
     // Renders vertices for upper/lower. No checking for skies, flood fill etc.

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
@@ -47,7 +47,7 @@ public partial class StaticCacheGeometryRenderer : IDisposable
     private readonly SkyGeometryManager m_skyGeometry = new();
     private readonly LookupArray<List<Sector>?> m_transferHeightsLookup = new();
     private readonly List<Sector> m_initMoveSectors = [];
-    private readonly Action<Side, Span<DynamicVertex>, WallLocation> m_renderCoverWallAction;
+    private readonly GeometryRenderer.RenderCoverWallAction m_renderCoverWallAction;
 
     private readonly Dictionary<CoverKey, StaticGeometryData> m_coverWallLookup = [];
     private readonly Dictionary<CoverKey, StaticGeometryData> m_coverFlatLookup = [];
@@ -432,7 +432,7 @@ public partial class StaticCacheGeometryRenderer : IDisposable
             if (m_vanillaRender && result.SkyVertices != null)
             {
                 var sideVertices = m_geometryRenderer.RenderTwoSidedUpperOrLowerRaw(WallLocation.Upper, side, facingSector, otherSector, isFrontSide);
-                AddOrUpdateCoverWall(side, sideVertices, WallLocation.Upper);
+                AddOrUpdateCoverWall(side, sideVertices, WallLocation.Upper, false);
             }
         }
 
@@ -462,7 +462,7 @@ public partial class StaticCacheGeometryRenderer : IDisposable
             if (m_vanillaRender && result.SkyVertices != null)
             {
                 var sideVertices = m_geometryRenderer.RenderTwoSidedUpperOrLowerRaw(WallLocation.Lower, side, facingSector, otherSector, isFrontSide);
-                AddOrUpdateCoverWall(side, sideVertices, WallLocation.Lower);
+                AddOrUpdateCoverWall(side, sideVertices, WallLocation.Lower, false);
             }
         }
 
@@ -599,7 +599,7 @@ public partial class StaticCacheGeometryRenderer : IDisposable
 
         var type = GetWallType(side, wall);
         if (m_vanillaRender && type != GeometryType.TwoSidedMiddleWall)
-            AddOrUpdateCoverWall(side, sideVertices, wall.Location);
+            AddOrUpdateCoverWall(side, sideVertices, wall.Location, wall.Location == WallLocation.Middle);
 
         if (wall.TextureHandle <= Constants.NullCompatibilityTextureIndex)
             return;
@@ -1177,7 +1177,7 @@ public partial class StaticCacheGeometryRenderer : IDisposable
     {
         var geometryType = side != null && wall != null ? GetWallType(side, wall) : GeometryType.Flat;
         if (side != null && wall != null && geometryType != GeometryType.TwoSidedMiddleWall)
-            AddOrUpdateCoverWall(side, vertices, wall.Location);
+            AddOrUpdateCoverWall(side, vertices, wall.Location, wall.Location == WallLocation.Middle);
 
         if (textureHandle <= Constants.NullCompatibilityTextureIndex)
             return;
@@ -1204,12 +1204,12 @@ public partial class StaticCacheGeometryRenderer : IDisposable
         staticGeometry.GeometryData.Vbo.Data.Length = Math.Max(staticGeometry.GeometryData.Vbo.Data.Length, startIndex + vertices.Length);
     }
 
-    private void AddOrUpdateCoverWall(Side side, Span<DynamicVertex> sideVertices, WallLocation location)
+    private void AddOrUpdateCoverWall(Side side, Span<DynamicVertex> sideVertices, WallLocation location, bool oneSided)
     {
         if (m_coverWallGeometry == null || m_coverWallGeometryOneSided == null)
             return;
 
-        var useGeometry = location == WallLocation.Middle && side.PartnerSide == null ? m_coverWallGeometryOneSided : m_coverWallGeometry;
+        var useGeometry = oneSided ? m_coverWallGeometryOneSided : m_coverWallGeometry;
         // This is uploaded as the max possible value so UploadSubData can be used even if it's new.
         var vbo = useGeometry.Vbo;
         var key = CoverKey.MakeCoverWallKey(side.Id, location);

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -19,6 +19,7 @@
 - Fix intermission font character width setting. (fixes Tele-Direct intermission font numbers).
 - Fix parsing both UMAPINFO and ZMAPINFO when present. ZMAPINFO takes priority. (fixes Crematomania MAP30 endgame).
 - Fix chainsaw/punch always using zero pitch when autoaim is on and there nothing to aim at.
+- Fix issue with software emulation that would cause issues with sprites rendering over lowers when a two-sided middle wall was set on the opposite side.
 
 ## Misc:
 - Refactor of old Status Bar renderer to data-driven SBARDEF format.


### PR DESCRIPTION
Fix issue with software emulation that would cause issues with sprites rendering over lowers when a two-sided middle wall was set on the opposite side.

fixes #1556 