### PR TITLE
sprite depth bias for z-fighting

### DIFF
--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
@@ -171,7 +171,7 @@ public class EntityProgram : RenderProgram
             colorMapTranslationOut = (intOptions >> 18);
 
             intOptions = floatBitsToInt(sectorIndex);
-            int sectorIndex = intOptions >> 16;
+            int sectorIndexInt = intOptions >> 16;
             int renderIndex = intOptions & 0xFFFF;
 
             intOptions = floatBitsToInt(offsetXYZ);
@@ -183,7 +183,7 @@ public class EntityProgram : RenderProgram
             offsetZOut = mix(offsetZOut, -offsetZOut, offsetZSign);
             renderIndexOut = renderIndex;
 
-            sectorColorMapIndexOut = texelFetch(sectorColormapTexture, sectorIndex).rgb;
+            sectorColorMapIndexOut = texelFetch(sectorColormapTexture, sectorIndexInt).rgb;
             gl_Position = vec4(mix(prevPos, pos, timeFrac), 1.0);
             positionZOut = gl_Position.z;
         }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
@@ -240,7 +240,7 @@ public class EntityProgram : RenderProgram
 
         void main()
         {
-            float leftU  = clamp(flipUOut[0], 0, 1);
+            float leftU = clamp(flipUOut[0], 0, 1);
             float rightU = 1 - clamp(flipUOut[0], 0, 1);
 
             vec3 pos = gl_in[0].gl_Position.xyz;
@@ -248,8 +248,8 @@ public class EntityProgram : RenderProgram
             pos.z += offsetZOut[0];
 
             ivec2 textureDim = textureSize(boundTexture, 0);
-            vec3 posMoveDir  = vec3(mix(prevViewRightNormal, viewRightNormal, timeFrac), 0);
-            vec3 offsetXY    = vec3(posMoveDir.xy * offsetXYOut[0], 0);
+            vec3 posMoveDir = vec3(mix(prevViewRightNormal, viewRightNormal, timeFrac), 0);
+            vec3 offsetXY = vec3(posMoveDir.xy * offsetXYOut[0], 0);
 
             vec3 minPos = pos - offsetXY;
             vec3 maxPos = pos + (posMoveDir * textureDim.x) + (vec3(0, 0, 1) * textureDim.y) - offsetXY;
@@ -275,7 +275,7 @@ public class EntityProgram : RenderProgram
             maxPosFrag = maxPos;
             zPosDepthFrag = (mvp * vec4(centerPosFrag, 1.0)).${Depth};
 
-            lightLevelFrag  = lightLevelOut[0];
+            lightLevelFrag = lightLevelOut[0];
             alphaFrag = alphaOut[0];
             fuzzFrag = fuzzOut[0];
             colorMapTranslationFrag = colorMapTranslationOut[0];

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
@@ -155,6 +155,7 @@ public class EntityProgram : RenderProgram
         out float positionZOut;
         out float offsetZOut;
         out float offsetXYOut;
+        out float renderIndexOut;
         out vec3 sectorColorMapIndexOut;
 
         uniform float timeFrac;
@@ -169,6 +170,10 @@ public class EntityProgram : RenderProgram
             lightLevelOut = (intOptions >> 10) & 0xFF;
             colorMapTranslationOut = (intOptions >> 18);
 
+            intOptions = floatBitsToInt(sectorIndex);
+            int sectorIndex = intOptions >> 16;
+            int renderIndex = intOptions & 0xFFFF;
+
             intOptions = floatBitsToInt(offsetXYZ);
             offsetXYOut = (intOptions >> 16) & 0x3FFF;
             offsetZOut = intOptions & 0x3FFF;
@@ -176,8 +181,9 @@ public class EntityProgram : RenderProgram
             float offsetZSign = float(((intOptions >> 30) & 1) > 0);
             offsetXYOut = mix(offsetXYOut, -offsetXYOut, offsetXYSign);
             offsetZOut = mix(offsetZOut, -offsetZOut, offsetZSign);
+            renderIndexOut = renderIndex;
 
-            sectorColorMapIndexOut = texelFetch(sectorColormapTexture, int(sectorIndex)).rgb;
+            sectorColorMapIndexOut = texelFetch(sectorColormapTexture, sectorIndex).rgb;
             gl_Position = vec4(mix(prevPos, pos, timeFrac), 1.0);
             positionZOut = gl_Position.z;
         }
