### PR TITLE
Allow for custom, non-vanilla white/inverse Invulernability overlay.

### DIFF
--- a/Core/Layer/Options/Sections/ListedConfigSection.cs
+++ b/Core/Layer/Options/Sections/ListedConfigSection.cs
@@ -93,6 +93,8 @@ public class ListedConfigSection : IOptionSection
         m_config.Render.LightMode.OptionDisabled = paletteMode;
         m_config.Render.EmulateInvulnerabilityColorMap.OptionDisabled = paletteMode;
         m_config.Render.DownScaleVanillaRenderSampleBuffer.OptionDisabled = m_config.Render.VanillaRender.Value == false;
+        
+        m_config.Render.AlternativeInvulnerabilityColor.OptionDisabled = m_config.Render.AlternativeInvulnerabilityOverlay.Value == false;
 
         m_config.Mouse.ForwardBackwardSpeed.OptionDisabled = m_config.Mouse.Look.Value == true;
 

--- a/Core/Layer/Worlds/WorldLayer.Render.Hud.cs
+++ b/Core/Layer/Worlds/WorldLayer.Render.Hud.cs
@@ -366,6 +366,13 @@ public partial class WorldLayer
             hud.Clear(box, powerup.DrawColor.Value, alpha);
         }
 
+        var invuln = Player.Inventory.PowerupEffectColorMap;
+        if (m_config.Render.AlternativeInvulnerabilityOverlay && invuln is { PowerupType: PowerupType.Invulnerable, DrawPowerupEffect: true })
+        {
+            var customColor = m_config.Render.AlternativeInvulnerabilityColor.Value;
+            hud.Clear(box, new Color((byte)customColor.X, (byte)customColor.Y, (byte)customColor.Z), 0.15f);
+        }
+        
         if (Player.BonusCount > 0)
         {
             const float PickupScaleAmount = 3f;

--- a/Core/Util/Configs/Components/ConfigRender.cs
+++ b/Core/Util/Configs/Components/ConfigRender.cs
@@ -3,6 +3,7 @@ using Helion.Util.Configs.Impl;
 using Helion.Util.Configs.Options;
 using Helion.Util.Configs.Values;
 using System.ComponentModel;
+using Helion.Geometry.Vectors;
 using static Helion.Util.Configs.Values.ConfigFilters;
 
 namespace Helion.Util.Configs.Components;
@@ -166,6 +167,14 @@ public class ConfigRender: ConfigElement<ConfigRender>
     [ConfigInfo("Emulates custom invulnerability palettes in true color mode. May not work well with all WADs. Application restart required.", restartRequired: true)]
     [OptionMenu(OptionSectionType.Render, "Emulate Invulnerability Colormap")]
     public readonly ConfigValue<bool> EmulateInvulnerabilityColorMap = new(false);
+    
+    [ConfigInfo("Uses a custom color overlay for Invulnerability instead of the vanilla inverse/white strobe.")]
+    [OptionMenu(OptionSectionType.Render, "Alternative Invulnerability Overlay")]
+    public readonly ConfigValue<bool> AlternativeInvulnerabilityOverlay = new(false);
+
+    [ConfigInfo("The color used for the alternative invulnerability overlay.")]
+    [OptionMenu(OptionSectionType.Render, "Alternative Invulnerability Color")]
+    public readonly ConfigValue<Vec3I> AlternativeInvulnerabilityColor = new((0, 255, 0), ClampColor);
 
     [ConfigInfo("Line contrast mode.", mapRestartRequired: true)]
     [OptionMenu(OptionSectionType.Render, "Line contrast mode")]

--- a/Core/World/Entities/Players/Player.cs
+++ b/Core/World/Entities/Players/Player.cs
@@ -134,6 +134,9 @@ public class Player : Entity
 
         foreach (PowerupType powerupType in PowerupsWithBrightness)
         {
+            if (powerupType == PowerupType.Invulnerable && WorldStatic.World.Config.Render.AlternativeInvulnerabilityOverlay)
+                continue;
+
             IPowerup? powerup = Inventory.GetPowerup(powerupType);
             if (powerup != null)
                 return powerup.DrawPowerupEffect;
@@ -144,7 +147,9 @@ public class Player : Entity
 
     public bool HasLightAmp() => Inventory.GetPowerup(PowerupType.LightAmp) != null;
 
-    public bool DrawInvulnerableColorMap() => Inventory.PowerupEffectColorMap != null && Inventory.PowerupEffectColorMap.DrawPowerupEffect;
+    public bool DrawInvulnerableColorMap() => 
+        !WorldStatic.World.Config.Render.AlternativeInvulnerabilityOverlay &&
+        Inventory.PowerupEffectColorMap is { DrawPowerupEffect: true };
     public int GetExtraLightRender() => WorldStatic.World.Config.Render.ExtraLight + (ExtraLight * Constants.ExtraLightFactor);
 
     public override double ViewZ => m_viewZ;


### PR DESCRIPTION
# From
<img width="1024" height="768" alt="helion_20260422_15 02 27 7431" src="https://github.com/user-attachments/assets/cbdeb76b-9203-44ea-806b-ba9d0b425d50" />

# To
<img width="1024" height="768" alt="helion_20260422_15 02 41 0013" src="https://github.com/user-attachments/assets/ba5e49f4-7e76-431a-95a5-6bad8ac682cf" />

---

This is a custom purple color, defined in the Render Config. Default Alternative is set to "Radiation Suit Green".