### PR TITLE
Sector light buffer refactor

### DIFF
--- a/Core/Render/OpenGL/Renderers/Legacy/World/DynamicVertex.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/DynamicVertex.cs
@@ -16,7 +16,7 @@ public struct DynamicVertex
     public float V;
 
     [VertexAttribute]
-    public float Options;
+    public float SurfaceOptions;
 
     [VertexAttribute]
     public float LightLevelAdd;
@@ -30,6 +30,6 @@ public struct DynamicVertex
     public float PrevU;
     public float PrevV;
 
-    [VertexAttribute(required: false)]
+    [VertexAttribute]
     public float ColorMapIndex;
 }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/DynamicVertex.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/DynamicVertex.cs
@@ -31,5 +31,5 @@ public struct DynamicVertex
     public float PrevV;
 
     [VertexAttribute]
-    public float ColorMapIndex;
+    public float RenderOptions;
 }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
@@ -145,10 +145,10 @@ public class EntityProgram : RenderProgram
         #version 330
 
         layout(location = 0) in vec3 pos;
-        layout(location = 1) in float options;
+        layout(location = 1) in float surfaceOptions;
         layout(location = 2) in vec3 prevPos;
         layout(location = 3) in float offsetXYZ;
-        layout(location = 4) in float colorMapAndRenderIndex;
+        layout(location = 4) in float renderOptions;
 
         flat out float lightLevelOut;
         flat out float alphaOut;
@@ -168,15 +168,15 @@ public class EntityProgram : RenderProgram
 
         void main()
         {
-            int intOptions = floatBitsToInt(options);
+            int intOptions = floatBitsToInt(surfaceOptions);
             alphaOut = (intOptions & 0xFF) / 255.0;
             fuzzOut = (intOptions >> 8) & 1;
             flipUOut = (intOptions >> 9) & 1;
             lightLevelOut = (intOptions >> 10) & 0xFF;
             colorMapTranslationOut = (intOptions >> 18);
 
-            intOptions = floatBitsToInt(colorMapAndRenderIndex);
-            int sectorIndexInt = intOptions >> 16;
+            intOptions = floatBitsToInt(renderOptions);
+            int lightIndexInt = intOptions >> 16;
             int renderIndex = intOptions & 0xFFFF;
 
             intOptions = floatBitsToInt(offsetXYZ);
@@ -188,8 +188,8 @@ public class EntityProgram : RenderProgram
             offsetZOut = mix(offsetZOut, -offsetZOut, offsetZSign);
             renderIndexOut = renderIndex;
 
-            sectorColorMapIndexOut = texelFetch(sectorColormapTexture, sectorIndexInt).rgb;
-            sectorFogOut = texelFetch(sectorFogTexture, sectorIndexInt).rgba;
+            sectorColorMapIndexOut = texelFetch(sectorColormapTexture, lightIndexInt).rgb;
+            sectorFogOut = texelFetch(sectorFogTexture, lightIndexInt).rgba;
             gl_Position = vec4(mix(prevPos, pos, timeFrac), 1.0);
             positionZOut = gl_Position.z;
         }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
@@ -284,8 +284,8 @@ public sealed class EntityRenderer : StyleRendererBase, IDisposable
         vertex.PrevPos.X = (float)(entity.PrevPosition.X - nudgeAmount.X);
         vertex.PrevPos.Y = (float)(entity.PrevPosition.Y - nudgeAmount.Y);
         vertex.PrevPos.Z = (float)entity.PrevPosition.Z;
-        vertex.Options = VertexOptions.Entity(alpha, fuzz, flipU, colorMapIndex, lightLevel);
-        vertex.ColorMapAndRenderIndex = VertexOptions.EntityColorMapAndRenderIndex(
+        vertex.SurfaceOptions = VertexOptions.EntityPackSurface(alpha, fuzz, flipU, colorMapIndex, lightLevel);
+        vertex.RenderOptions = VertexOptions.EntityPackRender(
             Renderer.GetLightBufferIndex(sector, WorldStatic.Sector3D && sector.Sectors3D.Length > 0 ? LightBufferType.Wall : LightBufferType.Floor), renderIndex);
 
         if (entity.Definition.Flags.SpawnCeiling() && m_vanillaRender)
@@ -298,7 +298,7 @@ public sealed class EntityRenderer : StyleRendererBase, IDisposable
             vertex.PrevPos.Z = entity.PrevPosition.Z != entity.Position.Z ? (float)entity.Sector.Ceiling.PrevZ : ceilingZ;
         }
         
-        vertex.OffsetXYZ = VertexOptions.EntityXYZ(offsetX, offsetZ);
+        vertex.OffsetXYZ = VertexOptions.EntityPackXYZ(offsetX, offsetZ);
         arrayData.Length = length + 1;
 
         if (m_healthBars && entity.Flags.Shootable() && (m_healthBarLimit <= 0 || m_healthBarLimit <= entity.Properties.Health))
@@ -326,10 +326,10 @@ public sealed class EntityRenderer : StyleRendererBase, IDisposable
         float min = 1f / (entity.Properties.HealthBarWidth + MinBarWidth - 5);
         // Normalized health percent (0-255)
         int health = (int)(Math.Max(min, entity.Health / (float)entity.Properties.Health) * 255f);
-        vertex.Options = VertexOptions.Entity(1, attackFlash ? 1 : 0, 0, entity.Properties.HealthBarWidth, health);
+        vertex.SurfaceOptions = VertexOptions.EntityPackSurface(1, attackFlash ? 1 : 0, 0, entity.Properties.HealthBarWidth, health);
         vertex.Pos = entityVertex.Pos;
         vertex.PrevPos = entityVertex.PrevPos;
-        vertex.OffsetXYZ = VertexOptions.EntityXYZ(0, offset);
+        vertex.OffsetXYZ = VertexOptions.EntityPackXYZ(0, offset);
 
         array.SetLength(array.Length + 1);
     }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
@@ -286,7 +286,7 @@ public sealed class EntityRenderer : StyleRendererBase, IDisposable
         vertex.PrevPos.Z = (float)entity.PrevPosition.Z;
         vertex.Options = VertexOptions.Entity(alpha, fuzz, flipU, colorMapIndex, lightLevel);
         vertex.ColorMapAndRenderIndex = VertexOptions.EntityColorMapAndRenderIndex(
-            Renderer.GetColorMapBufferIndex(sector, WorldStatic.Sector3D && sector.Sectors3D.Length > 0 ? LightBufferType.Wall : LightBufferType.Floor), renderIndex);
+            Renderer.GetLightBufferIndex(sector, WorldStatic.Sector3D && sector.Sectors3D.Length > 0 ? LightBufferType.Wall : LightBufferType.Floor), renderIndex);
 
         if (entity.Definition.Flags.SpawnCeiling() && m_vanillaRender)
         {

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityVertex.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityVertex.cs
@@ -11,7 +11,7 @@ public struct EntityVertex
     public Vec3F Pos;
 
     [VertexAttribute]
-    // X offset written to colormap option portion when in health bar mode
+    // X offset written to surface option portions when in health bar mode
     public float SurfaceOptions;
 
     [VertexAttribute]

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityVertex.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityVertex.cs
@@ -12,7 +12,7 @@ public struct EntityVertex
 
     [VertexAttribute]
     // X offset written to colormap option portion when in health bar mode
-    public float Options;
+    public float SurfaceOptions;
 
     [VertexAttribute]
     public Vec3F PrevPos;
@@ -20,6 +20,6 @@ public struct EntityVertex
     [VertexAttribute]
     public float OffsetXYZ;
 
-    [VertexAttribute(required: false)]
-    public float ColorMapAndRenderIndex;
+    [VertexAttribute]
+    public float RenderOptions;
 }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/CoverWallUtil.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/CoverWallUtil.cs
@@ -48,22 +48,22 @@ public class CoverWallUtil
         {
             DynamicVertex* v = startVertex;
             staticVertices[index++] = new StaticVertex(v->X, v->Y, v->Z + heights.AddTop, v->U, v->V,
-                v->Options, v->LightLevelAdd, 0);
+                v->SurfaceOptions, v->LightLevelAdd, 0);
             v++;
             staticVertices[index++] = new StaticVertex(v->X, v->Y, v->Z - heights.SubBottom, v->U, v->V,
-                v->Options, v->LightLevelAdd, 0);
+                v->SurfaceOptions, v->LightLevelAdd, 0);
             v++;
             staticVertices[index++] = new StaticVertex(v->X, v->Y, v->Z + heights.AddTop, v->U, v->V,
-                v->Options, v->LightLevelAdd, 0);
+                v->SurfaceOptions, v->LightLevelAdd, 0);
             v++;
             staticVertices[index++] = new StaticVertex(v->X, v->Y, v->Z - heights.SubBottom, v->U, v->V,
-                v->Options, v->LightLevelAdd, 0);
+                v->SurfaceOptions, v->LightLevelAdd, 0);
             v++;
             staticVertices[index++] = new StaticVertex(v->X, v->Y, v->Z + heights.AddTop, v->U, v->V,
-                v->Options, v->LightLevelAdd, 0);
+                v->SurfaceOptions, v->LightLevelAdd, 0);
             v++;
             staticVertices[index++] = new StaticVertex(v->X, v->Y, v->Z - heights.SubBottom, v->U, v->V,
-                v->Options, v->LightLevelAdd, 0);
+                v->SurfaceOptions, v->LightLevelAdd, 0);
         }
     }
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
@@ -771,14 +771,13 @@ public partial class GeometryRenderer : IDisposable
 
         if (side.OffsetChanged || m_sectorChangedLine || data == null)
         {
-            int colorMapIndex = Renderer.GetColorMapBufferIndex(lightLevelSector, LightBufferType.Wall);
-            int lightIndex = Renderer.GetLightBufferIndex(side, side.Middle, lightLevelSector);
+            int lightIndex = Renderer.GetLightBufferIndex(side, side.Middle, lightLevelSector, out var overrideLightIndex);
             int addAlpha = allowAlpha ? 0 : 1;
             WorldTriangulator.HandleOneSided(side, offsetSide ?? side, floor, ceiling, texture.UVInverse, ref wall, isFront: isFront);
             if (data == null)
-                data = GetWallVertices(wall, GetLightLevelAdd(side), lightIndex, colorMapIndex, GetWallLightLevel(side, side.Middle), side.Line.Id, WallLocation.Middle, addAlpha: addAlpha, alpha: side.Alpha);
+                data = GetWallVertices(wall, GetLightLevelAdd(side), lightIndex, overrideLightIndex, GetWallLightLevel(side, side.Middle), side.Line.Id, WallLocation.Middle, addAlpha: addAlpha, alpha: side.Alpha);
             else
-                SetWallVertices(data, wall, GetLightLevelAdd(side), lightIndex, colorMapIndex, GetWallLightLevel(side, side.Middle), side.Line.Id, WallLocation.Middle, addAlpha: addAlpha, alpha: side.Alpha);
+                SetWallVertices(data, wall, GetLightLevelAdd(side), lightIndex, overrideLightIndex, GetWallLightLevel(side, side.Middle), side.Line.Id, WallLocation.Middle, addAlpha: addAlpha, alpha: side.Alpha);
 
             SetCachedSide(m_vertexLookup, side, data);
         }
@@ -1132,17 +1131,16 @@ public partial class GeometryRenderer : IDisposable
 
             if (facingSide.OffsetChanged || m_sectorChangedLine || data == null)
             {
-                int colorMapIndex = Renderer.GetColorMapBufferIndex(lightLevelSector, LightBufferType.Wall);
-                int lightIndex = Renderer.GetLightBufferIndex(facingSide, facingSide.Lower, lightLevelSector);
+                int lightIndex = Renderer.GetLightBufferIndex(facingSide, facingSide.Lower, lightLevelSector, out var overrideLightIndex);
                 // This lower would clip into the upper texture. Pick the upper as the priority and stop at the ceiling.
                 if (top.Z > otherSector.Ceiling.Z && !TextureManager.IsSkyTexture(otherSector.Ceiling.TextureHandle))
                     top = otherSector.Ceiling;
 
                 WorldTriangulator.HandleTwoSidedLower(facingSide, top, bottom, texture.UVInverse, isFrontSide, ref wall);
                 if (data == null)
-                    data = GetWallVertices(wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Lower), facingSide.Line.Id, WallLocation.Lower);
+                    data = GetWallVertices(wall, GetLightLevelAdd(facingSide), lightIndex, overrideLightIndex, GetWallLightLevel(facingSide, facingSide.Lower), facingSide.Line.Id, WallLocation.Lower);
                 else
-                    SetWallVertices(data, wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Lower), facingSide.Line.Id, WallLocation.Lower);
+                    SetWallVertices(data, wall, GetLightLevelAdd(facingSide), lightIndex, overrideLightIndex, GetWallLightLevel(facingSide, facingSide.Lower), facingSide.Line.Id, WallLocation.Lower);
 
                 SetCachedSide(m_vertexLookup, facingSide, data);
             }
@@ -1255,13 +1253,12 @@ public partial class GeometryRenderer : IDisposable
 
             if (facingSide.OffsetChanged || m_sectorChangedLine || data == null)
             {
-                int colorMapIndex = Renderer.GetColorMapBufferIndex(lightLevelSector, LightBufferType.Wall);
-                int lightIndex = Renderer.GetLightBufferIndex(facingSide, facingSide.Upper, lightLevelSector);
+                int lightIndex = Renderer.GetLightBufferIndex(facingSide, facingSide.Upper, lightLevelSector, out var overrideLightIndex);
                 WorldTriangulator.HandleTwoSidedUpper(facingSide, top, bottom, texture.UVInverse, isFrontSide, ref wall);
                 if (data == null)
-                    data = GetWallVertices(wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Upper), facingSide.Line.Id, WallLocation.Upper);
+                    data = GetWallVertices(wall, GetLightLevelAdd(facingSide), lightIndex, overrideLightIndex, GetWallLightLevel(facingSide, facingSide.Upper), facingSide.Line.Id, WallLocation.Upper);
                 else
-                    SetWallVertices(data, wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Upper), facingSide.Line.Id, WallLocation.Upper);
+                    SetWallVertices(data, wall, GetLightLevelAdd(facingSide), lightIndex, overrideLightIndex, GetWallLightLevel(facingSide, facingSide.Upper), facingSide.Line.Id, WallLocation.Upper);
 
                 SetCachedSide(m_vertexUpperLookup, facingSide, data);
             }
@@ -1309,13 +1306,12 @@ public partial class GeometryRenderer : IDisposable
         WallVertices wall = default;
 
         GLLegacyTexture texture = m_glTextureManager.GetTexture(lowerWall.TextureHandle);
-        int colorMapIndex = Renderer.GetColorMapBufferIndex(facingSector, LightBufferType.Wall);
         int lightIndex = Renderer.GetLightBufferIndex(facingSector, LightBufferType.Wall);
         if (location == WallLocation.Upper)
             WorldTriangulator.HandleTwoSidedUpper(facingSide, facingSector.Ceiling, otherSector.Ceiling, texture.UVInverse, isFrontSide, ref wall);
         else
             WorldTriangulator.HandleTwoSidedLower(facingSide, otherSector.Floor, facingSector.Floor, texture.UVInverse, isFrontSide, ref wall);
-        SetWallVertices(m_wallVertices, wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, 0, facingSide.Line.Id, location);
+        SetWallVertices(m_wallVertices, wall, GetLightLevelAdd(facingSide), lightIndex, lightIndex, 0, facingSide.Line.Id, location);
         return m_wallVertices;
     }
 
@@ -1436,8 +1432,7 @@ public partial class GeometryRenderer : IDisposable
                     prevOffset = GetTransferHeightHackOffset(TextureManager, facingSide, otherSide, opening.BottomZ, opening.TopZ, previous: true);
             }
 
