### PR TITLE
Use Rgba32f instead of Rgb32f for TBOs

### DIFF
--- a/Core/Render/ColorMapBuffer.cs
+++ b/Core/Render/ColorMapBuffer.cs
@@ -5,7 +5,7 @@ namespace Helion.Render;
 
 public static class ColorMapBuffer
 {
-    const int LayerSize = Colormap.NumColors * Colormap.NumLayers * 3;
+    const int LayerSize = Colormap.NumColors * Colormap.NumLayers * 4;
     const int ColorMapSize = LayerSize * Palette.NumPalettes;
 
     public static float[] Create(Palette palette, List<Colormap> colormaps)
@@ -37,6 +37,7 @@ public static class ColorMapBuffer
                     buffer[offset++] = color.R / 255f;
                     buffer[offset++] = color.G / 255f;
                     buffer[offset++] = color.B / 255f;
+                    offset++;
                 }
             }
         }

--- a/Core/Render/ColorMapBuffer.cs
+++ b/Core/Render/ColorMapBuffer.cs
@@ -1,14 +1,15 @@
 ﻿using Helion.Graphics.Palettes;
+using Helion.Render.OpenGL.Textures;
 using System.Collections.Generic;
 
 namespace Helion.Render;
 
 public static class ColorMapBuffer
 {
-    const int LayerSize = Colormap.NumColors * Colormap.NumLayers * 4;
+    const int LayerSize = Colormap.NumColors * Colormap.NumLayers * GLBufferTextureStorage<float>.FourComponentLength;
     const int ColorMapSize = LayerSize * Palette.NumPalettes;
 
-    public static float[] Create(Palette palette, List<Colormap> colormaps)
+    public static float[] CreateRgba(Palette palette, List<Colormap> colormaps)
     {
         float[] buffer = new float[ColorMapSize * colormaps.Count];
 

--- a/Core/Render/OpenGL/Textures/GLBufferTextureStorage.cs
+++ b/Core/Render/OpenGL/Textures/GLBufferTextureStorage.cs
@@ -1,4 +1,5 @@
 ﻿using Helion.Render.OpenGL.Util;
+using Helion.Util.Assertion;
 using OpenTK.Graphics.OpenGL;
 using System;
 
@@ -6,13 +7,30 @@ namespace Helion.Render.OpenGL.Textures;
 
 public class GLBufferTextureStorage<T> where T : struct
 {
+    public const int FourComponentLength = 4;
+
     private readonly GLBufferTexture<T> m_bufferTexture;
     private GLMappedBuffer<T> m_mappedBuffer;
     private bool m_mapped;
 
     public GLBufferTextureStorage(string label, T[] data, SizedInternalFormat format, bool persistentBufferStorage)
     {
+        // This can be removed when OpenGL 3.3 support is dropped.
+        Assert.Precondition(AssertFormat(format), "OpenGL 3.3 does not support three component formats for TBOs.");
+
         m_bufferTexture = new(label, data, format, persistentBufferStorage);
+    }
+
+    private static bool AssertFormat(SizedInternalFormat format)
+    {
+        var stringFormat = format.ToString("g");
+        if (!stringFormat.StartsWith("Rgb", StringComparison.Ordinal))
+            return true;
+
+        if (!stringFormat.StartsWith("Rgba", StringComparison.Ordinal))
+            return false;
+
+        return true;
     }
 
     public GLMappedBuffer<T> GetMappedBufferAndBind()

--- a/Core/Render/OpenGL/Textures/GLBufferTextureStorage.cs
+++ b/Core/Render/OpenGL/Textures/GLBufferTextureStorage.cs
@@ -2,6 +2,7 @@
 using Helion.Util.Assertion;
 using OpenTK.Graphics.OpenGL;
 using System;
+using System.Xml.Linq;
 
 namespace Helion.Render.OpenGL.Textures;
 
@@ -24,13 +25,9 @@ public class GLBufferTextureStorage<T> where T : struct
     private static bool AssertFormat(SizedInternalFormat format)
     {
         var stringFormat = format.ToString("g");
-        if (!stringFormat.StartsWith("Rgb", StringComparison.Ordinal))
-            return true;
-
-        if (!stringFormat.StartsWith("Rgba", StringComparison.Ordinal))
-            return false;
-
-        return true;
+        var isThreeComponent = stringFormat.StartsWith("Rgb", StringComparison.Ordinal) &&
+                               !stringFormat.StartsWith("Rgba", StringComparison.Ordinal);
+        return !isThreeComponent;
     }
 
     public GLMappedBuffer<T> GetMappedBufferAndBind()

--- a/Core/Render/Renderer.World.cs
+++ b/Core/Render/Renderer.World.cs
@@ -172,8 +172,8 @@ public partial class Renderer
         if (alloc || m_lineHeightsBuffer == null)
         {
             m_lineHeightsBuffer?.Dispose();
-            m_lineHeightsBufferData = new float[world.Lines.Count * 3];
-            m_lineHeightsBuffer = new("Line heights data buffer", m_lineHeightsBufferData, SizedInternalFormat.Rgb32f, GLInfo.MapPersistentBitSupported);
+            m_lineHeightsBufferData = new float[world.Lines.Count * 4];
+            m_lineHeightsBuffer = new("Line heights data buffer", m_lineHeightsBufferData, SizedInternalFormat.Rgba32f, GLInfo.MapPersistentBitSupported);
 
             m_lineHeightsBuffer.Map(data =>
             {
@@ -201,17 +201,16 @@ public partial class Renderer
 
     private unsafe void SetSectorColorMapsBuffer(IWorld world, bool alloc)
     {
-        bool usePalette = false;
         if (alloc || m_sectorColorMapsBuffer == null)
         {
             // First index will always map to default colormap
             int sectorBufferCount = (world.Sectors.Count + 1) * LightBuffer.BufferSize;
             // PaletteColorMode is index to colormap, true color will be RGB mix
-            int size = usePalette ? 1 : 3;
+            int size = 4;
             var sectorBuffer = new float[sectorBufferCount * size];
 
             m_sectorColorMapsBuffer?.Dispose();
-            m_sectorColorMapsBuffer = new("Sector colormaps", sectorBuffer, usePalette ? SizedInternalFormat.R32f : SizedInternalFormat.Rgb32f, GLInfo.MapPersistentBitSupported);
+            m_sectorColorMapsBuffer = new("Sector colormaps", sectorBuffer, SizedInternalFormat.Rgba32f, GLInfo.MapPersistentBitSupported);
         }
 
         if (alloc)
@@ -219,26 +218,22 @@ public partial class Renderer
             m_sectorColorMapsBuffer.Map(data =>
             {
                 float* colorMapBuffer = (float*)data.ToPointer();
-                InitSectorColorMap(world, colorMapBuffer, usePalette);
+                InitSectorColorMap(world, colorMapBuffer);
             });
         }
         else
         {
             var mappedBuffer = m_sectorColorMapsBuffer.GetMappedBufferAndBind();
             float* colorMapBuffer = mappedBuffer.MappedMemoryPtr;
-            InitSectorColorMap(world, colorMapBuffer, usePalette);
+            InitSectorColorMap(world, colorMapBuffer);
             m_sectorColorMapsBuffer.Unbind();
         }
     }
 
-    private static unsafe void InitSectorColorMap(IWorld world, float* colorMapBuffer, bool usePalette)
+    private static unsafe void InitSectorColorMap(IWorld world, float* colorMapBuffer)
     {
-        if (!usePalette)
-        {
-            Vec3F* color = (Vec3F*)&colorMapBuffer[0];
-            *color = Vec3F.One;
-        }
-
+        *(Vec3F*)&colorMapBuffer[0] = Vec3F.One;
+        
         for (int i = 0; i < world.Sectors.Count; i++)
         {
             var sector = world.Sectors[i];
@@ -250,7 +245,7 @@ public partial class Renderer
     {
         int index = (sector.Id + 1) * LightBuffer.BufferSize;
 
-        const int VectorSize = 3;
+        const int VectorSize = 4;
         var setColor = GetSectorSetColor(colormap);
 
         *(Vec3F*)&colorMapBuffer[(index + LightBuffer.FloorOffset) * VectorSize] = setColor;
@@ -315,7 +310,7 @@ public partial class Renderer
             floorZ = Math.Max(floorZ, (float)line.BackFloorPlane.Z);
         }
 
-        var index = lineId * 3;
+        var index = lineId * 4;
         buffer[index] = prevFloorZ;
         buffer[index + 1] = floorZ;
 

--- a/Core/Render/Renderer.World.cs
+++ b/Core/Render/Renderer.World.cs
@@ -172,7 +172,7 @@ public partial class Renderer
         if (alloc || m_lineHeightsBuffer == null)
         {
             m_lineHeightsBuffer?.Dispose();
-            m_lineHeightsBufferData = new float[world.Lines.Count * 4];
+            m_lineHeightsBufferData = new float[world.Lines.Count * GLBufferTextureStorage<float>.FourComponentLength];
             m_lineHeightsBuffer = new("Line heights data buffer", m_lineHeightsBufferData, SizedInternalFormat.Rgba32f, GLInfo.MapPersistentBitSupported);
 
             m_lineHeightsBuffer.Map(data =>
@@ -291,7 +291,7 @@ public partial class Renderer
             for (int i = 0; i < world.StructLines.Length; i++)
             {
                 ref var line = ref world.StructLines.Data[i];
-                int index = i * 4;
+                int index = i * GLBufferTextureStorage<float>.FourComponentLength;
                 buffer[index] = (float)line.Segment.Start.X;
                 buffer[index + 1] = (float)line.Segment.Start.Y;
                 buffer[index + 2] = (float)line.Segment.End.X;
@@ -310,7 +310,7 @@ public partial class Renderer
             floorZ = Math.Max(floorZ, (float)line.BackFloorPlane.Z);
         }
 
-        var index = lineId * 4;
+        var index = lineId * GLBufferTextureStorage<float>.FourComponentLength;
         buffer[index] = prevFloorZ;
         buffer[index + 1] = floorZ;
 

--- a/Core/Render/Renderer.cs
+++ b/Core/Render/Renderer.cs
@@ -235,7 +235,7 @@ public partial class Renderer : IDisposable
             return;
 
         var colorMapData = ColorMapBuffer.Create(m_archiveCollection.Palette, m_archiveCollection.Definitions.Colormaps);
-        m_colorMapBuffer = new("Colormap buffer", colorMapData, SizedInternalFormat.Rgb32f, GLInfo.MapPersistentBitSupported);
+        m_colorMapBuffer = new("Colormap buffer", colorMapData, SizedInternalFormat.Rgba32f, GLInfo.MapPersistentBitSupported);
 
         m_colorMapBuffer.Map(data =>
         {

--- a/Core/Render/Renderer.cs
+++ b/Core/Render/Renderer.cs
@@ -234,7 +234,7 @@ public partial class Renderer : IDisposable
         if (!(ShaderVars.PaletteColorMode || ShaderVars.EmulateInvulnerabilityColorMap))
             return;
 
-        var colorMapData = ColorMapBuffer.Create(m_archiveCollection.Palette, m_archiveCollection.Definitions.Colormaps);
+        var colorMapData = ColorMapBuffer.CreateRgba(m_archiveCollection.Palette, m_archiveCollection.Definitions.Colormaps);
         m_colorMapBuffer = new("Colormap buffer", colorMapData, SizedInternalFormat.Rgba32f, GLInfo.MapPersistentBitSupported);
 
         m_colorMapBuffer.Map(data =>

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -28,3 +28,4 @@
 - Log config file path to console.
 - Add color to mark player special trigger lines in automap.
 - Verify file order in saves and include more detail on why a save is incompatible with the loaded files.
+- Update TBOs that use RGB32F to use RGBA32F for 3.3 cards that were never updated to support ARB_texture_buffer_object_rgb32.


### PR DESCRIPTION
Three component formats weren't officially part of OpenGL 3.3 and supported with the [ARB_texture_buffer_object_rgb32](http://www.opengl.org/registry/specs/ARB/texture_buffer_object_rgb32.txt) extension that most 3.3 cards appear to have. This ensures Helion will function across all 3.3 cards whether they have the extension or not. This GPU https://www.techpowerup.com/gpu-specs/geforce-gt-325m.c1504 was what triggered the issue running Windows 10 and rendered the world all black.