### PR TITLE
Fix vertical stripes with "block" characters in ENDOOM

### DIFF
--- a/Core/Layer/Endoom/TextScreen.cs
+++ b/Core/Layer/Endoom/TextScreen.cs
@@ -11,8 +11,8 @@
 
     public class TextScreen
     {
-        private int m_height;
-        private int m_width;
+        private int m_rows;
+        private int m_columns;
 
         private Color[] m_backgroundColors;
         private Color[] m_foregroundColors;
@@ -42,8 +42,8 @@
                 throw new Exception("Text screen data must contain at least (height * width * 2) bytes");
             }
 
-            m_height = rows;
-            m_width = columns;
+            m_rows = rows;
+            m_columns = columns;
             m_pixelHeight = pixelHeight;
 
             m_backgroundColors = new Color[rows * columns];
@@ -53,26 +53,25 @@
 
             for (int index = 0; index < rows * columns; index++)
             {
-                byte textByte = screenData[index * 2];
+                // See https://en.wikipedia.org/wiki/VGA_text_mode
+                // The first byte in each pair is a standard text character (convert to Unicode to use TTF fonts)
+                m_characters[index] = Convert.ToChar(Conversions.UnicodeByteMappings[screenData[index * 2]]);
+
+                // The second byte in each pair follows this format:
+                // Bytes 0-3: Foreground color
+                // Bytes 4-6: Background color
+                // Byte 7: Blink enable
                 byte colorByte = screenData[index * 2 + 1];
-
-                byte blink = (byte)(colorByte >> 7);
-                Color backColor = Conversions.TextColors[(byte)((byte)(colorByte << 1) >> 5)]; // Bits 4-6 (discard 7)
-                Color foreColor = Conversions.TextColors[(byte)((byte)(colorByte << 4) >> 4)]; // Bits 0-3              
-
-                m_characters[index] = Convert.ToChar(Conversions.UnicodeByteMappings[textByte]);
-                m_foregroundColors[index] = foreColor;
-                m_backgroundColors[index] = backColor;
-                m_blink[index] = blink != 0;
-
-                HasBlink |= (blink != 0);
+                m_foregroundColors[index] = Conversions.TextColors[(byte)((byte)(colorByte << 4) >> 4)];
+                m_backgroundColors[index] = Conversions.TextColors[(byte)((byte)(colorByte << 1) >> 5)];
+                HasBlink |= m_blink[index] = (byte)(colorByte >> 7) != 0;
             }
 
             using (MemoryStream fontDataStream = new MemoryStream(fontData))
             {
                 FontCollection fontCollection = new();
                 FontFamily consoleFontFamily = fontCollection.Add(fontDataStream, CultureInfo.InvariantCulture);
-                m_glyphHeight = pixelHeight / m_height;
+                m_glyphHeight = pixelHeight / m_rows;
                 m_glyphWidth = m_glyphHeight / 2;  // Assume use of 8x16 style fonts
                 m_font = consoleFontFamily.CreateFont(m_glyphHeight); // Use whatever pixel value fits all the lines   
             }