-            int colorMapIndex = Renderer.GetColorMapBufferIndex(lightLevelSector, LightBufferType.Wall);
-            int lightIndex = Renderer.GetLightBufferIndex(facingSide, facingSide.Middle, lightLevelSector);
+            int lightIndex = Renderer.GetLightBufferIndex(facingSide, facingSide.Middle, lightLevelSector, out var overrideLightIndex);
 
             WallVertices wall = default;
             WorldTriangulator.HandleTwoSidedMiddle(facingSide,
@@ -1445,9 +1440,9 @@ public partial class GeometryRenderer : IDisposable
                 clipPlanes: GetTwoSidedMiddleClipPlanes(facingSide, otherSide, facingSector, otherSector), restrictSpan: restrictSpan);
 
             if (data == null)
-                data = GetWallVertices(wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Middle), line.Id, WallLocation.None, alpha, addAlpha: 0);
+                data = GetWallVertices(wall, GetLightLevelAdd(facingSide), lightIndex, overrideLightIndex, GetWallLightLevel(facingSide, facingSide.Middle), line.Id, WallLocation.None, alpha, addAlpha: 0);
             else
-                SetWallVertices(data, wall, GetLightLevelAdd(facingSide), lightIndex, colorMapIndex, GetWallLightLevel(facingSide, facingSide.Middle), line.Id, WallLocation.None, alpha, addAlpha: 0);
+                SetWallVertices(data, wall, GetLightLevelAdd(facingSide), lightIndex, overrideLightIndex, GetWallLightLevel(facingSide, facingSide.Middle), line.Id, WallLocation.None, alpha, addAlpha: 0);
 
             SetCachedSide(m_vertexLookup, facingSide, data);
             line.RenderSegStart = saveStart;
@@ -1669,23 +1664,22 @@ public partial class GeometryRenderer : IDisposable
             var lookupData = generateSector3D ? GetSectorVertices3D(subsectors, geometryPlane, out var generate) : GetSectorVertices(subsectors, floor, id, out generate);
             if (generate || flatChanged)
             {
-                int colorMapIndex, lightIndex;
+                int lightIndex;
+                int overrideLightIndex;
                 SectorPlane lightPlane;
 
                 if (floor)
                 {
-                    lightIndex = Renderer.GetLightBufferIndex(lightLevelSector, SectorPlaneFace.Floor, LightBufferType.Floor);
-                    colorMapIndex = Renderer.GetColorMapBufferIndex(lightLevelSector, LightBufferType.Floor);
+                    lightIndex = Renderer.GetLightBufferIndex(lightLevelSector, SectorPlaneFace.Floor, LightBufferType.Floor, out overrideLightIndex);
                     lightPlane = sector.TransferFloorLightSector.Floor;
                 }
                 else
                 {
-                    lightIndex = Renderer.GetLightBufferIndex(lightLevelSector, SectorPlaneFace.Floor, LightBufferType.Ceiling);
-                    colorMapIndex = Renderer.GetColorMapBufferIndex(lightLevelSector, LightBufferType.Ceiling);
+                    lightIndex = Renderer.GetLightBufferIndex(lightLevelSector, SectorPlaneFace.Ceiling, LightBufferType.Ceiling, out overrideLightIndex);
                     lightPlane = sector.TransferCeilingLightSector.Ceiling;
                 }
 
-                var flatLightLevel = (byte)Math.Clamp(lightPlane.LightLevelAbsolute ? lightPlane.LightLevel : (short)0, (short)0, (short)255);
+                var flatLightLevel = (byte)Math.Clamp(lightPlane.LightLevelSet, (short)0, (short)255);
                 int upper = floor ? 0 : 1;
                 int lower = 1 - upper;
                 int addAlpha = allowAlpha ? 0 : 1;
@@ -1703,7 +1697,7 @@ public partial class GeometryRenderer : IDisposable
                     {
                         ref var second = ref m_subsectorVertices.Data[i];
                         ref var third = ref m_subsectorVertices.Data[i + 1];
-                        GetFlatVertices(lookupData, indexStart, ref root, ref second, ref third, lightIndex, colorMapIndex, flatLightLevel, upper, lower, addAlpha, alpha);
+                        GetFlatVertices(lookupData, indexStart, ref root, ref second, ref third, lightIndex, overrideLightIndex, flatLightLevel, upper, lower, addAlpha, alpha);
                         indexStart += 3;
                     }
                 }
@@ -1903,7 +1897,7 @@ public partial class GeometryRenderer : IDisposable
         }
     }
 
