### PR TITLE
add an option to control the OpenAL Soft resampler

### DIFF
--- a/Core/Audio/Impl/OpenALAudioSource.cs
+++ b/Core/Audio/Impl/OpenALAudioSource.cs
@@ -17,6 +17,8 @@ public class OpenALAudioSource : IAudioSource
     private const ALSourcei SourceDistanceModel = (ALSourcei)53248;
     private const ALSourcei SourceRelative = (ALSourcei)0x202;
 
+    private const ALSourcei SourceResamplerSoft = (ALSourcei)0x1212;
+
     public float Pitch { get; set; } = 1f;
 
     private AudioData m_audioData;
@@ -180,6 +182,11 @@ public class OpenALAudioSource : IAudioSource
     public float GetOffsetSeconds()
     {
         return AL.GetSource(m_sourceId, ALSourcef.SecOffset);
+    }
+
+    public void SetResampler(OpenALSoftResamplerType resampler)
+    {
+        AL.Source(m_sourceId, SourceResamplerSoft, resampler.Value);
     }
 
     public void Update(in UpdateParams updateParams)

--- a/Core/Audio/Impl/OpenALAudioSourceManager.cs
+++ b/Core/Audio/Impl/OpenALAudioSourceManager.cs
@@ -27,6 +27,8 @@ public class OpenALAudioSourceManager : IAudioSourceManager
     private readonly DynamicArray<int> m_playGroup = new();
     private readonly IConfig m_config;
 
+    private OpenALSoftResamplerType? m_currentResampler;
+
     public readonly OpenALAudioSystem AudioSystem;
 
     public OpenALAudioSourceManager(OpenALAudioSystem owner, ArchiveCollection archiveCollection, IConfig config)
@@ -34,6 +36,8 @@ public class OpenALAudioSourceManager : IAudioSourceManager
         AudioSystem = owner;
         m_archiveCollection = archiveCollection;
         m_config = config;
+        m_config.Audio.Resampler.OnChanged += Resampler_OnChanged;
+        SetAllResamplers(m_config.Audio.Resampler);
         OpenALDebug.Start("Setting distance model");
         AL.DistanceModel(ALDistanceModel.ExponentDistance);
         OpenALDebug.End("Setting distance model");
@@ -100,8 +104,25 @@ public class OpenALAudioSourceManager : IAudioSourceManager
             return null;
 
         OpenALAudioSource source = m_archiveCollection.DataCache.GetAudioSource(this, buffer, audioData);
+        if (m_currentResampler != null)
+        {
+            source.SetResampler(m_currentResampler);
+        }
         m_sources.Add(source);
         return source;
+    }
+
+    private void Resampler_OnChanged(object? sender, string e) => SetAllResamplers(e);
+    private void SetAllResamplers(string name)
+    {
+        m_currentResampler = OpenALSoftResamplerType.FromName(name);
+        if (m_currentResampler != null)
+        {
+            foreach (var source in m_sources)
+            {
+                source.SetResampler(m_currentResampler);
+            }
+        }
     }
 
     public void PlayGroup(SoundList audioSources)