@@ -198,6 +204,7 @@ public class EntityProgram : RenderProgram
         in float positionZOut[];
         in float offsetZOut[];
         in float offsetXYOut[];
+        in float renderIndexOut[];
         ${SectorColorMapVar}
 
         out vec2 uvFrag;
@@ -233,15 +240,17 @@ public class EntityProgram : RenderProgram
 
         void main()
         {
-            float leftU = clamp(flipUOut[0], 0, 1);
+            float leftU  = clamp(flipUOut[0], 0, 1);
             float rightU = 1 - clamp(flipUOut[0], 0, 1);
 
             vec3 pos = gl_in[0].gl_Position.xyz;
             zPosFrag = pos.z;
             pos.z += offsetZOut[0];
+
             ivec2 textureDim = textureSize(boundTexture, 0);
-            vec3 posMoveDir = vec3(mix(prevViewRightNormal, viewRightNormal, timeFrac), 0);
-            vec3 offsetXY = vec3(posMoveDir.xy * offsetXYOut[0], 0);
+            vec3 posMoveDir  = vec3(mix(prevViewRightNormal, viewRightNormal, timeFrac), 0);
+            vec3 offsetXY    = vec3(posMoveDir.xy * offsetXYOut[0], 0);
+
             vec3 minPos = pos - offsetXY;
             vec3 maxPos = pos + (posMoveDir * textureDim.x) + (vec3(0, 0, 1) * textureDim.y) - offsetXY;
 
@@ -264,45 +273,66 @@ public class EntityProgram : RenderProgram
             centerPosFrag = pos;
             minPosFrag = minPos;
             maxPosFrag = maxPos;
-            zPosDepthFrag = (mvp * vec4(centerPosFrag.x, centerPosFrag.y, centerPosFrag.z, 1)).${Depth};
+            zPosDepthFrag = (mvp * vec4(centerPosFrag, 1.0)).${Depth};
 
-            lightLevelFrag = lightLevelOut[0];
+            lightLevelFrag  = lightLevelOut[0];
             alphaFrag = alphaOut[0];
             fuzzFrag = fuzzOut[0];
             colorMapTranslationFrag = colorMapTranslationOut[0];
             sectorColorMapIndexFrag = sectorColorMapIndexOut[0];
 
-            gl_Position = glPosMin;
-            dist = (mvpNoPitch * vec4(minPos.x, minPos.y, minPos.z, 1)).${Depth};
+            // Push depth biased by the base times the renderIndex to prevent z-fighting
+            float depthBias = float(renderIndexOut[0]) * ${DepthBiasBase};
+
+            vec4 clip;
+            clip = glPosMin;
+            ${AdjustSpriteVertexClip}
+            gl_Position = clip;
+            dist = (mvpNoPitch * vec4(minPos, 1.0)).${Depth};
             uvFrag = vec2(leftU, 1);
             depthFrag = gl_Position.${Depth};
             EmitVertex();
 
-            gl_Position = mvp * vec4(maxPos.x, maxPos.y, minPos.z, 1);
-            dist = (mvpNoPitch * vec4(maxPos.x, maxPos.y, minPos.z, 1)).${Depth};
+            clip = mvp * vec4(maxPos.x, maxPos.y, minPos.z, 1.0);
+            ${AdjustSpriteVertexClip}
+            gl_Position = clip;
+            dist = (mvpNoPitch * vec4(maxPos.x, maxPos.y, minPos.z, 1.0)).${Depth};
             uvFrag = vec2(rightU, 1);
             depthFrag = gl_Position.${Depth};
             EmitVertex();
 
-            gl_Position = mvp * vec4(minPos.x, minPos.y, maxPos.z, 1);
-            dist = (mvpNoPitch * vec4(minPos.x, minPos.y, maxPos.z, 1)).${Depth};
+            clip = mvp * vec4(minPos.x, minPos.y, maxPos.z, 1.0);
+            ${AdjustSpriteVertexClip}
+            gl_Position = clip;
+            dist = (mvpNoPitch * vec4(minPos.x, minPos.y, maxPos.z, 1.0)).${Depth};
             uvFrag = vec2(leftU, 0);
             depthFrag = gl_Position.${Depth};
             EmitVertex();
 
-            gl_Position = glPosMax;
-            dist = (mvpNoPitch * vec4(maxPos.x, maxPos.y, maxPos.z, 1)).${Depth};
+            clip = glPosMax;
+            ${AdjustSpriteVertexClip}
+            gl_Position = clip;
+            dist = (mvpNoPitch * vec4(maxPos, 1.0)).${Depth};
             uvFrag = vec2(rightU, 0);
             depthFrag = gl_Position.${Depth};
             EmitVertex();
-    
+
             EndPrimitive();
         }  
     "
     .Replace("${SectorColorMapVar}", false ? "in int sectorColorMapIndexOut[];" : "in vec3 sectorColorMapIndexOut[];")
     .Replace("${SectorColorMapFrag}", false ? "flat out int sectorColorMapIndexFrag;" : "flat out vec3 sectorColorMapIndexFrag;")
     .Replace("${Depth}", ShaderVars.Depth)
