### PR TITLE
true color sprite colormap fix

### DIFF
--- a/Core/Render/OpenGL/Texture/GLTextureManager.cs
+++ b/Core/Render/OpenGL/Texture/GLTextureManager.cs
@@ -232,7 +232,7 @@ public abstract class GLTextureManager<GLTextureType> : IRendererTextureManager
         if (spriteRotation == null)
             return NullSpriteRotation;
 
-        if (!ArchiveCollection.StoreImageIndices && colorMapIndex >= 0)
+        if (!ArchiveCollection.StoreImageIndices && colorMapIndex > 0)
         {
             // For true color mode the image needs to be recreated using a different palette
             if (spriteRotation.TryGetTranslationRotation(colorMapIndex, out var translationRotation))

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -21,6 +21,7 @@
 - Fix chainsaw/punch always using zero pitch when autoaim is on and there nothing to aim at.
 - Fix issue with software emulation that would cause issues with sprites rendering over lowers when a two-sided middle wall was set on the opposite side.
 - Fix lite amp goggles/render.fullbright not increasing the light level when using palette color with true color overlays disabled.
+- Fix sprites being generated and duplicated at runtime in true color.
 
 ## Misc:
 - Refactor of old Status Bar renderer to data-driven SBARDEF format.


### PR DESCRIPTION
Don't regenerate for colormap index zero since the base set is already cached using the playpal just like other textures. This is causing every sprite to be duplicated and is causing the sprites to be generated the first time they are encountered which can cause stutters, since they need to be loaded from the archive, translated, generate the texture and upload to the GPU.