### PR TITLE
Sector3d movement fixes

### DIFF
--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.Sector3D.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.Sector3D.cs
@@ -197,6 +197,7 @@ public partial class GeometryRenderer
         m_fakeSide.ScrollData = m_fakeSideScrollData;
         m_fakeWall.TextureHandle = wall.TextureHandle;
         m_fakeWall.Location = wall.Location == WallLocation.Middle3D ? WallLocation.Middle : wall.Location;
+        m_fakeSideScrollData.Offset(m_fakeWall.Location, ScrollOffsetType.Current).Y = 0;
         m_fakeSideScrollData.Offset(m_fakeWall.Location, ScrollOffsetType.Previous).Y = 0;
 
         m_fakeWall.Offset.X = offset.X;
@@ -235,6 +236,11 @@ public partial class GeometryRenderer
                 continue;
             }
 
+            m_sliceSector.Ceiling.LastRenderChangeGametick = plane3D.ControlPlane.LastRenderChangeGametick;
+            m_sliceSector.Floor.LastRenderChangeGametick = nextPlane3D.ControlPlane.LastRenderChangeGametick;
+
+            SetSectorToSlice(m_sliceSector, plane3D.Plane, nextPlane3D.Plane, wallHeights3D);
+
             if (renderThrough && plane3D.Sector3D != anchorSector3D && plane3D.Sector3D?.IsSolid == true &&
                 plane3D.Face == PlaneFace3D.Top && nextPlane3D.Face == PlaneFace3D.Bottom)
             {
@@ -243,18 +249,13 @@ public partial class GeometryRenderer
                     anchorZ = nextPlane3D.GetZ();
                     prevAnchorZ = nextPlane3D.GetPrevZ();
                 }
-                SetWallOffset(m_fakeSide, m_fakeWall, offsetY, nextPlane3D.Plane, anchorZ, prevAnchorZ);
+
+                if (m_sliceSector.Ceiling.Z > m_sliceSector.Floor.Z)
+                    SetWallOffset(m_fakeSide, m_fakeWall, offsetY, nextPlane3D.Plane, anchorZ, prevAnchorZ);
+
                 continue;
             }
-            else
-            {
-                ResetWallOffset(m_fakeSide, m_fakeWall);
-            }
 
-            m_sliceSector.Ceiling.LastRenderChangeGametick = plane3D.ControlPlane.LastRenderChangeGametick;
-            m_sliceSector.Floor.LastRenderChangeGametick = nextPlane3D.ControlPlane.LastRenderChangeGametick;
-
-            SetSectorToSlice(m_sliceSector, plane3D.Plane, nextPlane3D.Plane, wallHeights3D);
             args.LightSector = nextPlane3D.LightSector;
             // This is a hack to force it to ignore the cached vertices
             args.Side.LastRenderGametick = -1;
@@ -378,13 +379,6 @@ public partial class GeometryRenderer
         }
 
         return side.Line.Flags.Unpegged.Lower ? side.Sector.Floor : side.Sector.Ceiling;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void ResetWallOffset(Side side, Wall wall)
-    {
-        side.ScrollData!.Offset(wall.Location, ScrollOffsetType.Current).Y = 0;
-        side.ScrollData!.Offset(wall.Location, ScrollOffsetType.Previous).Y = 0;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.Sector3D.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.Sector3D.cs
@@ -246,6 +246,10 @@ public partial class GeometryRenderer
                 SetWallOffset(m_fakeSide, m_fakeWall, offsetY, nextPlane3D.Plane, anchorZ, prevAnchorZ);
                 continue;
             }
+            else
+            {
+                ResetWallOffset(m_fakeSide, m_fakeWall);
+            }
 
             m_sliceSector.Ceiling.LastRenderChangeGametick = plane3D.ControlPlane.LastRenderChangeGametick;
             m_sliceSector.Floor.LastRenderChangeGametick = nextPlane3D.ControlPlane.LastRenderChangeGametick;
