### PR TITLE
Support transparency in static shader

### DIFF
--- a/Core/Layer/Worlds/WorldLayer.Render.Hud.cs
+++ b/Core/Layer/Worlds/WorldLayer.Render.Hud.cs
@@ -24,11 +24,11 @@ using Helion.Util.Consoles;
 using Helion.Util.Extensions;
 using Helion.Util.Timing;
 using Helion.World;
+using Helion.World.Entities;
 using Helion.World.Entities.Definition.States;
 using Helion.World.Entities.Inventories;
 using Helion.World.Entities.Inventories.Powerups;
 using Helion.World.Entities.Players;
-using Helion.World.Geometry.Sectors;
 using Helion.World.StatusBar;
 using System;
 using System.Collections.Generic;
@@ -658,22 +658,26 @@ public partial class WorldLayer
         int Length = (int)(5 * m_scale * m_config.Hud.CrosshairScale.Value);
 
         Color color;
-        bool target = Player.CrosshairTarget.Get() != null;
-        bool shouldShrink = m_config.Hud.CrosshairTargetShrink.Value && target;
+        var target = Player.CrosshairTarget.Get();
+        bool hasTarget = target != null;
+        bool shouldShrink = m_config.Hud.CrosshairTargetShrink.Value && hasTarget;
         int crosshairLength = shouldShrink ? (int)(Length * 0.8f) : Length;
 
         if (m_config.Hud.CrosshairHealthIndicator.Value)
         {
             // If the crosshair color and crosshair target color are not the same, then the player clearly wants it to change color
             // if we've detected a target.  Else, render a health indicator using hue angle (240 is blue, 120 green, 0 red).
-            color = target && m_config.Hud.CrosshairColor != m_config.Hud.CrosshairTargetColor
+            color = hasTarget && m_config.Hud.CrosshairColor != m_config.Hud.CrosshairTargetColor
                 ? ToColor(m_config.Hud.CrosshairTargetColor.Value)
-                : Color.FromHSV((int)(Math.Clamp(Player.Health, 0, 200) * 1.2f), 100, 100);
+                : GetPlayerHealthColor(Player);                
         }
         else
         {
-            color = target ? ToColor(m_config.Hud.CrosshairTargetColor.Value) : ToColor(m_config.Hud.CrosshairColor);
+            color = hasTarget ? ToColor(m_config.Hud.CrosshairTargetColor.Value) : ToColor(m_config.Hud.CrosshairColor);
         }
+
+        if (m_config.Hud.CrosshairTargetHealthIndicator.Value && target != null)
+            color = GetEnemyTargetColor(target);
 
         int totalCrosshairLength = crosshairLength * 2;
         if (Width == 1)
@@ -723,6 +727,19 @@ public partial class WorldLayer
                 hud.FillBox((center.X, center.Y, center.X + totalCrosshairLength, center.Y + totalCrosshairLength), color, alpha: alpha);
                 break;
         }
+    }
+
+    private static Color GetPlayerHealthColor(Player player)
+    {
+        return Color.FromHSV((int)(Math.Clamp(player.Health, 0, 200) * 1.2f), 100, 100);
+    }
+
+    private static Color GetEnemyTargetColor(Entity entity)
+    {
+        var normalizedHealth = Math.Clamp(entity.Health / (float)entity.Properties.Health, 0f, 1f);
+        // Scale health so that lower health enemies can show red
+        var scale = MathF.Pow(normalizedHealth, 0.4f);
+        return Color.FromHSV((int)(normalizedHealth * 120f * scale), 100, 100);
     }
 
     private static Color ToColor(CrossColor c) => c switch

--- a/Core/Render/OpenGL/Renderers/IStyleRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/IStyleRenderer.cs
@@ -1,0 +1,38 @@
+﻿
+using Helion.Render.OpenGL.Renderers.Legacy.World.Data;
+
+namespace Helion.Render.OpenGL.Renderers;
+
+public interface IStyleRenderer
+{
+    void Render(RenderDataStyle style);
+    bool HasStyleToRender(RenderDataStyle style);
+    bool HasAlphaToRender();
+    void RenderAllAlpha();
+}
+
+public abstract class StyleRendererBase : IStyleRenderer
+{
+    private static readonly RenderDataStyle[] AlphaStyles = [RenderDataStyle.Translucent, RenderDataStyle.Add, RenderDataStyle.ColorAdd];
+
+    public abstract bool HasStyleToRender(RenderDataStyle style);
+
+    public abstract void Render(RenderDataStyle style);
+
+    public bool HasAlphaToRender()
+    {
+        for (int i = 0; i < AlphaStyles.Length; i++)
+        {
+            if (HasStyleToRender(AlphaStyles[i]))
+                return true;
+        }
+
+        return false;
+    }
+
+    public void RenderAllAlpha()
+    {
+        for (int i = 0; i < AlphaStyles.Length; i++)
+            Render(AlphaStyles[i]);
+    }
+}

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Data/RenderWorldDataList.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Data/RenderWorldDataList.cs
@@ -43,13 +43,13 @@ public class RenderWorldDataList
 
     public void Draw()
     {
-        for (int i = 0; i < m_dataToRender.Count; i++)
+        for (int i = 0; i < m_dataToRender.Length; i++)
             m_dataToRender[i].Draw();
     }
 
     public void Clear()
     {
-        for (int i = 0; i < m_dataToRender.Count; i++)
+        for (int i = 0; i < m_dataToRender.Length; i++)
             m_dataToRender[i].Clear();
         m_dataToRender.Clear();
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Data/RenderWorldDataList.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Data/RenderWorldDataList.cs
@@ -1,5 +1,6 @@
 ﻿using Helion.Render.OpenGL.Shader;
 using Helion.Render.OpenGL.Texture.Legacy;
+using Helion.Util.Container;
 using System;
 using System.Collections.Generic;
 
@@ -9,6 +10,8 @@ public class RenderWorldDataList
 {
     public List<RenderWorldData> RenderData = [];
     private RenderWorldData?[] m_allRenderData = new RenderWorldData?[1024];
+    private readonly DynamicArray<RenderWorldData> m_dataToRender = new();
+    private int m_renderCount;
 
     public RenderWorldData Add(GLLegacyTexture texture, RenderProgram program, GLLegacyTexture? brightmapTexture = null)
     {
@@ -19,26 +22,38 @@ public class RenderWorldDataList
             Array.Copy(original, m_allRenderData, original.Length);
         }
 
-        RenderWorldData? data = m_allRenderData[texture.TextureId];
-        if (data != null)
-            return data;
+        var data = m_allRenderData[texture.TextureId];
+        if (data == null)
+        {
+            data = new(texture, program, brightmapTexture);
+            m_allRenderData[texture.TextureId] = data;
+            RenderData.Add(data);
+        }
 
-        RenderWorldData newData = new(texture, program, brightmapTexture);
-        m_allRenderData[texture.TextureId] = newData;
-        RenderData.Add(newData);
-        return newData;
+        if (data.RenderCount != m_renderCount)
+        {
+            m_dataToRender.Add(data);
+            data.RenderCount = m_renderCount;
+        }
+
+        return data;
     }
+
+    public bool HasDataToRender() => m_dataToRender.Length > 0;
 
     public void Draw()
     {
-        for (int i = 0; i < RenderData.Count; i++)
-            RenderData[i].Draw();
+        for (int i = 0; i < m_dataToRender.Count; i++)
+            m_dataToRender[i].Draw();
     }
 
     public void Clear()
     {
-        for (int i = 0; i < RenderData.Count; i++)
-            RenderData[i].Clear();
+        for (int i = 0; i < m_dataToRender.Count; i++)
+            m_dataToRender[i].Clear();
+        m_dataToRender.Clear();
+
+        m_renderCount++;
     }
 
     public void ReleaseUnmanagedResources()

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Data/RenderWorldDataManager.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Data/RenderWorldDataManager.cs
@@ -7,7 +7,7 @@ using Helion.World.Geometry.Walls;
 
 namespace Helion.Render.OpenGL.Renderers.Legacy.World.Data;
 
-public sealed class RenderWorldDataManager : IDisposable
+public sealed class RenderWorldDataManager : StyleRendererBase, IDisposable
 {
     private readonly GeometryTypeLookup<RenderWorldDataList> m_lookup = new(() => new RenderWorldDataList());
     private RenderWorldData? m_coverWalls;
@@ -77,11 +77,6 @@ public sealed class RenderWorldDataManager : IDisposable
         return HasGeometryType(GeometryType.Translucent) || HasGeometryType(GeometryType.TranslucentAdd) || HasGeometryType(GeometryType.TranslucentColorAdd);
     }
 
-    public bool HasStyle(RenderDataStyle style)
-    {
-        return m_lookup.Get(style.ToGeometryType()).RenderData.Count > 0;
-    }
-
     public bool HasGeometryType(GeometryType type)
     {
         return m_lookup.Get(type).RenderData.Count > 0;
@@ -97,21 +92,19 @@ public sealed class RenderWorldDataManager : IDisposable
         m_coverWalls?.Draw();
     }
 
-    public void RenderAllAlpha()
-    {
-        Render(GeometryType.Translucent);
-        Render(GeometryType.TranslucentAdd);
-        Render(GeometryType.TranslucentColorAdd);
-    }
-
     public void Render(GeometryType type)
     {
         m_lookup.Get(type).Draw();
     }
 
-    public void Render(RenderDataStyle style)
+    public override void Render(RenderDataStyle style)
     {
         m_lookup.Get(style.ToGeometryType()).Draw();
+    }
+
+    public override bool HasStyleToRender(RenderDataStyle style)
+    {
+        return m_lookup.Get(style.ToGeometryType()).HasDataToRender();
     }
 
     public void Dispose()

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
@@ -19,7 +19,7 @@ using System.Collections.Generic;
 
 namespace Helion.Render.OpenGL.Renderers.Legacy.World.Entities;
 
-public sealed class EntityRenderer : IDisposable
+public sealed class EntityRenderer : StyleRendererBase, IDisposable
 {
     const int MinBarWidth = 20;
     const int MaxBarWidth = 80;
@@ -74,6 +74,16 @@ public sealed class EntityRenderer : IDisposable
     public bool HasDataToRenderByStyle(RenderDataStyle style) => m_dataManager.HasDataToRenderByStyle(style);
 
     public void HealthBarMode(bool set) => m_program.HealthBarMode(set);
+
+    public override bool HasStyleToRender(RenderDataStyle style)
+    {
+        return m_dataManager.HasDataToRenderByStyle(style);
+    }
+
+    public override void Render(RenderDataStyle style)
+    {
+        m_dataManager.RenderByRenderStyle(style, PrimitiveType.Points);
+    }
 
     public void UpdateTo(IWorld world)
     {
@@ -435,27 +445,11 @@ public sealed class EntityRenderer : IDisposable
         m_programTransparent.Unbind();
     }
 
-    public void RenderOitCompositePass(RenderInfo renderInfo)
+    public void StartRenderOitCompositePass(RenderInfo renderInfo)
     {
         m_programComposite.Bind();
         GL.ActiveTexture(BindTextures.BoundTexture);
         SetUniforms(m_programComposite, renderInfo);
-        m_dataManager.RenderByRenderStyle(RenderDataStyle.Translucent, PrimitiveType.Points);
-
-        if (m_dataManager.HasDataToRenderByStyle(RenderDataStyle.Add))
-        {
-            LegacyWorldRenderer.SetBlendEquation(RenderDataStyle.Add);
-            m_dataManager.RenderByRenderStyle(RenderDataStyle.Add, PrimitiveType.Points);
-        }
-
-        if (m_dataManager.HasDataToRenderByStyle(RenderDataStyle.ColorAdd))
-        {
-            LegacyWorldRenderer.SetBlendEquation(RenderDataStyle.ColorAdd);
-            m_dataManager.RenderByRenderStyle(RenderDataStyle.ColorAdd, PrimitiveType.Points);
-        }
-
-        LegacyWorldRenderer.SetBlendEquation(RenderDataStyle.Normal);
-        m_programComposite.Unbind();
     }
 
     public void RenderOitFuzzRefractionPass(RenderInfo renderInfo, bool renderColor)

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.Sector3D.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.Sector3D.cs
@@ -48,7 +48,7 @@ public partial class GeometryRenderer
     }
 
     public void RenderSectorLine3D(Sector3D sector3D, int lineIndex, bool renderFront, bool renderBack,
-        Action<Side, Wall, Sector, GLLegacyTexture?, Span<DynamicVertex>>? renderVertices)
+        Action<Side, Wall, Sector, GLLegacyTexture?, Span<DynamicVertex>, Sector3D?>? renderVertices)
     {
         var sectorLine = sector3D.FakeSector.Lines[lineIndex];
         var parentSectorLine = sector3D.ParentSector.Lines[lineIndex];
@@ -65,7 +65,7 @@ public partial class GeometryRenderer
     }
 
     private void RenderSide3D(Sector3D sector3D, Side useSide, Side? parentSide, Side? oppositeParentSide,
-        Sector wallSector, bool isFront, Action<Side, Wall, Sector, GLLegacyTexture?, Span<DynamicVertex>>? renderVertices)
+        Sector wallSector, bool isFront, Action<Side, Wall, Sector, GLLegacyTexture?, Span<DynamicVertex>, Sector3D?>? renderVertices)
     {
         if (parentSide == null || !sector3D.CalculateWallHeights(parentSide, out var newWallHeights))
             return;
@@ -93,7 +93,7 @@ public partial class GeometryRenderer
             wallHeights3D: newWallHeights, style: sector3D.RenderDataStyle);
 
         if (result.Vertices.Length > 0 && renderVertices != null)