--- a/Core/Audio/Impl/OpenALSoftResamplerType.cs
+++ b/Core/Audio/Impl/OpenALSoftResamplerType.cs
@@ -1,0 +1,76 @@
+using OpenTK.Audio.OpenAL;
+using System;
+using System.Linq;
+using System.ComponentModel;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace Helion.Audio.Impl;
+
+public class OpenALSoftResamplerType
+{
+    private const ALGetInteger NumResamplersSoft = (ALGetInteger)0x1210;
+    private const ALGetInteger DefaultResamplerSoft = (ALGetInteger)0x1211;
+    private const ALGetString ResamplerNameSoft = (ALGetString)0x1213;
+
+    private static List<(string Name, int Value)> ResamplerOptions;
+    private static Dictionary<string, int> NameToIndexMap;
+    public static List<string> MenuOptions;
+
+    private static string? DefaultName;
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private delegate IntPtr ALGetStringiSOFTSignature(ALGetString a, int b);
+    static OpenALSoftResamplerType()
+    {
+        ResamplerOptions = new();
+        NameToIndexMap = new();
+        if (AL.IsExtensionPresent("AL_SOFT_source_resampler"))
+        {
+            var addr = AL.GetProcAddress("alGetStringiSOFT");
+
+            var alGetStringiSOFT = Marshal.GetDelegateForFunctionPointer<ALGetStringiSOFTSignature>(addr);
+            var numResamplers = AL.Get(NumResamplersSoft);
+
+            var defaultResamplerNum = AL.Get(DefaultResamplerSoft);
+            DefaultName = Marshal.PtrToStringAnsi(alGetStringiSOFT(ResamplerNameSoft, defaultResamplerNum));
+
+            for (var i = 0; i < numResamplers; i++)
+            {
+                var resamplerName = Marshal.PtrToStringAnsi(alGetStringiSOFT(ResamplerNameSoft, i));
+                if (resamplerName != null) {
+                    ResamplerOptions.Add((resamplerName, i));
+                    NameToIndexMap[resamplerName] = ResamplerOptions.Count - 1;
+                }
+            }
+        }
+        MenuOptions = (new[] {"Default"}).Concat(ResamplerOptions.ConvertAll(x => x.Name)).ToList();
+    }
+
+    private int m_optionsIndex;
+
+    private OpenALSoftResamplerType(int index)
+    {
+        m_optionsIndex = index;
+    }
+
+    public static OpenALSoftResamplerType? FromName(string name)
+    {
+        if (name == "Default")
+        {
+            if (DefaultName == null)
+            {
+                return null;
+            }
+            name = DefaultName;
+        }
+        if (NameToIndexMap.TryGetValue(name, out int index))
+        {
+            return new(index);
+        }
+        return null;
+    }
+
+    public string Name => ResamplerOptions[m_optionsIndex].Name;
+    public int Value => ResamplerOptions[m_optionsIndex].Value;
+}

--- a/Core/Layer/Options/OptionsLayer.cs
+++ b/Core/Layer/Options/OptionsLayer.cs
@@ -1,4 +1,5 @@
 ﻿using Helion.Audio.Sounds;
+using Helion.Audio.Impl;
 using Helion.Geometry;
 using Helion.Geometry.Boxes;
 using Helion.Geometry.Vectors;
@@ -243,6 +244,8 @@ public class OptionsLayer : IGameLayer, IAnimationLayer
 
             if (attr.Section == OptionSectionType.Hud) 
                 cfgSection.DynamicOptionProvider = (name) => name == "Status Bar Layout" ? m_sbarLayoutNames : null;
+            if (attr.Section == OptionSectionType.Audio) 
+                cfgSection.DynamicOptionProvider = (name) => name == "Sound Resampler" ? OpenALSoftResamplerType.MenuOptions : null;
 
             cfgSection.Add(value, attr, configAttr);
         }

--- a/Core/Util/Configs/Components/ConfigAudio.cs
+++ b/Core/Util/Configs/Components/ConfigAudio.cs
@@ -37,6 +37,10 @@ public class ConfigAudio: ConfigElement<ConfigAudio>
     [OptionMenu(OptionSectionType.Audio, "Same Sound Window")]
     public readonly ConfigValue<int> SameSoundWindow = new(1, GreaterOrEqual(1));
 
+    [ConfigInfo("Which audio resampler to use when playing sounds.")]
+    [OptionMenu(OptionSectionType.Audio, "Sound Resampler", isDynamicStringCycle: true)]
+    public readonly ConfigValue<string> Resampler = new("Default");
+
     [ConfigInfo("Randomize sound pitch.")]
     [OptionMenu(OptionSectionType.Audio, "Randomize Pitch", spacer: true)]
     public readonly ConfigValue<RandomPitch> RandomizePitch = new(RandomPitch.None);


### PR DESCRIPTION
Pretty much mirrors a very similar option from UZDoom, which, when set to Nearest, muffles the sounds a lot less than the default, which is Cubic Spline resampling. The available options are populated from what the library says is possible.

This PR has the menu option value defaulting to Nearest as I believe it represents the original Doom sounds the best, but happy to change ofc

Worth noting that this is dependent on the OpenAL implementation being OpenAL Soft, but I believe it always will be? The code should just ignore the option if the extension isn't present, however.

Only tested on Linux as I don't have a Windows machine, though the only part that could be platform-specific is the function pointer invoking.