@@ -377,7 +381,14 @@ public partial class GeometryRenderer
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static unsafe void SetWallOffset(Side side, Wall wall, float saveOffsetY, SectorPlane top, double anchorZ, double prevAnchorZ)
+    private static void ResetWallOffset(Side side, Wall wall)
+    {
+        side.ScrollData!.Offset(wall.Location, ScrollOffsetType.Current).Y = 0;
+        side.ScrollData!.Offset(wall.Location, ScrollOffsetType.Previous).Y = 0;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void SetWallOffset(Side side, Wall wall, float saveOffsetY, SectorPlane top, double anchorZ, double prevAnchorZ)
     {
         // Use scrolling data for offset since normal wall offsets can't interpolate
         side.ScrollData!.Offset(wall.Location, ScrollOffsetType.Current).Y = saveOffsetY + (float)(anchorZ - top.Z);

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
@@ -932,9 +932,9 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
         HandleSectorMoveStart(world, plane);
     }
 
-    private void HandleSectorMoveStart(WorldBase world, SectorPlane plane, bool check3D = true)
+    private void HandleSectorMoveStart(WorldBase world, SectorPlane plane, bool check3D = true, bool checkMovement = true)
     {
-        if ((plane.Dynamic & SectorDynamic.Movement) != 0)
+        if (checkMovement && (plane.Dynamic & SectorDynamic.Movement) != 0)
             return;
 
         StaticDataApplier.SetSectorDynamic(world, plane.Sector, plane.Facing.ToSectorPlanes(), SectorDynamic.Movement);
@@ -965,8 +965,9 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
                     HandleSectorMoveStart3D(world, parentSector3D);
                 }
 
+                // Need to ignore the movement check since it's flagged off the same plane.
                 if (sector3D.FakeSectorFlipped != null)
-                    HandleSectorMoveStart(world, sector3D.FakeSectorFlipped.GetSectorPlane(face), check3D: false);
+                    HandleSectorMoveStart(world, sector3D.FakeSectorFlipped.GetSectorPlane(face), check3D: false, checkMovement: false);
             }
         }
     }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
@@ -937,6 +937,7 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
         if (checkMovement && (plane.Dynamic & SectorDynamic.Movement) != 0)
             return false;
 
+        plane.Sector.MoveEventGameTick = world.Gametick;
         StaticDataApplier.SetSectorDynamic(world, plane.Sector, plane.Facing.ToSectorPlanes(), SectorDynamic.Movement);
 
         if (handlePlane)