-    private static unsafe void SetWallVertices(DynamicVertex[] data, in WallVertices wv, int lightLevelAdd, int lightBufferIndex, int colorMapIndex, byte wallLightLevel,
+    private static unsafe void SetWallVertices(DynamicVertex[] data, in WallVertices wv, int lightLevelAdd, int lightBufferIndex, int overrideLightIndex, byte wallLightLevel,
         int mapId, WallLocation location, float alpha = 1.0f, int addAlpha = 1)
     {
         var uvFlags = UvFlags.Normal;
@@ -1911,7 +1905,7 @@ public partial class GeometryRenderer : IDisposable
             uvFlags |= UvFlags.MirrorX;
         if (wv.TopLeft.V > wv.BottomRight.V)
             uvFlags |= UvFlags.MirrorY;
-        var colorMapAndLightLevel = VertexOptions.ColorMapIndex(colorMapIndex, wallLightLevel, uvFlags);
+        var colorMapAndLightLevel = VertexOptions.ColorMapIndex(lightBufferIndex, wallLightLevel, uvFlags);
         var lightLevelAddAndMapId = VertexOptions.LightLevelAdd(mapId, lightLevelAdd);
         var lower = location == WallLocation.Lower ? 1 : 0;
         var upper = location == WallLocation.Upper ? 1 : 0;
@@ -1928,7 +1922,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->V = wv.TopLeft.V;
             vertex->PrevU = wv.TopLeft.PrevU;
             vertex->PrevV = wv.TopLeft.PrevV;
-            vertex->Options = VertexOptions.World(1, alpha, addAlpha, upper, lower, lightBufferIndex);
+            vertex->Options = VertexOptions.World(1, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
             vertex->ColorMapIndex = colorMapAndLightLevel;
 
@@ -1943,7 +1937,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->V = wv.BottomRight.V;
             vertex->PrevU = wv.TopLeft.PrevU;
             vertex->PrevV = wv.BottomRight.PrevV;
-            vertex->Options = VertexOptions.World(1, alpha, addAlpha, upper, lower, lightBufferIndex);
+            vertex->Options = VertexOptions.World(1, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
             vertex->ColorMapIndex = colorMapAndLightLevel;
 
@@ -1958,7 +1952,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->V = wv.TopLeft.V;
             vertex->PrevU = wv.BottomRight.PrevU;
             vertex->PrevV = wv.TopLeft.PrevV;
-            vertex->Options = VertexOptions.World(1, alpha, addAlpha, upper, lower, lightBufferIndex);
+            vertex->Options = VertexOptions.World(1, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
             vertex->ColorMapIndex = colorMapAndLightLevel;
 
@@ -1973,7 +1967,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->V = wv.BottomRight.V;
             vertex->PrevU = wv.BottomRight.PrevU;
             vertex->PrevV = wv.BottomRight.PrevV;
-            vertex->Options = VertexOptions.World(0, alpha, addAlpha, upper, lower, lightBufferIndex);
+            vertex->Options = VertexOptions.World(0, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
             vertex->ColorMapIndex = colorMapAndLightLevel;
 
@@ -1988,7 +1982,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->V = wv.TopLeft.V;
             vertex->PrevU = wv.BottomRight.PrevU;
             vertex->PrevV = wv.TopLeft.PrevV;
-            vertex->Options = VertexOptions.World(0, alpha, addAlpha, upper, lower, lightBufferIndex);
+            vertex->Options = VertexOptions.World(0, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
             vertex->ColorMapIndex = colorMapAndLightLevel;
 
@@ -2003,13 +1997,13 @@ public partial class GeometryRenderer : IDisposable
             vertex->V = wv.BottomRight.V;
             vertex->PrevU = wv.TopLeft.PrevU;
             vertex->PrevV = wv.BottomRight.PrevV;
-            vertex->Options = VertexOptions.World(0, alpha, addAlpha, upper, lower, lightBufferIndex);
+            vertex->Options = VertexOptions.World(0, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
             vertex->ColorMapIndex = colorMapAndLightLevel;
         }
     }
 
-    private static unsafe DynamicVertex[] GetWallVertices(in WallVertices wv, int lightLevelAdd, int lightBufferIndex, int colorMapIndex, byte wallLightLevel,
+    private static unsafe DynamicVertex[] GetWallVertices(in WallVertices wv, int lightLevelAdd, int lightIndex, int overrideLightIndex, byte wallLightLevel,
         int mapId, WallLocation location, float alpha = 1.0f, int addAlpha = 1)
     {
         var uvFlags = UvFlags.Normal;
@@ -2017,7 +2011,7 @@ public partial class GeometryRenderer : IDisposable
             uvFlags |= UvFlags.MirrorX;
         if (wv.TopLeft.V > wv.BottomRight.V)
             uvFlags |= UvFlags.MirrorY;
-        var colorMapAndLightLevel = VertexOptions.ColorMapIndex(colorMapIndex, wallLightLevel, uvFlags);
+        var colorMapAndLightLevel = VertexOptions.ColorMapIndex(lightIndex, wallLightLevel, uvFlags);
         var lightLevelAddAndMapId = VertexOptions.LightLevelAdd(mapId, lightLevelAdd);
         var lower = location == WallLocation.Lower ? 1 : 0;
         var upper = location == WallLocation.Upper ? 1 : 0;
@@ -2044,7 +2038,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->V = wv.TopLeft.V;
             vertex->PrevU = wv.TopLeft.PrevU;
             vertex->PrevV = wv.TopLeft.PrevV;
-            vertex->Options = VertexOptions.World(1, alpha, addAlpha, upper, lower, lightBufferIndex);
+            vertex->Options = VertexOptions.World(1, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
             vertex->ColorMapIndex = colorMapAndLightLevel;
 
@@ -2060,7 +2054,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->V = wv.BottomRight.V;
             vertex->PrevU = wv.TopLeft.PrevU;
             vertex->PrevV = wv.BottomRight.PrevV;
-            vertex->Options = VertexOptions.World(1, alpha, addAlpha, upper, lower, lightBufferIndex);
+            vertex->Options = VertexOptions.World(1, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
             vertex->ColorMapIndex = colorMapAndLightLevel;
 
@@ -2076,7 +2070,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->V = wv.TopLeft.V;
             vertex->PrevU = wv.BottomRight.PrevU;
             vertex->PrevV = wv.TopLeft.PrevV;
-            vertex->Options = VertexOptions.World(1, alpha, addAlpha, upper, lower, lightBufferIndex);
+            vertex->Options = VertexOptions.World(1, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
             vertex->ColorMapIndex = colorMapAndLightLevel;
 
@@ -2092,7 +2086,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->V = wv.BottomRight.V;
             vertex->PrevU = wv.BottomRight.PrevU;
             vertex->PrevV = wv.BottomRight.PrevV;
-            vertex->Options = VertexOptions.World(0, alpha, addAlpha, upper, lower, lightBufferIndex);
+            vertex->Options = VertexOptions.World(0, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
             vertex->ColorMapIndex = colorMapAndLightLevel;
 
@@ -2108,7 +2102,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->V = wv.TopLeft.V;
             vertex->PrevU = wv.BottomRight.PrevU;
             vertex->PrevV = wv.TopLeft.PrevV;
-            vertex->Options = VertexOptions.World(0, alpha, addAlpha, upper, lower, lightBufferIndex);
+            vertex->Options = VertexOptions.World(0, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
             vertex->ColorMapIndex = colorMapAndLightLevel;
 
@@ -2124,7 +2118,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->V = wv.BottomRight.V;
             vertex->PrevU = wv.TopLeft.PrevU;
             vertex->PrevV = wv.BottomRight.PrevV;
-            vertex->Options = VertexOptions.World(0, alpha, addAlpha, upper, lower, lightBufferIndex);
+            vertex->Options = VertexOptions.World(0, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
             vertex->ColorMapIndex = colorMapAndLightLevel;
         }
@@ -2133,10 +2127,10 @@ public partial class GeometryRenderer : IDisposable
     }
 
     private static unsafe void GetFlatVertices(DynamicVertex[] vertices, int startIndex, ref TriangulatedWorldVertex root, ref TriangulatedWorldVertex second, ref TriangulatedWorldVertex third,
-        int lightLevelBufferIndex, int colorMapIndex, int flatLightLevel, int upper, int lower, int addAlpha, float alpha)
+        int lightLevelBufferIndex, int overrideLightIndex, int flatLightLevel, int upper, int lower, int addAlpha, float alpha)
     {
-        var options = VertexOptions.World(0, alpha, addAlpha, upper, lower, lightLevelBufferIndex);
-        float colorMapAndLightLevel = VertexOptions.ColorMapIndex(colorMapIndex, flatLightLevel);
+        var options = VertexOptions.World(0, alpha, addAlpha, upper, lower, overrideLightIndex);
+        float colorMapAndLightLevel = VertexOptions.ColorMapIndex(lightLevelBufferIndex, flatLightLevel);
         fixed (DynamicVertex* startVertex = &vertices[startIndex])
         {
             DynamicVertex* vertex = startVertex;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
@@ -1679,7 +1679,7 @@ public partial class GeometryRenderer : IDisposable
                     lightPlane = sector.TransferCeilingLightSector.Ceiling;
                 }
 
-                var flatLightLevel = (byte)Math.Clamp(lightPlane.LightLevelSet, (short)0, (short)255);
+                var flatLightLevel = (byte)Math.Clamp(lightPlane.LightLevelAdd, (short)0, (short)255);
                 int upper = floor ? 0 : 1;
                 int lower = 1 - upper;
                 int addAlpha = allowAlpha ? 0 : 1;
@@ -1897,7 +1897,7 @@ public partial class GeometryRenderer : IDisposable
         }
     }
 
-    private static unsafe void SetWallVertices(DynamicVertex[] data, in WallVertices wv, int lightLevelAdd, int lightBufferIndex, int overrideLightIndex, byte wallLightLevel,
+    private static unsafe void SetWallVertices(DynamicVertex[] data, in WallVertices wv, int lightLevelAdd, int lightIndex, int overrideLightIndex, byte wallLightLevel,
         int mapId, WallLocation location, float alpha = 1.0f, int addAlpha = 1)
     {
         var uvFlags = UvFlags.Normal;
@@ -1905,7 +1905,7 @@ public partial class GeometryRenderer : IDisposable
             uvFlags |= UvFlags.MirrorX;
         if (wv.TopLeft.V > wv.BottomRight.V)
             uvFlags |= UvFlags.MirrorY;
-        var colorMapAndLightLevel = VertexOptions.ColorMapIndex(lightBufferIndex, wallLightLevel, uvFlags);
+        var lightBufferIndex = VertexOptions.LightBufferIndex(lightIndex, wallLightLevel, uvFlags);
         var lightLevelAddAndMapId = VertexOptions.LightLevelAdd(mapId, lightLevelAdd);
         var lower = location == WallLocation.Lower ? 1 : 0;
         var upper = location == WallLocation.Upper ? 1 : 0;
@@ -1924,7 +1924,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->PrevV = wv.TopLeft.PrevV;
             vertex->Options = VertexOptions.World(1, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
-            vertex->ColorMapIndex = colorMapAndLightLevel;
+            vertex->ColorMapIndex = lightBufferIndex;
 
             vertex++;
             vertex->X = wv.TopLeft.X;
@@ -1939,7 +1939,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->PrevV = wv.BottomRight.PrevV;
             vertex->Options = VertexOptions.World(1, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
-            vertex->ColorMapIndex = colorMapAndLightLevel;
+            vertex->ColorMapIndex = lightBufferIndex;
 
             vertex++;
             vertex->X = wv.BottomRight.X;
@@ -1954,7 +1954,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->PrevV = wv.TopLeft.PrevV;
             vertex->Options = VertexOptions.World(1, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
-            vertex->ColorMapIndex = colorMapAndLightLevel;
+            vertex->ColorMapIndex = lightBufferIndex;
 
             vertex++;
             vertex->X = wv.BottomRight.X;
@@ -1969,7 +1969,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->PrevV = wv.BottomRight.PrevV;
             vertex->Options = VertexOptions.World(0, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
-            vertex->ColorMapIndex = colorMapAndLightLevel;
+            vertex->ColorMapIndex = lightBufferIndex;
 
             vertex++;
             vertex->X = wv.BottomRight.X;
@@ -1984,7 +1984,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->PrevV = wv.TopLeft.PrevV;
             vertex->Options = VertexOptions.World(0, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
-            vertex->ColorMapIndex = colorMapAndLightLevel;
+            vertex->ColorMapIndex = lightBufferIndex;
 
             vertex++;
             vertex->X = wv.TopLeft.X;
@@ -1999,7 +1999,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->PrevV = wv.BottomRight.PrevV;
             vertex->Options = VertexOptions.World(0, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
-            vertex->ColorMapIndex = colorMapAndLightLevel;
+            vertex->ColorMapIndex = lightBufferIndex;
         }
     }
 
@@ -2011,7 +2011,7 @@ public partial class GeometryRenderer : IDisposable
             uvFlags |= UvFlags.MirrorX;
         if (wv.TopLeft.V > wv.BottomRight.V)
             uvFlags |= UvFlags.MirrorY;
-        var colorMapAndLightLevel = VertexOptions.ColorMapIndex(lightIndex, wallLightLevel, uvFlags);
+        var lightBufferIndex = VertexOptions.LightBufferIndex(lightIndex, wallLightLevel, uvFlags);
         var lightLevelAddAndMapId = VertexOptions.LightLevelAdd(mapId, lightLevelAdd);
         var lower = location == WallLocation.Lower ? 1 : 0;
         var upper = location == WallLocation.Upper ? 1 : 0;
@@ -2040,7 +2040,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->PrevV = wv.TopLeft.PrevV;
             vertex->Options = VertexOptions.World(1, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
-            vertex->ColorMapIndex = colorMapAndLightLevel;
+            vertex->ColorMapIndex = lightBufferIndex;
 
             // 1
             vertex++;
@@ -2056,7 +2056,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->PrevV = wv.BottomRight.PrevV;
             vertex->Options = VertexOptions.World(1, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
-            vertex->ColorMapIndex = colorMapAndLightLevel;
+            vertex->ColorMapIndex = lightBufferIndex;
 
             // 2
             vertex++;
@@ -2072,7 +2072,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->PrevV = wv.TopLeft.PrevV;
             vertex->Options = VertexOptions.World(1, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
-            vertex->ColorMapIndex = colorMapAndLightLevel;
+            vertex->ColorMapIndex = lightBufferIndex;
 
             // 3
             vertex++;
@@ -2088,7 +2088,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->PrevV = wv.BottomRight.PrevV;
             vertex->Options = VertexOptions.World(0, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
-            vertex->ColorMapIndex = colorMapAndLightLevel;
+            vertex->ColorMapIndex = lightBufferIndex;
 
             // 4
             vertex++;
@@ -2104,7 +2104,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->PrevV = wv.TopLeft.PrevV;
             vertex->Options = VertexOptions.World(0, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
-            vertex->ColorMapIndex = colorMapAndLightLevel;
+            vertex->ColorMapIndex = lightBufferIndex;
 
             // 5
             vertex++;
@@ -2120,17 +2120,17 @@ public partial class GeometryRenderer : IDisposable
             vertex->PrevV = wv.BottomRight.PrevV;
             vertex->Options = VertexOptions.World(0, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
-            vertex->ColorMapIndex = colorMapAndLightLevel;
+            vertex->ColorMapIndex = lightBufferIndex;
         }
 
         return data;
     }
 
     private static unsafe void GetFlatVertices(DynamicVertex[] vertices, int startIndex, ref TriangulatedWorldVertex root, ref TriangulatedWorldVertex second, ref TriangulatedWorldVertex third,
-        int lightLevelBufferIndex, int overrideLightIndex, int flatLightLevel, int upper, int lower, int addAlpha, float alpha)
+        int lightIndex, int overrideLightIndex, int flatLightLevel, int upper, int lower, int addAlpha, float alpha)
     {
         var options = VertexOptions.World(0, alpha, addAlpha, upper, lower, overrideLightIndex);
-        float colorMapAndLightLevel = VertexOptions.ColorMapIndex(lightLevelBufferIndex, flatLightLevel);
+        float lightBufferIndex = VertexOptions.LightBufferIndex(lightIndex, flatLightLevel);
         fixed (DynamicVertex* startVertex = &vertices[startIndex])
         {
             DynamicVertex* vertex = startVertex;
@@ -2145,7 +2145,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->PrevU = root.PrevU;
             vertex->PrevV = root.PrevV;
             vertex->Options = options;
-            vertex->ColorMapIndex = colorMapAndLightLevel;
+            vertex->ColorMapIndex = lightBufferIndex;
 
             vertex++;
             vertex->X = second.X;
@@ -2159,7 +2159,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->PrevU = second.PrevU;
             vertex->PrevV = second.PrevV;
             vertex->Options = options;
-            vertex->ColorMapIndex = colorMapAndLightLevel;
+            vertex->ColorMapIndex = lightBufferIndex;
 
             vertex++;
             vertex->X = third.X;
@@ -2173,7 +2173,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->PrevU = third.PrevU;
             vertex->PrevV = third.PrevV;
             vertex->Options = options;
-            vertex->ColorMapIndex = colorMapAndLightLevel;
+            vertex->ColorMapIndex = lightBufferIndex;
         }
     }
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
@@ -144,9 +144,9 @@ public partial class GeometryRenderer : IDisposable
         m_renderTwoSidedMiddleSliceFunc = RenderTwoSidedMiddleSlice;
         m_renderSectorSliceFunc3D = RenderSectorSlice3D;
 
-        var options = VertexOptions.World(1, 1, 0, 0, 0, 0);
+        var options = VertexOptions.PackSurface(1, 1, 0, 0, 0, 0);
         for (int i = 0; i < m_wallVertices.Length; i++)
-            m_wallVertices[i].Options = options;
+            m_wallVertices[i].SurfaceOptions = options;
 
         m_world = null!;
     }
@@ -1905,7 +1905,7 @@ public partial class GeometryRenderer : IDisposable
             uvFlags |= UvFlags.MirrorX;
         if (wv.TopLeft.V > wv.BottomRight.V)
             uvFlags |= UvFlags.MirrorY;
-        var lightBufferIndex = VertexOptions.LightBufferIndex(lightIndex, wallLightLevel, uvFlags);
+        var lightBufferIndex = VertexOptions.PackRender(lightIndex, wallLightLevel, uvFlags);
         var lightLevelAddAndMapId = VertexOptions.LightLevelAdd(mapId, lightLevelAdd);
         var lower = location == WallLocation.Lower ? 1 : 0;
         var upper = location == WallLocation.Upper ? 1 : 0;
@@ -1922,7 +1922,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->V = wv.TopLeft.V;
             vertex->PrevU = wv.TopLeft.PrevU;
             vertex->PrevV = wv.TopLeft.PrevV;
-            vertex->Options = VertexOptions.World(1, alpha, addAlpha, upper, lower, overrideLightIndex);
+            vertex->SurfaceOptions = VertexOptions.PackSurface(1, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
             vertex->ColorMapIndex = lightBufferIndex;
 
@@ -1937,7 +1937,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->V = wv.BottomRight.V;
             vertex->PrevU = wv.TopLeft.PrevU;
             vertex->PrevV = wv.BottomRight.PrevV;
-            vertex->Options = VertexOptions.World(1, alpha, addAlpha, upper, lower, overrideLightIndex);
+            vertex->SurfaceOptions = VertexOptions.PackSurface(1, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
             vertex->ColorMapIndex = lightBufferIndex;
 
@@ -1952,7 +1952,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->V = wv.TopLeft.V;
             vertex->PrevU = wv.BottomRight.PrevU;
             vertex->PrevV = wv.TopLeft.PrevV;
-            vertex->Options = VertexOptions.World(1, alpha, addAlpha, upper, lower, overrideLightIndex);
+            vertex->SurfaceOptions = VertexOptions.PackSurface(1, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
             vertex->ColorMapIndex = lightBufferIndex;
 
@@ -1967,7 +1967,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->V = wv.BottomRight.V;
             vertex->PrevU = wv.BottomRight.PrevU;
             vertex->PrevV = wv.BottomRight.PrevV;
-            vertex->Options = VertexOptions.World(0, alpha, addAlpha, upper, lower, overrideLightIndex);
+            vertex->SurfaceOptions = VertexOptions.PackSurface(0, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
             vertex->ColorMapIndex = lightBufferIndex;
 
@@ -1982,7 +1982,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->V = wv.TopLeft.V;
             vertex->PrevU = wv.BottomRight.PrevU;
             vertex->PrevV = wv.TopLeft.PrevV;
-            vertex->Options = VertexOptions.World(0, alpha, addAlpha, upper, lower, overrideLightIndex);
+            vertex->SurfaceOptions = VertexOptions.PackSurface(0, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
             vertex->ColorMapIndex = lightBufferIndex;
 
@@ -1997,7 +1997,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->V = wv.BottomRight.V;
             vertex->PrevU = wv.TopLeft.PrevU;
             vertex->PrevV = wv.BottomRight.PrevV;
-            vertex->Options = VertexOptions.World(0, alpha, addAlpha, upper, lower, overrideLightIndex);
+            vertex->SurfaceOptions = VertexOptions.PackSurface(0, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
             vertex->ColorMapIndex = lightBufferIndex;
         }
@@ -2011,7 +2011,7 @@ public partial class GeometryRenderer : IDisposable
             uvFlags |= UvFlags.MirrorX;
         if (wv.TopLeft.V > wv.BottomRight.V)
             uvFlags |= UvFlags.MirrorY;
-        var lightBufferIndex = VertexOptions.LightBufferIndex(lightIndex, wallLightLevel, uvFlags);
+        var lightBufferIndex = VertexOptions.PackRender(lightIndex, wallLightLevel, uvFlags);
         var lightLevelAddAndMapId = VertexOptions.LightLevelAdd(mapId, lightLevelAdd);
         var lower = location == WallLocation.Lower ? 1 : 0;
         var upper = location == WallLocation.Upper ? 1 : 0;
@@ -2038,7 +2038,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->V = wv.TopLeft.V;
             vertex->PrevU = wv.TopLeft.PrevU;
             vertex->PrevV = wv.TopLeft.PrevV;
-            vertex->Options = VertexOptions.World(1, alpha, addAlpha, upper, lower, overrideLightIndex);
+            vertex->SurfaceOptions = VertexOptions.PackSurface(1, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
             vertex->ColorMapIndex = lightBufferIndex;
 
@@ -2054,7 +2054,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->V = wv.BottomRight.V;
             vertex->PrevU = wv.TopLeft.PrevU;
             vertex->PrevV = wv.BottomRight.PrevV;
-            vertex->Options = VertexOptions.World(1, alpha, addAlpha, upper, lower, overrideLightIndex);
+            vertex->SurfaceOptions = VertexOptions.PackSurface(1, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
             vertex->ColorMapIndex = lightBufferIndex;
 
@@ -2070,7 +2070,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->V = wv.TopLeft.V;
             vertex->PrevU = wv.BottomRight.PrevU;
             vertex->PrevV = wv.TopLeft.PrevV;
-            vertex->Options = VertexOptions.World(1, alpha, addAlpha, upper, lower, overrideLightIndex);
+            vertex->SurfaceOptions = VertexOptions.PackSurface(1, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
             vertex->ColorMapIndex = lightBufferIndex;
 
@@ -2086,7 +2086,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->V = wv.BottomRight.V;
             vertex->PrevU = wv.BottomRight.PrevU;
             vertex->PrevV = wv.BottomRight.PrevV;
-            vertex->Options = VertexOptions.World(0, alpha, addAlpha, upper, lower, overrideLightIndex);
+            vertex->SurfaceOptions = VertexOptions.PackSurface(0, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
             vertex->ColorMapIndex = lightBufferIndex;
 
@@ -2102,7 +2102,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->V = wv.TopLeft.V;
             vertex->PrevU = wv.BottomRight.PrevU;
             vertex->PrevV = wv.TopLeft.PrevV;
-            vertex->Options = VertexOptions.World(0, alpha, addAlpha, upper, lower, overrideLightIndex);
+            vertex->SurfaceOptions = VertexOptions.PackSurface(0, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
             vertex->ColorMapIndex = lightBufferIndex;
 
@@ -2118,7 +2118,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->V = wv.BottomRight.V;
             vertex->PrevU = wv.TopLeft.PrevU;
             vertex->PrevV = wv.BottomRight.PrevV;
-            vertex->Options = VertexOptions.World(0, alpha, addAlpha, upper, lower, overrideLightIndex);
+            vertex->SurfaceOptions = VertexOptions.PackSurface(0, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
             vertex->ColorMapIndex = lightBufferIndex;
         }
@@ -2129,8 +2129,8 @@ public partial class GeometryRenderer : IDisposable
     private static unsafe void GetFlatVertices(DynamicVertex[] vertices, int startIndex, ref TriangulatedWorldVertex root, ref TriangulatedWorldVertex second, ref TriangulatedWorldVertex third,
         int lightIndex, int overrideLightIndex, int flatLightLevel, int upper, int lower, int addAlpha, float alpha)
     {
-        var options = VertexOptions.World(0, alpha, addAlpha, upper, lower, overrideLightIndex);
-        float lightBufferIndex = VertexOptions.LightBufferIndex(lightIndex, flatLightLevel);
+        var options = VertexOptions.PackSurface(0, alpha, addAlpha, upper, lower, overrideLightIndex);
+        float lightBufferIndex = VertexOptions.PackRender(lightIndex, flatLightLevel);
         fixed (DynamicVertex* startVertex = &vertices[startIndex])
         {
             DynamicVertex* vertex = startVertex;
@@ -2144,7 +2144,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->V = root.V;
             vertex->PrevU = root.PrevU;
             vertex->PrevV = root.PrevV;
-            vertex->Options = options;
+            vertex->SurfaceOptions = options;
             vertex->ColorMapIndex = lightBufferIndex;
 
             vertex++;
@@ -2158,7 +2158,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->V = second.V;
             vertex->PrevU = second.PrevU;
             vertex->PrevV = second.PrevV;
-            vertex->Options = options;
+            vertex->SurfaceOptions = options;
             vertex->ColorMapIndex = lightBufferIndex;
 
             vertex++;
@@ -2172,7 +2172,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->V = third.V;
             vertex->PrevU = third.PrevU;
             vertex->PrevV = third.PrevV;
-            vertex->Options = options;
+            vertex->SurfaceOptions = options;
             vertex->ColorMapIndex = lightBufferIndex;
         }
     }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/GeometryRenderer.cs
@@ -1905,7 +1905,7 @@ public partial class GeometryRenderer : IDisposable
             uvFlags |= UvFlags.MirrorX;
         if (wv.TopLeft.V > wv.BottomRight.V)
             uvFlags |= UvFlags.MirrorY;
-        var lightBufferIndex = VertexOptions.PackRender(lightIndex, wallLightLevel, uvFlags);
+        var renderOptions = VertexOptions.PackRender(lightIndex, wallLightLevel, uvFlags);
         var lightLevelAddAndMapId = VertexOptions.LightLevelAdd(mapId, lightLevelAdd);
         var lower = location == WallLocation.Lower ? 1 : 0;
         var upper = location == WallLocation.Upper ? 1 : 0;
@@ -1924,7 +1924,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->PrevV = wv.TopLeft.PrevV;
             vertex->SurfaceOptions = VertexOptions.PackSurface(1, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
-            vertex->ColorMapIndex = lightBufferIndex;
+            vertex->RenderOptions = renderOptions;
 
             vertex++;
             vertex->X = wv.TopLeft.X;
@@ -1939,7 +1939,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->PrevV = wv.BottomRight.PrevV;
             vertex->SurfaceOptions = VertexOptions.PackSurface(1, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
-            vertex->ColorMapIndex = lightBufferIndex;
+            vertex->RenderOptions = renderOptions;
 
             vertex++;
             vertex->X = wv.BottomRight.X;
@@ -1954,7 +1954,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->PrevV = wv.TopLeft.PrevV;
             vertex->SurfaceOptions = VertexOptions.PackSurface(1, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
-            vertex->ColorMapIndex = lightBufferIndex;
+            vertex->RenderOptions = renderOptions;
 
             vertex++;
             vertex->X = wv.BottomRight.X;
@@ -1969,7 +1969,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->PrevV = wv.BottomRight.PrevV;
             vertex->SurfaceOptions = VertexOptions.PackSurface(0, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
-            vertex->ColorMapIndex = lightBufferIndex;
+            vertex->RenderOptions = renderOptions;
 
             vertex++;
             vertex->X = wv.BottomRight.X;
@@ -1984,7 +1984,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->PrevV = wv.TopLeft.PrevV;
             vertex->SurfaceOptions = VertexOptions.PackSurface(0, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
-            vertex->ColorMapIndex = lightBufferIndex;
+            vertex->RenderOptions = renderOptions;
 
             vertex++;
             vertex->X = wv.TopLeft.X;
@@ -1999,7 +1999,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->PrevV = wv.BottomRight.PrevV;
             vertex->SurfaceOptions = VertexOptions.PackSurface(0, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
-            vertex->ColorMapIndex = lightBufferIndex;
+            vertex->RenderOptions = renderOptions;
         }
     }
 
@@ -2011,7 +2011,7 @@ public partial class GeometryRenderer : IDisposable
             uvFlags |= UvFlags.MirrorX;
         if (wv.TopLeft.V > wv.BottomRight.V)
             uvFlags |= UvFlags.MirrorY;
-        var lightBufferIndex = VertexOptions.PackRender(lightIndex, wallLightLevel, uvFlags);
+        var renderOptions = VertexOptions.PackRender(lightIndex, wallLightLevel, uvFlags);
         var lightLevelAddAndMapId = VertexOptions.LightLevelAdd(mapId, lightLevelAdd);
         var lower = location == WallLocation.Lower ? 1 : 0;
         var upper = location == WallLocation.Upper ? 1 : 0;
@@ -2040,7 +2040,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->PrevV = wv.TopLeft.PrevV;
             vertex->SurfaceOptions = VertexOptions.PackSurface(1, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
-            vertex->ColorMapIndex = lightBufferIndex;
+            vertex->RenderOptions = renderOptions;
 
             // 1
             vertex++;
@@ -2056,7 +2056,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->PrevV = wv.BottomRight.PrevV;
             vertex->SurfaceOptions = VertexOptions.PackSurface(1, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
-            vertex->ColorMapIndex = lightBufferIndex;
+            vertex->RenderOptions = renderOptions;
 
             // 2
             vertex++;
@@ -2072,7 +2072,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->PrevV = wv.TopLeft.PrevV;
             vertex->SurfaceOptions = VertexOptions.PackSurface(1, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
-            vertex->ColorMapIndex = lightBufferIndex;
+            vertex->RenderOptions = renderOptions;
 
             // 3
             vertex++;
@@ -2088,7 +2088,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->PrevV = wv.BottomRight.PrevV;
             vertex->SurfaceOptions = VertexOptions.PackSurface(0, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
-            vertex->ColorMapIndex = lightBufferIndex;
+            vertex->RenderOptions = renderOptions;
 
             // 4
             vertex++;
@@ -2104,7 +2104,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->PrevV = wv.TopLeft.PrevV;
             vertex->SurfaceOptions = VertexOptions.PackSurface(0, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
-            vertex->ColorMapIndex = lightBufferIndex;
+            vertex->RenderOptions = renderOptions;
 
             // 5
             vertex++;
@@ -2120,7 +2120,7 @@ public partial class GeometryRenderer : IDisposable
             vertex->PrevV = wv.BottomRight.PrevV;
             vertex->SurfaceOptions = VertexOptions.PackSurface(0, alpha, addAlpha, upper, lower, overrideLightIndex);
             vertex->LightLevelAdd = lightLevelAddAndMapId;
-            vertex->ColorMapIndex = lightBufferIndex;
+            vertex->RenderOptions = renderOptions;
         }
 
         return data;
@@ -2129,8 +2129,8 @@ public partial class GeometryRenderer : IDisposable
     private static unsafe void GetFlatVertices(DynamicVertex[] vertices, int startIndex, ref TriangulatedWorldVertex root, ref TriangulatedWorldVertex second, ref TriangulatedWorldVertex third,
         int lightIndex, int overrideLightIndex, int flatLightLevel, int upper, int lower, int addAlpha, float alpha)
     {
-        var options = VertexOptions.PackSurface(0, alpha, addAlpha, upper, lower, overrideLightIndex);
-        float lightBufferIndex = VertexOptions.PackRender(lightIndex, flatLightLevel);
+        var surfaceOptions = VertexOptions.PackSurface(0, alpha, addAlpha, upper, lower, overrideLightIndex);
+        var renderOptions = VertexOptions.PackRender(lightIndex, flatLightLevel);
         fixed (DynamicVertex* startVertex = &vertices[startIndex])
         {
             DynamicVertex* vertex = startVertex;
@@ -2144,8 +2144,8 @@ public partial class GeometryRenderer : IDisposable
             vertex->V = root.V;
             vertex->PrevU = root.PrevU;
             vertex->PrevV = root.PrevV;
-            vertex->SurfaceOptions = options;
-            vertex->ColorMapIndex = lightBufferIndex;
+            vertex->SurfaceOptions = surfaceOptions;
+            vertex->RenderOptions = renderOptions;
 
             vertex++;
             vertex->X = second.X;
@@ -2158,8 +2158,8 @@ public partial class GeometryRenderer : IDisposable
             vertex->V = second.V;
             vertex->PrevU = second.PrevU;
             vertex->PrevV = second.PrevV;
-            vertex->SurfaceOptions = options;
-            vertex->ColorMapIndex = lightBufferIndex;
+            vertex->SurfaceOptions = surfaceOptions;
+            vertex->RenderOptions = renderOptions;
 
             vertex++;
             vertex->X = third.X;
@@ -2172,8 +2172,8 @@ public partial class GeometryRenderer : IDisposable
             vertex->V = third.V;
             vertex->PrevU = third.PrevU;
             vertex->PrevV = third.PrevV;
-            vertex->SurfaceOptions = options;
-            vertex->ColorMapIndex = lightBufferIndex;
+            vertex->SurfaceOptions = surfaceOptions;
+            vertex->RenderOptions = renderOptions;
         }
     }
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillProgram.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillProgram.cs
@@ -86,7 +86,7 @@ public class FloodFillProgram : RenderProgram
         layout(location = 4) in float prevZ;
         layout(location = 5) in float prevPlaneZ;
         layout(location = 6) in float surfaceOptions;
-        layout(location = 7) in float colorMapIndex;
+        layout(location = 7) in float renderOptions;
         layout(location = 8) in float mapId;
 
         flat out float planeZFrag;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillProgram.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillProgram.cs
@@ -85,7 +85,7 @@ public class FloodFillProgram : RenderProgram
         layout(location = 3) in float maxViewZ;
         layout(location = 4) in float prevZ;
         layout(location = 5) in float prevPlaneZ;
-        layout(location = 6) in float options;
+        layout(location = 6) in float surfaceOptions;
         layout(location = 7) in float colorMapIndex;
         layout(location = 8) in float mapId;
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillProgram.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillProgram.cs
@@ -117,11 +117,10 @@ public class FloodFillProgram : RenderProgram
             vertexPosFrag = mix(prevPos, pos, timeFrac);
             mapIdFrag = mapId;
 
-            ${ColorMapAndLightLevelSet}
-
             float alphaFrag;
             float addAlphaFrag;
             ${VertexOptionsSet}
+            ${ColorMapAndLightLevelSet}
 
             ${SectorColorMapVertexFunction}
             ${VertexLightBuffer}

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillRenderer.cs
@@ -111,7 +111,7 @@ public class FloodFillRenderer(LegacyGLTextureManager glTextureManager, FloodFil
 
         var upper = sideTexture == SideTexture.Upper ? 1 : 0;
         var lower = sideTexture == SideTexture.Lower ? 1 : 0;
-        var options = VertexOptions.World(0, 0, 0, upper, lower, data.LightIndex);
+        var options = VertexOptions.PackSurface(0, 0, 0, upper, lower, data.LightIndex);
 
         FloodFillVertex topLeft = new((vertices.TopLeft.X, vertices.TopLeft.Y, topZ),
             prevTopZ, planeZ, prevPlaneZ, minZ, maxZ, options, data.ColorMapAndLightLevel, mapId);
@@ -159,7 +159,7 @@ public class FloodFillRenderer(LegacyGLTextureManager glTextureManager, FloodFil
             lightIndex = Renderer.GetLightBufferIndex(sectorPlane.Sector, SectorPlaneFace.Ceiling, LightBufferType.Ceiling, out overrideLightIndex);
 
         var flatLightLevel = (byte)Math.Clamp(sectorPlane.LightLevelAdd, (short)0, (short)255);
-        var lightBufferIndex = VertexOptions.LightBufferIndex(lightIndex, flatLightLevel);
+        var lightBufferIndex = VertexOptions.PackRender(lightIndex, flatLightLevel);
 
         for (var node = m_freeData.First; node != null; node = node.Next)
         {
@@ -183,7 +183,7 @@ public class FloodFillRenderer(LegacyGLTextureManager glTextureManager, FloodFil
 
         var upper = sideTexture == SideTexture.Upper ? 1 : 0;
         var lower = sideTexture == SideTexture.Lower ? 1 : 0;
-        var options = VertexOptions.World(0, 0, 0, upper, lower, overrideLightIndex);
+        var options = VertexOptions.PackSurface(0, 0, 0, upper, lower, overrideLightIndex);
 
         FloodFillVertex topLeft = new((vertices.TopLeft.X, vertices.TopLeft.Y, vertices.TopLeft.Z),
             vertices.TopLeft.Z, planeZ, prevPlaneZ, minZ, maxZ, options, lightBufferIndex, mapId);
@@ -231,7 +231,7 @@ public class FloodFillRenderer(LegacyGLTextureManager glTextureManager, FloodFil
             float prevTopZ = vertices.PrevTopZ + currentAddHeight;
             float prevBottomZ = vertices.PrevBottomZ + currentAddHeight;
 
-            var options = VertexOptions.World(0, 0, 0, 0, 0, lightIndex);
+            var options = VertexOptions.PackSurface(0, 0, 0, 0, 0, lightIndex);
             FloodFillVertex topLeft = new((vertices.TopLeft.X, vertices.TopLeft.Y, topLeftZ),
                 prevTopZ, planeZ, prevPlaneZ, minZ, maxZ, options, colorMapAndLightLevel, mapId);
             FloodFillVertex topRight = new((vertices.BottomRight.X, vertices.BottomRight.Y, topLeftZ),

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillRenderer.cs
@@ -151,20 +151,14 @@ public class FloodFillRenderer(LegacyGLTextureManager glTextureManager, FloodFil
         float prevPlaneZ = (float)sectorPlane.PrevZ;
         FloodFillInfo floodFillInfo = GetOrCreateFloodFillInfo(sectorPlane);
 
-        int lightIndex, colorMapIndex;
+        int lightIndex;
         if (sectorPlane.Facing == SectorPlaneFace.Floor)
-        {
-            lightIndex = Renderer.GetLightBufferIndex(sectorPlane.Sector, SectorPlaneFace.Floor, LightBufferType.Floor);
-            colorMapIndex = Renderer.GetColorMapBufferIndex(sectorPlane.Sector, LightBufferType.Floor);
-        }
+            lightIndex = Renderer.GetLightBufferIndex(sectorPlane.Sector, SectorPlaneFace.Floor, LightBufferType.Floor, out _);
         else
-        {
-            lightIndex = Renderer.GetLightBufferIndex(sectorPlane.Sector, SectorPlaneFace.Ceiling, LightBufferType.Ceiling);
-            colorMapIndex = Renderer.GetColorMapBufferIndex(sectorPlane.Sector, LightBufferType.Ceiling);
-        }
+            lightIndex = Renderer.GetLightBufferIndex(sectorPlane.Sector, SectorPlaneFace.Ceiling, LightBufferType.Ceiling, out _);
 
         var flatLightLevel = (byte)Math.Clamp(sectorPlane.LightLevelAbsolute ? sectorPlane.LightLevel : (short)0, (short)0, (short)255);
-        var colorMapAndLightLevel = VertexOptions.ColorMapIndex(colorMapIndex, flatLightLevel);
+        var colorMapAndLightLevel = VertexOptions.ColorMapIndex(lightIndex, flatLightLevel);
 
         for (var node = m_freeData.First; node != null; node = node.Next)
         {
@@ -213,7 +207,7 @@ public class FloodFillRenderer(LegacyGLTextureManager glTextureManager, FloodFil
 
         if (isFloodFillPlane)
             ProjectFloodPlane(vbo, vbo.Data.Length, vertices, minZ, maxZ, planeZ, prevPlaneZ, lightIndex, 
-                maxPlaneZ > Constants.MaxTextureHeight ? -Constants.MaxTextureHeight : Constants.MaxTextureHeight, true, colorMapIndex, mapId);
+                maxPlaneZ > Constants.MaxTextureHeight ? -Constants.MaxTextureHeight : Constants.MaxTextureHeight, true, lightIndex, mapId);
 
         if (m_renderMode == FloodFillRenderMode.Dynamic)
             return 0;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillRenderer.cs
@@ -111,16 +111,16 @@ public class FloodFillRenderer(LegacyGLTextureManager glTextureManager, FloodFil
 
         var upper = sideTexture == SideTexture.Upper ? 1 : 0;
         var lower = sideTexture == SideTexture.Lower ? 1 : 0;
-        var options = VertexOptions.PackSurface(0, 0, 0, upper, lower, data.LightIndex);
+        var options = VertexOptions.PackSurface(0, 0, 0, upper, lower, data.OverrideLightIndex);
 
         FloodFillVertex topLeft = new((vertices.TopLeft.X, vertices.TopLeft.Y, topZ),
-            prevTopZ, planeZ, prevPlaneZ, minZ, maxZ, options, data.ColorMapAndLightLevel, mapId);
+            prevTopZ, planeZ, prevPlaneZ, minZ, maxZ, options, data.RenderOptions, mapId);
         FloodFillVertex topRight = new((vertices.BottomRight.X, vertices.BottomRight.Y, topZ),
-            prevTopZ, planeZ, prevPlaneZ, minZ, maxZ, options, data.ColorMapAndLightLevel, mapId);
+            prevTopZ, planeZ, prevPlaneZ, minZ, maxZ, options, data.RenderOptions, mapId);
         FloodFillVertex bottomLeft = new((vertices.TopLeft.X, vertices.TopLeft.Y, bottomZ),
-            prevBottomZ, planeZ, prevPlaneZ, minZ, maxZ, options, data.ColorMapAndLightLevel, mapId);
+            prevBottomZ, planeZ, prevPlaneZ, minZ, maxZ, options, data.RenderOptions, mapId);
         FloodFillVertex bottomRight = new((vertices.BottomRight.X, vertices.BottomRight.Y, bottomZ),
-            prevBottomZ, planeZ, prevPlaneZ, minZ, maxZ, options, data.ColorMapAndLightLevel, mapId);
+            prevBottomZ, planeZ, prevPlaneZ, minZ, maxZ, options, data.RenderOptions, mapId);
 
         var vbo = floodInfo.Vertices.Vbo;
         vbo.Data[data.VboOffset] = topLeft;
@@ -131,14 +131,14 @@ public class FloodFillRenderer(LegacyGLTextureManager glTextureManager, FloodFil
         vbo.Data[data.VboOffset + 5] = bottomRight;
 
         if (isFloodFillPlane)
-            ProjectFloodPlane(vbo, data.VboOffset + VerticesPerWall, vertices, minZ, maxZ, planeZ, prevPlaneZ, data.LightIndex,
-                maxPlaneZ > Constants.MaxTextureHeight ? -Constants.MaxTextureHeight : Constants.MaxTextureHeight, false, data.ColorMapAndLightLevel, mapId);
+            ProjectFloodPlane(vbo, data.VboOffset + VerticesPerWall, vertices, minZ, maxZ, planeZ, prevPlaneZ, data.OverrideLightIndex,
+                maxPlaneZ > Constants.MaxTextureHeight ? -Constants.MaxTextureHeight : Constants.MaxTextureHeight, false, data.RenderOptions, mapId);
 
         vbo.Bind();
         vbo.UploadSubData(data.VboOffset, data.Vertices);
     }
 
-    public int AddStaticWall(SectorPlane sectorPlane, WallVertices vertices, double minPlaneZ, double maxPlaneZ,
+    public int AddStaticWall(SectorPlane sectorPlane, in WallVertices vertices, double minPlaneZ, double maxPlaneZ,
         SideTexture sideTexture, int mapId, bool isFloodFillPlane = false)
     {
         if (m_textureManager != null && m_textureManager.IsSkyTexture(sectorPlane.TextureHandle))
@@ -217,7 +217,7 @@ public class FloodFillRenderer(LegacyGLTextureManager glTextureManager, FloodFil
     }
 
     private static void ProjectFloodPlane(VertexBufferObject<FloodFillVertex> vbo, int startIndex,
-       WallVertices vertices, float minZ, float maxZ, float planeZ, float prevPlaneZ, int lightIndex, int addHeight, bool add, float colorMapAndLightLevel, int mapId)
+       WallVertices vertices, float minZ, float maxZ, float planeZ, float prevPlaneZ, int overrideLightIndex, int addHeight, bool add, float renderOptions, int mapId)
     {
         int newLength = startIndex + FloodPlaneAddCount * VerticesPerWall;
         vbo.Data.EnsureCapacity(newLength);
@@ -231,15 +231,15 @@ public class FloodFillRenderer(LegacyGLTextureManager glTextureManager, FloodFil
             float prevTopZ = vertices.PrevTopZ + currentAddHeight;
             float prevBottomZ = vertices.PrevBottomZ + currentAddHeight;
 
-            var options = VertexOptions.PackSurface(0, 0, 0, 0, 0, lightIndex);
+            var surfaceOptions = VertexOptions.PackSurface(0, 0, 0, 0, 0, overrideLightIndex);
             FloodFillVertex topLeft = new((vertices.TopLeft.X, vertices.TopLeft.Y, topLeftZ),
-                prevTopZ, planeZ, prevPlaneZ, minZ, maxZ, options, colorMapAndLightLevel, mapId);
+                prevTopZ, planeZ, prevPlaneZ, minZ, maxZ, surfaceOptions, renderOptions, mapId);
             FloodFillVertex topRight = new((vertices.BottomRight.X, vertices.BottomRight.Y, topLeftZ),
-                prevTopZ, planeZ, prevPlaneZ, minZ, maxZ, options, colorMapAndLightLevel, mapId);
+                prevTopZ, planeZ, prevPlaneZ, minZ, maxZ, surfaceOptions, renderOptions, mapId);
             FloodFillVertex bottomLeft = new((vertices.TopLeft.X, vertices.TopLeft.Y, bottomRightZ),
-                prevBottomZ, planeZ, prevPlaneZ, minZ, maxZ, lightIndex, colorMapAndLightLevel, mapId);
+                prevBottomZ, planeZ, prevPlaneZ, minZ, maxZ, surfaceOptions, renderOptions, mapId);
             FloodFillVertex bottomRight = new((vertices.BottomRight.X, vertices.BottomRight.Y, bottomRightZ),
-                prevBottomZ, planeZ, prevPlaneZ, minZ, maxZ, options, colorMapAndLightLevel, mapId);
+                prevBottomZ, planeZ, prevPlaneZ, minZ, maxZ, surfaceOptions, renderOptions, mapId);
 
             buffer[startIndex++] = topLeft;
             buffer[startIndex++] = bottomLeft;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillRenderer.cs
@@ -158,7 +158,7 @@ public class FloodFillRenderer(LegacyGLTextureManager glTextureManager, FloodFil
         else
             lightIndex = Renderer.GetLightBufferIndex(sectorPlane.Sector, SectorPlaneFace.Ceiling, LightBufferType.Ceiling, out overrideLightIndex);
 
-        var flatLightLevel = (byte)Math.Clamp(sectorPlane.LightLevelAbsolute ? sectorPlane.LightLevel : (short)0, (short)0, (short)255);
+        var flatLightLevel = (byte)Math.Clamp(sectorPlane.LightLevelAdd, (short)0, (short)255);
         var lightBufferIndex = VertexOptions.LightBufferIndex(lightIndex, flatLightLevel);
 
         for (var node = m_freeData.First; node != null; node = node.Next)
@@ -170,7 +170,7 @@ public class FloodFillRenderer(LegacyGLTextureManager glTextureManager, FloodFil
             m_freeData.Remove(node);
             m_freeNodes.Add(node);
 
-            m_floodGeometry[data.Key - 1] = new(data.Key, data.TextureHandle, lightIndex, overrideLightIndex, data.VboOffset, data.Vertices);
+            m_floodGeometry[data.Key - 1] = new(data.Key, data.TextureHandle, overrideLightIndex, lightBufferIndex, data.VboOffset, data.Vertices);
             UpdateStaticWall(data.Key, sectorPlane, vertices, minPlaneZ, maxPlaneZ, sideTexture, mapId);
             return data.Key;
         }
@@ -179,11 +179,11 @@ public class FloodFillRenderer(LegacyGLTextureManager glTextureManager, FloodFil
         int newKey = m_floodGeometry.Length + 1;
         var vbo = floodFillInfo.Vertices.Vbo;
 
-        m_floodGeometry.Add(new FloodGeometry(newKey, floodFillInfo.TextureHandle, lightIndex, overrideLightIndex, vbo.Count, vertexCount));
+        m_floodGeometry.Add(new FloodGeometry(newKey, floodFillInfo.TextureHandle, overrideLightIndex, lightBufferIndex, vbo.Count, vertexCount));
 
         var upper = sideTexture == SideTexture.Upper ? 1 : 0;
         var lower = sideTexture == SideTexture.Lower ? 1 : 0;
-        var options = VertexOptions.World(0, 0, 0, upper, lower, lightIndex);
+        var options = VertexOptions.World(0, 0, 0, upper, lower, overrideLightIndex);
 
         FloodFillVertex topLeft = new((vertices.TopLeft.X, vertices.TopLeft.Y, vertices.TopLeft.Z),
             vertices.TopLeft.Z, planeZ, prevPlaneZ, minZ, maxZ, options, lightBufferIndex, mapId);
@@ -216,7 +216,7 @@ public class FloodFillRenderer(LegacyGLTextureManager glTextureManager, FloodFil
         return newKey;
     }
 
-    private static unsafe void ProjectFloodPlane(VertexBufferObject<FloodFillVertex> vbo, int startIndex,
+    private static void ProjectFloodPlane(VertexBufferObject<FloodFillVertex> vbo, int startIndex,
        WallVertices vertices, float minZ, float maxZ, float planeZ, float prevPlaneZ, int lightIndex, int addHeight, bool add, float colorMapAndLightLevel, int mapId)
     {
         int newLength = startIndex + FloodPlaneAddCount * VerticesPerWall;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillRenderer.cs
@@ -152,13 +152,14 @@ public class FloodFillRenderer(LegacyGLTextureManager glTextureManager, FloodFil
         FloodFillInfo floodFillInfo = GetOrCreateFloodFillInfo(sectorPlane);
 
         int lightIndex;
+        int overrideLightIndex;
         if (sectorPlane.Facing == SectorPlaneFace.Floor)
-            lightIndex = Renderer.GetLightBufferIndex(sectorPlane.Sector, SectorPlaneFace.Floor, LightBufferType.Floor, out _);
+            lightIndex = Renderer.GetLightBufferIndex(sectorPlane.Sector, SectorPlaneFace.Floor, LightBufferType.Floor, out overrideLightIndex);
         else
-            lightIndex = Renderer.GetLightBufferIndex(sectorPlane.Sector, SectorPlaneFace.Ceiling, LightBufferType.Ceiling, out _);
+            lightIndex = Renderer.GetLightBufferIndex(sectorPlane.Sector, SectorPlaneFace.Ceiling, LightBufferType.Ceiling, out overrideLightIndex);
 
         var flatLightLevel = (byte)Math.Clamp(sectorPlane.LightLevelAbsolute ? sectorPlane.LightLevel : (short)0, (short)0, (short)255);
-        var colorMapAndLightLevel = VertexOptions.ColorMapIndex(lightIndex, flatLightLevel);
+        var lightBufferIndex = VertexOptions.LightBufferIndex(lightIndex, flatLightLevel);
 
         for (var node = m_freeData.First; node != null; node = node.Next)
         {
@@ -169,7 +170,7 @@ public class FloodFillRenderer(LegacyGLTextureManager glTextureManager, FloodFil
             m_freeData.Remove(node);
             m_freeNodes.Add(node);
 
-            m_floodGeometry[data.Key - 1] = new(data.Key, data.TextureHandle, lightIndex, colorMapAndLightLevel, data.VboOffset, data.Vertices);
+            m_floodGeometry[data.Key - 1] = new(data.Key, data.TextureHandle, lightIndex, overrideLightIndex, data.VboOffset, data.Vertices);
             UpdateStaticWall(data.Key, sectorPlane, vertices, minPlaneZ, maxPlaneZ, sideTexture, mapId);
             return data.Key;
         }
@@ -178,20 +179,20 @@ public class FloodFillRenderer(LegacyGLTextureManager glTextureManager, FloodFil
         int newKey = m_floodGeometry.Length + 1;
         var vbo = floodFillInfo.Vertices.Vbo;
 
-        m_floodGeometry.Add(new FloodGeometry(newKey, floodFillInfo.TextureHandle, lightIndex, colorMapAndLightLevel, vbo.Count, vertexCount));
+        m_floodGeometry.Add(new FloodGeometry(newKey, floodFillInfo.TextureHandle, lightIndex, overrideLightIndex, vbo.Count, vertexCount));
 
         var upper = sideTexture == SideTexture.Upper ? 1 : 0;
         var lower = sideTexture == SideTexture.Lower ? 1 : 0;
         var options = VertexOptions.World(0, 0, 0, upper, lower, lightIndex);
 
         FloodFillVertex topLeft = new((vertices.TopLeft.X, vertices.TopLeft.Y, vertices.TopLeft.Z),
-            vertices.TopLeft.Z, planeZ, prevPlaneZ, minZ, maxZ, options, colorMapAndLightLevel, mapId);
+            vertices.TopLeft.Z, planeZ, prevPlaneZ, minZ, maxZ, options, lightBufferIndex, mapId);
         FloodFillVertex topRight = new((vertices.BottomRight.X, vertices.BottomRight.Y, vertices.TopLeft.Z),
-            vertices.TopLeft.Z, planeZ, prevPlaneZ, minZ, maxZ, options, colorMapAndLightLevel, mapId);
+            vertices.TopLeft.Z, planeZ, prevPlaneZ, minZ, maxZ, options, lightBufferIndex, mapId);
         FloodFillVertex bottomLeft = new((vertices.TopLeft.X, vertices.TopLeft.Y, vertices.BottomRight.Z),
-            vertices.BottomRight.Z, planeZ, prevPlaneZ, minZ, maxZ, options, colorMapAndLightLevel, mapId);
+            vertices.BottomRight.Z, planeZ, prevPlaneZ, minZ, maxZ, options, lightBufferIndex, mapId);
         FloodFillVertex bottomRight = new((vertices.BottomRight.X, vertices.BottomRight.Y, vertices.BottomRight.Z),
-            vertices.BottomRight.Z, planeZ, prevPlaneZ, minZ, maxZ, options, colorMapAndLightLevel, mapId);
+            vertices.BottomRight.Z, planeZ, prevPlaneZ, minZ, maxZ, options, lightBufferIndex, mapId);
 
         int offset = vbo.Data.Length;
         int newLength = vbo.Data.Length + VerticesPerWall;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillVertex.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillVertex.cs
@@ -5,7 +5,7 @@ using Helion.Render.OpenGL.Vertex;
 namespace Helion.Render.OpenGL.Renderers.Legacy.World.Geometry.Portals.FloodFill;
 
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public struct FloodFillVertex(Vec3F pos, float prevZ, float planeZ, float prevPlaneZ, float minPlaneZ, float maxPlaneZ, float options, float colorMapAndLightLevel, int mapId)
+public struct FloodFillVertex(Vec3F pos, float prevZ, float planeZ, float prevPlaneZ, float minPlaneZ, float maxPlaneZ, float surfaceOptions, float renderOptions, int mapId)
 {
     [VertexAttribute("pos", size: 3)]
     public Vec3F Pos = pos;
@@ -26,10 +26,10 @@ public struct FloodFillVertex(Vec3F pos, float prevZ, float planeZ, float prevPl
     public float PrevPlaneZ = prevPlaneZ;
 
     [VertexAttribute("surfaceOptions", size: 1)]
-    public float SurfaceOptions = options;
+    public float SurfaceOptions = surfaceOptions;
 
-    [VertexAttribute("colorMapIndex", size: 1)]
-    public float ColorMapIndex = colorMapAndLightLevel;
+    [VertexAttribute("renderOptions", size: 1)]
+    public float RenderOptions = renderOptions;
 
     [VertexAttribute("mapId", size: 1, required: false)]
     public float MapId = mapId;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillVertex.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillVertex.cs
@@ -25,10 +25,10 @@ public struct FloodFillVertex(Vec3F pos, float prevZ, float planeZ, float prevPl
     [VertexAttribute("prevPlaneZ", size: 1)]
     public float PrevPlaneZ = prevPlaneZ;
 
-    [VertexAttribute("options", size: 1)]
-    public float Options = options;
+    [VertexAttribute("surfaceOptions", size: 1)]
+    public float SurfaceOptions = options;
 
-    [VertexAttribute("colorMapIndex", size: 1, required: false)]
+    [VertexAttribute("colorMapIndex", size: 1)]
     public float ColorMapIndex = colorMapAndLightLevel;
 
     [VertexAttribute("mapId", size: 1, required: false)]

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodGeometry.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodGeometry.cs
@@ -1,11 +1,11 @@
 ﻿namespace Helion.Render.OpenGL.Renderers.Legacy.World.Geometry.Portals.FloodFill;
 
-public readonly struct FloodGeometry(int key, int textureHandle, int lightIndex, float colorMapAndLightLevel, int vboOffset, int vertices)
+public readonly struct FloodGeometry(int key, int textureHandle, int overrideLightIndex, float renderOptions, int vboOffset, int vertices)
 {
     public readonly int Key = key;
     public readonly int TextureHandle = textureHandle;
-    public readonly int LightIndex = lightIndex;
-    public readonly float ColorMapAndLightLevel = colorMapAndLightLevel;
+    public readonly int OverrideLightIndex = overrideLightIndex;
+    public readonly float RenderOptions = renderOptions;
     public readonly int VboOffset = vboOffset;
     public readonly int Vertices = vertices;
 }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
@@ -622,7 +622,7 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
             {
                 DynamicVertex* v = startVertex + i;
                 staticVertices.Data[staticStartIndex + i] = new StaticVertex(v->X, v->Y, v->Z, v->U, v->V,
-                    v->Options, v->LightLevelAdd, v->ColorMapIndex);
+                    v->SurfaceOptions, v->LightLevelAdd, v->ColorMapIndex);
             }
 
             staticVertices.SetLength(staticVertices.Length + vertices.Length);
@@ -637,7 +637,7 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
             {
                 DynamicVertex* v = startVertex + i;
                 staticVertices[index + i] = new StaticVertex(v->X, v->Y, v->Z, v->U, v->V,
-                    v->Options, v->LightLevelAdd, v->ColorMapIndex);
+                    v->SurfaceOptions, v->LightLevelAdd, v->ColorMapIndex);
             }
         }
     }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
@@ -622,7 +622,7 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
             {
                 DynamicVertex* v = startVertex + i;
                 staticVertices.Data[staticStartIndex + i] = new StaticVertex(v->X, v->Y, v->Z, v->U, v->V,
-                    v->SurfaceOptions, v->LightLevelAdd, v->ColorMapIndex);
+                    v->SurfaceOptions, v->LightLevelAdd, v->RenderOptions);
             }
 
             staticVertices.SetLength(staticVertices.Length + vertices.Length);
@@ -637,7 +637,7 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
             {
                 DynamicVertex* v = startVertex + i;
                 staticVertices[index + i] = new StaticVertex(v->X, v->Y, v->Z, v->U, v->V,
-                    v->SurfaceOptions, v->LightLevelAdd, v->ColorMapIndex);
+                    v->SurfaceOptions, v->LightLevelAdd, v->RenderOptions);
             }
         }
     }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
@@ -105,7 +105,7 @@ public class InterpolationShader : RenderProgram
 
         layout(location = 0) in vec3 pos;
         layout(location = 1) in vec2 uv;
-        layout(location = 2) in float options;
+        layout(location = 2) in float surfaceOptions;
         layout(location = 3) in float lightLevelAdd;
         layout(location = 4) in vec3 prevPos;
         layout(location = 5) in vec2 prevUV;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
@@ -109,7 +109,7 @@ public class InterpolationShader : RenderProgram
         layout(location = 3) in float lightLevelAdd;
         layout(location = 4) in vec3 prevPos;
         layout(location = 5) in vec2 prevUV;
-        layout(location = 6) in float colorMapIndex;
+        layout(location = 6) in float renderOptions;
 
         out vec2 uvFrag;
         flat out float alphaFrag;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/VertexFunction.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/VertexFunction.cs
@@ -45,7 +45,7 @@ public static class VertexFunction
 
     public static string ColorMapAndLightLevelSet =>
         @"            
-            int lightLevelIndexAndLightLevel = floatBitsToInt(colorMapIndex);
+            int lightLevelIndexAndLightLevel = floatBitsToInt(renderOptions);
             vertexLightLevelFrag = float(lightLevelIndexAndLightLevel & 0xFF);
             float lightLevelBufferIndex = float((lightLevelIndexAndLightLevel >> 10) & 0x3FFFFF);
             colorMapIndexFrag = lightLevelBufferIndex;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/VertexFunction.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/VertexFunction.cs
@@ -35,7 +35,7 @@ public static class VertexFunction
 
     public static string VertexOptionsSet =>
         @"  
-            int intOptions = floatBitsToInt(options);
+            int intOptions = floatBitsToInt(surfaceOptions);
             alphaFrag = (intOptions & 0xFF) / 255.0;
             float topLeft = float((intOptions >> 8) & 1);
             addAlphaFrag = float((intOptions >> 9) & 1);

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/VertexFunction.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/VertexFunction.cs
@@ -41,14 +41,16 @@ public static class VertexFunction
             addAlphaFrag = float((intOptions >> 9) & 1);
             upperFrag = float((intOptions >> 10) & 1);
             lowerFrag =  float((intOptions >> 11) & 1);
-            float lightLevelBufferIndex = float(intOptions >> 12);";
+            float overrideLightIndex = float(float(intOptions >> 12));";
 
     public static string ColorMapAndLightLevelSet =>
         @"            
-            int colorMapAndLightLevel = floatBitsToInt(colorMapIndex);
-            vertexLightLevelFrag = float(colorMapAndLightLevel & 0xFF);
-            colorMapIndexFrag = float((colorMapAndLightLevel >> 10) & 0x3FFFFF);
-            uvFlags = float((colorMapAndLightLevel >> 8) & 0x3);";
+            int lightLevelIndexAndLightLevel = floatBitsToInt(colorMapIndex);
+            vertexLightLevelFrag = float(lightLevelIndexAndLightLevel & 0xFF);
+            float lightLevelBufferIndex = float((lightLevelIndexAndLightLevel >> 10) & 0x3FFFFF);
+            colorMapIndexFrag = lightLevelBufferIndex;
+            lightLevelBufferIndex = mix(lightLevelBufferIndex, overrideLightIndex - 1, float(overrideLightIndex > 0));
+            uvFlags = float((lightLevelIndexAndLightLevel >> 8) & 0x3);";
 
     public static string LightLevelAddAndMapIdSet =>
         @"

--- a/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
@@ -104,7 +104,7 @@ public class StaticShader : RenderProgram
         layout(location = 1) in vec2 uv;
         layout(location = 2) in float lightLevelAdd;
         layout(location = 3) in float surfaceOptions;
-        layout(location = 4) in float colorMapIndex;
+        layout(location = 4) in float renderOptions;
 
         out vec2 uvFrag;
         flat out float alphaFrag;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
@@ -103,7 +103,7 @@ public class StaticShader : RenderProgram
         layout(location = 0) in vec3 pos;
         layout(location = 1) in vec2 uv;
         layout(location = 2) in float lightLevelAdd;
-        layout(location = 3) in float options;
+        layout(location = 3) in float surfaceOptions;
         layout(location = 4) in float colorMapIndex;
 
         out vec2 uvFrag;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/StaticVertex.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/StaticVertex.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 namespace Helion.Render.OpenGL.Renderers.Legacy.World;
 
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-public struct StaticVertex(float x, float y, float z, float u, float v, float options, float lightLevelAdd, float colorMapIndex)
+public struct StaticVertex(float x, float y, float z, float u, float v, float surfaceOptions, float lightLevelAdd, float renderOptions)
 {
     [VertexAttribute("pos", size: 3)]
     public float X = x;
@@ -19,8 +19,8 @@ public struct StaticVertex(float x, float y, float z, float u, float v, float op
     public float LightLevelAdd = lightLevelAdd;
 
     [VertexAttribute]
-    public float SurfaceOptions = options;
+    public float SurfaceOptions = surfaceOptions;
 
-    [VertexAttribute(required: false)]
-    public float ColorMapIndex = colorMapIndex;
+    [VertexAttribute]
+    public float RenderOptions = renderOptions;
 }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/StaticVertex.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/StaticVertex.cs
@@ -19,7 +19,7 @@ public struct StaticVertex(float x, float y, float z, float u, float v, float op
     public float LightLevelAdd = lightLevelAdd;
 
     [VertexAttribute]
-    public float Options = options;
+    public float SurfaceOptions = options;
 
     [VertexAttribute(required: false)]
     public float ColorMapIndex = colorMapIndex;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/VertexOptions.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/VertexOptions.cs
@@ -14,10 +14,10 @@ public static class VertexOptions
     }
 
     // UvFlags only required for walls
-    public static unsafe float ColorMapIndex(int colorMapIndex, int vertexLightLevel, UvFlags uvFlags = UvFlags.Normal)
+    public static unsafe float LightBufferIndex(int lightIndex, int vertexLightLevel, UvFlags uvFlags = UvFlags.Normal)
     {
-        // colorMapIndex 22 bits, uvFlags 2 bits, vertexLightLevel 8 bits
-        int packed = ((colorMapIndex & 0x3FFFFF) << 10) | (((int)uvFlags & 0x3) << 8) | (vertexLightLevel & 0xFF);
+        // lightIndex 22 bits, uvFlags 2 bits, vertexLightLevel 8 bits
+        int packed = ((lightIndex & 0x3FFFFF) << 10) | (((int)uvFlags & 0x3) << 8) | (vertexLightLevel & 0xFF);
         return *(float*)&packed;
     }
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/VertexOptions.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/VertexOptions.cs
@@ -5,6 +5,7 @@ namespace Helion.Render.OpenGL.Renderers.Legacy.World;
 
 public static class VertexOptions
 {
+    // When overrideLightIndex is non-zero then lighting uses index overrideLightIndex - 1
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe float PackSurface(int topLeft, float alpha, int addAlpha, int upper, int lower, int overrideLightIndex)
     {

--- a/Core/Render/OpenGL/Renderers/Legacy/World/VertexOptions.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/VertexOptions.cs
@@ -6,10 +6,10 @@ namespace Helion.Render.OpenGL.Renderers.Legacy.World;
 public static class VertexOptions
 {
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static unsafe float World(int topLeft, float alpha, int addAlpha, int upper, int lower, int lightLevelBufferIndex)
+    public static unsafe float World(int topLeft, float alpha, int addAlpha, int upper, int lower, int overrideLightIndex)
     {
         int alphaByte = (int)(alpha * 255.0f);
-        int packed = (alphaByte & 0xFF) | (topLeft << 8) | (addAlpha << 9) | (upper << 10) | (lower << 11) | (lightLevelBufferIndex << 12);
+        int packed = (alphaByte & 0xFF) | (topLeft << 8) | (addAlpha << 9) | (upper << 10) | (lower << 11) | (overrideLightIndex << 12);
         return *(float*)&packed;
     }
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/VertexOptions.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/VertexOptions.cs
@@ -6,15 +6,16 @@ namespace Helion.Render.OpenGL.Renderers.Legacy.World;
 public static class VertexOptions
 {
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static unsafe float World(int topLeft, float alpha, int addAlpha, int upper, int lower, int overrideLightIndex)
+    public static unsafe float PackSurface(int topLeft, float alpha, int addAlpha, int upper, int lower, int overrideLightIndex)
     {
         int alphaByte = (int)(alpha * 255.0f);
         int packed = (alphaByte & 0xFF) | (topLeft << 8) | (addAlpha << 9) | (upper << 10) | (lower << 11) | (overrideLightIndex << 12);
         return *(float*)&packed;
     }
-
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     // UvFlags only required for walls
-    public static unsafe float LightBufferIndex(int lightIndex, int vertexLightLevel, UvFlags uvFlags = UvFlags.Normal)
+    public static unsafe float PackRender(int lightIndex, int vertexLightLevel, UvFlags uvFlags = UvFlags.Normal)
     {
         // lightIndex 22 bits, uvFlags 2 bits, vertexLightLevel 8 bits
         int packed = ((lightIndex & 0x3FFFFF) << 10) | (((int)uvFlags & 0x3) << 8) | (vertexLightLevel & 0xFF);

--- a/Core/Render/OpenGL/Renderers/Legacy/World/VertexOptions.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/VertexOptions.cs
@@ -35,7 +35,7 @@ public static class VertexOptions
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static unsafe float Entity(float alpha, int fuzz, int flipU, int colormap, int lightLevel)
+    public static unsafe float EntityPackSurface(float alpha, int fuzz, int flipU, int colormap, int lightLevel)
     {
         int alphaByte = (int)(alpha * 255.0f);
         int packed = (alphaByte & 0xFF) | (fuzz << 8) | (flipU << 9) | (Math.Clamp(lightLevel, 0, 255) << 10) | (colormap << 18);
@@ -43,14 +43,14 @@ public static class VertexOptions
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static unsafe float EntityColorMapAndRenderIndex(int colorMapIndex, int renderIndex)
+    public static unsafe float EntityPackRender(int colorMapIndex, int renderIndex)
     {
         int packed = colorMapIndex << 16 | renderIndex;
         return *(float*)&packed;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static unsafe float EntityXYZ(int offsetXY, int offsetZ)
+    public static unsafe float EntityPackXYZ(int offsetXY, int offsetZ)
     {
         // Shift negative bit for mask to get absolute value and sign bit to remove branches
         int maskXY = offsetXY >> 31;

--- a/Core/Render/Renderer.World.cs
+++ b/Core/Render/Renderer.World.cs
@@ -41,24 +41,21 @@ public partial class Renderer
     private float[] m_mapBufferData = [];
     private float[] m_lineHeightsBufferData = [];
 
-    public static int GetLightBufferIndex(Side side, Wall wall, Sector sector)
+    const int VectorSize = 4;
+
+    public static int GetLightBufferIndex(Side side, Wall wall, Sector sector, out int overrideLightIndex)
     {
         // The shader will add the light level at this index plus the vertex light level.
         // Return LightBuffer.DarkIndex (lightlevel=0) to not add the sectors light level if absolute.
-        if (side.Flags.LightLevelAbsolute || wall.LightLevelAbsolute)
-            return LightBuffer.DarkIndex;
-
+        overrideLightIndex = side.Flags.LightLevelAbsolute || wall.LightLevelAbsolute ? 1 : 0;
         return GetLightBufferIndex(sector, LightBufferType.Wall);
     }
 
-    public static int GetLightBufferIndex(Sector sector, SectorPlaneFace planeType, LightBufferType type)
+    public static int GetLightBufferIndex(Sector sector, SectorPlaneFace planeType, LightBufferType type, out int overrideLightIndex)
     {
         var transferLightSector = planeType == SectorPlaneFace.Floor ? sector.TransferFloorLightSector : sector.TransferCeilingLightSector;
         var plane = transferLightSector.GetSectorPlane(planeType);
-
-        if (plane.LightLevelAbsolute)
-            return LightBuffer.DarkIndex;
-
+        overrideLightIndex = plane.LightLevelAbsolute ? 1 : 0;
         return GetLightBufferIndex(sector, type);
     }
 
@@ -70,17 +67,6 @@ public partial class Renderer
             LightBufferType.Ceiling => sector.TransferCeilingLightSector.Id * LightBuffer.BufferSize + LightBuffer.SectorIndexStart + LightBuffer.CeilingOffset,
             LightBufferType.Wall => sector.Id * LightBuffer.BufferSize + LightBuffer.SectorIndexStart + LightBuffer.WallOffset,
             _ => sector.Id * LightBuffer.BufferSize + LightBuffer.SectorIndexStart,
-        };
-    }
-
-    public static int GetColorMapBufferIndex(Sector sector, LightBufferType type)
-    {
-        return type switch
-        {
-            LightBufferType.Floor => (sector.TransferFloorLightSector.Id + 1) * LightBuffer.BufferSize + LightBuffer.FloorOffset,
-            LightBufferType.Ceiling => (sector.TransferCeilingLightSector.Id + 1) * LightBuffer.BufferSize + LightBuffer.CeilingOffset,
-            LightBufferType.Wall => (sector.Id + 1) * LightBuffer.BufferSize + LightBuffer.WallOffset,
-            _ => sector.Id + 1,
         };
     }
 
@@ -130,7 +116,7 @@ public partial class Renderer
         if (alloc || m_lightBufferStorage == null)
         {
             m_lightBufferStorage?.Dispose();
-            m_lightBufferData = new byte[world.Sectors.Count * LightBuffer.BufferSize + LightBuffer.SectorIndexStart];
+            m_lightBufferData = AllocLightSectorBufferBuffer<byte>(world);
             m_lightBufferStorage = new("Sector lights texture buffer", m_lightBufferData, SizedInternalFormat.R8ui, GLInfo.MapPersistentBitSupported);
 
             m_lightBufferStorage.Map(data =>
@@ -158,7 +144,7 @@ public partial class Renderer
 
         for (int i = 0; i < world.Sectors.Count; i++)
         {
-            Sector sector = world.Sectors[i];
+            var sector = world.Sectors[i];
             var lightLevel = (byte)Math.Clamp(sector.LightLevel, (short)0, (short)255);
             int index = sector.Id * LightBuffer.BufferSize + LightBuffer.SectorIndexStart;
             lightBuffer[index + LightBuffer.FloorOffset] = lightLevel;
@@ -211,14 +197,8 @@ public partial class Renderer
     {
         if (alloc || m_sectorColorMapsBuffer == null)
         {
-            // First index will always map to default colormap
-            int sectorBufferCount = (world.Sectors.Count + 1) * LightBuffer.BufferSize;
-            // PaletteColorMode is index to colormap, true color will be RGB mix
-            int size = 4;
-            var sectorBuffer = new float[sectorBufferCount * size];
-
             m_sectorColorMapsBuffer?.Dispose();
-            m_sectorColorMapsBuffer = new("Sector colormaps", sectorBuffer, SizedInternalFormat.Rgba32f, GLInfo.MapPersistentBitSupported);
+            m_sectorColorMapsBuffer = new("Sector colormaps", AllocLightSectorBufferBuffer<float>(world), SizedInternalFormat.Rgba32f, GLInfo.MapPersistentBitSupported);
         }
 
         if (alloc)
@@ -238,18 +218,18 @@ public partial class Renderer
         }
     }
 
+    private static T[] AllocLightSectorBufferBuffer<T>(IWorld world) where T : struct
+    {
+        var sectorBufferCount = world.Sectors.Count * LightBuffer.BufferSize + LightBuffer.SectorIndexStart;
+        return new T[sectorBufferCount * VectorSize];
+    }
+
     private unsafe void SetSectorFogBuffer(IWorld world, bool alloc)
     {
         if (alloc || m_sectorFogBuffer == null)
         {
-            // First index will always map to default colormap
-            int sectorBufferCount = (world.Sectors.Count + 1) * LightBuffer.BufferSize;
-            // PaletteColorMode is index to colormap, true color will be RGB mix
-            int size = 4;
-            var sectorBuffer = new float[sectorBufferCount * size];
-
             m_sectorFogBuffer?.Dispose();
-            m_sectorFogBuffer = new("Sector fog", sectorBuffer, SizedInternalFormat.Rgba32f, GLInfo.MapPersistentBitSupported);
+            m_sectorFogBuffer = new("Sector fog", AllocLightSectorBufferBuffer<float>(world), SizedInternalFormat.Rgba32f, GLInfo.MapPersistentBitSupported);
         }
 
         if (alloc)
@@ -293,13 +273,22 @@ public partial class Renderer
 
     private static unsafe void SetSectorFog(float* fadeBuffer, int sectorId, Color fadeColor, short lightLevel, float fogDensity)
     {
-        int index = (sectorId + 1) * LightBuffer.BufferSize;
-        const int VectorSize = 4;
-
+        int index = sectorId * LightBuffer.BufferSize + LightBuffer.SectorIndexStart;
         var fade = GetSectorFogDensity(fadeColor, lightLevel, fogDensity);
+
         *(Vec4F*)&fadeBuffer[(index + LightBuffer.FloorOffset) * VectorSize] = fade;
         *(Vec4F*)&fadeBuffer[(index + LightBuffer.CeilingOffset) * VectorSize] = fade;
         *(Vec4F*)&fadeBuffer[(index + LightBuffer.WallOffset) * VectorSize] = fade;
+    }
+
+    private static unsafe void SetSectorColorMap(float* colorMapBuffer, Sector sector, Colormap? colormap)
+    {
+        int index = sector.Id * LightBuffer.BufferSize + LightBuffer.SectorIndexStart;
+        var setColor = GetSectorSetColor(colormap);
+
+        *(Vec3F*)&colorMapBuffer[(index + LightBuffer.FloorOffset) * VectorSize] = setColor;
+        *(Vec3F*)&colorMapBuffer[(index + LightBuffer.CeilingOffset) * VectorSize] = setColor;
+        *(Vec3F*)&colorMapBuffer[(index + LightBuffer.WallOffset) * VectorSize] = setColor;
     }
 
     private static Vec4F GetSectorFogDensity(Color fadeColor, short lightLevel, float fogDensity)
@@ -314,18 +303,6 @@ public partial class Renderer
             fogDensity *= FadeFactor;
 
         return new(fadeColor.R / 255f, fadeColor.G / 255f, fadeColor.B / 255f, fogDensity);
-    }
-
-    private static unsafe void SetSectorColorMap(float* colorMapBuffer, Sector sector, Colormap? colormap)
-    {
-        int index = (sector.Id + 1) * LightBuffer.BufferSize;
-
-        const int VectorSize = 4;
-        var setColor = GetSectorSetColor(colormap);
-
-        *(Vec3F*)&colorMapBuffer[(index + LightBuffer.FloorOffset) * VectorSize] = setColor;
-        *(Vec3F*)&colorMapBuffer[(index + LightBuffer.CeilingOffset) * VectorSize] = setColor;
-        *(Vec3F*)&colorMapBuffer[(index + LightBuffer.WallOffset) * VectorSize] = setColor;
     }
 
     private static Vec3F GetSectorSetColor(Colormap? colormap)

--- a/Core/Render/Renderer.World.cs
+++ b/Core/Render/Renderer.World.cs
@@ -25,23 +25,19 @@ public partial class Renderer
         Both = 3
     }
 
+    private unsafe delegate void SetLightBufferPtrAction<T>(IWorld world, T* data);
+
     private readonly SectorUpdates m_updateLightSectors = new();
     private readonly SectorUpdates m_updateColorMapSectors = new();
     private readonly SectorUpdates m_updateFogColorSectors = new();
     private readonly SectorUpdates m_updateLineHeights = new();
 
-    private GLBufferTextureStorage<byte>? m_lightBufferStorage;
+    private GLBufferTextureStorage<byte>? m_sectorLightsBuffer;
     private GLBufferTextureStorage<float>? m_sectorColorMapsBuffer;
     private GLBufferTextureStorage<float>? m_sectorFogBuffer;
     private GLBufferTextureStorage<float>? m_colorMapBuffer;
     private GLBufferTextureStorage<float>? m_mapDataBuffer;
     private GLBufferTextureStorage<float>? m_lineHeightsBuffer;
-
-    private byte[] m_lightBufferData = [];
-    private float[] m_mapBufferData = [];
-    private float[] m_lineHeightsBufferData = [];
-
-    const int VectorSize = 4;
 
     public static int GetLightBufferIndex(Side side, Wall wall, Sector sector, out int overrideLightIndex)
     {
@@ -70,7 +66,7 @@ public partial class Renderer
         };
     }
 
-    public void UpdateToNewWorld(IWorld world)
+    public unsafe void UpdateToNewWorld(IWorld world)
     {
         m_lastDrawWorldCmd = default;
         m_updateLightSectors.ClearAndReset();
@@ -105,56 +101,16 @@ public partial class Renderer
 
         var alloc = !m_world.SameAsPreviousMap;
         SetMapDataBuffer(world, alloc);
-        SetLightDataBuffer(world, alloc);
-        SetSectorColorMapsBuffer(world, alloc);
-        SetSectorFogBuffer(world, alloc);
+        m_sectorLightsBuffer = InitLightBuffer(world, alloc, m_sectorLightsBuffer, InitLightBuffer, "Sector light levels", SizedInternalFormat.R8ui);
+        m_sectorColorMapsBuffer = InitLightBuffer(world, alloc, m_sectorColorMapsBuffer, InitSectorColorMap, "Sector colormaps", SizedInternalFormat.Rgba32f);
+        m_sectorFogBuffer = InitLightBuffer(world, alloc, m_sectorFogBuffer, InitSectorFogBuffer, "Sector fog", SizedInternalFormat.Rgba32f);
         SetLineHeights(world, alloc);
-    }
-
-    private unsafe void SetLightDataBuffer(IWorld world, bool alloc)
-    {
-        if (alloc || m_lightBufferStorage == null)
-        {
-            m_lightBufferStorage?.Dispose();
-            m_lightBufferData = AllocLightSectorArray<byte>(world);
-            m_lightBufferStorage = new("Sector lights texture buffer", m_lightBufferData, SizedInternalFormat.R8ui, GLInfo.MapPersistentBitSupported);
-
-            m_lightBufferStorage.Map(data =>
-            {
-                var lightBuffer = (byte*)data.ToPointer();
-                SetLightBuffer(world, lightBuffer);
-            });
-        }
-        else
-        {
-            var lightBuffer = m_lightBufferStorage.GetMappedBufferAndBind();
-            SetLightBuffer(world, lightBuffer.MappedMemoryPtr);
-            m_lightBufferStorage.Unbind();
-        }
-    }
-
-    private unsafe void SetLightBuffer(IWorld world, byte* lightBuffer)
-    {        
-        lightBuffer[LightBuffer.DarkIndex] = 0;
-        lightBuffer[LightBuffer.FullBrightIndex] = 255;
-
-        for (int i = 0; i < LightBuffer.ColorMapCount; i++)
-            lightBuffer[LightBuffer.ColorMapStartIndex + i] =
-                (byte)(256 - ((LightBuffer.ColorMapCount - i) * 256 / LightBuffer.ColorMapCount));
-
-        for (int i = 0; i < world.Sectors.Count; i++)
-        {
-            var sector = world.Sectors[i];
-            var lightLevel = sector.GetByteLightLevel();
-            SetSectorLight(lightBuffer, sector, lightLevel);
-        }
     }
 
     private unsafe void SetLineHeights(IWorld world, bool alloc)
     {
         if (!world.Config.Render.VanillaRender)
         {
-            m_lineHeightsBufferData = [];
             m_lineHeightsBuffer?.Dispose();
             m_lineHeightsBuffer = null;
             return;
@@ -163,8 +119,7 @@ public partial class Renderer
         if (alloc || m_lineHeightsBuffer == null)
         {
             m_lineHeightsBuffer?.Dispose();
-            m_lineHeightsBufferData = new float[world.Lines.Count * GLBufferTextureStorage<float>.FourComponentLength];
-            m_lineHeightsBuffer = new("Line heights data buffer", m_lineHeightsBufferData, SizedInternalFormat.Rgba32f, GLInfo.MapPersistentBitSupported);
+            m_lineHeightsBuffer = new("Line heights data buffer", new float[world.Lines.Count * GLBufferTextureStorage<float>.FourComponentLength], SizedInternalFormat.Rgba32f, GLInfo.MapPersistentBitSupported);
 
             m_lineHeightsBuffer.Map(data =>
             {
@@ -190,59 +145,50 @@ public partial class Renderer
         }
     }
 
+    private static unsafe GLBufferTextureStorage<T> InitLightBuffer<T>(IWorld world, bool alloc, GLBufferTextureStorage<T>? bufferStorage, 
+        SetLightBufferPtrAction<T> setAction, string name, SizedInternalFormat format) where T : struct
+    {
+        if (alloc || bufferStorage == null)
+        {
+            bufferStorage?.Dispose();
+            bufferStorage = new(name, AllocLightSectorArray<T>(world), format, GLInfo.MapPersistentBitSupported);
+
+            bufferStorage.Map(data =>
+            {
+                var lightBuffer = (T*)data.ToPointer();
+                setAction(world, lightBuffer);
+            });
+        }
+        else
+        {
+            var lightBuffer = bufferStorage.GetMappedBufferAndBind();
+            setAction(world, lightBuffer.MappedMemoryPtr);
+            bufferStorage.Unbind();
+        }
+
+        return bufferStorage;
+    }
+
     private static T[] AllocLightSectorArray<T>(IWorld world) where T : struct
     {
         var sectorBufferCount = world.Sectors.Count * LightBuffer.BufferSize + LightBuffer.SectorIndexStart;
-        return new T[sectorBufferCount * VectorSize];
+        return new T[sectorBufferCount * GLBufferTextureStorage<float>.FourComponentLength];
     }
 
-    private unsafe void SetSectorColorMapsBuffer(IWorld world, bool alloc)
+    private unsafe void InitLightBuffer(IWorld world, byte* lightBuffer)
     {
-        if (alloc || m_sectorColorMapsBuffer == null)
-        {
-            m_sectorColorMapsBuffer?.Dispose();
-            m_sectorColorMapsBuffer = new("Sector colormaps", AllocLightSectorArray<float>(world), SizedInternalFormat.Rgba32f, GLInfo.MapPersistentBitSupported);
-        }
+        lightBuffer[LightBuffer.DarkIndex] = 0;
+        lightBuffer[LightBuffer.FullBrightIndex] = 255;
 
-        if (alloc)
-        {
-            m_sectorColorMapsBuffer.Map(data =>
-            {
-                float* colorMapBuffer = (float*)data.ToPointer();
-                InitSectorColorMap(world, colorMapBuffer);
-            });
-        }
-        else
-        {
-            var mappedBuffer = m_sectorColorMapsBuffer.GetMappedBufferAndBind();
-            float* colorMapBuffer = mappedBuffer.MappedMemoryPtr;
-            InitSectorColorMap(world, colorMapBuffer);
-            m_sectorColorMapsBuffer.Unbind();
-        }
-    }
+        for (int i = 0; i < LightBuffer.ColorMapCount; i++)
+            lightBuffer[LightBuffer.ColorMapStartIndex + i] =
+                (byte)(256 - ((LightBuffer.ColorMapCount - i) * 256 / LightBuffer.ColorMapCount));
 
-    private unsafe void SetSectorFogBuffer(IWorld world, bool alloc)
-    {
-        if (alloc || m_sectorFogBuffer == null)
+        for (int i = 0; i < world.Sectors.Count; i++)
         {
-            m_sectorFogBuffer?.Dispose();
-            m_sectorFogBuffer = new("Sector fog", AllocLightSectorArray<float>(world), SizedInternalFormat.Rgba32f, GLInfo.MapPersistentBitSupported);
-        }
-
-        if (alloc)
-        {
-            m_sectorFogBuffer.Map(data =>
-            {
-                float* fogBuffer = (float*)data.ToPointer();
-                InitSectorFogBuffer(world, fogBuffer);
-            });
-        }
-        else
-        {
-            var mappedBuffer = m_sectorFogBuffer.GetMappedBufferAndBind();
-            float* fadeBuffer = mappedBuffer.MappedMemoryPtr;
-            InitSectorFogBuffer(world, fadeBuffer);
-            m_sectorFogBuffer.Unbind();
+            var sector = world.Sectors[i];
+            var lightLevel = sector.GetByteLightLevel();
+            SetSectorLight(lightBuffer, sector, lightLevel);
         }
     }
 
@@ -273,9 +219,9 @@ public partial class Renderer
         var index = sectorId * LightBuffer.BufferSize + LightBuffer.SectorIndexStart;
         var fade = GetSectorFogDensity(fadeColor, lightLevel, fogDensity);
 
-        *(Vec4F*)&fadeBuffer[(index + LightBuffer.FloorOffset) * VectorSize] = fade;
-        *(Vec4F*)&fadeBuffer[(index + LightBuffer.CeilingOffset) * VectorSize] = fade;
-        *(Vec4F*)&fadeBuffer[(index + LightBuffer.WallOffset) * VectorSize] = fade;
+        *(Vec4F*)&fadeBuffer[(index + LightBuffer.FloorOffset) * GLBufferTextureStorage<float>.FourComponentLength] = fade;
+        *(Vec4F*)&fadeBuffer[(index + LightBuffer.CeilingOffset) * GLBufferTextureStorage<float>.FourComponentLength] = fade;
+        *(Vec4F*)&fadeBuffer[(index + LightBuffer.WallOffset) * GLBufferTextureStorage<float>.FourComponentLength] = fade;
     }
 
     private static unsafe void SetSectorColorMap(float* colorMapBuffer, Sector sector, Colormap? colormap)
@@ -283,9 +229,9 @@ public partial class Renderer
         var index = sector.Id * LightBuffer.BufferSize + LightBuffer.SectorIndexStart;
         var setColor = GetSectorSetColor(colormap);
 
-        *(Vec3F*)&colorMapBuffer[(index + LightBuffer.FloorOffset) * VectorSize] = setColor;
-        *(Vec3F*)&colorMapBuffer[(index + LightBuffer.CeilingOffset) * VectorSize] = setColor;
-        *(Vec3F*)&colorMapBuffer[(index + LightBuffer.WallOffset) * VectorSize] = setColor;
+        *(Vec3F*)&colorMapBuffer[(index + LightBuffer.FloorOffset) * GLBufferTextureStorage<float>.FourComponentLength] = setColor;
+        *(Vec3F*)&colorMapBuffer[(index + LightBuffer.CeilingOffset) * GLBufferTextureStorage<float>.FourComponentLength] = setColor;
+        *(Vec3F*)&colorMapBuffer[(index + LightBuffer.WallOffset) * GLBufferTextureStorage<float>.FourComponentLength] = setColor;
     }
 
     private static Vec4F GetSectorFogDensity(Color fadeColor, short lightLevel, float fogDensity)
@@ -321,7 +267,6 @@ public partial class Renderer
     {
         if (!world.Config.Render.VanillaRender)
         {
-            m_mapBufferData = [];
             m_mapDataBuffer?.Dispose();
             m_mapDataBuffer = null;
             return;
@@ -331,8 +276,7 @@ public partial class Renderer
             return;
 
         m_mapDataBuffer?.Dispose();
-        m_mapBufferData = new float[world.Lines.Count * 6];
-        m_mapDataBuffer = new("Map data buffer", m_mapBufferData, SizedInternalFormat.Rgba32f, false);
+        m_mapDataBuffer = new("Map data buffer", new float[world.Lines.Count * 6], SizedInternalFormat.Rgba32f, false);
 
         m_mapDataBuffer.Map(data =>
         {
@@ -426,10 +370,10 @@ public partial class Renderer
 
     private unsafe void UpdateLights()
     {
-        if (m_updateLightSectors.UpdateSectors.Length == 0 || m_lightBufferStorage == null || m_sectorFogBuffer == null)
+        if (m_updateLightSectors.UpdateSectors.Length == 0 || m_sectorLightsBuffer == null || m_sectorFogBuffer == null)
             return;
 
-        var lightBuffer = m_lightBufferStorage.GetMappedBufferAndBind();
+        var lightBuffer = m_sectorLightsBuffer.GetMappedBufferAndBind();
         var lightData = lightBuffer.MappedMemoryPtr;
 
         var fogBuffer = m_sectorFogBuffer.GetMappedBufferAndBind();
@@ -443,7 +387,8 @@ public partial class Renderer
             SetSectorFog(fogData, sector.Id, sector.FogColor, lightLevel, sector.FogDensity);
         }
 
-        m_lightBufferStorage.Unbind();
+        m_sectorLightsBuffer.Unbind();
+        m_sectorFogBuffer.Unbind();
     }
 
     private unsafe void SetSectorLight(byte* lightData, Sector sector, byte lightLevel)

--- a/Core/Render/Renderer.World.cs
+++ b/Core/Render/Renderer.World.cs
@@ -47,7 +47,7 @@ public partial class Renderer
     {
         // The shader will add the light level at this index plus the vertex light level.
         // Return LightBuffer.DarkIndex (lightlevel=0) to not add the sectors light level if absolute.
-        overrideLightIndex = side.Flags.LightLevelAbsolute || wall.LightLevelAbsolute ? 1 : 0;
+        overrideLightIndex = side.Flags.LightLevelAbsolute || wall.LightLevelAbsolute ? LightBuffer.DarkIndex + 1 : 0;
         return GetLightBufferIndex(sector, LightBufferType.Wall);
     }
 
@@ -55,7 +55,7 @@ public partial class Renderer
     {
         var transferLightSector = planeType == SectorPlaneFace.Floor ? sector.TransferFloorLightSector : sector.TransferCeilingLightSector;
         var plane = transferLightSector.GetSectorPlane(planeType);
-        overrideLightIndex = plane.LightLevelAbsolute ? 1 : 0;
+        overrideLightIndex = plane.LightLevelAbsolute ? LightBuffer.DarkIndex + 1 : 0;
         return GetLightBufferIndex(sector, type);
     }
 
@@ -116,7 +116,7 @@ public partial class Renderer
         if (alloc || m_lightBufferStorage == null)
         {
             m_lightBufferStorage?.Dispose();
-            m_lightBufferData = AllocLightSectorBufferBuffer<byte>(world);
+            m_lightBufferData = AllocLightSectorArray<byte>(world);
             m_lightBufferStorage = new("Sector lights texture buffer", m_lightBufferData, SizedInternalFormat.R8ui, GLInfo.MapPersistentBitSupported);
 
             m_lightBufferStorage.Map(data =>
@@ -145,11 +145,8 @@ public partial class Renderer
         for (int i = 0; i < world.Sectors.Count; i++)
         {
             var sector = world.Sectors[i];
-            var lightLevel = (byte)Math.Clamp(sector.LightLevel, (short)0, (short)255);
-            int index = sector.Id * LightBuffer.BufferSize + LightBuffer.SectorIndexStart;
-            lightBuffer[index + LightBuffer.FloorOffset] = lightLevel;
-            lightBuffer[index + LightBuffer.CeilingOffset] = lightLevel;
-            lightBuffer[index + LightBuffer.WallOffset] = lightLevel;
+            var lightLevel = sector.GetByteLightLevel();
+            SetSectorLight(lightBuffer, sector, lightLevel);
         }
     }
 
@@ -193,12 +190,18 @@ public partial class Renderer
         }
     }
 
+    private static T[] AllocLightSectorArray<T>(IWorld world) where T : struct
+    {
+        var sectorBufferCount = world.Sectors.Count * LightBuffer.BufferSize + LightBuffer.SectorIndexStart;
+        return new T[sectorBufferCount * VectorSize];
+    }
+
     private unsafe void SetSectorColorMapsBuffer(IWorld world, bool alloc)
     {
         if (alloc || m_sectorColorMapsBuffer == null)
         {
             m_sectorColorMapsBuffer?.Dispose();
-            m_sectorColorMapsBuffer = new("Sector colormaps", AllocLightSectorBufferBuffer<float>(world), SizedInternalFormat.Rgba32f, GLInfo.MapPersistentBitSupported);
+            m_sectorColorMapsBuffer = new("Sector colormaps", AllocLightSectorArray<float>(world), SizedInternalFormat.Rgba32f, GLInfo.MapPersistentBitSupported);
         }
 
         if (alloc)
@@ -218,18 +221,12 @@ public partial class Renderer
         }
     }
 
-    private static T[] AllocLightSectorBufferBuffer<T>(IWorld world) where T : struct
-    {
-        var sectorBufferCount = world.Sectors.Count * LightBuffer.BufferSize + LightBuffer.SectorIndexStart;
-        return new T[sectorBufferCount * VectorSize];
-    }
-
     private unsafe void SetSectorFogBuffer(IWorld world, bool alloc)
     {
         if (alloc || m_sectorFogBuffer == null)
         {
             m_sectorFogBuffer?.Dispose();
-            m_sectorFogBuffer = new("Sector fog", AllocLightSectorBufferBuffer<float>(world), SizedInternalFormat.Rgba32f, GLInfo.MapPersistentBitSupported);
+            m_sectorFogBuffer = new("Sector fog", AllocLightSectorArray<float>(world), SizedInternalFormat.Rgba32f, GLInfo.MapPersistentBitSupported);
         }
 
         if (alloc)
@@ -273,7 +270,7 @@ public partial class Renderer
 
     private static unsafe void SetSectorFog(float* fadeBuffer, int sectorId, Color fadeColor, short lightLevel, float fogDensity)
     {
-        int index = sectorId * LightBuffer.BufferSize + LightBuffer.SectorIndexStart;
+        var index = sectorId * LightBuffer.BufferSize + LightBuffer.SectorIndexStart;
         var fade = GetSectorFogDensity(fadeColor, lightLevel, fogDensity);
 
         *(Vec4F*)&fadeBuffer[(index + LightBuffer.FloorOffset) * VectorSize] = fade;
@@ -283,7 +280,7 @@ public partial class Renderer
 
     private static unsafe void SetSectorColorMap(float* colorMapBuffer, Sector sector, Colormap? colormap)
     {
-        int index = sector.Id * LightBuffer.BufferSize + LightBuffer.SectorIndexStart;
+        var index = sector.Id * LightBuffer.BufferSize + LightBuffer.SectorIndexStart;
         var setColor = GetSectorSetColor(colormap);
 
         *(Vec3F*)&colorMapBuffer[(index + LightBuffer.FloorOffset) * VectorSize] = setColor;
@@ -441,15 +438,20 @@ public partial class Renderer
         for (int i = 0; i < m_updateLightSectors.UpdateSectors.Length; i++)
         {
             var sector = m_updateLightSectors.UpdateSectors[i];
-            var level = (byte)Math.Clamp(sector.LightLevel, (short)0, (short)255);
-            var index = sector.Id * LightBuffer.BufferSize + LightBuffer.SectorIndexStart;
-            lightData[index + LightBuffer.FloorOffset] = level;
-            lightData[index + LightBuffer.CeilingOffset] = level;
-            lightData[index + LightBuffer.WallOffset] = level;
-            SetSectorFog(fogData, sector.Id, sector.FogColor, level, sector.FogDensity);
+            var lightLevel = sector.GetByteLightLevel();
+            SetSectorLight(lightData, sector, lightLevel);
+            SetSectorFog(fogData, sector.Id, sector.FogColor, lightLevel, sector.FogDensity);
         }
 
         m_lightBufferStorage.Unbind();
+    }
+
+    private unsafe void SetSectorLight(byte* lightData, Sector sector, byte lightLevel)
+    {
+        var index = sector.Id * LightBuffer.BufferSize + LightBuffer.SectorIndexStart;
+        lightData[index + LightBuffer.FloorOffset] = lightLevel;
+        lightData[index + LightBuffer.CeilingOffset] = lightLevel;
+        lightData[index + LightBuffer.WallOffset] = lightLevel;
     }
 
     private unsafe void UpdateColorMaps()

--- a/Core/Render/Renderer.cs
+++ b/Core/Render/Renderer.cs
@@ -981,7 +981,7 @@ public partial class Renderer : IDisposable
         m_worldRenderer.Dispose();
         m_framebufferRenderer.Dispose();
         m_automapRenderer.Dispose();
-        m_lightBufferStorage?.Dispose();
+        m_sectorLightsBuffer?.Dispose();
         m_sectorColorMapsBuffer?.Dispose();
         m_sectorFogBuffer?.Dispose();
         m_transitionRenderer?.Dispose();

--- a/Core/Render/Renderer.cs
+++ b/Core/Render/Renderer.cs
@@ -633,7 +633,7 @@ public partial class Renderer : IDisposable
 
     private void BindLightBuffer()
     {
-        m_lightBufferStorage?.BindTexture(BindTextures.SectorLight);
+        m_sectorLightsBuffer?.BindTexture(BindTextures.SectorLight);
     }
 
     private void BindMapDataBuffer()

--- a/Core/World/Geometry/Builder/UdmfGeometryBuilder.cs
+++ b/Core/World/Geometry/Builder/UdmfGeometryBuilder.cs
@@ -48,7 +48,7 @@ public class UdmfGeometryBuilder
             offsets.Scale.Y = mapSector.ScaleFloorY;
 
             var floorPlane = CreateSectorPlane(mapSector, SectorPlaneFace.Floor, textureManager, offsets);
-            floorPlane.LightLevel = mapSector.LightFloor;
+            floorPlane.LightLevelSet = mapSector.LightFloor;
             floorPlane.LightLevelAbsolute = mapSector.LightFloorAbsolute;
 
             offsets = default;
@@ -61,7 +61,7 @@ public class UdmfGeometryBuilder
             offsets.Scale.Y = mapSector.ScaleCeilingY;
 
             var ceilingPlane = CreateSectorPlane(mapSector, SectorPlaneFace.Ceiling, textureManager, offsets);
-            ceilingPlane.LightLevel = mapSector.LightCeiling;
+            ceilingPlane.LightLevelSet = mapSector.LightCeiling;
             ceilingPlane.LightLevelAbsolute = mapSector.LightCeilingAbsolute;
 
             GetSectorSpecial(mapSector, needsTranslation, out var sectorSpecial, out var sectorData);

--- a/Core/World/Geometry/Builder/UdmfGeometryBuilder.cs
+++ b/Core/World/Geometry/Builder/UdmfGeometryBuilder.cs
@@ -48,7 +48,7 @@ public class UdmfGeometryBuilder
             offsets.Scale.Y = mapSector.ScaleFloorY;
 
             var floorPlane = CreateSectorPlane(mapSector, SectorPlaneFace.Floor, textureManager, offsets);
-            floorPlane.LightLevelSet = mapSector.LightFloor;
+            floorPlane.LightLevelAdd = mapSector.LightFloor;
             floorPlane.LightLevelAbsolute = mapSector.LightFloorAbsolute;
 
             offsets = default;
@@ -61,7 +61,7 @@ public class UdmfGeometryBuilder
             offsets.Scale.Y = mapSector.ScaleCeilingY;
 
             var ceilingPlane = CreateSectorPlane(mapSector, SectorPlaneFace.Ceiling, textureManager, offsets);
-            ceilingPlane.LightLevelSet = mapSector.LightCeiling;
+            ceilingPlane.LightLevelAdd = mapSector.LightCeiling;
             ceilingPlane.LightLevelAbsolute = mapSector.LightCeilingAbsolute;
 
             GetSectorSpecial(mapSector, needsTranslation, out var sectorSpecial, out var sectorData);

--- a/Core/World/Geometry/Sectors/Sector.cs
+++ b/Core/World/Geometry/Sectors/Sector.cs
@@ -17,8 +17,10 @@ using Helion.World.Geometry.Sides;
 using Helion.World.Special;
 using Helion.World.Special.Specials;
 using Helion.World.Static;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using static Helion.World.Entities.EntityManager;
 using Vector2D = Helion.Models.Vector2D;
 
@@ -233,6 +235,9 @@ public sealed class Sector : IFloorCeilingAnchor
 
     public short FloorRenderLightLevel => TransferFloorLightSector.Floor.LightLevel;
     public short CeilingRenderLightLevel => TransferCeilingLightSector.Ceiling.LightLevel;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public byte GetByteLightLevel() => (byte)Math.Clamp(LightLevel, (short)0, (short)255);
 
     public void SetFriction(double friction)
     {

--- a/Core/World/Geometry/Sectors/SectorPlane.cs
+++ b/Core/World/Geometry/Sectors/SectorPlane.cs
@@ -23,6 +23,7 @@ public sealed class SectorPlane : ISoundSource
     public double PrevZ;
     public int TextureHandle;
     public short LightLevel;
+    public short LightLevelAdd;
     public int LastRenderChangeGametick;
     public int LastRenderGametick;
     public int Id;

--- a/Tests/Unit/GameAction/Udmf/UdmfMap.cs
+++ b/Tests/Unit/GameAction/Udmf/UdmfMap.cs
@@ -228,7 +228,8 @@ public class UdmfMap
         sector.Ceiling.RenderOffsets.Offset.Y.Should().Be(48);
         sector.Ceiling.RenderOffsets.Scale.X.Should().Be(3);
         sector.Ceiling.RenderOffsets.Scale.Y.Should().Be(2);
-        sector.Ceiling.LightLevel.Should().Be(64);
+        sector.Ceiling.LightLevel.Should().Be(96);
+        sector.Ceiling.LightLevelAdd.Should().Be(64);
         sector.Ceiling.LightLevelAbsolute.Should().BeFalse();
         sector.Ceiling.RenderOffsets.Rotate.Should().Be(MathHelper.ToRadians(160));
 
@@ -236,7 +237,8 @@ public class UdmfMap
         sector.Floor.RenderOffsets.Offset.Y.Should().Be(24);
         sector.Floor.RenderOffsets.Scale.X.Should().Be(0.5);
         sector.Floor.RenderOffsets.Scale.Y.Should().Be(0.6);
-        sector.Floor.LightLevel.Should().Be(128);
+        sector.Floor.LightLevel.Should().Be(96);
+        sector.Floor.LightLevelAdd.Should().Be(128);
         sector.Floor.LightLevelAbsolute.Should().BeTrue();
         sector.Floor.RenderOffsets.Rotate.Should().Be(MathHelper.ToRadians(45));
 


### PR DESCRIPTION
Unify sector light, color, and fog color to use same buffer method that allows the index to be the same. This removes the separated light index and color index for color and fog and merges them into the same index.

This also frees up 20 bits of space in the SurfaceOptions float for future use.

Fixes incorrect absolute light level handling of flats in UDMF.