-    .Replace("${BoxDefines}", BoxDefines);
+    .Replace("${BoxDefines}", BoxDefines)
+    .Replace("${DepthBiasBase}", ShaderVars.ReversedZ ? "1e-5" : "4e-5")
+    .Replace("${AdjustSpriteVertexClip}", AdjustSpriteVertexClip());
+
+    private static string AdjustSpriteVertexClip()
+    {
+        if (ShaderVars.ReversedZ)
+            return "clip.z += (depthBias * (clip.z / clip.w)) * clip.w;";
+        return "clip.z -= (depthBias * (1 - (clip.z / clip.w * 0.5 + 0.5))) * clip.w;";
+    }
 
     protected override string? FragmentShader() => @"
         #version 330

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
@@ -16,7 +16,6 @@ using Helion.World.Geometry.Sectors;
 using OpenTK.Graphics.OpenGL;
 using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
 
 namespace Helion.Render.OpenGL.Renderers.Legacy.World.Entities;
 
@@ -34,8 +33,6 @@ public sealed class EntityRenderer : IDisposable
     private readonly EntityCompositeProgram m_programComposite = new();
     private readonly EntityFuzzRefractionProgram m_programFuzzRefraction = new();
     private readonly RenderDataManager<EntityVertex> m_dataManager;
-    private readonly Dictionary<Vec2D, int> m_renderPositions = new(1024, new Vec2DComparer());
-    private readonly HashSet<SpritePosKey> m_spriteRenderPositions = new(1024);
     private readonly DynamicArray<SpriteDefinition?> m_spriteDefs = new(1024);
     private readonly SpriteRotation m_nullSpriteRotation;
     private readonly ArchiveCollection m_archiveCollection;
@@ -44,7 +41,6 @@ public sealed class EntityRenderer : IDisposable
     private TransferHeightView m_transferHeightView = TransferHeightView.Middle;
     private bool m_spriteAlpha;
     private bool m_spriteClip;
-    private bool m_spriteZCheck;
     private bool m_vanillaRender;
     private bool m_healthBars;
     private bool m_attackIndicator;
@@ -64,7 +60,6 @@ public sealed class EntityRenderer : IDisposable
         m_dataManager = new(m_program, textureManager.BlackTexture);
         m_spriteAlpha = m_config.Render.SpriteTransparency;
         m_spriteClip = m_config.Render.SpriteClip;
-        m_spriteZCheck = m_config.Render.SpriteZCheck;
         m_spriteClipMin = m_config.Render.SpriteClipMin;
         m_vanillaRender = m_config.Render.VanillaRender;
         m_spriteClipFactorMax = (float)m_config.Render.SpriteClipFactorMax;