@@ -979,10 +980,8 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
 
     private void HandleSectorMoveStartForLines(WorldBase world, Sector sector, bool checkOpposingSector3D)
     {
-        if (sector.CheckCount == WorldStatic.CheckCounter)
+        if (SectorLinesProcessed(world, sector))
             return;
-
-        sector.CheckCount = WorldStatic.CheckCounter;
 
         for (int i = 0; i < sector.Lines.Length; i++)
         {
@@ -1078,6 +1077,7 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
 
     private void HandleSectorMoveComplete(WorldBase world, Sector sector, SectorPlane plane, bool check3D = true, bool handlePlane = true)
     {
+        sector.MoveEventGameTick = world.Gametick;
         StaticDataApplier.ClearSectorDynamicMovement(world, plane);
 
         if (sector.Sector3D != null)
@@ -1154,10 +1154,8 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
 
     private void HandleSectorMoveCompleteForLines(WorldBase world, Sector sector, bool checkOpposingSector3D)
     {
-        if (sector.CheckCount == WorldStatic.CheckCounter)
+        if (SectorLinesProcessed(world, sector))
             return;
-
-        sector.CheckCount = WorldStatic.CheckCounter;
 
         int lineCount = sector.Lines.Length;
         for (int i = 0; i < lineCount; i++)
@@ -1184,6 +1182,15 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
             CheckForFloodFill(line.Back, line.Front, line.Back.Sector.GetRenderSector(TransferHeightView.Middle),
                 line.Front.Sector.GetRenderSector(TransferHeightView.Middle), true);
         }
+    }
+    private static bool SectorLinesProcessed(WorldBase world, Sector sector)
+    {
+        if (sector.CheckCount == WorldStatic.CheckCounter || sector.MoveEventGameTick == sector.MoveProcessedGameTick)
+            return true;
+
+        sector.CheckCount = WorldStatic.CheckCounter;
+        sector.MoveProcessedGameTick = world.Gametick;
+        return false;
     }
 
     private void World_SideTextureChanged(object? sender, SideTextureEvent e)

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
@@ -932,13 +932,15 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
         HandleSectorMoveStart(world, plane);
     }
 
-    private bool HandleSectorMoveStart(WorldBase world, SectorPlane plane, bool check3D = true, bool checkMovement = true)
+    private bool HandleSectorMoveStart(WorldBase world, SectorPlane plane, bool check3D = true, bool checkMovement = true, bool handlePlane = true)
     {
         if (checkMovement && (plane.Dynamic & SectorDynamic.Movement) != 0)
             return false;
 
         StaticDataApplier.SetSectorDynamic(world, plane.Sector, plane.Facing.ToSectorPlanes(), SectorDynamic.Movement);
-        ClearGeometryVertices(plane.Static);
+
+        if (handlePlane)
+            ClearGeometryVertices(plane.Static);
 
         if (m_vanillaRender && m_coverFlatLookup.TryGetValue(CoverKey.MakeFlatKey(plane.Sector.Id, plane.Facing), out var coverGeometry))
             ClearGeometryVertices(coverGeometry);
@@ -953,7 +955,8 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
             {
                 var sector3D = plane.Sector.TaggedSectors3D[i];
                 var startSuccess = HandleSectorMoveStart(world, sector3D.FakeSector.GetSectorPlane(face), check3D: false);
-                HandleSectorMoveStart(world, sector3D.ParentSector.GetSectorPlane(face), check3D: false);
+
+                HandleSectorMoveStart(world, sector3D.ParentSector.GetSectorPlane(face), check3D: false, handlePlane: false);
 
                 // This can also affect rendering of 3D sectors in this parent sector.
                 for (int j = 0; j < sector3D.ParentSector.Sectors3D.Length; j++)
@@ -1073,7 +1076,7 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
         HandleSectorMoveComplete(world, plane.Sector, plane);
     }
 
-    private void HandleSectorMoveComplete(WorldBase world, Sector sector, SectorPlane plane, bool check3D = true)
+    private void HandleSectorMoveComplete(WorldBase world, Sector sector, SectorPlane plane, bool check3D = true, bool handlePlane = true)
     {
         StaticDataApplier.ClearSectorDynamicMovement(world, plane);
 
@@ -1092,7 +1095,9 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
         else
             m_geometryRenderer.SetRenderCeiling(plane);
 
-        AddSectorPlane(sector, plane.Facing, floor, true);
+        if (handlePlane)
+            AddSectorPlane(sector, plane.Facing, floor, true);
+
         HandleSectorMoveCompleteForLines(world, sector, !check3D);
 
         if (WorldStatic.Sector3D && check3D)
@@ -1107,9 +1112,8 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
 
                 HandleSectorMoveComplete(world, plane.Sector, sector3D.FakeSector.GetSectorPlane(flippedFace), check3D: false);
 
-                sector3D.ParentSector.Floor.SetSectorMoveChanged(m_world.Gametick);
-                sector3D.ParentSector.Ceiling.SetSectorMoveChanged(m_world.Gametick);
-                HandleSectorMoveComplete(world, sector3D.ParentSector, sector3D.ParentSector.GetSectorPlane(flippedFace), check3D: false);
+                if (handlePlane)
+                    HandleSectorMoveComplete(world, sector3D.ParentSector, sector3D.ParentSector.GetSectorPlane(flippedFace), check3D: false, handlePlane: false);
 
                 for (int j = 0; j < sector3D.ParentSector.Sectors3D.Length; j++)
                 {

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
@@ -932,10 +932,10 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
         HandleSectorMoveStart(world, plane);
     }
 
-    private void HandleSectorMoveStart(WorldBase world, SectorPlane plane, bool check3D = true, bool checkMovement = true)
+    private bool HandleSectorMoveStart(WorldBase world, SectorPlane plane, bool check3D = true, bool checkMovement = true)
     {
         if (checkMovement && (plane.Dynamic & SectorDynamic.Movement) != 0)
-            return;
+            return false;
 
         StaticDataApplier.SetSectorDynamic(world, plane.Sector, plane.Facing.ToSectorPlanes(), SectorDynamic.Movement);
         ClearGeometryVertices(plane.Static);
@@ -952,7 +952,7 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
             for (int i = 0; i < plane.Sector.TaggedSectors3D.Length; i++)
             {
                 var sector3D = plane.Sector.TaggedSectors3D[i];
-                HandleSectorMoveStart(world, sector3D.FakeSector.GetSectorPlane(face), check3D: false);
+                var startSuccess = HandleSectorMoveStart(world, sector3D.FakeSector.GetSectorPlane(face), check3D: false);
                 HandleSectorMoveStart(world, sector3D.ParentSector.GetSectorPlane(face), check3D: false);
 
                 // This can also affect rendering of 3D sectors in this parent sector.
@@ -967,9 +967,11 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
 
                 // Need to ignore the movement check since it's flagged off the same plane.
                 if (sector3D.FakeSectorFlipped != null)
-                    HandleSectorMoveStart(world, sector3D.FakeSectorFlipped.GetSectorPlane(face), check3D: false, checkMovement: false);
+                    HandleSectorMoveStart(world, sector3D.FakeSectorFlipped.GetSectorPlane(face), check3D: false, checkMovement: startSuccess);
             }
         }
+
+        return true;
     }
 
     private void HandleSectorMoveStartForLines(WorldBase world, Sector sector, bool checkOpposingSector3D)
@@ -1099,6 +1101,10 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
             for (int i = 0; i < sector.TaggedSectors3D.Length; i++)
             {
                 var sector3D = plane.Sector.TaggedSectors3D[i];
+                // Multiple 3D sectors can be moving. If any other is moving then ignore.
+                if (HasOtherMovementSector3D(sector3D))
+                    continue;
+
                 HandleSectorMoveComplete(world, plane.Sector, sector3D.FakeSector.GetSectorPlane(flippedFace), check3D: false);
 
                 sector3D.ParentSector.Floor.SetSectorMoveChanged(m_world.Gametick);
@@ -1120,6 +1126,18 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
                 AddSector3D(sector3D, plane.Facing.ToSectorPlanes(), true);
             }
         }
+    }
+
+    private static bool HasOtherMovementSector3D(Sector3D sector3D)
+    {
+        for (int j = 0; j < sector3D.ParentSector.Sectors3D.Length; j++)
+        {
+            var parentSector3D = sector3D.ParentSector.Sectors3D[j];
+            if (parentSector3D.ControlSector.IsMoving)
+                return true;
+        }        
+
+        return false;
     }
 
     private void HandleSectorMoveComplete3D(WorldBase world, Sector3D sector3D)

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
@@ -1126,6 +1126,7 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
         sector3D.FakeSector.Floor.SetSectorMoveChanged(world.Gametick);
         sector3D.FakeSector.Ceiling.SetSectorMoveChanged(world.Gametick);
         HandleSectorMoveComplete(world, sector3D.FakeSector, sector3D.FakeSector.Floor, check3D: false);