-            renderVertices(useSide, useSide.Middle, wallSector, result.Texture, result.Vertices);
+            renderVertices(useSide, useSide.Middle, wallSector, result.Texture, result.Vertices, sector3D);
     }
 
     private Span<SectorPlane3D> MergePlanes(SectorPlane3D[] a, SectorPlane3D[] b, Sector3D ignorePlane)

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.Sector3D.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.Sector3D.cs
@@ -1,5 +1,4 @@
-﻿using Helion.Geometry.Planes;
-using Helion.Geometry.Vectors;
+﻿using Helion.Geometry.Vectors;
 using Helion.Maps.Specials;
 using Helion.Render.OpenGL.Renderers.Legacy.World.Data;
 using Helion.Render.OpenGL.Texture.Legacy;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
@@ -373,6 +373,18 @@ public partial class GeometryRenderer : IDisposable
     public void RenderWallClipPortals(RenderInfo renderInfo) =>
         Portals.RenderWallClip(renderInfo);
 
+    public bool HasStaticAlphaGeometry() =>
+        m_staticCacheGeometryRenderer.HasAlphaGeometry();
+
+    public bool HasStaticStyle(RenderDataStyle style) =>
+        m_staticCacheGeometryRenderer.HasStyle(style);
+
+    public void RenderAllStaticAlpha() =>
+        m_staticCacheGeometryRenderer.RenderAllAlpha();
+
+    public void RenderStaticStyle(RenderDataStyle style) =>
+        m_staticCacheGeometryRenderer.Render(style.ToGeometryType());
+
     public void RenderSector(Sector sector, in Vec3D viewPosition, in Vec3D prevViewPosition)
     {
         m_buffer = true;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
@@ -95,6 +95,7 @@ public partial class GeometryRenderer : IDisposable
     private readonly Func<RenderWallSliceArgs, RenderWallSliceResult> m_renderTwoSidedMiddleSliceFunc;
 
     private TextureManager TextureManager => m_archiveCollection.TextureManager;
+    public StaticCacheGeometryRenderer StaticRenderer => m_staticCacheGeometryRenderer;
 
     public GeometryRenderer(IConfig config, ArchiveCollection archiveCollection, LegacyGLTextureManager glTextureManager,
         RenderProgram program, RenderProgram staticProgram, RenderWorldDataManager worldDataManager, bool unitTest = false)
@@ -372,15 +373,6 @@ public partial class GeometryRenderer : IDisposable
 
     public void RenderWallClipPortals(RenderInfo renderInfo) =>
         Portals.RenderWallClip(renderInfo);
-
-    public bool HasStaticAlphaGeometry() =>
-        m_staticCacheGeometryRenderer.HasAlphaGeometry();
-
-    public bool HasStaticStyle(RenderDataStyle style) =>
-        m_staticCacheGeometryRenderer.HasStyle(style);
-
-    public void RenderAllStaticAlpha() =>
-        m_staticCacheGeometryRenderer.RenderAllAlpha();
 
     public void RenderStaticStyle(RenderDataStyle style) =>
         m_staticCacheGeometryRenderer.Render(style.ToGeometryType());
@@ -1073,7 +1065,6 @@ public partial class GeometryRenderer : IDisposable
 
         GLLegacyTexture texture = m_glTextureManager.GetTexture(lowerWall.TextureHandle);
         GLLegacyTexture? brightmapTexture = m_glTextureManager.GetBrightmapTexture(lowerWall.TextureHandle);
-        RenderWorldData renderData = m_worldDataManager.GetRenderData(texture, m_program, GeometryType.Wall, brightmapTexture);
 
         SectorPlane top = otherSector.Floor;
         SectorPlane bottom = facingSector.Floor;
@@ -1120,7 +1111,10 @@ public partial class GeometryRenderer : IDisposable
             }
 
             if (m_buffer)
+            {
+                var renderData = m_worldDataManager.GetRenderData(texture, m_program, GeometryType.Wall, brightmapTexture);
                 renderData.Vbo.Add(data);
+            }
             vertices = data;
             skyVertices = null;
         }
@@ -1170,7 +1164,6 @@ public partial class GeometryRenderer : IDisposable
         WallVertices wall = default;
         GLLegacyTexture texture = m_glTextureManager.GetTexture(upperWall.TextureHandle);
         GLLegacyTexture? brightmapTexture = m_glTextureManager.GetBrightmapTexture(upperWall.TextureHandle);
-        RenderWorldData renderData = m_worldDataManager.GetRenderData(texture, m_program, GeometryType.Wall, brightmapTexture);
 
         SectorPlane top = facingSector.Ceiling;
         SectorPlane bottom = otherSector.Ceiling;
@@ -1237,7 +1230,10 @@ public partial class GeometryRenderer : IDisposable
             }
 
             if (m_buffer)
+            {
+                var renderData = m_worldDataManager.GetRenderData(texture, m_program, GeometryType.Wall, brightmapTexture);
                 renderData.Vbo.Add(data);
+            }
             vertices = data;
             skyVertices = null;
         }
@@ -1366,8 +1362,6 @@ public partial class GeometryRenderer : IDisposable
         DynamicVertex[]? data = m_vertexLookup[facingSide.Id];
         var geometryType = alpha < 1 ? GeometryType.Translucent : GeometryType.TwoSidedMiddleWall;
 
-        var renderData = m_worldDataManager.GetRenderData(texture, m_program, geometryType, brightmapTexture);
-
         if (facingSide.OffsetChanged || m_sectorChangedLine || data == null)
         {
             lightLevelSector ??= facingSector;
@@ -1411,7 +1405,10 @@ public partial class GeometryRenderer : IDisposable
 
         // See RenderOneSided() for an ASCII image of why we do this.
         if (m_buffer)
+        {
+            var renderData = m_worldDataManager.GetRenderData(texture, m_program, geometryType, brightmapTexture);
             renderData.Vbo.Add(data);
+        }
         vertices = data;
     }
 
@@ -1570,7 +1567,6 @@ public partial class GeometryRenderer : IDisposable
         var brightmapTexture = m_glTextureManager.GetBrightmapTexture(textureHandle);
 
         var geometryType = GetGeometryType(style, GeometryType.Flat);
-        var renderData = m_worldDataManager.GetRenderData(texture, m_program, geometryType, brightmapTexture);
         var flatChanged = FlatChanged(renderPlane);
         var sector = subsectors[0].Sector;
         int id = geometryPlane.Sector.Id;
@@ -1666,6 +1662,7 @@ public partial class GeometryRenderer : IDisposable
             vertices = lookupData;
             if (m_buffer)
             {
+                var renderData = m_worldDataManager.GetRenderData(texture, m_program, geometryType, brightmapTexture);
                 renderData.Vbo.Add(lookupData);
                 // Don't need to clip floor on lower view and ceiling on upper view
                 if (sector.TransferHeights != null

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
@@ -479,12 +479,12 @@ public partial class GeometryRenderer : IDisposable
                 if ((sector3D.RenderPlanes & SectorPlanes.Ceiling) != 0)
                 {
                     RenderFlat(subsectors, sector3D.ControlTop, sector3D.FakeTop, floor: true, renderFlood: false, m_ceilingVertexLookupInvalidated, out _, out _,
-                        lightLevelSector: sector3D.LightTop, allowAlpha: true, alpha: sector3D.Alpha, style: sector3D.RenderDataStyle, isSector3D: true);
+                        lightLevelSector: sector3D.LightTop, allowAlpha: true, alpha: sector3D.Alpha, style: sector3D.RenderDataStyle);
 
                     if (sector3D.FakeTopFlipped != null)
                     {
                         RenderFlat(subsectors, sector3D.ControlTop, sector3D.FakeTopFlipped, floor: false, renderFlood: false, m_ceilingVertexLookupInvalidated, out _, out _,
-                            lightLevelSector: sector3D.LightTop, allowAlpha: true, alpha: sector3D.Alpha, style: sector3D.RenderDataStyle, isSector3D: true);
+                            lightLevelSector: sector3D.LightTop, allowAlpha: true, alpha: sector3D.Alpha, style: sector3D.RenderDataStyle);
                     }
                 }
             }
@@ -503,12 +503,12 @@ public partial class GeometryRenderer : IDisposable
                 if ((sector3D.RenderPlanes & SectorPlanes.Floor) != 0)
                 {
                     RenderFlat(subsectors, sector3D.ControlBottom, sector3D.FakeBottom, floor: false, renderFlood: false, m_ceilingVertexLookupInvalidated, out _, out _,
-                        lightLevelSector: sector3D.LightBottom, allowAlpha: true, alpha: sector3D.Alpha, style: sector3D.RenderDataStyle, isSector3D: true);
+                        lightLevelSector: sector3D.LightBottom, allowAlpha: true, alpha: sector3D.Alpha, style: sector3D.RenderDataStyle);
 
                     if (sector3D.FakeBottomFlipped != null)
                     {
                         RenderFlat(subsectors, sector3D.ControlBottom, sector3D.FakeBottomFlipped, floor: true, renderFlood: false, m_ceilingVertexLookupInvalidated, out _, out _,
-                            lightLevelSector: sector3D.LightBottom, allowAlpha: true, alpha: sector3D.Alpha, style: sector3D.RenderDataStyle, isSector3D: true);
+                            lightLevelSector: sector3D.LightBottom, allowAlpha: true, alpha: sector3D.Alpha, style: sector3D.RenderDataStyle);
                     }
                 }
             }
@@ -1542,7 +1542,7 @@ public partial class GeometryRenderer : IDisposable
     }
 
     public void RenderSectorFlats(Sector renderSector, SectorPlane renderPlane, SectorPlane geometryPlane, bool floor, bool renderFlood,
-        out DynamicVertex[]? vertices, out SkyGeometryVertex[]? skyVertices, Sector? lightLevelSector = null, bool allowAlpha = false, RenderDataStyle style = RenderDataStyle.Normal)
+        out DynamicVertex[]? vertices, out SkyGeometryVertex[]? skyVertices, Sector? lightLevelSector = null, bool allowAlpha = false, float alpha = 1, RenderDataStyle style = RenderDataStyle.Normal)
     {
         if (renderSector.Id >= m_subsectors.Length)
         {
@@ -1553,7 +1553,7 @@ public partial class GeometryRenderer : IDisposable
 
         var subsectors = m_subsectors[renderSector.Id];
         var invalidatedLookup = floor ? m_floorVertexLookupInvalidated : m_ceilingVertexLookupInvalidated;
-        RenderFlat(subsectors, renderPlane, geometryPlane, floor, renderFlood, invalidatedLookup, out vertices, out skyVertices, lightLevelSector, allowAlpha, style: style);
+        RenderFlat(subsectors, renderPlane, geometryPlane, floor, renderFlood, invalidatedLookup, out vertices, out skyVertices, lightLevelSector, allowAlpha, alpha, style: style);
     }
 
     // Doom would render flats with no texture ("-") as black. If the flat isn't flagged to allow alpha then the black texture must be used.
@@ -1562,7 +1562,7 @@ public partial class GeometryRenderer : IDisposable
 
     private void RenderFlat(DynamicArray<Subsector> subsectors, SectorPlane renderPlane, SectorPlane geometryPlane, bool floor, bool renderFlood,
         BitArray flatInvalidatedVertexLookup, out DynamicVertex[]? vertices, out SkyGeometryVertex[]? skyVertices,
-        Sector? lightLevelSector = null, bool allowAlpha = false, float alpha = 1, RenderDataStyle style = RenderDataStyle.Normal, bool isSector3D = false)
+        Sector? lightLevelSector = null, bool allowAlpha = false, float alpha = 1, RenderDataStyle style = RenderDataStyle.Normal)
     {
         var textureHandle = GetFlatTextureHandle(renderPlane.TextureHandle, allowAlpha);
         var isSky = TextureManager.IsSkyTexture(textureHandle);

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryType.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryType.cs
@@ -6,9 +6,9 @@ namespace Helion.Render.OpenGL.Renderers.Legacy.World.Geometry;
 public enum GeometryType
 {
     Wall,
+    TwoSidedMiddleWall,
     Middle3D,
     Flat,
-    TwoSidedMiddleWall,
 
     Fuzzy,
     Translucent,
@@ -22,7 +22,7 @@ public static class GeometryTypeExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool NeedsCoverWall(this GeometryType style)
     {
-        return (int)style < (int)GeometryType.TwoSidedMiddleWall;
+        return (int)style < (int)GeometryType.Fuzzy && style != GeometryType.TwoSidedMiddleWall;
     }
 }
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryType.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryType.cs
@@ -6,15 +6,24 @@ namespace Helion.Render.OpenGL.Renderers.Legacy.World.Geometry;
 public enum GeometryType
 {
     Wall,
-    TwoSidedMiddleWall,
     Middle3D,
     Flat,
+    TwoSidedMiddleWall,
 
     Fuzzy,
     Translucent,
     TranslucentAdd,
     TranslucentColorAdd,
     Count
+}
+
+public static class GeometryTypeExtensions
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool NeedsCoverWall(this GeometryType style)
+    {
+        return (int)style < (int)GeometryType.TwoSidedMiddleWall;
+    }
 }
 
 public static class RenderDataStyleExtensions

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.Sector3D.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.Sector3D.cs
@@ -14,7 +14,7 @@ public partial class StaticCacheGeometryRenderer
     private readonly Func<RenderWallSliceArgs, RenderWallSliceResult> m_renderTwoSidedLowerSliceFunc;
     private readonly Func<RenderWallSliceArgs, RenderWallSliceResult> m_renderTwoSidedUpperSliceFunc;
     private readonly Func<RenderWallSliceArgs, RenderWallSliceResult> m_renderTwoSidedMiddleSliceFunc;