@@ -89,23 +84,14 @@ public sealed class EntityRenderer : IDisposable
     public void Clear(IWorld world)
     {
         m_dataManager.Clear();
-        m_renderPositions.Clear();
-        m_spriteRenderPositions.Clear();
         m_spriteAlpha = m_config.Render.SpriteTransparency;
         m_spriteClip = m_config.Render.SpriteClip;
-        m_spriteZCheck = m_config.Render.SpriteZCheck;
         m_spriteClipMin = m_config.Render.SpriteClipMin;
         m_spriteClipFactorMax = (float)m_config.Render.SpriteClipFactorMax;
         m_healthBars = m_config.Render.HealthBar.Enable;
         m_attackIndicator = m_config.Render.HealthBar.AttackIndicator;
         m_healthBarLimit = m_config.Render.HealthBar.HealthLimit;
         m_brightMaps = m_config.Render.Brightmaps;
-    }
-
-    public void ClearRenderPositions()
-    {
-        m_renderPositions.Clear();
-        m_spriteRenderPositions.Clear();
     }
 
     private static uint CalculateRotation(uint viewAngle, uint entityAngle)
@@ -174,9 +160,7 @@ public sealed class EntityRenderer : IDisposable
         return m_textureManager.GetSpriteRotation(spriteDefinition, frame, rotation, colorMapIndex);
     }
 
-    const double NudgeFactor = 0.0001;
-
-    public void RenderEntity(Entity entity, in Vec2D position)
+    public void RenderEntity(Entity entity, in Vec2D position, int renderIndex)
     {        
         Vec3D centerBottom = entity.Position;
         Vec2D entityPos = new(centerBottom.X, centerBottom.Y);
@@ -206,27 +190,6 @@ public sealed class EntityRenderer : IDisposable
             uint viewAngle = ViewClipper.ToDiamondAngle(position, entityPos);
             uint entityAngle = ViewClipper.DiamondAngleFromRadians(entity.AngleRadians);
             rotation = CalculateRotation(viewAngle, entityAngle);
-        }
-        
-        if (m_spriteZCheck)
-        {
-            var spritePosKey = new SpritePosKey(entityPos, spriteIndex);
-            if (m_spriteRenderPositions.Add(spritePosKey))
-            {
-                ref int count = ref CollectionsMarshal.GetValueRefOrAddDefault(m_renderPositions, entityPos, out var exists);
-                if (exists)
-                {
-                    var nudge = NudgeFactor * count * Math.Sqrt(entity.RenderDistanceSquared);
-                    var angle = Math.Atan2(centerBottom.Y - position.Y, centerBottom.X - position.X);
-                    nudgeAmount.X = Math.Cos(angle) * nudge;
-                    nudgeAmount.Y = Math.Sin(angle) * nudge;
-                    count++;
-                }
-                else
-                {
-                    count = 1;
-                }
-            }
         }
 
         var colorMapIndex = entity.Properties.ColormapIndex ?? entity.GetTranslationColorMap();
@@ -312,7 +275,8 @@ public sealed class EntityRenderer : IDisposable
         vertex.PrevPos.Y = (float)(entity.PrevPosition.Y - nudgeAmount.Y);
         vertex.PrevPos.Z = (float)entity.PrevPosition.Z;
         vertex.Options = VertexOptions.Entity(alpha, fuzz, flipU, colorMapIndex, lightLevel);
-        vertex.ColorMapIndex = Renderer.GetColorMapBufferIndex(sector, WorldStatic.Sector3D && sector.Sectors3D.Length > 0 ? LightBufferType.Wall : LightBufferType.Floor);
+        vertex.ColorMapIndex = VertexOptions.EntityColorMapAndRenderIndex(
+            Renderer.GetColorMapBufferIndex(sector, WorldStatic.Sector3D && sector.Sectors3D.Length > 0 ? LightBufferType.Wall : LightBufferType.Floor), renderIndex);
 
         if (entity.Definition.Flags.SpawnCeiling() && m_vanillaRender)
         {

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -179,9 +179,9 @@ public class LegacyWorldRenderer : WorldRenderer
                 if (m_renderStatic)
                     RenderSides(world, index);
 
-                m_entityRenderer.ClearRenderPositions();
+                int renderIndex = 0;
                 for (var entity = world.RenderBlockmap.HeadRenderEntities[index]; entity != null; entity = entity.RenderBlockNext)
-                    RenderEntity(world, entity);
+                    RenderEntity(world, entity, renderIndex++);
             }
         }
 
