### PR TITLE
Add pool for entity sprite render data

### DIFF
--- a/Core/Render/OpenGL/Renderers/Legacy/Hud/HudDrawBufferData.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/Hud/HudDrawBufferData.cs
@@ -7,7 +7,7 @@ public class HudDrawBufferData(GLLegacyTexture texture, GLLegacyTexture? brightm
 {
     public GLLegacyTexture Texture = texture;
     public GLLegacyTexture? BrightmapTexture = brightmapTexture;
-    public readonly DynamicArray<HudVertex> Vertices = new(128);
+    public readonly DynamicArray<HudVertex> Vertices = new(128, arrayPool: true);
 
     public void Set(GLLegacyTexture texture, GLLegacyTexture? brightmapTexture = null)
     {

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Data/RenderData.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Data/RenderData.cs
@@ -1,11 +1,14 @@
-﻿using System;
-using System.Diagnostics.CodeAnalysis;
-using Helion.Render.OpenGL.Buffer.Array.Vertex;
+﻿using Helion.Render.OpenGL.Buffer.Array.Vertex;
+using Helion.Render.OpenGL.Renderers.Legacy.World.Entities;
 using Helion.Render.OpenGL.Shader;
 using Helion.Render.OpenGL.Texture.Legacy;
 using Helion.Render.OpenGL.Vertex;
+using Helion.Resources;
 using Helion.Util.Container;
+using Helion.World;
 using OpenTK.Graphics.OpenGL;
+using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Helion.Render.OpenGL.Renderers.Legacy.World.Data;
 
@@ -18,16 +21,25 @@ public class RenderData<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTyp
     public DynamicArray<TVertex> ArrayData;
     public int RenderCount;
     private bool m_disposed;
+
+    public RenderData(GLLegacyTexture texture, RenderProgram program, GLLegacyTexture? brightmapTexture = null) : this(program)
+    {
+        Set(texture, brightmapTexture);
+    }
+
+    public RenderData(RenderProgram program)
+    {
+        Vao = new("Entity VAO");
+        Vbo = new("Entity VBO");
+        Attributes.BindAndApply(Vbo, Vao, program.Attributes);
+        ArrayData = Vbo.Data;
+        Texture = null!;
+    }
     
-    public RenderData(GLLegacyTexture texture, RenderProgram program, GLLegacyTexture? brightmapTexture = null)
+    public void Set(GLLegacyTexture texture, GLLegacyTexture? brightmapTexture = null)
     {
         Texture = texture;
         BrightmapTexture = brightmapTexture;
-        Vao = new($"Attributes for {texture.Name}");
-        Vbo = new($"Vertices for {texture.Name}");
-        ArrayData = Vbo.Data;
-
-        Attributes.BindAndApply(Vbo, Vao, program.Attributes);
     }
 
     ~RenderData()

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Data/RenderData.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Data/RenderData.cs
@@ -1,11 +1,8 @@
 ﻿using Helion.Render.OpenGL.Buffer.Array.Vertex;
-using Helion.Render.OpenGL.Renderers.Legacy.World.Entities;
 using Helion.Render.OpenGL.Shader;
 using Helion.Render.OpenGL.Texture.Legacy;
 using Helion.Render.OpenGL.Vertex;
-using Helion.Resources;
 using Helion.Util.Container;
-using Helion.World;
 using OpenTK.Graphics.OpenGL;
 using System;
 using System.Diagnostics.CodeAnalysis;
@@ -17,14 +14,14 @@ public class RenderData<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTyp
     public DynamicVertexBuffer<TVertex> Vbo;
     public VertexArrayObject Vao;
     public GLLegacyTexture Texture;
-    public GLLegacyTexture? BrightmapTexture;
+    public GLLegacyTexture? BrightMapTexture;
     public DynamicArray<TVertex> ArrayData;
     public int RenderCount;
     private bool m_disposed;
 
-    public RenderData(GLLegacyTexture texture, RenderProgram program, GLLegacyTexture? brightmapTexture = null) : this(program)
+    public RenderData(RenderProgram program, GLLegacyTexture texture, GLLegacyTexture? brightMapTexture = null) : this(program)
     {
-        Set(texture, brightmapTexture);
+        Set(texture, brightMapTexture);
     }
 
     public RenderData(RenderProgram program)
@@ -36,10 +33,10 @@ public class RenderData<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTyp
         Texture = null!;
     }
     
-    public void Set(GLLegacyTexture texture, GLLegacyTexture? brightmapTexture = null)
+    public void Set(GLLegacyTexture texture, GLLegacyTexture? brightMapTexture = null)
     {
         Texture = texture;
-        BrightmapTexture = brightmapTexture;
+        BrightMapTexture = brightMapTexture;
     }
 
     ~RenderData()
@@ -60,8 +57,8 @@ public class RenderData<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTyp
         GL.ActiveTexture(BindTextures.BoundTexture);
         Texture.Bind();
         GL.ActiveTexture(BindTextures.BrightmapTexture);
-        if (BrightmapTexture != null)
-            BrightmapTexture.Bind();
+        if (BrightMapTexture != null)
+            BrightMapTexture.Bind();
         else
             GL.BindTexture(TextureTarget.Texture2D, 0);
         Vao.Bind();

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Data/RenderDataCollection.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Data/RenderDataCollection.cs
@@ -17,16 +17,17 @@ namespace Helion.Render.OpenGL.Renderers.Legacy.World.Data;
 /// </summary>
 public class RenderDataCollection<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TVertex> : IDisposable where TVertex : struct
 {
-    const int GrowthSize = 1024;
     private readonly DynamicArray<RenderData<TVertex>?> m_allRenderData = new(2048);
     private readonly DynamicArray<RenderData<TVertex>> m_dataToRender = new(2048);
     private readonly RenderProgram m_program;
+    private readonly RenderDataPool<TVertex> m_renderDataPool;
     private int m_renderCount;
     private bool m_disposed;
     
-    public RenderDataCollection(RenderProgram program)
+    public RenderDataCollection(RenderProgram program, RenderDataPool<TVertex> renderDataPool)
     {
         m_program = program;
+        m_renderDataPool = renderDataPool;
     }
 
     ~RenderDataCollection()
@@ -54,11 +55,7 @@ public class RenderDataCollection<[DynamicallyAccessedMembers(DynamicallyAccesse
         
         if (data == null)
         {
-            if (WorldStatic.DataCache != null && typeof(TVertex) == typeof(EntityVertex))
-                data = (WorldStatic.DataCache.GetEntityRenderData(texture, m_program, brightmapTexture) as RenderData<TVertex>)!;
-            else
-                data = new(texture, m_program, brightmapTexture);
-
+            data = m_renderDataPool.Get(texture, brightmapTexture);
             data.RenderCount = m_renderCount - 1;
             m_allRenderData[texture.TextureId] = data;
         }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Data/RenderDataCollection.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Data/RenderDataCollection.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
+using Helion.Render.OpenGL.Renderers.Legacy.World.Entities;
 using Helion.Render.OpenGL.Shader;
 using Helion.Render.OpenGL.Texture.Legacy;
 using Helion.Util.Container;
+using Helion.Util.Loggers;
+using Helion.World;
 using OpenTK.Graphics.OpenGL;
 
 namespace Helion.Render.OpenGL.Renderers.Legacy.World.Data;
@@ -14,8 +17,9 @@ namespace Helion.Render.OpenGL.Renderers.Legacy.World.Data;
 /// </summary>
 public class RenderDataCollection<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TVertex> : IDisposable where TVertex : struct
 {
-    private readonly DynamicArray<RenderData<TVertex>?> m_allRenderData = new();
-    private readonly DynamicArray<RenderData<TVertex>> m_dataToRender = new();
+    const int GrowthSize = 1024;
+    private readonly DynamicArray<RenderData<TVertex>?> m_allRenderData = new(2048);
+    private readonly DynamicArray<RenderData<TVertex>> m_dataToRender = new(2048);
     private readonly RenderProgram m_program;
     private int m_renderCount;
     private bool m_disposed;
@@ -45,14 +49,17 @@ public class RenderDataCollection<[DynamicallyAccessedMembers(DynamicallyAccesse
     
     public RenderData<TVertex> Get(GLLegacyTexture texture, GLLegacyTexture? brightmapTexture = null)
     {
-        if (texture.TextureId >= m_allRenderData.Length)
-            ResizeToSupportIndex(texture.TextureId);
-
+        m_allRenderData.EnsureCapacity(texture.TextureId + 1);
         RenderData<TVertex>? data = m_allRenderData[texture.TextureId];
         
         if (data == null)
         {
-            data = new(texture, m_program, brightmapTexture) { RenderCount = m_renderCount - 1 };
+            if (WorldStatic.DataCache != null && typeof(TVertex) == typeof(EntityVertex))
+                data = (WorldStatic.DataCache.GetEntityRenderData(texture, m_program, brightmapTexture) as RenderData<TVertex>)!;
+            else
+                data = new(texture, m_program, brightmapTexture);
+
+            data.RenderCount = m_renderCount - 1;
             m_allRenderData[texture.TextureId] = data;
         }
 
@@ -63,14 +70,6 @@ public class RenderDataCollection<[DynamicallyAccessedMembers(DynamicallyAccesse
         }
 
         return data;
-    }
-    
-    private void ResizeToSupportIndex(int index)
-    {
-        const int GrowthSize = 1024;
-
-        int nextLargestSize = ((index / GrowthSize) + 1) * GrowthSize;
-        m_allRenderData.Resize(nextLargestSize);
     }
     
     public void Render(PrimitiveType primitive)

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Data/RenderDataCollection.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Data/RenderDataCollection.cs
@@ -1,11 +1,8 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
-using Helion.Render.OpenGL.Renderers.Legacy.World.Entities;
 using Helion.Render.OpenGL.Shader;
 using Helion.Render.OpenGL.Texture.Legacy;
 using Helion.Util.Container;
-using Helion.Util.Loggers;
-using Helion.World;
 using OpenTK.Graphics.OpenGL;
 
 namespace Helion.Render.OpenGL.Renderers.Legacy.World.Data;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Data/RenderDataManager.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Data/RenderDataManager.cs
@@ -26,14 +26,14 @@ public class RenderDataManager<[DynamicallyAccessedMembers(DynamicallyAccessedMe
     private readonly RenderData<TVertex> m_healthBarData;
     private bool m_disposed;
 
-    public RenderDataManager(RenderProgram program, GLLegacyTexture healthBarTexture)
+    public RenderDataManager(RenderProgram program, GLLegacyTexture healthBarTexture, RenderDataPool<TVertex> renderDataPool)
     {
         Assert.Precondition(RenderStyleLookup.Length == (int)RenderStyle.Count, "Render style lookup size mismatch");
         m_renderDataStyles = new RenderDataCollection<TVertex>[(int)RenderDataStyle.Count];
         for (int i = 0; i < m_renderDataStyles.Length; i++)
-            m_renderDataStyles[i] = new(program);
+            m_renderDataStyles[i] = new(program, renderDataPool);
 
-        m_healthBarData = new(healthBarTexture, program);
+        m_healthBarData = new(program, healthBarTexture);
     }
 
     ~RenderDataManager()

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Data/RenderDataPool.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Data/RenderDataPool.cs
@@ -1,0 +1,54 @@
+﻿using Helion.Render.OpenGL.Shader;
+using Helion.Render.OpenGL.Texture.Legacy;
+using Helion.Util.Container;
+using Helion.Util.Loggers;
+using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Helion.Render.OpenGL.Renderers.Legacy.World.Data;
+
+public class RenderDataPool<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TVertex> where TVertex : struct
+{
+    private readonly RenderProgram m_program;
+    private readonly DynamicArray<RenderData<TVertex>> m_entityRenderData;
+
+    public int PoolSize { get; set; }
+    public int UseCount { get; set; }
+
+    public RenderDataPool(RenderProgram program, int poolSize)
+    {
+        PoolSize = poolSize;
+        m_program = program;
+        m_entityRenderData = new(poolSize);
+        RefillPool(PoolSize);
+    }
+
+    public void RefillPool(int size)
+    {
+        size = Math.Min(size, PoolSize);
+        for (int i = m_entityRenderData.Length; i < size; i++)
+            m_entityRenderData.AddUnsafe(new RenderData<TVertex>(m_program));
+    }
+
+    public RenderData<TVertex> Get(GLLegacyTexture texture, GLLegacyTexture? brightMapTexture = null)
+    {
+        if (m_entityRenderData.Length > 0)
+        {
+            var data = m_entityRenderData.RemoveLast();
+            data.Set(texture, brightMapTexture);
+            UseCount++;
+            return data;
+        }
+
+        UseCount++;
+        LogExhaustion();
+        return new RenderData<TVertex>(m_program, texture, brightMapTexture);
+    }
+
+    [Conditional("DEBUG")]
+    public void LogExhaustion()
+    {
+        HelionLog.Info($"RenderDataPool exhausted. Consider increasing the size. {UseCount}");
+    }
+}

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
@@ -89,6 +89,7 @@ public sealed class EntityRenderer : StyleRendererBase, IDisposable
     {
         m_vanillaRender = world.Config.Render.VanillaRender;
         m_lastViewerEntityId = -1;
+        world.DataCache.InitEntityRenderData(m_program);
     }
     
     public void Clear(IWorld world)

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
@@ -25,6 +25,7 @@ public sealed class EntityRenderer : StyleRendererBase, IDisposable
     const int MaxBarWidth = 80;
     const int MinHealth = 20;
     const int MaxHealth = 4000;
+    const int RenderPoolSize = 2048;
 
     private readonly IConfig m_config;
     private readonly LegacyGLTextureManager m_textureManager;
@@ -36,6 +37,7 @@ public sealed class EntityRenderer : StyleRendererBase, IDisposable
     private readonly DynamicArray<SpriteDefinition?> m_spriteDefs = new(1024);
     private readonly SpriteRotation m_nullSpriteRotation;
     private readonly ArchiveCollection m_archiveCollection;
+    private readonly RenderDataPool<EntityVertex> m_renderDataPool;
     private Vec2F m_viewRightNormal;
     private Vec2F m_prevViewRightNormal;
     private TransferHeightView m_transferHeightView = TransferHeightView.Middle;
@@ -57,7 +59,8 @@ public sealed class EntityRenderer : StyleRendererBase, IDisposable
         m_textureManager = textureManager;
         m_archiveCollection = archiveCollection;
         m_nullSpriteRotation = m_textureManager.NullSpriteRotation;
-        m_dataManager = new(m_program, textureManager.BlackTexture);
+        m_renderDataPool = new(m_program, RenderPoolSize);
+        m_dataManager = new(m_program, textureManager.BlackTexture, m_renderDataPool);
         m_spriteAlpha = m_config.Render.SpriteTransparency;
         m_spriteClip = m_config.Render.SpriteClip;
         m_spriteClipMin = m_config.Render.SpriteClipMin;
@@ -89,7 +92,7 @@ public sealed class EntityRenderer : StyleRendererBase, IDisposable
     {
         m_vanillaRender = world.Config.Render.VanillaRender;
         m_lastViewerEntityId = -1;
-        world.DataCache.InitEntityRenderData(m_program);
+        m_renderDataPool.RefillPool(RenderPoolSize / 4);
     }
     
     public void Clear(IWorld world)

--- a/Core/Render/OpenGL/Vertex/Attributes.cs
+++ b/Core/Render/OpenGL/Vertex/Attributes.cs
@@ -5,6 +5,7 @@ using Helion.Render.OpenGL.Shader;
 using OpenTK.Graphics.OpenGL;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -144,6 +145,7 @@ public static class Attributes
         return nextAvailableIndex;
     }
 
+    [Conditional("DEBUG")]
     private static void AssertCorrectMappingOrThrow<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TVertex>(ProgramAttributes shaderAttribs) where TVertex : struct
     {
         Type type = typeof(TVertex);

--- a/Core/Util/DataCache.cs
+++ b/Core/Util/DataCache.cs
@@ -27,6 +27,10 @@ using Helion.Render.OpenGL.Renderers.Legacy.World.Sky.Sphere;
 using Helion.World.Geometry.Islands;
 using Helion.World.Entities.Players;
 using Helion.Maps.Specials;
+using Helion.Render.OpenGL.Renderers.Legacy.World.Entities;
+using Helion.Render.OpenGL.Shader;
+using Helion.Util.Loggers;
+using Helion.Render.OpenGL.Renderers.Legacy.World.Data;
 
 namespace Helion.Util;
 
@@ -35,20 +39,22 @@ public class DataCache
     private static int StaticId;
     public int Id;
     private const int DefaultLength = 1024;
+    private const int EntityRenderLength = 1024;
 
     public int EntityLength;
     public int EntityId;
     public Entity[] Entities = new Entity[DefaultLength];
+    private bool InitRenderData;
 
     private readonly DynamicArray<int> m_entities = new(DefaultLength);
     private readonly DynamicArray<LinkableNode<Entity>> m_entityNodes = new(DefaultLength);
     private readonly DynamicArray<LinkableNode<DynamicIsland>> m_islandNodes = new(DefaultLength);
-    private readonly DynamicArray<IAudioSource> m_audioSources = new();
+    private readonly DynamicArray<IAudioSource> m_audioSources = new(64);
     private readonly DynamicArray<DynamicArray<Entity>> m_entityLists = new();
-    private readonly DynamicArray<DynamicArray<RenderableGlyph>> m_glyphs = new();
-    private readonly DynamicArray<DynamicArray<RenderableSentence>> m_sentences = new();
-    private readonly DynamicArray<RenderableString> m_strings = new();
-    private readonly DynamicArray<HudDrawBufferData> m_hudDrawBufferData = new();
+    private readonly DynamicArray<DynamicArray<RenderableGlyph>> m_glyphs = new(256);
+    private readonly DynamicArray<DynamicArray<RenderableSentence>> m_sentences = new(64);
+    private readonly DynamicArray<RenderableString> m_strings = new(64);
+    private readonly DynamicArray<HudDrawBufferData> m_hudDrawBufferData = new(64);
     private readonly DynamicArray<LinkedListNode<WaitingSound>> m_waitingSoundNodes = new();
     private readonly DynamicArray<LinkedListNode<ISpecial>> m_specialNodes = new();
     private readonly DynamicArray<LinkedListNode<ConsoleMessage>> m_consoleMessageNodes = new(256);
@@ -60,6 +66,7 @@ public class DataCache
     private readonly DynamicArray<DynamicVertex[]> m_wallVertices = new(DefaultLength);
     private readonly DynamicArray<SkyGeometryVertex[]> m_skyWallVertices = new(DefaultLength);
     private readonly DynamicArray<LinkedListNode<Entity>> m_entityLinkedListNodes = new(32);
+    private readonly DynamicArray<RenderData<EntityVertex>> m_entityRenderData = new(EntityRenderLength);
 
     public bool CacheEntities = true;
 
@@ -81,6 +88,31 @@ public class DataCache
             entity.Index = i;
             entity.Id = i;
         }
+    }
+
+    public void InitEntityRenderData(RenderProgram program)
+    {
+        var maxLength = EntityRenderLength / 4;
+        if (!InitRenderData)
+        {
+            InitRenderData = true;
+            maxLength = EntityRenderLength;
+        }
+
+        for (int i = m_entityRenderData.Length; i < maxLength; i++)
+            m_entityRenderData.Add(new RenderData<EntityVertex>(program));
+    }
+
+    public RenderData<EntityVertex> GetEntityRenderData(GLLegacyTexture texture, RenderProgram program, GLLegacyTexture? brightmapTexture = null)
+    {
+        if (m_entityRenderData.Length > 0)
+        {
+            var data = m_entityRenderData.RemoveLast();
+            data.Set(texture, brightmapTexture);
+            return data;
+        }
+
+        return new RenderData<EntityVertex>(texture, program, brightmapTexture);
     }
 
     // Clear pointers to references that could keep the world around and prevent garbage collection.

--- a/Core/Util/DataCache.cs
+++ b/Core/Util/DataCache.cs
@@ -27,10 +27,6 @@ using Helion.Render.OpenGL.Renderers.Legacy.World.Sky.Sphere;
 using Helion.World.Geometry.Islands;
 using Helion.World.Entities.Players;
 using Helion.Maps.Specials;
-using Helion.Render.OpenGL.Renderers.Legacy.World.Entities;
-using Helion.Render.OpenGL.Shader;
-using Helion.Util.Loggers;
-using Helion.Render.OpenGL.Renderers.Legacy.World.Data;
 
 namespace Helion.Util;
 
@@ -44,7 +40,6 @@ public class DataCache
     public int EntityLength;
     public int EntityId;
     public Entity[] Entities = new Entity[DefaultLength];
-    private bool InitRenderData;
 
     private readonly DynamicArray<int> m_entities = new(DefaultLength);
     private readonly DynamicArray<LinkableNode<Entity>> m_entityNodes = new(DefaultLength);
@@ -66,7 +61,6 @@ public class DataCache
     private readonly DynamicArray<DynamicVertex[]> m_wallVertices = new(DefaultLength);
     private readonly DynamicArray<SkyGeometryVertex[]> m_skyWallVertices = new(DefaultLength);
     private readonly DynamicArray<LinkedListNode<Entity>> m_entityLinkedListNodes = new(32);
-    private readonly DynamicArray<RenderData<EntityVertex>> m_entityRenderData = new(EntityRenderLength);
 
     public bool CacheEntities = true;
 
@@ -88,31 +82,6 @@ public class DataCache
             entity.Index = i;
             entity.Id = i;
         }
-    }
-
-    public void InitEntityRenderData(RenderProgram program)
-    {
-        var maxLength = EntityRenderLength / 4;
-        if (!InitRenderData)
-        {
-            InitRenderData = true;
-            maxLength = EntityRenderLength;
-        }
-
-        for (int i = m_entityRenderData.Length; i < maxLength; i++)
-            m_entityRenderData.Add(new RenderData<EntityVertex>(program));
-    }
-
-    public RenderData<EntityVertex> GetEntityRenderData(GLLegacyTexture texture, RenderProgram program, GLLegacyTexture? brightmapTexture = null)
-    {
-        if (m_entityRenderData.Length > 0)
-        {
-            var data = m_entityRenderData.RemoveLast();
-            data.Set(texture, brightmapTexture);
-            return data;
-        }
-
-        return new RenderData<EntityVertex>(texture, program, brightmapTexture);
     }
 
     // Clear pointers to references that could keep the world around and prevent garbage collection.

--- a/Core/World/Entities/Entity.cs
+++ b/Core/World/Entities/Entity.cs
@@ -102,7 +102,7 @@ public partial class Entity : IDisposable, ITickable, ISoundSource, IFloorCeilin
     public IFloorCeilingAnchor LowestCeilingObject;
     public double LowestCeilingZ;
     public double HighestFloorZ;
-    public DynamicArray<Sector> IntersectSectors = new();
+    public DynamicArray<Sector> IntersectSectors = new(arrayPool: true);
     public int Id;
     public int ThingId;
     // Index in Blockmap.BlockLines
@@ -137,7 +137,7 @@ public partial class Entity : IDisposable, ITickable, ISoundSource, IFloorCeilin
     public virtual int ProjectileKickBack => Properties.ProjectileKickBack;
 
     public bool IsBlocked() => BlockingEntity != null || BlockingBlockLineIndex != -1 || BlockingSectorPlane != null;
-    public readonly DynamicArray<LinkableNode<Entity>> SectorNodes = new();
+    public readonly DynamicArray<LinkableNode<Entity>> SectorNodes = new(arrayPool: true);
     public readonly DynamicArray<int> IntersectMidTexLines = new(); 
     public bool IsDisposed;
     public bool WaitSoundDispose;

--- a/Core/World/Physics/TryMoveData.cs
+++ b/Core/World/Physics/TryMoveData.cs
@@ -31,7 +31,7 @@ public class TryMoveData
     public DynamicArray<int> IntersectSpecialLines = new(16);
     public DynamicArray<int> ImpactSpecialLines = new(16);
     public DynamicArray<int> IntersectMidTexLines = new(16);
-    public DynamicArray<Sector> IntersectSectors = new(16);
+    public DynamicArray<Sector> IntersectSectors = new(16, arrayPool: true);
 
     public void Clear()
     {

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -42,3 +42,4 @@
 - Use colormap index one for lite amp goggles instead of zero to match original doom behavior.
 - Removed sprite overlap code from CPU and use sprite detph bias on GPU instead to fix z-fighting.
 - Add support for transparent rendering in static shader.
+- Add pool for entity sprite VBO/VAOs to fix stutter when encountering a new sprite to render.


### PR DESCRIPTION
Implement pool for entity sprite render data that pre-allocates the VAO/VBO combination. Previously when a new sprite was encountered these were allocated during play which can cause micro stutters because of the CPU+GPU allocation and is more likely to invoke garbage collection because memory was being allocated.

Includes some better sizing for DynamicArray and setting some to use ArrayPool to encourage reuse instead of leaving around the garbage collector to clean up.