+        HandleSectorMoveComplete(world, sector3D.FakeSector, sector3D.FakeSector.Ceiling, check3D: false);
     }
 
     private void HandleSectorMoveCompleteForLines(WorldBase world, Sector sector, bool checkOpposingSector3D)

--- a/Core/Util/DataCache.cs
+++ b/Core/Util/DataCache.cs
@@ -430,9 +430,12 @@ public class DataCache
 
     public void FreeLightChangeSpecial(LightChangeSpecial special)
     {
-        special.World = null!;
-        special.Sector = null!;
-        m_lightChanges.Add(special);
+        if (special.GetType() == typeof(LightChangeSpecial))
+        {
+            special.World = null!;
+            special.Sector = null!;
+            m_lightChanges.Add(special);
+        }
     }
 
     public SectorMoveSpecial GetSectorMoveSpecial(IWorld world, Sector sector, double start, double dest,
@@ -508,8 +511,11 @@ public class DataCache
 
     public void FreeSwitchChangeSpecial(SwitchChangeSpecial special)
     {
-        special.Free();
-        m_switchSpecials.Add(special);
+        if (special.GetType() == typeof(SwitchChangeSpecial))
+        {
+            special.Free();
+            m_switchSpecials.Add(special);
+        }
     }
 
     public StairSpecial GetStairSpecial()

--- a/Core/World/Geometry/Sectors/Sector.cs
+++ b/Core/World/Geometry/Sectors/Sector.cs
@@ -78,6 +78,8 @@ public sealed class Sector : IFloorCeilingAnchor
     public int SoundValidationCount;
     public int SoundBlock;
     public int CheckCount;
+    public int MoveEventGameTick = -1;
+    public int MoveProcessedGameTick;
     public bool MarkAutomap;
     public bool Flood;
     public bool Silent;

--- a/Core/World/Special/SpecialManager.cs
+++ b/Core/World/Special/SpecialManager.cs
@@ -106,22 +106,23 @@ public sealed class SpecialManager : ITickable, IDisposable
     public void Clear()
     {
         foreach (var special in m_specials)
-        {
-            if (special is SectorMoveSpecial moveSpecial)
-                m_dataCache.FreeSectorMoveSpecial(moveSpecial);
-            else if (special is LightChangeSpecial lightSpecial)
-                m_dataCache.FreeLightChangeSpecial(lightSpecial);
-        }
+            FreeSpecial(special);
+
         foreach (var special in m_destroyedMoveSpecials)
-        {
-            if (special is SectorMoveSpecial moveSpecial)
-                m_dataCache.FreeSectorMoveSpecial(moveSpecial);
-            else if (special is LightChangeSpecial lightSpecial)
-                m_dataCache.FreeLightChangeSpecial(lightSpecial);
-        }
+            FreeSpecial(special);
 
         m_specials.Clear();
         m_destroyedMoveSpecials.Clear();
+    }
+
+    private void FreeSpecial(ISpecial special)
+    {
+        if (special.GetType() == typeof(SectorMoveSpecial))
+            m_dataCache.FreeSectorMoveSpecial((SectorMoveSpecial)special);
+        else if (special.GetType() == typeof(LightChangeSpecial))
+            m_dataCache.FreeLightChangeSpecial((LightChangeSpecial)special);
+        else if (special.GetType() == typeof(SwitchChangeSpecial))
+            m_dataCache.FreeSwitchChangeSpecial((SwitchChangeSpecial)special);
     }
 
     public void Dispose()
@@ -152,7 +153,7 @@ public sealed class SpecialManager : ITickable, IDisposable
             else if (special is StairSpecial stair)
                 data.StairSpecials.Add(stair.ToStairSpecialModel());
             else if (special is ElevatorSpecial elevator)
-                data.ElevatorSpecials.Add(elevator.ToSpecialModel());
+                data.ElevatorSpecials.Add(elevator.ToSpecialElevatorModel());
             else if (special is SwitchChangeSpecial switchChange)
                 data.SwitchSpecials.Add(switchChange.ToSpecialModel());
             else if (special is SectorMoveSpecial move)
@@ -259,7 +260,7 @@ public sealed class SpecialManager : ITickable, IDisposable
                 RemoveSpecial(switchSpecial);
             switchSpecial = m_dataCache.GetSwitchChangeSpecial(m_world, args.ActivateLineSpecial, GetSwitchType(args.ActivateLineSpecial.Special));
             if (switchSpecial.Tick() == SpecialTickStatus.Destroy)
-                m_dataCache.FreeSwitchChangeSpecial(switchSpecial);
+                FreeSpecial(switchSpecial);
             else
                 AddSpecial(switchSpecial);
         }