-    private readonly Action<Side, Wall, Sector, GLLegacyTexture?, Span<DynamicVertex>>? m_renderSectorWallVertices3D;
+    private readonly Action<Side, Wall, Sector, GLLegacyTexture?, Span<DynamicVertex>, Sector3D?>? m_renderSectorWallVertices3D;
 
     private void AddSectors3D(Sector sector, bool update)
     {
@@ -24,19 +24,6 @@ public partial class StaticCacheGeometryRenderer
 
     private void AddSector3D(Sector3D sector3D, SectorPlanes planes, bool update)
     {
-        //if (sector3D.Alpha < 1f || sector3D.RenderDataStyle != RenderDataStyle.Normal)
-        //{
-        //    sector3D.FakeSector.Floor.Dynamic |= SectorDynamic.Alpha;
-        //    sector3D.FakeSector.Ceiling.Dynamic |= SectorDynamic.Alpha;
-        //    m_world.RenderBlockmap.LinkDynamic(m_world, sector3D);
-        //    return;
-        //}
-
-        if (sector3D.ParentSectorId == 58)
-        {
-            int lol = 1;
-        }
-
         AddSectorPlanes3D(sector3D, planes, update);
 
         if (!sector3D.ShouldRenderWalls)
@@ -91,8 +78,8 @@ public partial class StaticCacheGeometryRenderer
         sector3D.ParentSector.TransferFloorLightSector = saveTransfer;
     }
 
-    private void RenderSectorWallVertices3D(Side side, Wall wall, Sector wallSector, GLLegacyTexture? texture, Span<DynamicVertex> vertices)
+    private void RenderSectorWallVertices3D(Side side, Wall wall, Sector wallSector, GLLegacyTexture? texture, Span<DynamicVertex> vertices, Sector3D? sector3D)
     {
-        UpdateVertices(ref wall.Static, wall.TextureHandle, vertices, null, side, wall, true, texture);
+        UpdateVertices(ref wall.Static, wall.TextureHandle, vertices, null, side, wall, true, texture, sector3D);
     }
 }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.Sector3D.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.Sector3D.cs
@@ -1,5 +1,4 @@
-﻿using Helion.Render.OpenGL.Renderers.Legacy.World.Data;
-using Helion.Render.OpenGL.Texture.Legacy;
+﻿using Helion.Render.OpenGL.Texture.Legacy;
 using Helion.World.Geometry.Sectors;
 using Helion.World.Geometry.Sides;
 using Helion.World.Geometry.Walls;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.Sector3D.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.Sector3D.cs
@@ -24,13 +24,13 @@ public partial class StaticCacheGeometryRenderer
 
     private void AddSector3D(Sector3D sector3D, SectorPlanes planes, bool update)
     {
-        if (sector3D.Alpha < 1f || sector3D.RenderDataStyle != RenderDataStyle.Normal)
-        {
-            sector3D.FakeSector.Floor.Dynamic |= SectorDynamic.Alpha;
-            sector3D.FakeSector.Ceiling.Dynamic |= SectorDynamic.Alpha;
-            m_world.RenderBlockmap.LinkDynamic(m_world, sector3D);
-            return;
-        }
+        //if (sector3D.Alpha < 1f || sector3D.RenderDataStyle != RenderDataStyle.Normal)
+        //{
+        //    sector3D.FakeSector.Floor.Dynamic |= SectorDynamic.Alpha;
+        //    sector3D.FakeSector.Ceiling.Dynamic |= SectorDynamic.Alpha;
+        //    m_world.RenderBlockmap.LinkDynamic(m_world, sector3D);
+        //    return;
+        //}
 
         AddSectorPlanes3D(sector3D, planes, update);
 
@@ -62,24 +62,24 @@ public partial class StaticCacheGeometryRenderer
         if ((planes & SectorPlanes.Ceiling) != 0)
         {
             AddSectorPlane(sector3D.ParentSector, sector3D.ControlTop.Facing, floor: true, update: update, renderSector: sector3D.ControlSector,
-                lightLevelSector: sector3D.LightTop, geometryPlane: sector3D.FakeBottom, allowAlpha: true, isSector3D: true);
+                lightLevelSector: sector3D.LightTop, geometryPlane: sector3D.FakeBottom, allowAlpha: true, sector3D: sector3D);
 
             if (sector3D.FakeBottomFlipped != null)
             {
                 AddSectorPlane(sector3D.ParentSector, sector3D.ControlTop.Facing, floor: false, update: update, renderSector: sector3D.ControlSector,
-                    lightLevelSector: sector3D.LightTop, geometryPlane: sector3D.FakeBottomFlipped, allowAlpha: true, isSector3D: true);
+                    lightLevelSector: sector3D.LightTop, geometryPlane: sector3D.FakeBottomFlipped, allowAlpha: true, sector3D: sector3D);
             }
         }
 
         if ((planes & SectorPlanes.Floor) != 0)
         {
             AddSectorPlane(sector3D.ParentSector, sector3D.ControlBottom.Facing, floor: false, update: update, renderSector: sector3D.ControlSector,
-                lightLevelSector: sector3D.LightBottom, geometryPlane: sector3D.FakeTop, allowAlpha: true, isSector3D: true);
+                lightLevelSector: sector3D.LightBottom, geometryPlane: sector3D.FakeTop, allowAlpha: true, sector3D: sector3D);
 
             if (sector3D.FakeTopFlipped != null)
             {
                 AddSectorPlane(sector3D.ParentSector, sector3D.ControlBottom.Facing, floor: true, update: update, renderSector: sector3D.ControlSector,
-                    lightLevelSector: sector3D.LightBottom, geometryPlane: sector3D.FakeTopFlipped, allowAlpha: true, isSector3D: true);
+                    lightLevelSector: sector3D.LightBottom, geometryPlane: sector3D.FakeTopFlipped, allowAlpha: true, sector3D: sector3D);
             }
         }
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.Sector3D.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.Sector3D.cs
@@ -32,6 +32,11 @@ public partial class StaticCacheGeometryRenderer
         //    return;
         //}
 
+        if (sector3D.ParentSectorId == 58)
+        {
+            int lol = 1;
+        }
+
         AddSectorPlanes3D(sector3D, planes, update);
 
         if (!sector3D.ShouldRenderWalls)

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
@@ -1216,7 +1216,7 @@ public partial class StaticCacheGeometryRenderer : IDisposable
         SectorPlane? plane, Side? side, Wall? wall, bool repeat, GLLegacyTexture? texture = null, Sector3D? sector3D = null)
     {
         var geometryType = side != null && wall != null ? GetWallType(side, wall, sector3D) : GeometryType.Flat;
-        if (side != null && wall != null && geometryType != GeometryType.TwoSidedMiddleWall)
+        if (side != null && wall != null && geometryType != GeometryType.TwoSidedMiddleWall && (sector3D == null || sector3D.RenderDataStyle == RenderDataStyle.Normal))
             AddOrUpdateCoverWall(side, vertices, wall.Location, wall.Location == WallLocation.Middle);
 
         if (textureHandle <= Constants.NullCompatibilityTextureIndex)

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
@@ -429,7 +429,7 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
                 result.SkyVertices = result.SkyVertices2;
             }
 
-            SetSideVertices(side, side.Upper, update, result.Vertices, upperVisible, true);
+            SetSideVertices(side, side.Upper, update, result.Vertices, upperVisible, true, null);
             // Sky hack and skyVertices2 are done from the facingSector, otherwise use the otherSector like normal.
             // Required for id24 flat mapping using different floor/ceiling textures.
             AddSkyGeometry(side, WallLocation.Upper, null, result.SkyVertices, skyHack || result.SkyVertices2 != null ? facingSector : otherSector, update);
@@ -461,7 +461,7 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
                 result = new(sideVertices, skyVertices, null);
             }
 
-            SetSideVertices(side, side.Lower, update, result.Vertices, lowerVisible, true);
+            SetSideVertices(side, side.Lower, update, result.Vertices, lowerVisible, true, null);
             AddSkyGeometry(side, WallLocation.Lower, null, result.SkyVertices, otherSector, update);
 
             if (!update && result.SkyVertices == null)
@@ -490,7 +490,7 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
                 result = new(sideVertices, null, null);
             }
 
-            SetSideVertices(side, side.Middle, update, result.Vertices, true, repeatY: side.Flags.WrapMidTex);
+            SetSideVertices(side, side.Middle, update, result.Vertices, true, repeatY: side.Flags.WrapMidTex, null);
 
             var sideVisibility = SideTexture.None;
             if (upperVisible)
@@ -597,7 +597,7 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
         }
     }
 
-    private void SetSideVertices(Side side, Wall wall, bool update, Span<DynamicVertex> sideVertices, bool visible, bool repeatY)
+    private void SetSideVertices(Side side, Wall wall, bool update, Span<DynamicVertex> sideVertices, bool visible, bool repeatY, Sector3D? sector3D)
     {
         if (sideVertices.Length == 0 || !visible)
             return;
@@ -608,7 +608,7 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
             return;
         }
 
-        var type = GetWallType(side, wall);
+        var type = GetWallType(side, wall, sector3D);
         if (m_vanillaRender && type.NeedsCoverWall())
             AddOrUpdateCoverWall(side, sideVertices, wall.Location, wall.Location == WallLocation.Middle);
 
@@ -620,7 +620,7 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
         AddVertices(vertices, sideVertices);
     }
 
-    private static GeometryType GetWallType(Side side, Wall wall, Sector3D? sector3D = null)
+    private static GeometryType GetWallType(Side side, Wall wall, Sector3D? sector3D)
     {
         if (sector3D != null && (wall.Location == WallLocation.Middle3D || wall.Location == WallLocation.Middle))
         {
@@ -1231,7 +1231,7 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
          
         if (staticGeometry.GeometryData == null)
         {
-            AddNewGeometry(textureHandle, vertices, geometryType, plane, side, wall, repeat, texture);
+            AddNewGeometry(textureHandle, vertices, geometryType, plane, side, wall, repeat, texture, sector3D);
             return;
         }
 
@@ -1311,19 +1311,20 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
         }
     }
 
