### PR TITLE
entity light index fix

### DIFF
--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
@@ -176,8 +176,8 @@ public class EntityProgram : RenderProgram
             colorMapTranslationOut = (intOptions >> 18);
 
             intOptions = floatBitsToInt(renderOptions);
-            int lightIndexInt = intOptions >> 16;
-            int renderIndex = intOptions & 0xFFFF;
+            int lightIndexInt = (intOptions >> 12) & 0xFFFFF;
+            int renderIndex = intOptions & 0xFFF;
 
             intOptions = floatBitsToInt(offsetXYZ);
             offsetXYOut = (intOptions >> 16) & 0x3FFF;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/VertexOptions.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/VertexOptions.cs
@@ -43,9 +43,9 @@ public static class VertexOptions
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static unsafe float EntityPackRender(int colorMapIndex, int renderIndex)
+    public static unsafe float EntityPackRender(int lightIndex, int renderIndex)
     {
-        int packed = colorMapIndex << 16 | renderIndex;
+        int packed = (lightIndex << 12) | (renderIndex & 0xFFF);
         return *(float*)&packed;
     }
 


### PR DESCRIPTION
increase size for the light index in the entity render options since large maps can overflow past 65536