@@ -256,7 +256,7 @@ public class LegacyWorldRenderer : WorldRenderer
         m_geometryRenderer.SetBufferCoverWall(true);
     }
 
-    void RenderEntity(IWorld world, Entity entity)
+    void RenderEntity(IWorld world, Entity entity, int renderIndex)
     {
         if (entity.FrameState.Frame.IsInvisible || entity.Flags.Invisible() || entity.Flags.NoSector() || entity == m_viewerEntity || entity.Properties.RenderStyle == RenderStyle.None)
             return;
@@ -276,7 +276,7 @@ public class LegacyWorldRenderer : WorldRenderer
             return;
 
         entity.LastRenderGametick = world.Gametick;
-        m_entityRenderer.RenderEntity(entity, m_renderData.ViewPosInterpolated);     
+        m_entityRenderer.RenderEntity(entity, m_renderData.ViewPosInterpolated, renderIndex);     
     }
 
     protected override void PerformRender(IWorld world, RenderInfo renderInfo, GLFramebuffer framebuffer)

--- a/Core/Render/OpenGL/Renderers/Legacy/World/VertexOptions.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/VertexOptions.cs
@@ -41,6 +41,13 @@ public static class VertexOptions
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static unsafe float EntityColorMapAndRenderIndex(int colorMapIndex, int renderIndex)
+    {
+        int packed = colorMapIndex << 16 | renderIndex;
+        return *(float*)&packed;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe float EntityXYZ(int offsetXY, int offsetZ)
     {
         // Shift negative bit for mask to get absolute value and sign bit to remove branches

--- a/Core/Util/Configs/Components/ConfigRender.cs
+++ b/Core/Util/Configs/Components/ConfigRender.cs
@@ -151,10 +151,6 @@ public class ConfigRender: ConfigElement<ConfigRender>
     [OptionMenu(OptionSectionType.Render, "Fuzz Amount", sliderMin: 0, sliderMax: 5.0, sliderStep: .1)]
     public readonly ConfigValue<double> FuzzAmount = new(1);
 
-    [ConfigInfo("Prevent sprites from overlapping and Z-fighting.")]
-    [OptionMenu(OptionSectionType.Render, "Sprite Z-fighting Check")]
-    public readonly ConfigValue<bool> SpriteZCheck = new(true);
-
     [ConfigInfo("Enable sprite transparency.")]
     [OptionMenu(OptionSectionType.Render, "Sprite Transparency")]
     public readonly ConfigValue<bool> SpriteTransparency = new(true);

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -33,3 +33,4 @@
 - Verify file order in saves and include more detail on why a save is incompatible with the loaded files.
 - Update TBOs that use RGB32F to use RGBA32F for 3.3 cards that were never updated to support ARB_texture_buffer_object_rgb32.
 - Use colormap index one for lite amp goggles instead of zero to match original doom behavior.
+- Removed sprite overlap code from CPU and use sprite detph bias on GPU instead to fix z-fighting.


### PR DESCRIPTION
Use sprite depth bias on GPU with index from the render blockmap to fix z-fighting issues. This is more effective since it doesn't check for exact overlap and other sprite conditions because every object is pushed in the depth. This also means that the objects aren't physically pushed and rendered in different positions and improves the performance that removes the lookups and push math on the CPU.

Works for both reverse z and the old projection on older cards that do not support glClipControl. There is a small range where things can still z-fight but this method should still be an overall improvement here too.

Tested with 1,000 sprites in a single block and appears to have no issues.