### PR TITLE
Lite amp colormap

### DIFF
--- a/Core/Layer/Worlds/WorldLayer.Render.Hud.cs
+++ b/Core/Layer/Worlds/WorldLayer.Render.Hud.cs
@@ -543,6 +543,9 @@ public partial class WorldLayer
             lightLevel = GLHelper.DoomLightLevelToColor(lightLevel, extraLight);
         }
 
+        if (Player.HasLightAmp())
+            colorMapIndex = Constants.ColorMapIndex.LightAmp;
+
         var camera = World.GetCameraPlayer().GetCamera(m_lastTickInfo.Fraction);
         var colorMixUniforms = Renderer.GetColorMix(Player, camera);
         var colorMix = colorMixUniforms.Global;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
@@ -382,7 +382,7 @@ public sealed class EntityRenderer : IDisposable
         program.BrightmapTexture(BindTextures.BrightmapTexture);
         program.ColormapTexture(BindTextures.Colormap);
         program.SectorColormapTexture(BindTextures.SectorColormap);
-        program.ExtraLight(renderInfo.Uniforms.ExtraLight);
+        program.ExtraLight(renderInfo.Uniforms.ExtraLightOrColorMapIndex);
         program.HasInvulnerability(renderInfo.Uniforms.DrawInvulnerability);
         program.LightLevelMix(renderInfo.Uniforms.Mix);
         program.Mvp(renderInfo.Uniforms.Mvp);

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillRenderer.cs
@@ -349,7 +349,7 @@ public class FloodFillRenderer(LegacyGLTextureManager glTextureManager, FloodFil
         program.MvpNoPitch(renderInfo.Uniforms.MvpNoPitch);
         program.TimeFrac(renderInfo.TickFraction);
         program.LightLevelMix(renderInfo.Uniforms.Mix);
-        program.ExtraLight(renderInfo.Uniforms.ExtraLight);
+        program.ExtraLight(renderInfo.Uniforms.ExtraLightOrColorMapIndex);
         program.DistanceOffset(renderInfo.Uniforms.DistanceOffset);
         program.ColorMix(renderInfo.Uniforms.ColorMix.Global);
         program.PaletteIndex((int)renderInfo.Uniforms.PaletteIndex);

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -738,7 +738,7 @@ public class LegacyWorldRenderer : WorldRenderer
         program.MvpNoPitch(renderInfo.Uniforms.MvpNoPitch);
         program.TimeFrac(renderInfo.TickFraction);
         program.LightLevelMix(renderInfo.Uniforms.Mix);
-        program.ExtraLight(renderInfo.Uniforms.ExtraLight);
+        program.ExtraLight(renderInfo.Uniforms.ExtraLightOrColorMapIndex);
         program.DistanceOffset(renderInfo.Uniforms.DistanceOffset);
         program.ColorMix(renderInfo.Uniforms.ColorMix.Global);
         program.PaletteIndex((int)renderInfo.Uniforms.PaletteIndex);
@@ -768,7 +768,7 @@ public class LegacyWorldRenderer : WorldRenderer
         program.Mvp(renderInfo.Uniforms.Mvp);
         program.MvpNoPitch(renderInfo.Uniforms.MvpNoPitch);
         program.LightLevelMix(renderInfo.Uniforms.Mix);
-        program.ExtraLight(renderInfo.Uniforms.ExtraLight);
+        program.ExtraLight(renderInfo.Uniforms.ExtraLightOrColorMapIndex);
         program.DistanceOffset(renderInfo.Uniforms.DistanceOffset);
         program.ColorMix(renderInfo.Uniforms.ColorMix.Global);
         program.PaletteIndex((int)renderInfo.Uniforms.PaletteIndex);

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/FragFunction.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/FragFunction.cs
@@ -117,8 +117,7 @@ public class FragFunction
             ${EntityColorMapFrag}
             int usePalette = paletteIndex;
             int lightLevelOffset = (lightColorIndex * 256);
-            lightLevelOffset = int(mix(lightLevelOffset, 32 * 256, float(hasInvulnerability)));
-            lightLevelOffset = int(mix(lightLevelOffset, 0, float(lightLevelMix)));"
+            lightLevelOffset = int(mix(lightLevelOffset, 32 * 256, float(hasInvulnerability)));"
             .Replace("${EntityColorMapFrag}", ctx == ColorMapFetchContext.Entity ?
                 // if useColormap is not default(0) then override with the uniform colormap. This overrides translations with boom colormaps etc.
                 @"useColormap = int(mix(useColormap, colorMapTranslationFrag, float(useColormap == 0)));"

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/LightLevel.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/LightLevel.cs
@@ -46,7 +46,8 @@ int lightNum = int(lightLevel / 8);
 int startMap = (30 - lightNum) * 2;
 float lightIndex = min(2560 / abs(dist), 47);
 float lightColor = clamp((startMap - lightIndex / 2) - extraLight, 0, 31);
-int lightColorIndex = int(lightColor);
+// Directly set the index when extraLight < 0 to the absolute value
+int lightColorIndex = int(mix(lightColor, abs(extraLight) - 1, float(extraLight < 0)));
 "
 + (ShaderVars.PaletteColorMode ? "" :
 @"

--- a/Core/Render/OpenGL/Renderers/Legacy/World/ShaderUniforms.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/ShaderUniforms.cs
@@ -14,7 +14,7 @@ public struct ShaderUniforms(
     float timeFrac,
     bool drawInvulnerability,
     float mix,
-    int extraLight,
+    int extraLightOrColorMapIndex,
     float distanceOffset,
     ColorMixUniforms colorMix,
     float fuzzDiv,
@@ -31,7 +31,7 @@ public struct ShaderUniforms(
     public float TimeFrac = timeFrac;
     public float Mix = mix;
     public bool DrawInvulnerability = drawInvulnerability;
-    public int ExtraLight = extraLight;
+    public int ExtraLightOrColorMapIndex = extraLightOrColorMapIndex;
     public float DistanceOffset = distanceOffset;
     public ColorMixUniforms ColorMix = colorMix;
     public float FuzzDiv = fuzzDiv;

--- a/Core/Render/Renderer.cs
+++ b/Core/Render/Renderer.cs
@@ -294,7 +294,7 @@ public partial class Renderer : IDisposable
     public static ShaderUniforms GetShaderUniforms(IConfig config, RenderInfo renderInfo)
     {
         bool drawInvulnerability = false;
-        int extraLight = 0;
+        int extraLightOrColorMapIndex = 0;
         float mix = 0.0f;
         var colorMix = GetColorMix(renderInfo.ViewerEntity, renderInfo.Camera);
         PaletteIndex paletteIndex = PaletteIndex.Normal;
@@ -303,21 +303,29 @@ public partial class Renderer : IDisposable
         if (renderInfo.ViewerEntity.PlayerObj != null)
         {
             var player = renderInfo.ViewerEntity.PlayerObj;
+            extraLightOrColorMapIndex = player.GetExtraLightRender();
+
             if (!player.DrawInvulnerableColorMap() && player.DrawFullBright())
-                mix = 1.0f;
+            {
+                extraLightOrColorMapIndex = GetFixedColorMapIndex(Constants.ColorMapIndex.FullBright);
+                mix = 1.0f;            
+            }
+
             if (player.DrawInvulnerableColorMap())
                 drawInvulnerability = true;
-
-            extraLight = player.GetExtraLightRender();
 
             if (ShaderVars.PaletteColorMode)
             {
                 colorMapUniforms = GetColorMapUniforms(renderInfo.ViewerEntity, renderInfo.Camera);
 
                 if (!config.Window.PaletteTrueColorOverlay)
-                {
-                    mix = 0.0f;
                     paletteIndex = PaletteUtil.GetPalette(config, player);
+
+                // Force to use 1st colormap to match original fixedcolormap behavior
+                if (player.HasLightAmp())
+                {
+                    mix = 0;
+                    extraLightOrColorMapIndex = GetFixedColorMapIndex(Constants.ColorMapIndex.LightAmp);
                 }
             }
         }
@@ -332,7 +340,7 @@ public partial class Renderer : IDisposable
             GetTimeFrac(),
             drawInvulnerability,
             mix,
-            extraLight,
+            extraLightOrColorMapIndex,
             GetDistanceOffset(renderInfo),
             colorMix,
             GetFuzzDiv(renderInfo.Config, renderInfo.Viewport),
@@ -343,6 +351,11 @@ public partial class Renderer : IDisposable
             maxDistance,
             config.Render.Brightmaps,
             GetDownScaleAmount(config, renderInfo));
+    }
+
+    public static int GetFixedColorMapIndex(int index)
+    {
+        return -index - 1;
     }
 
     public static bool GetNativeLetterBoxes(IConfig config, Dimension renderDimension, out Box2I left, out Box2I right)

--- a/Core/Util/Constants.cs
+++ b/Core/Util/Constants.cs
@@ -351,6 +351,12 @@ public static class Constants
         public const int ColorMapCount = 32;
     }
 
+    public static class ColorMapIndex
+    {
+        public const int FullBright = 0;
+        public const int LightAmp = 1;
+    }
+
     public const double Epsilon = 0.00001;
     public const double EntityShootDistance = 2048.0;
     public const double EntityMeleeDistance = 64.0;

--- a/Core/World/Entities/Players/Player.cs
+++ b/Core/World/Entities/Players/Player.cs
@@ -142,6 +142,8 @@ public class Player : Entity
         return false;
     }
 
+    public bool HasLightAmp() => Inventory.GetPowerup(PowerupType.LightAmp) != null;
+
     public bool DrawInvulnerableColorMap() => Inventory.PowerupEffectColorMap != null && Inventory.PowerupEffectColorMap.DrawPowerupEffect;
     public int GetExtraLightRender() => WorldStatic.World.Config.Render.ExtraLight + (ExtraLight * Constants.ExtraLightFactor);
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -20,6 +20,7 @@
 - Fix parsing both UMAPINFO and ZMAPINFO when present. ZMAPINFO takes priority. (fixes Crematomania MAP30 endgame).
 - Fix chainsaw/punch always using zero pitch when autoaim is on and there nothing to aim at.
 - Fix issue with software emulation that would cause issues with sprites rendering over lowers when a two-sided middle wall was set on the opposite side.
+- Fix lite amp goggles/render.fullbright not increasing the light level when using palette color with true color overlays disabled.
 
 ## Misc:
 - Refactor of old Status Bar renderer to data-driven SBARDEF format.
@@ -29,3 +30,4 @@
 - Add color to mark player special trigger lines in automap.
 - Verify file order in saves and include more detail on why a save is incompatible with the loaded files.
 - Update TBOs that use RGB32F to use RGBA32F for 3.3 cards that were never updated to support ARB_texture_buffer_object_rgb32.
+- Use colormap index one for lite amp goggles instead of zero to match original doom behavior.


### PR DESCRIPTION
Set colormap index to 1 to match original doom lite amp goggles behavior.

Remove forcing light index to zero when lightLevelMix is 1 since the colormap index can be set directly.