### PR TITLE
fix teleport special not randomizing exit point when used with TIDs

### DIFF
--- a/Core/World/Special/Specials/ActionSpecials.cs
+++ b/Core/World/Special/Specials/ActionSpecials.cs
@@ -415,7 +415,7 @@ public static class ActionSpecials
         var teleportEntities = GetEntities(world, sourceTid);
         for (var entity = teleportEntities.Current(); entity != null; entity = teleportEntities.Advance())
         {
-            var teleport = new TeleportSpecial(entity, null, world, targetTid, 0, fog, options: TeleportOptions.MapSpot);
+            var teleport = new TeleportSpecial(entity, null, world, targetTid, 0, fog);
             success |= teleport.Teleport();
         }
 

--- a/Core/World/Special/Specials/TeleportSpecial.cs
+++ b/Core/World/Special/Specials/TeleportSpecial.cs
@@ -9,6 +9,7 @@ using Helion.World.Geometry.Lines;
 using Helion.World.Geometry.Sectors;
 using System;
 using System.Runtime.CompilerServices;
+using System.Collections.Generic;
 
 namespace Helion.World.Special.Specials;
 
@@ -25,7 +26,6 @@ public enum TeleportOptions
     None = 0,
     KeepHeight = 1,
     KeepMomentum = 2,
-    MapSpot = 4
 }
 
 public struct TeleportSpecial
@@ -42,6 +42,9 @@ public struct TeleportSpecial
     private readonly TeleportFog m_fogFlags;
     private readonly TeleportType m_type;
     private readonly TeleportOptions m_options;
+
+    // list used to avoid re-allocations in teleport code
+    private static readonly List<Entity> randomSpotList = new();
 
     public static TeleportFog GetTeleportFog(Line line)
     {
@@ -296,31 +299,52 @@ public struct TeleportSpecial
                 teleportNode = teleportNode.Next;
             }
         }
-        else if (m_tag == -1)
-        {
-            foreach (Entity entity in m_world.FindByTid(m_tid))
-            {
-                if (entity.Flags.IsTeleportSpot() || ((m_options & TeleportOptions.MapSpot) != 0) && entity.Definition.Type == EntityType.MapSpot)
-                {
-                    pos = GetTeleportPosition(entity);
-                    angle = entity.AngleRadians;
-                    return true;
-                }
-            }
-        }
         else
         {
-            var teleportNode = m_world.EntityManager.TeleportSpots.First;
-            while (teleportNode != null)
+            // the intended use case of the TID-based specials is to randomly pick a Teleport Target
+            // thing with the right TID, but there's some edge case handling for old WADs inherited from ZDoom
+            randomSpotList.Clear();
+            foreach (Entity entity in m_world.FindByTid(m_tid))
             {
-                if (teleportNode.Value.Sector.Tag == m_tag && teleportNode.Value.ThingId == m_tid)
+                if ((m_tag == -1 || entity.Sector.Tag == m_tag) && entity.Flags.IsTeleportSpot())
                 {
-                    Entity entity = teleportNode.Value;
-                    pos = GetTeleportPosition(entity);
-                    angle = entity.AngleRadians;
-                    return true;
+                    randomSpotList.Add(entity);
                 }
-                teleportNode = teleportNode.Next;
+            }
+
+            if (randomSpotList.Count > 0)
+            {
+                int choice = m_world.Random.NextByte() % randomSpotList.Count;
+                var entity = randomSpotList[choice];
+                // don't hold onto references to the entities for too long
+                randomSpotList.Clear();
+                pos = GetTeleportPosition(entity);
+                angle = entity.AngleRadians;
+                return true;
+            }
+            else if (m_tag == -1) // compatibility edge cases used in both ZDoom and DSDA-Doom
+            {
+                // teleport to first map spot (e.g. Hexen MAP10)
+                foreach (Entity entity in m_world.FindByTid(m_tid))
+                {
+                    if (entity.Definition.Type == EntityType.MapSpot)
+                    {
+                        pos = GetTeleportPosition(entity);
+                        angle = entity.AngleRadians;
+                        return true;
+                    }
+                }
+
+                // if even that failed, teleport to first non-solid thing (e.g. Caldera MAP13)
+                foreach (Entity entity in m_world.FindByTid(m_tid))
+                {
+                    if (!entity.Flags.Solid())
+                    {
+                        pos = GetTeleportPosition(entity);
+                        angle = entity.AngleRadians;
+                        return true;
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
The hexen-derived teleport specials that DSDA-Doom has also put into their UDMF spec is supposed to choose a random teleport spot entity when TIDs are used, whereas the existing Helion implementation was just using the first. I've also refactored the way this works to mirror the code used in both ZDoom and DSDA-Doom when a teleport spot thing isn't found - it's supposed to fall back to the first map spot, and then the first non-solid thing. Unfortunately that behavior is simply there to handle Hexen being a bit sloppy on occasion but it'll be needed for strict compat between ports now...

(referenced implementations at https://github.com/kraflab/dsda-doom/blob/master/prboom2/src/p_telept.c#L67 and https://github.com/UZDoom/UZDoom/blob/trunk/src/playsim/p_teleport.cpp#L274)