### PR TITLE
don't write colors when pixel is fully transparent so they stay black

### DIFF
--- a/Core/Graphics/Image.cs
+++ b/Core/Graphics/Image.cs
@@ -140,23 +140,25 @@ public class Image
             foreach (ref TPixel pixel in pixelRow)
             {
                 pixel.ToRgba32(ref tempPixel);
-
-                argbData[offset] = tempPixel.A;
-                argbData[offset + 1] = tempPixel.R;
-                argbData[offset + 2] = tempPixel.G;
-                argbData[offset + 3] = tempPixel.B;
-
-                if (indices != null && paletteTranslation != null && paletteTranslationColorLookup != null && tempPixel.A != 0)
+                if (tempPixel.A != 0)
                 {
-                    var nearestIndex = paletteTranslationColorLookup.GetIndex(tempPixel.R, tempPixel.G, tempPixel.B);
-                    indices[index] = nearestIndex;
+                    argbData[offset] = tempPixel.A;
+                    argbData[offset + 1] = tempPixel.R;
+                    argbData[offset + 2] = tempPixel.G;
+                    argbData[offset + 3] = tempPixel.B;
 
-                    if (colorTranslation != null)
+                    if (indices != null && paletteTranslation != null && paletteTranslationColorLookup != null && tempPixel.A != 0)
                     {
-                        var color = paletteTranslation.DefaultLayer[colorTranslation[nearestIndex]];
-                        argbData[offset + 1] = color.R;
-                        argbData[offset + 2] = color.G;
-                        argbData[offset + 3] = color.B;
+                        var nearestIndex = paletteTranslationColorLookup.GetIndex(tempPixel.R, tempPixel.G, tempPixel.B);
+                        indices[index] = nearestIndex;
+
+                        if (colorTranslation != null)
+                        {
+                            var color = paletteTranslation.DefaultLayer[colorTranslation[nearestIndex]];
+                            argbData[offset + 1] = color.R;
+                            argbData[offset + 2] = color.G;
+                            argbData[offset + 3] = color.B;
+                        }
                     }
                 }
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -28,6 +28,7 @@
 - Right-extend "block" characters in ENDOOM to emulate VGA "line graphics enable" mode.
 - Fix A_Refire not calling noise alert.
 - Match Doom behavior in the thing tick function that wouldn't advance the state for zero duration frames and leave them in a -1 loop.
+- Fix PNGs with fully transparent pixels loading colors that causes rendering issues when used with texture filtering.
 
 ## Misc:
 - Refactor of old Status Bar renderer to data-driven SBARDEF format.


### PR DESCRIPTION
SD21_PNG was rendering incorrectly when paired with bilinear/trilinear texture filtering. This is because the fully transparent pixels in the images were RGB 255,255,255 instead of zero so the colors were being blended and appear even worse with the additive color blending. 