@@ -86,15 +85,15 @@
         public Graphics.Image GenerateImage(bool blinkOn)
         {
             float xOffset = 0, yOffset = 0;
-            using (Image<Argb32> bitmap = new Image<Argb32>(m_glyphWidth * m_width, m_pixelHeight))
+            using (Image<Argb32> bitmap = new Image<Argb32>(m_glyphWidth * m_columns, m_pixelHeight))
             {
                 bitmap.Mutate(ctx =>
                 {
                     int index = 0;
-                    for (int row = 0; row < m_height; row++)
+                    for (int row = 0; row < m_rows; row++)
                     {
                         xOffset = 0;
-                        for (int column = 0; column < m_width; column++)
+                        for (int column = 0; column < m_columns; column++)
                         {
                             Color foregroundColor = m_foregroundColors[index];
                             Color backgroundColor = m_backgroundColors[index];

--- a/Core/Layer/Endoom/TextScreen.cs
+++ b/Core/Layer/Endoom/TextScreen.cs
@@ -16,15 +16,19 @@
 
         private Color[] m_backgroundColors;
         private Color[] m_foregroundColors;
-        private char[] m_characters;
+        private byte[] m_ansiCharacters;
+        private char[] m_unicodeCharacters;
         private bool[] m_blink;
         private Font m_font;
         private int m_pixelHeight;
         private int m_glyphWidth;
         private int m_glyphHeight;
+        private int m_actualGlyphWidth;
 
         // This value indicates whether there are any blinking characters in this text screen
         public readonly bool HasBlink;
+
+        private readonly char FULLBLOCK = (char)0x2588;
 
         /// <summary>
         /// Represents a screen full of double-byte (color plus character) characters, similar to an 80x25 console text buffer
@@ -48,14 +52,16 @@
 
             m_backgroundColors = new Color[rows * columns];
             m_foregroundColors = new Color[rows * columns];
-            m_characters = new char[rows * columns];
+            m_unicodeCharacters = new char[rows * columns];
+            m_ansiCharacters = new byte[rows * columns];
             m_blink = new bool[rows * columns];
 
             for (int index = 0; index < rows * columns; index++)
             {
                 // See https://en.wikipedia.org/wiki/VGA_text_mode
                 // The first byte in each pair is a standard text character (convert to Unicode to use TTF fonts)
-                m_characters[index] = Convert.ToChar(Conversions.UnicodeByteMappings[screenData[index * 2]]);
+                m_ansiCharacters[index] = screenData[index * 2];
+                m_unicodeCharacters[index] = Convert.ToChar(Conversions.UnicodeByteMappings[screenData[index * 2]]);
 
                 // The second byte in each pair follows this format:
                 // Bytes 0-3: Foreground color
@@ -74,6 +80,7 @@
                 m_glyphHeight = pixelHeight / m_rows;
                 m_glyphWidth = m_glyphHeight / 2;  // Assume use of 8x16 style fonts
                 m_font = consoleFontFamily.CreateFont(m_glyphHeight); // Use whatever pixel value fits all the lines   
+                m_actualGlyphWidth = (int)TextMeasurer.MeasureSize($"{FULLBLOCK}", new TextOptions(m_font)).Width;
             }
         }
 
@@ -84,21 +91,21 @@
         /// <returns>A rendering of this text buffer</returns>
         public Graphics.Image GenerateImage(bool blinkOn)
         {
-            float xOffset = 0, yOffset = 0;
+            int xOffset = 0, yOffset = 0;
             using (Image<Argb32> bitmap = new Image<Argb32>(m_glyphWidth * m_columns, m_pixelHeight))
             {
                 bitmap.Mutate(ctx =>
                 {
-                    int index = 0;
+                    int charIndex = 0;
                     for (int row = 0; row < m_rows; row++)
                     {
                         xOffset = 0;
                         for (int column = 0; column < m_columns; column++)
                         {
-                            Color foregroundColor = m_foregroundColors[index];
-                            Color backgroundColor = m_backgroundColors[index];
-                            char textCharacter = m_characters[index];
-                            bool characterBlinking = m_blink[index];
+                            Color foregroundColor = m_foregroundColors[charIndex];
+                            Color backgroundColor = m_backgroundColors[charIndex];
+                            char textCharacter = m_unicodeCharacters[charIndex];
+                            bool characterBlinking = m_blink[charIndex];
 
                             ctx.FillPolygon(
                                 backgroundColor,
@@ -111,9 +118,20 @@
                             {
                                 ctx.DrawText($"{textCharacter}", m_font, foregroundColor, new PointF() { X = xOffset, Y = yOffset });
                             }
-                            xOffset += m_glyphWidth;
 
-                            index++;
+                            // Special case: extend "box drawing" characters C0-DF rightward.
+                            // This emulates VGA "line graphics enable" mode.
+                            if ((0xC0 <= m_ansiCharacters[charIndex]) && (m_ansiCharacters[charIndex] <= 0xDF))
+                            {
+                                Rectangle sourceRectangle = new(xOffset + m_actualGlyphWidth - 1, yOffset, 1, m_glyphHeight);
+                                for (int fillColumn = xOffset + m_actualGlyphWidth; fillColumn < xOffset + m_glyphWidth; fillColumn++)
+                                {
+                                    ctx.DrawImage(bitmap, new Point(fillColumn, yOffset), sourceRectangle, 1.0f);
+                                }
+                            }
+
+                            xOffset += m_glyphWidth;
+                            charIndex++;
                         }
                         yOffset += m_glyphHeight;
                     }

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -24,6 +24,7 @@
 - Fix sprites being generated and duplicated at runtime in true color.
 - Fix font coloring that was rendering dark in menus (fixes Antaresian Reliquary colored font rendering).
 - Fix sky texture not working when it's not in the texture namespace.
+- Right-extend "block" characters in ENDOOM to emulate VGA "line graphics enable" mode
 
 ## Misc:
 - Refactor of old Status Bar renderer to data-driven SBARDEF format.


### PR DESCRIPTION
In "real" VGA text modes, characters are 8x16 pixels and are typically drawn in the default 80x25 text modes as if they are *9x16* pixels.  In "line graphics enable" mode, characters `C0` through `DF` (which are all blocks of various sizes) are special, and get their eighth column duplicated across that one-pixel "gap" column.

There is a similar problem inherent in how our VGA font is hinted.  When the characters are rendered as 30 pixels tall, the "full block" character only ends up being 12 pixels wide.  If the background color is different from the foreground color, it will bleed through, looking a bit like the `|` character.

In this change, I am emulating the legacy VGA behavior by copying the last column of pixels drawn for these "block" characters and duplicating it until I hit the right side of the "tile".