-    private void AddNewGeometry(int textureHandle, Span<DynamicVertex> vertices, GeometryType geometryType, SectorPlane? plane, Side? side, Wall? wall, bool repeat, GLLegacyTexture? texture = null)
+    private void AddNewGeometry(int textureHandle, Span<DynamicVertex> vertices, GeometryType geometryType, SectorPlane? plane, Side? side, Wall? wall, bool repeat, 
+        GLLegacyTexture? texture, Sector3D? sector3D)
     {
         if (m_freeManager.GetAndRemove(textureHandle, vertices.Length, out StaticGeometryData? existing))
         {
             if (plane != null)
             {
                 plane.Static = existing.Value;
-                UpdateVertices(ref plane.Static, textureHandle, vertices, plane, side, wall, repeat);
+                UpdateVertices(ref plane.Static, textureHandle, vertices, plane, side, wall, repeat, texture, sector3D);
             }
             else if (wall != null)
             {
                 wall.Static = existing.Value;
-                UpdateVertices(ref wall.Static, textureHandle, vertices, plane, side, wall, repeat);
+                UpdateVertices(ref wall.Static, textureHandle, vertices, plane, side, wall, repeat, texture, sector3D);
             }
 
             return;
@@ -1332,7 +1333,7 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
         // This texture exists, append to the vbo
         if (m_textureToGeometryLookup.TryGetValue(geometryType, textureHandle, repeat, out GeometryData? data))
         {
-            SetRuntimeGeometryData(plane, side, wall, textureHandle, data, vertices, repeat);
+            SetRuntimeGeometryData(plane, side, wall, textureHandle, data, vertices, repeat, sector3D);
             AddVertices(data.Vbo.Data, vertices);
             // TODO this causes the entire vbo to be uploaded when we could use sub-buffer
             data.Vbo.SetNotUploaded();
@@ -1340,16 +1341,16 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
         }
 
         data = AllocateGeometryData(geometryType, textureHandle, repeat, overrideTexture: texture);
-        SetRuntimeGeometryData(plane, side, wall, textureHandle, data, vertices, repeat);
+        SetRuntimeGeometryData(plane, side, wall, textureHandle, data, vertices, repeat, sector3D);
         AddVertices(data.Vbo.Data, vertices);
         data.Vbo.SetNotUploaded();
     }
 
-    private void SetRuntimeGeometryData(SectorPlane? plane, Side? side, Wall? wall, int textureHandle, GeometryData geometryData, Span<DynamicVertex> vertices, bool repeat)
+    private void SetRuntimeGeometryData(SectorPlane? plane, Side? side, Wall? wall, int textureHandle, GeometryData geometryData, Span<DynamicVertex> vertices, bool repeat, Sector3D? sector3D)
     {
         if (side != null && wall != null)
         {
-            SetSideData(ref wall.Static, GetWallType(side, wall), textureHandle, geometryData.Vbo.Count, vertices.Length, repeat, geometryData);
+            SetSideData(ref wall.Static, GetWallType(side, wall, sector3D), textureHandle, geometryData.Vbo.Count, vertices.Length, repeat, geometryData);
             return;
         }
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
@@ -625,7 +625,7 @@ public partial class StaticCacheGeometryRenderer : IDisposable
 
     private static GeometryType GetWallType(Side side, Wall wall, Sector3D? sector3D = null)
     {
-        if (sector3D != null)
+        if (sector3D != null && (wall.Location == WallLocation.Middle3D || wall.Location == WallLocation.Middle))
         {
             if (sector3D.RenderDataStyle != RenderDataStyle.Normal)
                 return sector3D.RenderDataStyle.ToGeometryType();
@@ -633,8 +633,12 @@ public partial class StaticCacheGeometryRenderer : IDisposable
                 return GeometryType.Translucent;
         }
 
-        if (wall.Location == WallLocation.Middle && side.Line.Alpha < 1)
+        if (wall.Location == WallLocation.Middle && (side.Line.Alpha < 1 || side.RenderDataStyle != RenderDataStyle.Normal))
+        {
+            if (side.RenderDataStyle != RenderDataStyle.Normal)
+                return side.RenderDataStyle.ToGeometryType();
             return GeometryType.Translucent;
+        }
 
         if (wall.Location == WallLocation.Middle3D)
             return GeometryType.Middle3D;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
@@ -749,6 +749,7 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
         var alpha = 1f;
         if (sector3D != null && (sector3D.Alpha < 1 || sector3D.RenderDataStyle != RenderDataStyle.Normal))
         {
+            style = sector3D.RenderDataStyle;
             if (style == RenderDataStyle.Normal)
                 style = RenderDataStyle.Translucent;
             alpha = sector3D.Alpha;
@@ -1215,7 +1216,7 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
         SectorPlane? plane, Side? side, Wall? wall, bool repeat, GLLegacyTexture? texture = null, Sector3D? sector3D = null)
     {
         var geometryType = side != null && wall != null ? GetWallType(side, wall, sector3D) : GeometryType.Flat;
-        if (side != null && wall != null && geometryType != GeometryType.TwoSidedMiddleWall && (sector3D == null || sector3D.RenderDataStyle == RenderDataStyle.Normal))
+        if (side != null && wall != null && geometryType.NeedsCoverWall())
             AddOrUpdateCoverWall(side, vertices, wall.Location, wall.Location == WallLocation.Middle);
 
         if (textureHandle <= Constants.NullCompatibilityTextureIndex)

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
@@ -1,5 +1,6 @@
 ﻿using Helion.Geometry.Vectors;
 using Helion.Render.OpenGL.Buffer.Array.Vertex;
+using Helion.Render.OpenGL.Renderers.Legacy.World.Data;
 using Helion.Render.OpenGL.Renderers.Legacy.World.Geometry.Portals.FloodFill;
 using Helion.Render.OpenGL.Renderers.Legacy.World.Sky;
 using Helion.Render.OpenGL.Renderers.Legacy.World.Sky.Sphere;
@@ -178,6 +179,19 @@ public partial class StaticCacheGeometryRenderer : IDisposable
                 data.Vbo.UploadIfNeeded();
             }
         }
+    }
+
+    public bool HasAlphaGeometry() =>
+        HasStyle(RenderDataStyle.Translucent) || HasStyle(RenderDataStyle.ColorAdd) || HasStyle(RenderDataStyle.Add);
+
+    public bool HasStyle(RenderDataStyle style) =>
+        m_geometry.GetGeometry(style.ToGeometryType()).Count > 0;
+
+    public void RenderAllAlpha()
+    {
+        Render(GeometryType.Translucent);
+        Render(GeometryType.TranslucentAdd);
+        Render(GeometryType.TranslucentColorAdd);
     }
 
     private void World_SectorPlaneTransformed(object? sender, SectorPlane plane)
@@ -614,6 +628,9 @@ public partial class StaticCacheGeometryRenderer : IDisposable
         if (wall.Location == WallLocation.Middle3D)
             return GeometryType.Middle3D;
 
+        if (wall.Location == WallLocation.Middle && side.Line.Alpha < 1)
+            return GeometryType.Translucent;
+
         return wall.Location == WallLocation.Middle && side.PartnerSide != null ? GeometryType.TwoSidedMiddleWall : GeometryType.Wall;
     }
 
@@ -714,10 +731,17 @@ public partial class StaticCacheGeometryRenderer : IDisposable
     }
 
     private void AddSectorPlane(Sector sectorForSubsectors, SectorPlaneFace face, bool floor, bool update = false, 
-        Sector? renderSector = null, Sector? lightLevelSector = null, SectorPlane? geometryPlane = null, bool allowAlpha = false, bool isSector3D = false)
+        Sector? renderSector = null, Sector? lightLevelSector = null, SectorPlane? geometryPlane = null, bool allowAlpha = false, Sector3D? sector3D = null)
     {
         if ((floor && sectorForSubsectors.Floor.NoRender) || (!floor && sectorForSubsectors.Ceiling.NoRender))
             return;
+
+        var style = RenderDataStyle.Normal;
+        if (sector3D != null && (sector3D.Alpha < 1 || sector3D.RenderDataStyle != RenderDataStyle.Normal))
+        {
+            if (style == RenderDataStyle.Normal)
+                style = RenderDataStyle.Translucent;
+        }
 
         renderSector ??= sectorForSubsectors.GetRenderSector(TransferHeightView.Middle);
         lightLevelSector ??= renderSector;
@@ -727,7 +751,7 @@ public partial class StaticCacheGeometryRenderer : IDisposable
         var plane = face == SectorPlaneFace.Floor ? sectorForSubsectors.Floor : sectorForSubsectors.Ceiling;
         geometryPlane ??= plane;
         m_geometryRenderer.RenderSectorFlats(sectorForSubsectors, renderPlane, geometryPlane, floor, renderFlood: false, out var renderedVertices, out var renderedSkyVertices,
-            lightLevelSector: lightLevelSector, allowAlpha: allowAlpha);
+            lightLevelSector: lightLevelSector, allowAlpha: allowAlpha, style: style);
 
         AddSkyGeometry(null, WallLocation.None, geometryPlane, renderedSkyVertices, sectorForSubsectors, update);
 
@@ -747,8 +771,7 @@ public partial class StaticCacheGeometryRenderer : IDisposable
             return;
         }
 
-        var geometryType = GeometryType.Flat;
-
+        var geometryType = style.ToGeometryType();
         var vertices = GetTextureVertices(geometryType, textureHandle, true);
         if (m_textureToGeometryLookup.TryGetValue(geometryType, textureHandle, true, out var geometryData))
         {
@@ -771,6 +794,9 @@ public partial class StaticCacheGeometryRenderer : IDisposable
 
     public void RenderFlats() => 
         RenderGeometry(m_geometry.GetGeometry(GeometryType.Flat));
+
+    public void Render(GeometryType type) =>
+        RenderGeometry(m_geometry.GetGeometry(type));
 
     public void RenderCoverWalls() =>
         RenderCoverInternal(m_coverWallGeometry);

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
@@ -404,7 +404,7 @@ public partial class StaticCacheGeometryRenderer : IDisposable
         bool ceilingDynamic = (side.Sector.Ceiling.Dynamic & SectorDynamic.Movement) != 0 || (otherSide.Sector.Ceiling.Dynamic & SectorDynamic.Movement) != 0;
         bool upper = !(ceilingDynamic && side.IsDynamic);
         bool lower = !(floorDynamic && side.IsDynamic);
-        bool middle = !((floorDynamic || ceilingDynamic) && side.IsDynamic) && (side.Dynamic & SectorDynamic.Alpha) == 0; // Middle with alpha is drawn separately through dynamic rendering.
+        bool middle = !((floorDynamic || ceilingDynamic) && side.IsDynamic);
 
         m_geometryRenderer.SetRenderTwoSided(side);
 
@@ -623,13 +623,21 @@ public partial class StaticCacheGeometryRenderer : IDisposable
         AddVertices(vertices, sideVertices);
     }
 
-    private static GeometryType GetWallType(Side side, Wall wall)
+    private static GeometryType GetWallType(Side side, Wall wall, Sector3D? sector3D = null)
     {
-        if (wall.Location == WallLocation.Middle3D)
-            return GeometryType.Middle3D;
+        if (sector3D != null)
+        {
+            if (sector3D.RenderDataStyle != RenderDataStyle.Normal)
+                return sector3D.RenderDataStyle.ToGeometryType();
+            if (sector3D.Alpha < 1)
+                return GeometryType.Translucent;
+        }
 
         if (wall.Location == WallLocation.Middle && side.Line.Alpha < 1)
             return GeometryType.Translucent;
+
+        if (wall.Location == WallLocation.Middle3D)
+            return GeometryType.Middle3D;
 
         return wall.Location == WallLocation.Middle && side.PartnerSide != null ? GeometryType.TwoSidedMiddleWall : GeometryType.Wall;
     }
@@ -1201,9 +1209,9 @@ public partial class StaticCacheGeometryRenderer : IDisposable
     }
 
     private void UpdateVertices(ref StaticGeometryData staticGeometry, int textureHandle, Span<DynamicVertex> vertices,
-        SectorPlane? plane, Side? side, Wall? wall, bool repeat, GLLegacyTexture? texture = null)
+        SectorPlane? plane, Side? side, Wall? wall, bool repeat, GLLegacyTexture? texture = null, Sector3D? sector3D = null)
     {
-        var geometryType = side != null && wall != null ? GetWallType(side, wall) : GeometryType.Flat;
+        var geometryType = side != null && wall != null ? GetWallType(side, wall, sector3D) : GeometryType.Flat;
         if (side != null && wall != null && geometryType != GeometryType.TwoSidedMiddleWall)
             AddOrUpdateCoverWall(side, vertices, wall.Location, wall.Location == WallLocation.Middle);
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
@@ -27,7 +27,7 @@ using System.Runtime.InteropServices;
 
 namespace Helion.Render.OpenGL.Renderers.Legacy.World.Geometry.Static;
 
-public partial class StaticCacheGeometryRenderer : IDisposable
+public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposable
 {
     const int WallVertices = 6;
     private const SectorDynamic IgnoreFlags = SectorDynamic.Movement;
@@ -181,17 +181,14 @@ public partial class StaticCacheGeometryRenderer : IDisposable
         }
     }
 
