### PR TITLE
preserve angle in DoTeleportGroup

### DIFF
--- a/Core/World/Special/Specials/ActionSpecials.cs
+++ b/Core/World/Special/Specials/ActionSpecials.cs
@@ -506,10 +506,16 @@ public static class ActionSpecials
         var teleportPosXY = Vec2D.Rotate(diff.X, diff.Y, angle);
         var teleportPos = new Vec3D(teleportSpot.Position.X + teleportPosXY.X, teleportSpot.Position.Y + teleportPosXY.Y, teleportSpot.Position.Z);
         var save = teleportSpot.Position;
+        var originalEntityAngle = entity.AngleRadians;
         teleportSpot.Position = teleportPos;
 
         var teleport = new TeleportSpecial(entity, null, world, 0, 0, fog);
         var success = teleport.Teleport(teleportSpot);
+
+        if (success)
+        {
+            entity.AngleRadians = originalEntityAngle + angle;
+        }
 
         teleportSpot.Position = save;
         return success;


### PR DESCRIPTION
Observed and intended behavior from ZDoom here is to rotate the teleported entities in the same orientation difference as the teleport entities themselves