@@ -334,7 +335,7 @@ public sealed class SpecialManager : ITickable, IDisposable
                 var nextNode = node.Next;
                 if (node.Value is SwitchChangeSpecial switchSpecial && node.Value.Tick() == SpecialTickStatus.Destroy)
                 {
-                    m_dataCache.FreeSwitchChangeSpecial(switchSpecial);
+                    FreeSpecial(switchSpecial);
                     RemoveSpecialNode(node);
                 }
 
@@ -358,7 +359,7 @@ public sealed class SpecialManager : ITickable, IDisposable
                     RemoveSpecialNode(node);
 
                     if (special is SwitchChangeSpecial switchSpecial)
-                        m_dataCache.FreeSwitchChangeSpecial(switchSpecial);
+                        FreeSpecial(switchSpecial);
                 }
 
                 node = nextNode;
@@ -370,23 +371,23 @@ public sealed class SpecialManager : ITickable, IDisposable
     {
         for (int i = 0; i < m_destroyedMoveSpecials.Count; i++)
         {
-            ISectorSpecial sectorSpecial = m_destroyedMoveSpecials[i];
+            var sectorSpecial = m_destroyedMoveSpecials[i];
             sectorSpecial.FinalizeDestroy();
-            if (sectorSpecial is LightChangeSpecial lightChange)
-                m_world.DataCache.FreeLightChangeSpecial(lightChange);
+            if (sectorSpecial.GetType() == typeof(LightChangeSpecial))
+                FreeSpecial(sectorSpecial);
         }
 
         // Only invoke after all specials have been destroyed on this tick. Otherwise interpolation values can be off
         for (int i = 0; i < m_destroyedMoveSpecials.Count; i++)
         {
-            ISectorSpecial sectorSpecial = m_destroyedMoveSpecials[i];
+            var sectorSpecial = m_destroyedMoveSpecials[i];
             if (sectorSpecial is not SectorMoveSpecial moveSpecial)
                 continue;
 
             if (!sectorSpecial.MultiSector)
             {
                 SectorSpecialDestroyed?.Invoke(this, moveSpecial);
-                m_dataCache.FreeSectorMoveSpecial(moveSpecial);
+                FreeSpecial(moveSpecial);
                 continue;
             }
 

--- a/Core/World/Special/SpecialManager.cs
+++ b/Core/World/Special/SpecialManager.cs
@@ -9,6 +9,7 @@ using Helion.Models;
 using Helion.Resources;
 using Helion.Resources.Definitions;
 using Helion.Util;
+using Helion.Util.Assertion;
 using Helion.Util.Container;
 using Helion.Util.RandomGenerators;
 using Helion.World.Entities;
@@ -75,7 +76,7 @@ public sealed class SpecialManager : ITickable, IDisposable
 
     public LinkedList<ISpecial> GetSpecials() => m_specials;
 
-    public EventHandler<ISectorSpecial>? SectorSpecialDestroyed;
+    public EventHandler<SectorPlane>? SectorMoveComplete;
 
     public SpecialManager(WorldBase world, IRandom random)
     {
@@ -117,12 +118,12 @@ public sealed class SpecialManager : ITickable, IDisposable
 
     private void FreeSpecial(ISpecial special)
     {
-        if (special.GetType() == typeof(SectorMoveSpecial))
-            m_dataCache.FreeSectorMoveSpecial((SectorMoveSpecial)special);
-        else if (special.GetType() == typeof(LightChangeSpecial))
-            m_dataCache.FreeLightChangeSpecial((LightChangeSpecial)special);
-        else if (special.GetType() == typeof(SwitchChangeSpecial))
-            m_dataCache.FreeSwitchChangeSpecial((SwitchChangeSpecial)special);
+        if (special is SectorMoveSpecial move)
+            m_dataCache.FreeSectorMoveSpecial(move);
+        else if (special is LightChangeSpecial light)
+            m_dataCache.FreeLightChangeSpecial(light);
+        else if (special is SwitchChangeSpecial switchChange)
+            m_dataCache.FreeSwitchChangeSpecial(switchChange);
     }
 
     public void Dispose()
@@ -222,9 +223,10 @@ public sealed class SpecialManager : ITickable, IDisposable
 
         for (int i = 0; i < m_destroyedMoveSpecials.Count; i++)
         {
-            ISectorSpecial sectorSpecial = m_destroyedMoveSpecials[i];
+            var sectorSpecial = m_destroyedMoveSpecials[i];
             sectorSpecial.ResetInterpolation();
-            SectorSpecialDestroyed?.Invoke(this, sectorSpecial);
+            if (sectorSpecial is SectorMoveSpecial move)
+                InvokeSectorMoveComplete(move);
         }
     }
 
@@ -325,7 +327,7 @@ public sealed class SpecialManager : ITickable, IDisposable
     public void Tick()
     {
         if (m_destroyedMoveSpecials.Count > 0)
-            TickDestroyedMoveSpecials();
+            FinalizeDestroyedMoveSpecials();
 
         if (m_world.WorldState == WorldState.Exit)
         {
@@ -367,7 +369,7 @@ public sealed class SpecialManager : ITickable, IDisposable
         }
     }
 
-    private void TickDestroyedMoveSpecials()
+    private void FinalizeDestroyedMoveSpecials()
     {
         for (int i = 0; i < m_destroyedMoveSpecials.Count; i++)
         {
@@ -386,7 +388,7 @@ public sealed class SpecialManager : ITickable, IDisposable
 
             if (!sectorSpecial.MultiSector)
             {
-                SectorSpecialDestroyed?.Invoke(this, moveSpecial);
+                InvokeSectorMoveComplete(moveSpecial);
                 FreeSpecial(moveSpecial);
                 continue;
             }
@@ -397,13 +399,20 @@ public sealed class SpecialManager : ITickable, IDisposable
             {
                 moveSpecial.Sector = sector;
                 moveSpecial.SectorPlane = plane;
-                SectorSpecialDestroyed?.Invoke(this, moveSpecial);
+                InvokeSectorMoveComplete(moveSpecial);
             }
 
             m_sectorPlanes.Clear();
         }
 
         m_destroyedMoveSpecials.Clear();
+    }
+
+    private void InvokeSectorMoveComplete(SectorMoveSpecial moveSpecial)
+    {
+        Assert.Precondition(moveSpecial.SectorPlane != null, "SectorMoveSpecial was null. Most likely was released to DataCache before invoking.");
+        if (moveSpecial.SectorPlane != null)
+            SectorMoveComplete?.Invoke(this, moveSpecial.SectorPlane);
     }
 
     public SectorMoveSpecial AddDelayedSpecial(SectorMoveSpecial special, int delayTics)

--- a/Core/World/Special/Specials/ElevatorSpecial.cs
+++ b/Core/World/Special/Specials/ElevatorSpecial.cs
@@ -7,18 +7,17 @@ using System.Collections.Generic;
 
 namespace Helion.World.Special.Specials;
 
-public class ElevatorSpecial : ISectorSpecial
+public class ElevatorSpecial : SectorMoveSpecial
 {
     private readonly SectorMoveSpecial m_firstMove;
     private readonly SectorMoveSpecial m_secondMove;
 
-    public Sector Sector { get; set; }
-    public bool IsPaused => false;
+    public override bool IsPaused => false;
 
-    public bool OverrideEquals => true;
+    public override bool OverrideEquals => true;
 
-    public virtual bool MultiSector => true;
-    public virtual void GetSectors(List<(Sector, SectorPlane)> data)
+    public override bool MultiSector => true;
+    public override void GetSectors(List<(Sector, SectorPlane)> data)
     {
         data.Add((m_firstMove.Sector, m_firstMove.SectorPlane));
         data.Add((m_secondMove.Sector, m_secondMove.SectorPlane));
@@ -58,7 +57,7 @@ public class ElevatorSpecial : ISectorSpecial
         m_secondMove = secondMove;
     }
 
-    public SpecialTickStatus Tick()
+    public override SpecialTickStatus Tick()
     {
         m_firstMove.Tick();
         if (m_firstMove.MoveStatus == SectorMoveStatus.Blocked)
@@ -69,39 +68,39 @@ public class ElevatorSpecial : ISectorSpecial
         return SpecialTickStatus.Continue;
     }
 
-    public void ResetInterpolation()
+    public override void ResetInterpolation()
     {
         m_firstMove.ResetInterpolation();
         m_secondMove.ResetInterpolation();
     }
 
-    public void FinalizeDestroy()
+    public override void FinalizeDestroy()
     {
         m_firstMove.FinalizeDestroy();
         m_secondMove.FinalizeDestroy();
     }
 
-    public void Free()
+    public override void Free()
     {
 
     }
 
-    public void Pause()
-    {
-        // Not required
-    }
-
-    public void Resume()
+    public override void Pause()
     {
         // Not required
     }
 
-    public bool Use(Entity entity)
+    public override void Resume()
+    {
+        // Not required
+    }
+
+    public override bool Use(Entity entity)
     {
         return false;
     }
 
-    public ElevatorSpecialModel ToSpecialModel()
+    public ElevatorSpecialModel ToSpecialElevatorModel()
     {
         return new()
         {

--- a/Core/World/Special/Specials/SectorMoveSpecial.cs
+++ b/Core/World/Special/Specials/SectorMoveSpecial.cs
@@ -18,7 +18,7 @@ public class SectorMoveSpecial : ISectorSpecial
     public SectorPlane SectorPlane;
     public SectorMoveData MoveData;
     public SectorSoundData SoundData;
-    public bool IsPaused { get; private set; }
+    public virtual bool IsPaused { get; private set; }
     public SectorMoveStatus MoveStatus;
     public MoveDirection MoveDirection;
     public int DelayTics;
@@ -406,7 +406,7 @@ public class SectorMoveSpecial : ISectorSpecial
         return true;
     }
 
-    public void Pause()
+    public virtual void Pause()
     {
         IsPaused = true;
         SectorPlane.PrevZ = SectorPlane.Z;
@@ -414,7 +414,7 @@ public class SectorMoveSpecial : ISectorSpecial
             StopSound(SoundData.MovementSound);
     }
 
-    public void Resume()
+    public virtual void Resume()
     {
         IsPaused = false;
         if (SoundData.MovementSound != null)

--- a/Core/World/WorldBase.cs
+++ b/Core/World/WorldBase.cs
@@ -738,7 +738,7 @@ public abstract partial class WorldBase : IWorld
         SetEntityLightSectors();
 
         StaticDataApplier.DetermineStaticData(this);
-        SpecialManager.SectorSpecialDestroyed += SpecialManager_SectorSpecialDestroyed;
+        SpecialManager.SectorMoveComplete += SpecialManager_SectorMoveComplete;
     }
 
     private void SetEntityLightSectors()
@@ -802,12 +802,10 @@ public abstract partial class WorldBase : IWorld
         return true;
     }
 
-    private void SpecialManager_SectorSpecialDestroyed(object? sender, ISectorSpecial special)
+    private void SpecialManager_SectorMoveComplete(object? sender, SectorPlane sectorPlane)
     {
-        if (special is not SectorMoveSpecial move)
-            return;
-
-        SectorMoveComplete?.Invoke(this, move.SectorPlane);
+        sectorPlane.Sector.MoveEventGameTick = Gametick;
+        SectorMoveComplete?.Invoke(this, sectorPlane);
     }
 
     public Player? GetLineOfSightPlayer(Entity entity, bool allAround)
@@ -1380,7 +1378,7 @@ public abstract partial class WorldBase : IWorld
     public void Dispose()
     {
         OnDestroying?.Invoke(this, EventArgs.Empty);
-        SpecialManager.SectorSpecialDestroyed -= SpecialManager_SectorSpecialDestroyed;
+        SpecialManager.SectorMoveComplete -= SpecialManager_SectorMoveComplete;
         SoundManager.UnregisterEvents();
         PerformDispose();
         GC.SuppressFinalize(this);
@@ -2812,6 +2810,7 @@ public abstract partial class WorldBase : IWorld
 
     public virtual SectorMoveStatus MoveSectorZ(double speed, double destZ, SectorMoveSpecial moveSpecial)
     {
+        moveSpecial.Sector.MoveEventGameTick = Gametick;
         if (moveSpecial.IsInitialMove)
             SectorMoveStart?.Invoke(this, moveSpecial.SectorPlane);
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <AssemblyVersion>0.9.9.1</AssemblyVersion>
-    <FileVersion>0.9.9.1</FileVersion>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <FileVersion>1.0.0.0</FileVersion>
     
     <Nullable>enable</Nullable>
     <NullableContextOptions>enable</NullableContextOptions>


### PR DESCRIPTION
Fix elevator specials staying in the dynamic renderer after they have stopped moving.

Fix missing incorrect offset being set in 3D sector wall rendering when previous slice is moving and the next is not.

Fix move complete not being called on 3D sectors fake ceiling.

Do not move sector 3D's parent sector floor and ceiling to dynamic rendering since they can't change.

Add handling for duplicate line processing when sectors start/complete movement.