-    public bool HasAlphaGeometry() =>
-        HasStyle(RenderDataStyle.Translucent) || HasStyle(RenderDataStyle.ColorAdd) || HasStyle(RenderDataStyle.Add);
-
-    public bool HasStyle(RenderDataStyle style) =>
-        m_geometry.GetGeometry(style.ToGeometryType()).Count > 0;
-
-    public void RenderAllAlpha()
+    public override void Render(RenderDataStyle style)
     {
-        Render(GeometryType.Translucent);
-        Render(GeometryType.TranslucentAdd);
-        Render(GeometryType.TranslucentColorAdd);
+        Render(style.ToGeometryType());
+    }
+
+    public override bool HasStyleToRender(RenderDataStyle style)
+    {
+        return m_geometry.GetGeometry(style.ToGeometryType()).Count > 0;
     }
 
     private void World_SectorPlaneTransformed(object? sender, SectorPlane plane)
@@ -612,7 +609,7 @@ public partial class StaticCacheGeometryRenderer : IDisposable
         }
 
         var type = GetWallType(side, wall);
-        if (m_vanillaRender && type != GeometryType.TwoSidedMiddleWall)
+        if (m_vanillaRender && type.NeedsCoverWall())
             AddOrUpdateCoverWall(side, sideVertices, wall.Location, wall.Location == WallLocation.Middle);
 
         if (wall.TextureHandle <= Constants.NullCompatibilityTextureIndex)
@@ -849,6 +846,8 @@ public partial class StaticCacheGeometryRenderer : IDisposable
         for (int i = 0; i < geometry.Count; i++)
         {
             var data = geometry[i];
+            if (data.Vbo.Count == 0)
+                continue;
 
             GL.ActiveTexture(BindTextures.BoundTexture);
             bool isNullCompatTex = data.TextureHandle <= Constants.NullCompatibilityTextureIndex;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
@@ -737,10 +737,12 @@ public partial class StaticCacheGeometryRenderer : IDisposable
             return;
 
         var style = RenderDataStyle.Normal;
+        var alpha = 1f;
         if (sector3D != null && (sector3D.Alpha < 1 || sector3D.RenderDataStyle != RenderDataStyle.Normal))
         {
             if (style == RenderDataStyle.Normal)
                 style = RenderDataStyle.Translucent;
+            alpha = sector3D.Alpha;
         }
 
         renderSector ??= sectorForSubsectors.GetRenderSector(TransferHeightView.Middle);
@@ -751,7 +753,7 @@ public partial class StaticCacheGeometryRenderer : IDisposable
         var plane = face == SectorPlaneFace.Floor ? sectorForSubsectors.Floor : sectorForSubsectors.Ceiling;
         geometryPlane ??= plane;
         m_geometryRenderer.RenderSectorFlats(sectorForSubsectors, renderPlane, geometryPlane, floor, renderFlood: false, out var renderedVertices, out var renderedSkyVertices,
-            lightLevelSector: lightLevelSector, allowAlpha: allowAlpha, style: style);
+            lightLevelSector: lightLevelSector, allowAlpha: allowAlpha, alpha: alpha, style: style);
 
         AddSkyGeometry(null, WallLocation.None, geometryPlane, renderedSkyVertices, sectorForSubsectors, update);
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
@@ -213,16 +213,7 @@ public class InterpolationShader : RenderProgram
 
             void main() {
                 float colorClamp = 1;
-                if (checkPlaneClip == 1) {
-                    ivec2 sampleCoords = ivec2(clamp(gl_FragCoord.xy / downScaleAmount, vec2(0.0), screenBounds / downScaleAmount));
-                    float wallClipDepth = texelFetch(wallClipTexture, sampleCoords, 0).a;
-                    float planeClipDepth = texelFetch(planeClipTexture, sampleCoords, 0).g;
-                    // This is for alpha walls and vanilla rendering
-                    // There is no depth buffer at this point so sample the plane clip texture to discard
-                    if (wallClipDepth <= depthFrag || planeClipDepth <= depthFrag)
-                        discard;
-                }
-
+                ${TransparentDiscard}
                 ${LightLevelFragFunction}
                 ${SectorColorMapFragFunction}
                 ${FragColorFunction}
@@ -237,7 +228,8 @@ public class InterpolationShader : RenderProgram
         .Replace("${OitVariables}", FragFunction.OitFragVariables(GetOitOptions()))
         .Replace("${OutTargets}", GetOutTargets(planeClip))
         .Replace("${VertexGapVariables}", FragFunction.VertexGapVariables)
-        .Replace("${OutPlane}", PlaneClip.GetOutPlane(planeClip));
+        .Replace("${OutPlane}", PlaneClip.GetOutPlane(planeClip))
+        .Replace("${TransparentDiscard}", PlaneClip.GetTransparentDiscard(GetOitOptions()));
     }
 
     private OitOptions GetOitOptions()

--- a/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationTransparentShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationTransparentShader.cs
@@ -2,7 +2,7 @@
 
 public class InterpolationTransparentShader : InterpolationShader
 {
-    public InterpolationTransparentShader() : base("OIT Transparent")
+    public InterpolationTransparentShader() : base("OIT Interpolation Transparent")
     {
 
     }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -538,21 +538,22 @@ public class LegacyWorldRenderer : WorldRenderer
 
     private unsafe void RenderTransparent(RenderInfo renderInfo, GLFramebuffer framebuffer)
     {
-        var fuzzData = m_entityRenderer.HasDataToRenderByStyle(RenderDataStyle.Fuzzy); 
-        var alphaData = m_entityRenderer.HasDataToRenderByStyle(RenderDataStyle.Translucent) || m_entityRenderer.HasDataToRenderByStyle(RenderDataStyle.Add) || 
-            m_entityRenderer.HasDataToRenderByStyle(RenderDataStyle.ColorAdd);
+        var hasEntityFuzzData = m_entityRenderer.HasDataToRenderByStyle(RenderDataStyle.Fuzzy); 
+        var hasEntityAlphaData = m_entityRenderer.HasAlphaToRender();
         var hasDynamicAlphaGeometry = m_worldDataManager.HasAlphaToRender();
         var hasStaticAlphaGeometry = m_geometryRenderer.StaticRenderer.HasAlphaToRender();
-        if (!fuzzData && !alphaData && !hasDynamicAlphaGeometry && !hasStaticAlphaGeometry)
+        if (!hasEntityFuzzData && !hasEntityAlphaData && !hasDynamicAlphaGeometry && !hasStaticAlphaGeometry)
             return;
 
         m_oitFrameBuffer.StartRender();
         GL.DepthMask(false);
-        m_entityRenderer.RenderOitTransparentPass(renderInfo);
+
+        if (hasEntityAlphaData || hasEntityFuzzData)
+            m_entityRenderer.RenderOitTransparentPass(renderInfo);
 
         m_oitFrameBuffer.BindTextures(BindTextures.AccumTexture, BindTextures.AccumCountTexture, BindTextures.FuzzTexture, BindTextures.OpaqueTexture, framebuffer);
 
-        if (fuzzData)
+        if (hasEntityFuzzData)
         {
             if (m_postProcessingEffects)
             {
@@ -593,8 +594,12 @@ public class LegacyWorldRenderer : WorldRenderer
         ResetBlendEquations();
         framebuffer.Bind();
 
-        m_entityRenderer.StartRenderOitCompositePass(renderInfo);
-        RenderCompositeStyles(m_entityRenderer);
+        if (hasEntityAlphaData || hasEntityFuzzData)
+        {
+            m_entityRenderer.StartRenderOitCompositePass(renderInfo);
+            RenderCompositeStyles(m_entityRenderer);
+        }
+
         SetBlendEquation(RenderDataStyle.Normal);
 
         if (hasDynamicAlphaGeometry)
@@ -617,7 +622,7 @@ public class LegacyWorldRenderer : WorldRenderer
             SetBlendEquation(RenderDataStyle.Normal);
         }
 
-        if (fuzzData)
+        if (hasEntityFuzzData)
             m_entityRenderer.RenderOitFuzzRefractionPass(renderInfo, true);
 
         GL.DepthMask(true);

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -46,6 +46,8 @@ public class LegacyWorldRenderer : WorldRenderer
     private readonly StaticPlaneClipShaderMrt m_staticPlaneClipMrtProgram = new();
     private readonly StaticWallClipShader m_staticWallClipProgram = new();
     private readonly StaticWallClipAlphaShader m_staticWallClipAlphaProgram = new();
+    private readonly StaticTransparentShader m_staticTransparentProgram = new();
+    private readonly StaticCompositeShader m_staticCompositeProgram = new();
     private readonly RenderWorldDataManager m_worldDataManager = new();
     private readonly ArchiveCollection m_archiveCollection;
     private readonly LegacyGLTextureManager m_textureManager;
@@ -539,8 +541,9 @@ public class LegacyWorldRenderer : WorldRenderer
         var fuzzData = m_entityRenderer.HasDataToRenderByStyle(RenderDataStyle.Fuzzy); 
         var alphaData = m_entityRenderer.HasDataToRenderByStyle(RenderDataStyle.Translucent) || m_entityRenderer.HasDataToRenderByStyle(RenderDataStyle.Add) || 
             m_entityRenderer.HasDataToRenderByStyle(RenderDataStyle.ColorAdd);
-        var hasAlphaGeometry = m_worldDataManager.HasAlpha();
-        if (!fuzzData && !alphaData && !hasAlphaGeometry)
+        var hasDynamicAlphaGeometry = m_worldDataManager.HasAlpha();
+        var hasStaticAlphaGeometry = m_geometryRenderer.HasStaticAlphaGeometry();
+        if (!fuzzData && !alphaData && !hasDynamicAlphaGeometry && !hasStaticAlphaGeometry)
             return;
 
         m_oitFrameBuffer.StartRender();
@@ -574,15 +577,23 @@ public class LegacyWorldRenderer : WorldRenderer
         SetInterpolationUniforms(m_interpolationTransparentProgram, renderInfo, m_vanillaRender);
         GL.ActiveTexture(BindTextures.BoundTexture);
 
-        if (hasAlphaGeometry)
+        if (hasDynamicAlphaGeometry)
             m_worldDataManager.RenderAllAlpha();
+
+        m_staticTransparentProgram.Bind();
+        m_staticTransparentProgram.VertexGapClampUV(false);
+        SetStaticUniforms(m_staticProgram, renderInfo);
+        GL.ActiveTexture(BindTextures.BoundTexture);
+
+        if (hasStaticAlphaGeometry)
+            m_geometryRenderer.RenderAllStaticAlpha();
 
         ResetBlendEquations();
         framebuffer.Bind();
 
         m_entityRenderer.RenderOitCompositePass(renderInfo);
 
-        if (hasAlphaGeometry)
+        if (hasDynamicAlphaGeometry)
         {
             m_interpolationCompositeProgram.Bind();
             m_interpolationCompositeProgram.VertexGapClampUV(false);
@@ -601,6 +612,30 @@ public class LegacyWorldRenderer : WorldRenderer
             {
                 SetBlendEquation(RenderDataStyle.ColorAdd);
                 m_worldDataManager.Render(RenderDataStyle.ColorAdd);
+            }
+
+            SetBlendEquation(RenderDataStyle.Normal);
+        }
+
+        if (hasStaticAlphaGeometry)
+        {
+            m_staticCompositeProgram.Bind();
+            m_staticCompositeProgram.VertexGapClampUV(false);
+            SetStaticUniforms(m_staticCompositeProgram, renderInfo);
+            GL.ActiveTexture(BindTextures.BoundTexture);
+
+            m_geometryRenderer.RenderStaticStyle(RenderDataStyle.Translucent);
+
+            if (m_geometryRenderer.HasStaticStyle(RenderDataStyle.Add))
+            {
+                SetBlendEquation(RenderDataStyle.Add);
+                m_geometryRenderer.RenderStaticStyle(RenderDataStyle.Add);
+            }
+
+            if (m_worldDataManager.HasStyle(RenderDataStyle.ColorAdd))
+            {
+                SetBlendEquation(RenderDataStyle.ColorAdd);
+                m_geometryRenderer.RenderStaticStyle(RenderDataStyle.ColorAdd);
             }
 
             SetBlendEquation(RenderDataStyle.Normal);
@@ -776,6 +811,12 @@ public class LegacyWorldRenderer : WorldRenderer
         program.LightMode(renderInfo.Uniforms.LightMode);
         program.GammaCorrection(renderInfo.Uniforms.GammaCorrection);
         program.UseBrightmaps(renderInfo.Uniforms.UseBrightmaps);
+
+        if (program is StaticCompositeShader)
+        {
+            program.AccumTexture(BindTextures.AccumTexture);
+            program.AccumCountTextre(BindTextures.AccumCountTexture);
+        }
     }
 
     private void ReleaseUnmanagedResources()

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -799,6 +799,8 @@ public class LegacyWorldRenderer : WorldRenderer
         program.ColormapTexture(BindTextures.Colormap);
         program.SectorColormapTexture(BindTextures.SectorColormap);
         program.BrightmapTexture(BindTextures.BrightmapTexture);
+        program.PlaneClipTexture(BindTextures.PlaneClipTexture);
+        program.WallClipTexture(BindTextures.WallClipTexture);
         program.HasInvulnerability(renderInfo.Uniforms.DrawInvulnerability);
         program.Mvp(renderInfo.Uniforms.Mvp);
         program.MvpNoPitch(renderInfo.Uniforms.MvpNoPitch);
@@ -811,11 +813,18 @@ public class LegacyWorldRenderer : WorldRenderer
         program.LightMode(renderInfo.Uniforms.LightMode);
         program.GammaCorrection(renderInfo.Uniforms.GammaCorrection);
         program.UseBrightmaps(renderInfo.Uniforms.UseBrightmaps);
+        program.SetSpriteClipDownScaleAmount(renderInfo.Uniforms.DownScaleAmount);
+        program.ScreenBounds((renderInfo.Viewport.Width - 1, renderInfo.Viewport.Height - 1));
 
         if (program is StaticCompositeShader)
         {
             program.AccumTexture(BindTextures.AccumTexture);
-            program.AccumCountTextre(BindTextures.AccumCountTexture);
+            program.AccumCountTextre(BindTextures.AccumCountTexture);            
+        }
+
+        if (program is StaticCompositeShader || program is StaticTransparentShader)
+        {
+            program.CheckPlaneClip(true);
         }
     }
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -242,7 +242,7 @@ public class LegacyWorldRenderer : WorldRenderer
         if (sides == null)
             return;
 
-        // DynamicSides are either scrolling textures or alpha, neither should setup cover walls.
+        // DynamicSides are scrolling textures and should not setup cover walls.
         m_geometryRenderer.SetBufferCoverWall(false);
         for (int i = 0; i < sides.Length; i++)
         {
@@ -541,10 +541,12 @@ public class LegacyWorldRenderer : WorldRenderer
         var fuzzData = m_entityRenderer.HasDataToRenderByStyle(RenderDataStyle.Fuzzy); 
         var alphaData = m_entityRenderer.HasDataToRenderByStyle(RenderDataStyle.Translucent) || m_entityRenderer.HasDataToRenderByStyle(RenderDataStyle.Add) || 
             m_entityRenderer.HasDataToRenderByStyle(RenderDataStyle.ColorAdd);
-        var hasDynamicAlphaGeometry = m_worldDataManager.HasAlpha();
-        var hasStaticAlphaGeometry = m_geometryRenderer.HasStaticAlphaGeometry();
+        var hasDynamicAlphaGeometry = m_worldDataManager.HasAlphaToRender();
+        var hasStaticAlphaGeometry = m_geometryRenderer.StaticRenderer.HasAlphaToRender();
         if (!fuzzData && !alphaData && !hasDynamicAlphaGeometry && !hasStaticAlphaGeometry)
             return;
+
+        hasDynamicAlphaGeometry = false;
 
         m_oitFrameBuffer.StartRender();
         GL.DepthMask(false);
@@ -587,13 +589,15 @@ public class LegacyWorldRenderer : WorldRenderer
             m_staticTransparentProgram.VertexGapClampUV(false);
             SetStaticUniforms(m_staticTransparentProgram, renderInfo);
             GL.ActiveTexture(BindTextures.BoundTexture);
-            m_geometryRenderer.RenderAllStaticAlpha();
+            m_geometryRenderer.StaticRenderer.RenderAllAlpha();
         }
 
         ResetBlendEquations();
         framebuffer.Bind();
 
-        m_entityRenderer.RenderOitCompositePass(renderInfo);
+        m_entityRenderer.StartRenderOitCompositePass(renderInfo);
+        RenderCompositeStyles(m_entityRenderer);
+        SetBlendEquation(RenderDataStyle.Normal);
 
         if (hasDynamicAlphaGeometry)
         {
@@ -601,21 +605,7 @@ public class LegacyWorldRenderer : WorldRenderer
             m_interpolationCompositeProgram.VertexGapClampUV(false);
             SetInterpolationUniforms(m_interpolationCompositeProgram, renderInfo);
             GL.ActiveTexture(BindTextures.BoundTexture);
-
-            m_worldDataManager.Render(RenderDataStyle.Translucent);
-
-            if (m_worldDataManager.HasStyle(RenderDataStyle.Add))
-            {
-                SetBlendEquation(RenderDataStyle.Add);
-                m_worldDataManager.Render(RenderDataStyle.Add);
-            }
-
-            if (m_worldDataManager.HasStyle(RenderDataStyle.ColorAdd))
-            {
-                SetBlendEquation(RenderDataStyle.ColorAdd);
-                m_worldDataManager.Render(RenderDataStyle.ColorAdd);
-            }
-
+            RenderCompositeStyles(m_worldDataManager);
             SetBlendEquation(RenderDataStyle.Normal);
         }
 
@@ -625,21 +615,7 @@ public class LegacyWorldRenderer : WorldRenderer
             m_staticCompositeProgram.VertexGapClampUV(false);
             SetStaticUniforms(m_staticCompositeProgram, renderInfo);
             GL.ActiveTexture(BindTextures.BoundTexture);
-
-            m_geometryRenderer.RenderStaticStyle(RenderDataStyle.Translucent);
-
-            if (m_geometryRenderer.HasStaticStyle(RenderDataStyle.Add))
-            {
-                SetBlendEquation(RenderDataStyle.Add);
-                m_geometryRenderer.RenderStaticStyle(RenderDataStyle.Add);
-            }
-
-            if (m_worldDataManager.HasStyle(RenderDataStyle.ColorAdd))
-            {
-                SetBlendEquation(RenderDataStyle.ColorAdd);
-                m_geometryRenderer.RenderStaticStyle(RenderDataStyle.ColorAdd);
-            }
-
+            RenderCompositeStyles(m_geometryRenderer.StaticRenderer);
             SetBlendEquation(RenderDataStyle.Normal);
         }
 
@@ -647,6 +623,23 @@ public class LegacyWorldRenderer : WorldRenderer
             m_entityRenderer.RenderOitFuzzRefractionPass(renderInfo, true);
 
         GL.DepthMask(true);
+    }
+
+    private static void RenderCompositeStyles(IStyleRenderer styleRenderer)
+    {
+        styleRenderer.Render(RenderDataStyle.Translucent);
+
+        if (styleRenderer.HasStyleToRender(RenderDataStyle.Add))
+        {
+            SetBlendEquation(RenderDataStyle.Add);
+            styleRenderer.Render(RenderDataStyle.Add);
+        }
+
+        if (styleRenderer.HasStyleToRender(RenderDataStyle.ColorAdd))
+        {
+            SetBlendEquation(RenderDataStyle.ColorAdd);
+            styleRenderer.Render(RenderDataStyle.ColorAdd);
+        }
     }
 
     public static void SetBlendEquation(RenderDataStyle style)

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -546,8 +546,6 @@ public class LegacyWorldRenderer : WorldRenderer
         if (!fuzzData && !alphaData && !hasDynamicAlphaGeometry && !hasStaticAlphaGeometry)
             return;
 
