### PR TITLE
move teleport flag clearing to before dormant check

### DIFF
--- a/Core/World/Entities/Entity.cs
+++ b/Core/World/Entities/Entity.cs
@@ -532,10 +532,10 @@ public partial class Entity : IDisposable, ITickable, ISoundSource, IFloorCeilin
 
     public virtual void Tick()
     {
+        Flags.ClearTeleported();
+
         if (Flags.Dormant())
             return;
-
-        Flags.ClearTeleported();
 
         if (FrozenTics > 0)
             FrozenTics--;


### PR DESCRIPTION
Currently Entities don't forget they've been teleported when they're dormant, so they can't teleport more than once. This just makes the flag clearing happen before that dormant check