-        hasDynamicAlphaGeometry = false;
-
         m_oitFrameBuffer.StartRender();
         GL.DepthMask(false);
         m_entityRenderer.RenderOitTransparentPass(renderInfo);

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -535,7 +535,7 @@ public class LegacyWorldRenderer : WorldRenderer
         ResetBlendEquations();
     }
 
-    private unsafe void RenderTransparent(RenderInfo renderInfo, GLFramebuffer framebuffer)
+    private void RenderTransparent(RenderInfo renderInfo, GLFramebuffer framebuffer)
     {
         var hasEntityFuzzData = m_entityRenderer.HasDataToRenderByStyle(RenderDataStyle.Fuzzy); 
         var hasEntityAlphaData = m_entityRenderer.HasAlphaToRender();

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -35,7 +35,6 @@ public class LegacyWorldRenderer : WorldRenderer
     private readonly InterpolationShader m_interpolationProgram = new("Main");
     private readonly InterpolationTransparentShader m_interpolationTransparentProgram = new();
     private readonly InterpolationCompositeShader m_interpolationCompositeProgram = new();
-    private readonly InterpolationPlaneClipShader m_interpolationPlaneClipProgram = new();
     private readonly InterpolationPlaneClipAlphaShader m_interpolationPlaneClipAlphaProgram = new();
     private readonly InterpolationPlaneClipShaderMrt m_interpolationPlaneClipMrtProgram = new();
     private readonly InterpolationWallClipShader m_interpolationWallClipShader = new();

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -320,7 +320,7 @@ public class LegacyWorldRenderer : WorldRenderer
         {
             m_interpolationProgram.Bind();
             GL.ActiveTexture(BindTextures.BoundTexture);
-            SetInterpolationUniforms(m_interpolationProgram, renderInfo, false);
+            SetInterpolationUniforms(m_interpolationProgram, renderInfo);
             m_interpolationProgram.VertexGapClampUV(m_pixelGapCorrection);
             m_worldDataManager.RenderWalls();
             m_interpolationProgram.VertexGapClampUV(false);
@@ -345,7 +345,7 @@ public class LegacyWorldRenderer : WorldRenderer
 
         m_interpolationProgram.Bind();
         GL.ActiveTexture(BindTextures.BoundTexture);
-        SetInterpolationUniforms(m_interpolationProgram, renderInfo, false);
+        SetInterpolationUniforms(m_interpolationProgram, renderInfo);
         m_interpolationProgram.VertexGapClampUV(m_pixelGapCorrection);
         m_worldDataManager.RenderWalls();
 
@@ -452,7 +452,7 @@ public class LegacyWorldRenderer : WorldRenderer
     }
 
     private void WritePlaneClipData(PlaneClipFrameBuffer planeClipFrameBuffer, RenderInfo renderInfo, GLFramebuffer framebuffer, bool walls)
-    {        
+    {
         planeClipFrameBuffer.BindFrameBuffer();
         PlaneClipFrameBuffer.StartRender();
         GL.Disable(EnableCap.Blend);
@@ -461,7 +461,7 @@ public class LegacyWorldRenderer : WorldRenderer
         {
             m_interpolationWallClipShader.Bind();
             GL.ActiveTexture(BindTextures.BoundTexture);
-            SetInterpolationUniforms(m_interpolationWallClipShader, renderInfo, false);
+            SetInterpolationUniforms(m_interpolationWallClipShader, renderInfo);
             GL.Disable(EnableCap.CullFace);
             m_worldDataManager.RenderCoverWalls();
             m_geometryRenderer.RenderWallClipPortals(renderInfo);
@@ -469,7 +469,7 @@ public class LegacyWorldRenderer : WorldRenderer
             m_interpolationWallClipShader.Unbind();
 
             m_interpolationWallClipAlphaProgram.Bind();
-            SetInterpolationUniforms(m_interpolationWallClipAlphaProgram, renderInfo, false);
+            SetInterpolationUniforms(m_interpolationWallClipAlphaProgram, renderInfo);
 
             if (WorldStatic.Sector3D)
             {
@@ -487,7 +487,7 @@ public class LegacyWorldRenderer : WorldRenderer
                 (WorldStatic.Sector3D ? m_interpolationPlaneClipAlphaProgram : m_interpolationPlaneClipAlphaProgram) : m_interpolationPlaneClipMrtProgram;
             program.Bind();
             GL.ActiveTexture(BindTextures.BoundTexture);
-            SetInterpolationUniforms(program, renderInfo, false);
+            SetInterpolationUniforms(program, renderInfo);
             m_worldDataManager.RenderFlats();
         }
 
@@ -571,22 +571,24 @@ public class LegacyWorldRenderer : WorldRenderer
             m_entityRenderer.RenderOitTransparentFuzzPass(renderInfo);
         }
 
-        m_interpolationTransparentProgram.Bind();
-        // Alpha walls are the exception to pixel gap correction. Only required for opaque walls.
-        m_interpolationTransparentProgram.VertexGapClampUV(false);
-        SetInterpolationUniforms(m_interpolationTransparentProgram, renderInfo, m_vanillaRender);
-        GL.ActiveTexture(BindTextures.BoundTexture);
-
         if (hasDynamicAlphaGeometry)
+        {
+            m_interpolationTransparentProgram.Bind();
+            // Alpha walls are the exception to pixel gap correction. Only required for opaque walls.
+            m_interpolationTransparentProgram.VertexGapClampUV(false);
+            SetInterpolationUniforms(m_interpolationTransparentProgram, renderInfo);
+            GL.ActiveTexture(BindTextures.BoundTexture);
             m_worldDataManager.RenderAllAlpha();
-
-        m_staticTransparentProgram.Bind();
-        m_staticTransparentProgram.VertexGapClampUV(false);
-        SetStaticUniforms(m_staticProgram, renderInfo);
-        GL.ActiveTexture(BindTextures.BoundTexture);
+        }
 
         if (hasStaticAlphaGeometry)
+        {
+            m_staticTransparentProgram.Bind();
+            m_staticTransparentProgram.VertexGapClampUV(false);
+            SetStaticUniforms(m_staticTransparentProgram, renderInfo);
+            GL.ActiveTexture(BindTextures.BoundTexture);
             m_geometryRenderer.RenderAllStaticAlpha();
+        }
 
         ResetBlendEquations();
         framebuffer.Bind();
@@ -597,7 +599,7 @@ public class LegacyWorldRenderer : WorldRenderer
         {
             m_interpolationCompositeProgram.Bind();
             m_interpolationCompositeProgram.VertexGapClampUV(false);
-            SetInterpolationUniforms(m_interpolationCompositeProgram, renderInfo, m_vanillaRender);
+            SetInterpolationUniforms(m_interpolationCompositeProgram, renderInfo);
             GL.ActiveTexture(BindTextures.BoundTexture);
 
             m_worldDataManager.Render(RenderDataStyle.Translucent);
@@ -758,7 +760,7 @@ public class LegacyWorldRenderer : WorldRenderer
         m_primitiveRenderer.AddSegment(seg, color, alpha, type);
     }
 
-    private static void SetInterpolationUniforms(InterpolationShader program, RenderInfo renderInfo, bool checkPlaneClip)
+    private void SetInterpolationUniforms(InterpolationShader program, RenderInfo renderInfo)
     {
         program.Bind();
         program.BoundTexture(BindTextures.BoundTexture);
@@ -780,19 +782,22 @@ public class LegacyWorldRenderer : WorldRenderer
         program.ColorMapIndex(renderInfo.Uniforms.ColorMapUniforms.GlobalIndex);
         program.LightMode(renderInfo.Uniforms.LightMode);
         program.GammaCorrection(renderInfo.Uniforms.GammaCorrection);
-        program.CheckPlaneClip(checkPlaneClip);
         program.UseBrightmaps(renderInfo.Uniforms.UseBrightmaps);
         program.SetSpriteClipDownScaleAmount(renderInfo.Uniforms.DownScaleAmount);
         program.ScreenBounds((renderInfo.Viewport.Width - 1, renderInfo.Viewport.Height - 1));
+        program.CheckPlaneClip(false);
 
         if (program is InterpolationCompositeShader)
         {
             program.AccumTexture(BindTextures.AccumTexture);
             program.AccumCountTextre(BindTextures.AccumCountTexture);
         }
+
+        if (program is InterpolationTransparentShader || program is InterpolationCompositeShader)
+            program.CheckPlaneClip(m_vanillaRender);
     }
 
-    private static void SetStaticUniforms(StaticShader program, RenderInfo renderInfo)
+    private void SetStaticUniforms(StaticShader program, RenderInfo renderInfo)
     {
         program.BoundTexture(BindTextures.BoundTexture);
         program.SectorLightTexture(BindTextures.SectorLight);
@@ -815,6 +820,7 @@ public class LegacyWorldRenderer : WorldRenderer
         program.UseBrightmaps(renderInfo.Uniforms.UseBrightmaps);
         program.SetSpriteClipDownScaleAmount(renderInfo.Uniforms.DownScaleAmount);
         program.ScreenBounds((renderInfo.Viewport.Width - 1, renderInfo.Viewport.Height - 1));
+        program.CheckPlaneClip(false);
 
         if (program is StaticCompositeShader)
         {
@@ -823,9 +829,7 @@ public class LegacyWorldRenderer : WorldRenderer
         }
 
         if (program is StaticCompositeShader || program is StaticTransparentShader)
-        {
-            program.CheckPlaneClip(true);
-        }
+            program.CheckPlaneClip(m_vanillaRender);
     }
 
     private void ReleaseUnmanagedResources()

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/PlaneClip.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/PlaneClip.cs
@@ -78,6 +78,23 @@ public static class PlaneClip
         .Replace("${DiscardNegativeMapId}", GetDiscardNegativeMapId(discardNegativeMapId));
     }
 
+    public static string GetTransparentDiscard(OitOptions options)
+    {
+        if (options == OitOptions.None)
+            return "";
+
+        return @"
+            if (checkPlaneClip == 1) {
+                ivec2 sampleCoords = ivec2(clamp(gl_FragCoord.xy / downScaleAmount, vec2(0.0), screenBounds / downScaleAmount));
+                float wallClipDepth = texelFetch(wallClipTexture, sampleCoords, 0).a;
+                float planeClipDepth = texelFetch(planeClipTexture, sampleCoords, 0).g;
+                // This is for alpha walls and vanilla rendering
+                // There is no depth buffer at this point so sample the plane clip texture to discard
+                if (wallClipDepth <= depthFrag || planeClipDepth <= depthFrag)
+                    discard;
+            }";
+    }
+
     private static string GetDiscardNegativeMapId(bool discard)
     {
         if (!discard)

--- a/Core/Render/OpenGL/Renderers/Legacy/World/StaticCompositeShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/StaticCompositeShader.cs
@@ -1,0 +1,9 @@
+﻿namespace Helion.Render.OpenGL.Renderers.Legacy.World;
+
+public class StaticCompositeShader : StaticShader
+{
+    public StaticCompositeShader() : base("OIT Static Composite")
+    {
+
+    }
+}

--- a/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
@@ -205,17 +205,8 @@ public class StaticShader : RenderProgram
             ${OitVariables}
 
             void main() {
-                // TODO should only be for OIT passes?
                 float colorClamp = 1;
-                if (checkPlaneClip == 1) {
-                    ivec2 sampleCoords = ivec2(clamp(gl_FragCoord.xy / downScaleAmount, vec2(0.0), screenBounds / downScaleAmount));
-                    float wallClipDepth = texelFetch(wallClipTexture, sampleCoords, 0).a;
-                    float planeClipDepth = texelFetch(planeClipTexture, sampleCoords, 0).g;
-                    // This is for alpha walls and vanilla rendering
-                    // There is no depth buffer at this point so sample the plane clip texture to discard
-                    if (wallClipDepth <= depthFrag || planeClipDepth <= depthFrag)
-                        discard;
-                }
+                ${TransparentDiscard}
                 ${LightLevelFragFunction}
                 ${SectorColorMapFragFunction}
                 ${FragColorFunction}
@@ -230,7 +221,8 @@ public class StaticShader : RenderProgram
         .Replace("${OitVariables}", FragFunction.OitFragVariables(GetOitOptions()))
         .Replace("${OutTargets}", GetOutTargets(planeClip))
         .Replace("${VertexGapVariables}", FragFunction.VertexGapVariables)
-        .Replace("${OutPlane}", PlaneClip.GetOutPlane(planeClip));
+        .Replace("${OutPlane}", PlaneClip.GetOutPlane(planeClip))
+        .Replace("${TransparentDiscard}", PlaneClip.GetTransparentDiscard(GetOitOptions()));
     }
 
     private OitOptions GetOitOptions()

--- a/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
@@ -27,6 +27,8 @@ public class StaticShader : RenderProgram
     private readonly int m_gammaCorrectionLocation;
     private readonly int m_vertexGapClampUV;
     private readonly int m_useBrightmapsLocation;
+    private readonly int m_accumTextureLocation;
+    private readonly int m_accumCountTextureLocation;
 
     public StaticShader(string name) : base($"WorldStatic - {name}")
     {
@@ -48,6 +50,8 @@ public class StaticShader : RenderProgram
         m_gammaCorrectionLocation = Uniforms.GetLocation("gammaCorrection");
         m_vertexGapClampUV = Uniforms.GetLocation("vertexGapClampUV");
         m_useBrightmapsLocation = Uniforms.GetLocation("useBrightmaps");
+        m_accumTextureLocation = Uniforms.GetLocation("accum");
+        m_accumCountTextureLocation = Uniforms.GetLocation("accumCount");
     }
 
     public void BoundTexture(TextureUnit unit) => ProgramUniforms.Set(unit, m_boundTextureLocation);
@@ -55,6 +59,8 @@ public class StaticShader : RenderProgram
     public void ColormapTexture(TextureUnit unit) => ProgramUniforms.Set(unit, m_colormapTextureLocation);
     public void SectorColormapTexture(TextureUnit unit) => ProgramUniforms.Set(unit, m_sectorColormapTextureLocation);
     public void BrightmapTexture(TextureUnit unit) => ProgramUniforms.Set(unit, m_brightmapTextureLocation);
+    public void AccumTexture(TextureUnit unit) => ProgramUniforms.Set(unit, m_accumTextureLocation);
+    public void AccumCountTextre(TextureUnit unit) => ProgramUniforms.Set(unit, m_accumCountTextureLocation);
 
     public void HasInvulnerability(bool invul) => ProgramUniforms.Set(invul, m_hasInvulnerabilityLocation);
     public void Mvp(mat4 mvp) => ProgramUniforms.Set(mvp, m_mvpLocation);
@@ -176,8 +182,20 @@ public class StaticShader : RenderProgram
 
             ${LightLevelFragVariables}
             ${SectorColorMapFragVariables}
+            ${OitVariables}
 
             void main() {
+                // TODO should only be for OIT passes?
+                float colorClamp = 1;
+                //if (checkPlaneClip == 1) {
+                //    ivec2 sampleCoords = ivec2(clamp(gl_FragCoord.xy / downScaleAmount, vec2(0.0), screenBounds / downScaleAmount));
+                //    float wallClipDepth = texelFetch(wallClipTexture, sampleCoords, 0).a;
+                //    float planeClipDepth = texelFetch(planeClipTexture, sampleCoords, 0).g;
+                //    // This is for alpha walls and vanilla rendering
+                //    // There is no depth buffer at this point so sample the plane clip texture to discard
+                //    if (wallClipDepth <= depthFrag || planeClipDepth <= depthFrag)
+                //        discard;
+                //}
                 ${LightLevelFragFunction}
                 ${SectorColorMapFragFunction}
                 ${FragColorFunction}
@@ -186,11 +204,30 @@ public class StaticShader : RenderProgram
         "
         .Replace("${LightLevelFragFunction}", LightLevel.FragFunction)
         .Replace("${LightLevelFragVariables}", LightLevel.FragVariables(LightLevelOptions.Default))
-        .Replace("${FragColorFunction}", FragFunction.FragColorFunction(FragColorFunctionOptions.AddAlpha | FragColorFunctionOptions.Colormap | FragColorFunctionOptions.VertexGapClampUV | FragColorFunctionOptions.Brightmaps))
+        .Replace("${FragColorFunction}", FragFunction.FragColorFunction(FragColorFunctionOptions.AddAlpha | FragColorFunctionOptions.Colormap | FragColorFunctionOptions.VertexGapClampUV | FragColorFunctionOptions.Brightmaps, oitOptions: GetOitOptions()))
         .Replace("${SectorColorMapFragVariables}", SectorColorMap.FragVariables)
         .Replace("${SectorColorMapFragFunction}", SectorColorMap.FragFunction)
+        .Replace("${OitVariables}", FragFunction.OitFragVariables(GetOitOptions()))
+        .Replace("${OutTargets}", GetOutTargets(planeClip))
         .Replace("${VertexGapVariables}", FragFunction.VertexGapVariables)
-        .Replace("${OutTargets}", PlaneClip.GetOutTargets(planeClip))
         .Replace("${OutPlane}", PlaneClip.GetOutPlane(planeClip));
+    }
+
+    private OitOptions GetOitOptions()
+    {
+        if (this is StaticTransparentShader)
+            return OitOptions.OitTransparentPass;
+        if (this is StaticCompositeShader)
+            return OitOptions.OitCompositePass;
+        return OitOptions.None;
+    }
+
+    private string GetOutTargets(bool planeClip)
+    {
+        var options = GetOitOptions();
+        if (options == OitOptions.OitTransparentPass)
+            return "";
+
+        return PlaneClip.GetOutTargets(planeClip);
     }
 }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
@@ -29,6 +29,11 @@ public class StaticShader : RenderProgram
     private readonly int m_useBrightmapsLocation;
     private readonly int m_accumTextureLocation;
     private readonly int m_accumCountTextureLocation;
+    private readonly int m_planeClipTextureLocation;
+    private readonly int m_checkPlaneClipLocation;
+    private readonly int m_wallClipTextureLocation;
+    private readonly int m_downScaleAmountLocation;
+    private readonly int m_screenBoundsLocation;
 
     public StaticShader(string name) : base($"WorldStatic - {name}")
     {
@@ -52,6 +57,11 @@ public class StaticShader : RenderProgram
         m_useBrightmapsLocation = Uniforms.GetLocation("useBrightmaps");
         m_accumTextureLocation = Uniforms.GetLocation("accum");
         m_accumCountTextureLocation = Uniforms.GetLocation("accumCount");
+        m_planeClipTextureLocation = Uniforms.GetLocation("planeClipTexture");
+        m_checkPlaneClipLocation = Uniforms.GetLocation("checkPlaneClip");
+        m_wallClipTextureLocation = Uniforms.GetLocation("wallClipTexture");
+        m_downScaleAmountLocation = Uniforms.GetLocation("downScaleAmount");
+        m_screenBoundsLocation = Uniforms.GetLocation("screenBounds");
     }
 
     public void BoundTexture(TextureUnit unit) => ProgramUniforms.Set(unit, m_boundTextureLocation);
@@ -61,6 +71,8 @@ public class StaticShader : RenderProgram
     public void BrightmapTexture(TextureUnit unit) => ProgramUniforms.Set(unit, m_brightmapTextureLocation);
     public void AccumTexture(TextureUnit unit) => ProgramUniforms.Set(unit, m_accumTextureLocation);
     public void AccumCountTextre(TextureUnit unit) => ProgramUniforms.Set(unit, m_accumCountTextureLocation);
+    public void PlaneClipTexture(TextureUnit unit) => ProgramUniforms.Set(unit, m_planeClipTextureLocation);
+    public void WallClipTexture(TextureUnit unit) => ProgramUniforms.Set(unit, m_wallClipTextureLocation);
 
     public void HasInvulnerability(bool invul) => ProgramUniforms.Set(invul, m_hasInvulnerabilityLocation);
     public void Mvp(mat4 mvp) => ProgramUniforms.Set(mvp, m_mvpLocation);
@@ -75,6 +87,9 @@ public class StaticShader : RenderProgram
     public void GammaCorrection(float value) => ProgramUniforms.Set(value, m_gammaCorrectionLocation);
     public void VertexGapClampUV(bool value) => ProgramUniforms.Set(value, m_vertexGapClampUV);
     public void UseBrightmaps(bool value) => ProgramUniforms.Set(value, m_useBrightmapsLocation);
+    public void CheckPlaneClip(bool value) => ProgramUniforms.Set(value, m_checkPlaneClipLocation);
+    public void SetSpriteClipDownScaleAmount(float value) => ProgramUniforms.Set(value, m_downScaleAmountLocation);
+    public void ScreenBounds(Vec2I value) => ProgramUniforms.Set(value, m_screenBoundsLocation);
 
     protected override string VertexShader() => @"
         #version 330
@@ -179,6 +194,11 @@ public class StaticShader : RenderProgram
             uniform int paletteIndex;
             uniform int colormapIndex;
             uniform int useBrightmaps;
+            uniform sampler2D planeClipTexture;
+            uniform sampler2D wallClipTexture;
+            uniform int checkPlaneClip;
+            uniform float downScaleAmount;
+            uniform ivec2 screenBounds;
 
             ${LightLevelFragVariables}
             ${SectorColorMapFragVariables}
@@ -187,15 +207,15 @@ public class StaticShader : RenderProgram
             void main() {
                 // TODO should only be for OIT passes?
                 float colorClamp = 1;
-                //if (checkPlaneClip == 1) {
-                //    ivec2 sampleCoords = ivec2(clamp(gl_FragCoord.xy / downScaleAmount, vec2(0.0), screenBounds / downScaleAmount));
-                //    float wallClipDepth = texelFetch(wallClipTexture, sampleCoords, 0).a;
-                //    float planeClipDepth = texelFetch(planeClipTexture, sampleCoords, 0).g;
-                //    // This is for alpha walls and vanilla rendering
-                //    // There is no depth buffer at this point so sample the plane clip texture to discard
-                //    if (wallClipDepth <= depthFrag || planeClipDepth <= depthFrag)
-                //        discard;
-                //}
+                if (checkPlaneClip == 1) {
+                    ivec2 sampleCoords = ivec2(clamp(gl_FragCoord.xy / downScaleAmount, vec2(0.0), screenBounds / downScaleAmount));
+                    float wallClipDepth = texelFetch(wallClipTexture, sampleCoords, 0).a;
+                    float planeClipDepth = texelFetch(planeClipTexture, sampleCoords, 0).g;
+                    // This is for alpha walls and vanilla rendering
+                    // There is no depth buffer at this point so sample the plane clip texture to discard
+                    if (wallClipDepth <= depthFrag || planeClipDepth <= depthFrag)
+                        discard;
+                }
                 ${LightLevelFragFunction}
                 ${SectorColorMapFragFunction}
                 ${FragColorFunction}

--- a/Core/Render/OpenGL/Renderers/Legacy/World/StaticTransparentShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/StaticTransparentShader.cs
@@ -1,0 +1,9 @@
+﻿namespace Helion.Render.OpenGL.Renderers.Legacy.World;
+
+public class StaticTransparentShader : StaticShader
+{
+    public StaticTransparentShader() : base("OIT Static Transparent")
+    {
+
+    }
+}

--- a/Core/Util/Configs/Components/ConfigHud.cs
+++ b/Core/Util/Configs/Components/ConfigHud.cs
@@ -160,6 +160,10 @@ public class ConfigHud: ConfigElement<ConfigHud>
     [OptionMenu(OptionSectionType.Hud, "Crosshair Health Indicator")]
     public readonly ConfigValue<bool> CrosshairHealthIndicator = new(false);
 
+    [ConfigInfo("Use crosshair target health indicator.  Crosshair gets redder as the target loses health.")]
+    [OptionMenu(OptionSectionType.Hud, "Crosshair Target Health Indicator")]
+    public readonly ConfigValue<bool> CrosshairTargetHealthIndicator = new(false);
+
     [ConfigInfo("Crosshair transparency.")]
     [OptionMenu(OptionSectionType.Hud, "Crosshair Transparency", sliderMin: 0, sliderMax: 1.0, sliderStep: .05)]
     public readonly ConfigValue<double> CrosshairTransparency = new(0.5, ClampNormalized);

--- a/Core/World/Geometry/Sides/Side.cs
+++ b/Core/World/Geometry/Sides/Side.cs
@@ -1,6 +1,7 @@
 using Helion.Geometry.Vectors;
 using Helion.Graphics.Palettes;
 using Helion.Maps.Specials;
+using Helion.Render.OpenGL.Renderers.Legacy.World.Data;
 using Helion.Render.OpenGL.Renderers.Legacy.World.Geometry.Static;
 using Helion.World.Geometry.Lines;
 using Helion.World.Geometry.Sectors;
@@ -62,6 +63,7 @@ public sealed class Side
     public SectorPlanes MidTextureFlood;
     public SideFlags Flags;
     public float Alpha = 1f;
+    public RenderDataStyle RenderDataStyle;
 
     public Side(int id, Vec2I offset, Wall upper, Wall middle, Wall lower, Sector sector)
         : this(id, offset, upper, middle, lower, sector, 0, false, false, false, false)

--- a/Core/World/Static/SectorDynamic.cs
+++ b/Core/World/Static/SectorDynamic.cs
@@ -10,5 +10,4 @@ public enum SectorDynamic
     TransferHeights = 2,
     Scroll = 4,
     ScrollY = 8,
-    Alpha = 16
 }

--- a/Core/World/Static/StaticDataApplier.cs
+++ b/Core/World/Static/StaticDataApplier.cs
@@ -132,7 +132,7 @@ public class StaticDataApplier
 
     private static bool ShouldLink(Sector sector, SectorDynamic sectorDynamic)
     {
-        return sector.BlockmapNodes.Length == 0 && (sectorDynamic & (SectorDynamic.Movement | SectorDynamic.Scroll | SectorDynamic.Alpha)) != 0;
+        return sector.BlockmapNodes.Length == 0 && (sectorDynamic & (SectorDynamic.Movement | SectorDynamic.Scroll)) != 0;
     }
 
     private static void SetSectorTransferHeights(Sector sector)

--- a/Core/World/Static/StaticDataApplier.cs
+++ b/Core/World/Static/StaticDataApplier.cs
@@ -44,16 +44,6 @@ public class StaticDataApplier
     {
         CheckFloodFill(world, line);
 
-        //if (line.Back != null && line.Alpha < 1)
-        //{
-        //    line.Front.Dynamic |= SectorDynamic.Alpha;
-        //    line.Back.Dynamic |= SectorDynamic.Alpha;
-        //    world.RenderBlockmap.LinkDynamicSide(line.Front);
-        //    if (line.Front.Sector != line.Back.Sector)
-        //        world.RenderBlockmap.LinkDynamicSide(line.Back);
-        //    return;
-        //}
-
         if (line.Front.ScrollData != null)
         {
             line.Front.Dynamic |= SectorDynamic.Scroll;

--- a/Core/World/Static/StaticDataApplier.cs
+++ b/Core/World/Static/StaticDataApplier.cs
@@ -44,15 +44,15 @@ public class StaticDataApplier
     {
         CheckFloodFill(world, line);
 
-        if (line.Back != null && line.Alpha < 1)
-        {
-            line.Front.Dynamic |= SectorDynamic.Alpha;
-            line.Back.Dynamic |= SectorDynamic.Alpha;
-            world.RenderBlockmap.LinkDynamicSide(line.Front);
-            if (line.Front.Sector != line.Back.Sector)
-                world.RenderBlockmap.LinkDynamicSide(line.Back);
-            return;
-        }
+        //if (line.Back != null && line.Alpha < 1)
+        //{
+        //    line.Front.Dynamic |= SectorDynamic.Alpha;
+        //    line.Back.Dynamic |= SectorDynamic.Alpha;
+        //    world.RenderBlockmap.LinkDynamicSide(line.Front);
+        //    if (line.Front.Sector != line.Back.Sector)
+        //        world.RenderBlockmap.LinkDynamicSide(line.Back);
+        //    return;
+        //}
 
         if (line.Front.ScrollData != null)
         {

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -10,6 +10,7 @@
 - Added Line_SetBlocking
 - Added TeleportGroup and TeleportInSector
 - Added Floor_LowerInstant, Floor_RaiseInstant, Ceiling_LowerInstant, Ceiling_RaiseInstant
+- Added feature to show enemy's health in crosshair when targeted
 
 ## Bug Fixes:
 - Fix nextmap/previousmap breaking on WADs with maps that exit to the same map.

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -38,3 +38,4 @@
 - Update TBOs that use RGB32F to use RGBA32F for 3.3 cards that were never updated to support ARB_texture_buffer_object_rgb32.
 - Use colormap index one for lite amp goggles instead of zero to match original doom behavior.
 - Removed sprite overlap code from CPU and use sprite detph bias on GPU instead to fix z-fighting.
+- Add support for transparent rendering in static shader.

--- a/Tests/Unit/GameAction/3DSector/Sector3D_Walls.cs
+++ b/Tests/Unit/GameAction/3DSector/Sector3D_Walls.cs
@@ -475,14 +475,14 @@ public class Sector3D_Walls
         prevOffset.Y.Should().Be(slice.Offset.Y);
     }
 
-    private void RenderSectorWallVertices3D(Side side, Wall wall, Sector wallSector, GLLegacyTexture? texture, Span<DynamicVertex> vertices)
+    private void RenderSectorWallVertices3D(Side side, Wall wall, Sector wallSector, GLLegacyTexture? texture, Span<DynamicVertex> vertices, Sector3D? sector3D)
     {
         var slice = m_slices[m_sliceIndex++];
         wallSector.Ceiling.Z.Should().Be(slice.TopZ);
         wallSector.Floor.Z.Should().Be(slice.BottomZ);
     }
 
-    private void EmptyRenderSectorWallVertices3D(Side side, Wall wall, Sector wallSector, GLLegacyTexture? texture, Span<DynamicVertex> vertices)
+    private void EmptyRenderSectorWallVertices3D(Side side, Wall wall, Sector wallSector, GLLegacyTexture? texture, Span<DynamicVertex> vertices, Sector3D? sector3D)
     {
 
     }


### PR DESCRIPTION
Adds support transparency in the static shader. Previously anything with alpha or transparent render styles was forced into the dynamic renderer. This change is more important now with 3d floor support that can make transparent objects more common where it was previously limited to two-sided middle walls.

Update RenderWorldDataList to keep track of data sets that actually need to be rendered because they have data. Matches functionality from the EntityRenderer.

Unify alpha rendering with IStyleRenderer.