### PR TITLE
3d floor global fog color blend support

### DIFF
--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityProgram.cs
@@ -140,7 +140,7 @@ public class EntityProgram : RenderProgram
     public void SetSpriteClipDownScaleAmount(float value) => ProgramUniforms.Set(value, m_downScaleAmountLocation);
     public void ColorClamp(float value) => ProgramUniforms.Set(value, m_colorClampLocation);
     public void UseSectorColor(bool value) => ProgramUniforms.Set(value, m_useSectorColorLocation);
-    public void UseSectorFog(bool value) => ProgramUniforms.Set(value, m_useSectorFogLocation);
+    public void UseSectorFog(int value) => ProgramUniforms.Set(value, m_useSectorFogLocation);
 
     private const string BoxDefines = @"
         const float BoxWidth = 20;
@@ -199,21 +199,23 @@ public class EntityProgram : RenderProgram
             renderIndexOut = renderIndex;
 
             textureDimOut = textureSize(boundTexture, 0);
-            if (useSectorColor == 1)
-                sectorColorMapIndexOut = texelFetch(sectorColormapTexture, lightIndexInt).rgb;
-            else
-                sectorColorMapIndexOut = vec3(1);
+            //if (useSectorColor == 1)
+            //    sectorColorMapIndexOut = texelFetch(sectorColormapTexture, lightIndexInt).rgb;
+            //else
+            //    sectorColorMapIndexOut = vec3(1);
 
-            if (useSectorFog == 1)
-                sectorFogOut = texelFetch(sectorFogTexture, lightIndexInt).rgba;
-            else
-                sectorFogOut = vec4(0);
+            //if (useSectorFog == 1)
+            //    sectorFogOut = texelFetch(sectorFogTexture, lightIndexInt).rgba;
+            //else
+            //    sectorFogOut = vec4(0);
+            
+            ${SectorColorMapVertexFunction}
 
             gl_Position = vec4(mix(prevPos, pos, timeFrac), 1.0);
             positionZOut = gl_Position.z;
         }
     "
-    .Replace("${SectorColorMapVertexFunction}", SectorColorMap.VertexFunction("lightIndexInt", "sectorColorMapIndexOut", "sectorFogColorOut"));
+    .Replace("${SectorColorMapVertexFunction}", SectorColorMap.VertexFunction("lightIndexInt", "sectorColorMapIndexOut", "sectorFogOut"));
 
     protected override string? GeometryShader() => @"
         #version 330 core
@@ -427,6 +429,7 @@ public class EntityProgram : RenderProgram
         uniform float downScaleAmount;
         uniform vec2 downScaleSampleFactor;
         uniform float colorClamp;
+        uniform int useSectorFog;
 
         uniform sampler2D planeClipTexture;
         uniform sampler2D wallClipTexture;

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
@@ -379,7 +379,7 @@ public sealed class EntityRenderer : StyleRendererBase, IDisposable
         program.CheckPlaneClip(m_vanillaRender);
         program.UseBrightmaps(renderInfo.Uniforms.UseBrightmaps);
         program.UseSectorColor(renderInfo.Uniforms.SectorColor);
-        program.UseSectorFog(renderInfo.Uniforms.SectorFog);
+        program.UseSectorFog(renderInfo.Uniforms.SectorFogIndex);
         program.SetSpriteClipDownScaleAmount(Math.Max(renderInfo.Uniforms.DownScaleAmount, 1));
         program.ColorClamp(1f);
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillProgram.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillProgram.cs
@@ -83,7 +83,7 @@ public class FloodFillProgram : RenderProgram
     public void GammaCorrection(float value) => ProgramUniforms.Set(value, m_gammaCorrectionLocation);
     public void UseBrightmaps(bool value) => ProgramUniforms.Set(value, m_useBrightmapsLocation);
     public void UseSectorColor(bool value) => ProgramUniforms.Set(value, m_useSectorColorLocation);
-    public void UseSectorFog(bool value) => ProgramUniforms.Set(value, m_useSectorFogLocation);
+    public void UseSectorFog(int value) => ProgramUniforms.Set(value, m_useSectorFogLocation);
 
     protected override string VertexShader() => @"
         #version 330
@@ -183,6 +183,7 @@ public class FloodFillProgram : RenderProgram
             uniform int paletteIndex;
             uniform int colormapIndex;
             uniform int useBrightmaps;
+            uniform int useSectorFog;
 
             ${LightLevelFragVariables}
             ${SectorColorMapFragVariables}

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Portals/FloodFill/FloodFillRenderer.cs
@@ -355,7 +355,7 @@ public class FloodFillRenderer(LegacyGLTextureManager glTextureManager, FloodFil
         program.GammaCorrection(renderInfo.Uniforms.GammaCorrection);
         program.UseBrightmaps(renderInfo.Uniforms.UseBrightmaps);
         program.UseSectorColor(renderInfo.Uniforms.SectorColor);
-        program.UseSectorFog(renderInfo.Uniforms.SectorFog);
+        program.UseSectorFog(renderInfo.Uniforms.SectorFogIndex);
     }
 
     public void ClearVertices()

--- a/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/InterpolationShader.cs
@@ -104,7 +104,7 @@ public class InterpolationShader : RenderProgram
     public void ScreenBounds(Vec2I value) => ProgramUniforms.Set(value, m_screenBoundsLocation);
     public void FogBarrier(bool value) => ProgramUniforms.Set(value, m_fogBarrierLocation);
     public void UseSectorColor(bool value) => ProgramUniforms.Set(value, m_useSectorColorLocation);
-    public void UseSectorFog(bool value) => ProgramUniforms.Set(value, m_useSectorFogLocation);
+    public void UseSectorFog(int value) => ProgramUniforms.Set(value, m_useSectorFogLocation);
 
     protected override string VertexShader()
     {
@@ -233,6 +233,7 @@ public class InterpolationShader : RenderProgram
             uniform int useBrightmaps;
             uniform float downScaleAmount;
             uniform ivec2 screenBounds;
+            uniform int useSectorFog;
 
             ${LightLevelFragVariables}
             ${SectorColorMapFragVariables}

--- a/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/LegacyWorldRenderer.cs
@@ -814,7 +814,7 @@ public class LegacyWorldRenderer : WorldRenderer
         program.GammaCorrection(renderInfo.Uniforms.GammaCorrection);
         program.UseBrightmaps(renderInfo.Uniforms.UseBrightmaps);
         program.UseSectorColor(renderInfo.Uniforms.SectorColor);
-        program.UseSectorFog(renderInfo.Uniforms.SectorFog);
+        program.UseSectorFog(renderInfo.Uniforms.SectorFogIndex);
         program.SetSpriteClipDownScaleAmount(renderInfo.Uniforms.DownScaleAmount);
         program.ScreenBounds((renderInfo.Viewport.Width - 1, renderInfo.Viewport.Height - 1));
         program.CheckPlaneClip(false);
@@ -853,7 +853,7 @@ public class LegacyWorldRenderer : WorldRenderer
         program.GammaCorrection(renderInfo.Uniforms.GammaCorrection);
         program.UseBrightmaps(renderInfo.Uniforms.UseBrightmaps);
         program.UseSectorColor(renderInfo.Uniforms.SectorColor);
-        program.UseSectorFog(renderInfo.Uniforms.SectorFog);
+        program.UseSectorFog(renderInfo.Uniforms.SectorFogIndex);
         program.SetSpriteClipDownScaleAmount(renderInfo.Uniforms.DownScaleAmount);
         program.ScreenBounds((renderInfo.Viewport.Width - 1, renderInfo.Viewport.Height - 1));
         program.CheckPlaneClip(false);

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/FragFunction.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/FragFunction.cs
@@ -211,8 +211,8 @@ public class FragFunction
             // If b channel is -1 then r channel is colormap index. if b channel is >= 0 then the rgb values are a true color mix.
             // This is to support Sector_SetColor to have true color mixes when still using palette color mode.
             + "fragColor.rgb *= mix(vec3(1), min(sectorColorMapIndexFrag, 1), float(sectorColorMapIndexFrag.b >= 0));"
-            + @"
-                float fogFactor = clamp(1.0 - exp(-sectorFogColorFrag.a * dist3D), 0.0, 1.0);
+            + $@"
+                float fogFactor = clamp(mix(1.0 - exp(-sectorFogColorFrag.a * dist3D), 0.5, float(useSectorFog == {ShaderUniforms.ViewBlendFog})), 0.0, 1.0);
                 fragColor.rgb = mix(fragColor.rgb, sectorFogColorFrag.rgb, fogFactor);"
             // Fog barriers need to ignore texture color and just apply fog color + factor directly. Only relevant to the OIT transparent pass for level geometry.
             + ((oitOptions != OitOptions.OitTransparentPass || ctx == ColorMapFetchContext.Entity) ? "" : "fragColor.rgba = mix(fragColor.rgba, vec4(sectorFogColorFrag.rgb, fogFactor), fogBarrier);")

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Shader/SectorColorMap.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Shader/SectorColorMap.cs
@@ -21,8 +21,8 @@ uniform samplerBuffer sectorFogTexture;";
             else
                 {colorVar} = vec3(1);
 
-            if (useSectorFog == 1)
-                {fogVar} = texelFetch(sectorFogTexture, int({indexVar})).rgba;
+            if (useSectorFog >= 1)
+                {fogVar} = texelFetch(sectorFogTexture, int(mix({indexVar}, 0, float(useSectorFog == {ShaderUniforms.ViewBlendFog})))).rgba;
             else
                 {fogVar} = vec4(0);
             ";

--- a/Core/Render/OpenGL/Renderers/Legacy/World/ShaderUniforms.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/ShaderUniforms.cs
@@ -26,8 +26,12 @@ public struct ShaderUniforms(
     bool useBrightmaps,
     bool sectorColor,
     bool sectorFog,
+    int viewBlendSectorFogIndex,
     float downScaleAmount)
 {
+    public const int ViewBlendFog = 2;
+    public const int NoViewBlendSectorIndex = -1;
+
     public mat4 Mvp = mvp;
     public mat4 MvpNoPitch = mvpNoPitch;
     public float TimeFrac = timeFrac;
@@ -45,5 +49,7 @@ public struct ShaderUniforms(
     public bool UseBrightmaps = useBrightmaps;
     public bool SectorColor = sectorColor;
     public bool SectorFog = sectorFog;
+     public int SectorFogIndex = sectorFog ? viewBlendSectorFogIndex >= 0 ? ViewBlendFog : 1 : 0;
+    public int ViewBlendFogSectorIndex = viewBlendSectorFogIndex;
     public float DownScaleAmount = downScaleAmount;
 }

--- a/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/StaticShader.cs
@@ -101,7 +101,7 @@ public class StaticShader : RenderProgram
     public void ScreenBounds(Vec2I value) => ProgramUniforms.Set(value, m_screenBoundsLocation);
     public void FogBarrier(bool value) => ProgramUniforms.Set(value, m_fogBarrierLocation);
     public void UseSectorColor(bool value) => ProgramUniforms.Set(value, m_useSectorColorLocation);
-    public void UseSectorFog(bool value) => ProgramUniforms.Set(value, m_useSectorFogLocation);
+    public void UseSectorFog(int value) => ProgramUniforms.Set(value, m_useSectorFogLocation);
 
     protected override string VertexShader()
     {
@@ -226,6 +226,7 @@ public class StaticShader : RenderProgram
             uniform int checkPlaneClip;
             uniform float downScaleAmount;
             uniform ivec2 screenBounds;
+            uniform int useSectorFog;
 
             ${LightLevelFragVariables}
             ${SectorColorMapFragVariables}

--- a/Core/Render/Renderer.World.cs
+++ b/Core/Render/Renderer.World.cs
@@ -32,6 +32,7 @@ public partial class Renderer
     private readonly SectorUpdates m_updateColorMapSectors = new();
     private readonly SectorUpdates m_updateFogColorSectors = new();
     private readonly SectorUpdates m_updateLineHeights = new();
+    private Vec4F m_lastGlobalViewFog;
 
     private GLBufferTextureStorage<byte>? m_sectorLightsBuffer;
     private GLBufferTextureStorage<float>? m_sectorColorMapsBuffer;
@@ -213,23 +214,46 @@ public partial class Renderer
         for (int i = 0; i < world.Sectors.Count; i++)
         {
             var sector = world.Sectors[i];
-            SetSectorFog(fadeBuffer, length, sector.Id, sector.FogColor, Math.Clamp(sector.LightLevel, (short)0, (short)255), sector.FogDensity);
+            SetSectorFog(fadeBuffer, length, sector, sector.FogColor, Math.Clamp(sector.LightLevel, (short)0, (short)255), sector.FogDensity);
         }
     }
 
-    private unsafe void SetSectorFog(float* fadeBuffer, int bufferLength, int sectorId, Color fadeColor, short lightLevel, float fogDensity)
+    private unsafe void SetGlobalViewFog(int sectorId)
     {
-        var index = sectorId * LightBuffer.BufferSize + LightBuffer.SectorIndexStart;
-        var fade = GetSectorFogDensity(fadeColor, lightLevel, fogDensity);
+        if (m_sectorFogBuffer == null || m_world == null || sectorId >= m_world.Sectors.Count)
+            return;
 
-        if (fadeColor.Uint != 0)
+        var sector = m_world.Sectors[sectorId];
+        var fog = GetSectorFogDensity(sector.FogColor, sector.LightLevel, sector.FogDensity);
+        if (fog == m_lastGlobalViewFog)
+            return;
+
+        m_lastGlobalViewFog = fog;
+        var fogBuffer = m_sectorFogBuffer.GetMappedBufferAndBind();
+        var fogData = fogBuffer.MappedMemoryPtr;
+
+        // Sectors fog color start after LightBuffer.SectorIndexStart so index 0 can be used for forcing a global view color.
+        *(Vec4F*)&fogData[0] = fog;
+
+        m_sectorFogBuffer.Unbind();
+    }
+
+    private unsafe void SetSectorFog(float* fogBuffer, int bufferLength, Sector sector, Color fogColor, short lightLevel, float fogDensity)
+    {
+        var index = sector.Id * LightBuffer.BufferSize + LightBuffer.SectorIndexStart;
+        var fog = GetSectorFogDensity(fogColor, lightLevel, fogDensity);
+
+        if (sector.IgnoreFogColor)
+            fog = Vec4F.Zero;
+
+        if (fogColor.Uint != 0)
             m_sectorFog = true;
 
-        Assert.Precondition(bufferLength > index + (GLBufferTextureStorage<float>.FourComponentLength * 3), $"Invalid sector id {sectorId} for sector fog buffer");
+        Assert.Precondition(bufferLength > index + (GLBufferTextureStorage<float>.FourComponentLength * 3), $"Invalid sector id {sector.Id} for sector fog buffer");
 
-        *(Vec4F*)&fadeBuffer[(index + LightBuffer.FloorOffset) * GLBufferTextureStorage<float>.FourComponentLength] = fade;
-        *(Vec4F*)&fadeBuffer[(index + LightBuffer.CeilingOffset) * GLBufferTextureStorage<float>.FourComponentLength] = fade;
-        *(Vec4F*)&fadeBuffer[(index + LightBuffer.WallOffset) * GLBufferTextureStorage<float>.FourComponentLength] = fade;
+        *(Vec4F*)&fogBuffer[(index + LightBuffer.FloorOffset) * GLBufferTextureStorage<float>.FourComponentLength] = fog;
+        *(Vec4F*)&fogBuffer[(index + LightBuffer.CeilingOffset) * GLBufferTextureStorage<float>.FourComponentLength] = fog;
+        *(Vec4F*)&fogBuffer[(index + LightBuffer.WallOffset) * GLBufferTextureStorage<float>.FourComponentLength] = fog;
     }
 
     private unsafe void SetSectorColorMap(float* colorMapBuffer, int bufferLength, Sector sector, Colormap? colormap)
@@ -409,7 +433,7 @@ public partial class Renderer
         {
             var sector = m_updateLightSectors.UpdateSectors[i];
             var lightLevel = sector.GetByteLightLevel();
-            SetSectorFog(fogData, fogBufferLength, sector.Id, sector.FogColor, lightLevel, sector.FogDensity);
+            SetSectorFog(fogData, fogBufferLength, sector, sector.FogColor, lightLevel, sector.FogDensity);
         }
 
         m_sectorFogBuffer.Unbind();
@@ -454,7 +478,7 @@ public partial class Renderer
         for (int i = 0; i < m_updateFogColorSectors.UpdateSectors.Length; i++)
         {
             var sector = m_updateFogColorSectors.UpdateSectors[i];
-            SetSectorFog(fogBuffer, mappedBufferLength, sector.Id, sector.FogColor, sector.LightLevel, sector.FogDensity);
+            SetSectorFog(fogBuffer, mappedBufferLength, sector, sector.FogColor, sector.LightLevel, sector.FogDensity);
         }
 
         m_sectorFogBuffer.Unbind();

--- a/Core/Render/Renderer.cs
+++ b/Core/Render/Renderer.cs
@@ -331,6 +331,10 @@ public partial class Renderer : IDisposable
             }
         }
 
+        int viewBlendSectorFogIndex = ShaderUniforms.NoViewBlendSectorIndex;
+        if (renderInfo.SectorFog && renderInfo.ViewerEntity.Sector.GetViewSector3D(renderInfo.ViewerEntity, out var viewSector3D) && (viewSector3D.Flags & SectorFlags3D.NoViewFade) == 0)
+            viewBlendSectorFogIndex = viewSector3D.ControlSector.Id;
+
         int maxDistance = config.Render.MaxDistance.Value;
         if (maxDistance <= 0)
             maxDistance = Constants.DefaultMaxDistance;
@@ -353,6 +357,7 @@ public partial class Renderer : IDisposable
             renderInfo.BrightMaps,
             renderInfo.SectorColor,
             renderInfo.SectorFog,
+            viewBlendSectorFogIndex,
             GetDownScaleAmount(config, renderInfo));
     }
 
@@ -877,6 +882,9 @@ public partial class Renderer : IDisposable
             cmd.AutomapOffset, cmd.AutomapScale, m_config.Render, viewSector, transferHeightsView, 
             m_archiveCollection.BrightMapFetched, m_sectorColor, m_sectorFog);
         m_renderInfo.Uniforms = GetShaderUniforms(m_config, m_renderInfo);
+
+        if (m_renderInfo.Uniforms.SectorFog && m_renderInfo.Uniforms.ViewBlendFogSectorIndex != ShaderUniforms.NoViewBlendSectorIndex)
+            SetGlobalViewFog(m_renderInfo.Uniforms.ViewBlendFogSectorIndex);
 
         DrawHudImagesIfAnyQueued(viewport, m_renderInfo.Uniforms);
 

--- a/Core/World/Geometry/Sectors/Sector.cs
+++ b/Core/World/Geometry/Sectors/Sector.cs
@@ -89,6 +89,7 @@ public sealed class Sector : IFloorCeilingAnchor
     public bool Silent;
     public bool NoAttack;
     public bool HasDamageSector3D;
+    public bool IgnoreFogColor;
     public Sector3D? Sector3D;
     public int ActivatedByLineId = -1;
     public WeakEntity SoundTarget = WeakEntity.Default;
@@ -636,6 +637,23 @@ public sealed class Sector : IFloorCeilingAnchor
 
         sector3d = null;
         height = 0;
+        return false;
+    }
+
+    public bool GetViewSector3D(Entity entity, [NotNullWhen(true)] out Sector3D? sector3d)
+    {
+        if (WorldStatic.Sector3D && Sectors3D.Length > 0)
+        {
+            var viewZ = entity.Position.Z + entity.ViewZ;
+            for (int i = 0; i < Sectors3D.Length; i++)
+            {
+                sector3d = Sectors3D[i];
+                if (viewZ > sector3d.ControlBottom.Z && viewZ < sector3d.ControlTop.Z)
+                    return true;
+            }
+        }
+
+        sector3d = null;
         return false;
     }
 

--- a/Core/World/Geometry/Sectors/Sector3D.cs
+++ b/Core/World/Geometry/Sectors/Sector3D.cs
@@ -30,7 +30,8 @@ public enum SectorFlags3D
     UseUpperTexture = 2048,
     UseLowerTexture = 4096,
     AdditiveTransparency = 8192,
-    Fade = 65536,
+    // When this flag is not set UZDoom will render the fog color as a global blend color and not have fade density. When set it renders the fog color in the 3D sector as expected.
+    NoViewFade = 65536,
     ResetAbove = 131072,
 
     // Helion Flags
@@ -180,6 +181,10 @@ public sealed class Sector3D
         ClipPrevBottomZ = ControlBottom.PrevZ;
 
         ClipStyle = RenderDataStyle == RenderDataStyle.Normal && (Flags & SectorFlags3D.LightTransfer) == 0 ? ClipStyle.Solid : ClipStyle.NotSolid;
+
+        // Currently can't render this because of the shader fetch based on sector id. Likely doesn't matter since it's an unviewable control sector anyway.
+        if ((Flags & SectorFlags3D.NoViewFade) == 0)
+            ControlSector.IgnoreFogColor = true;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
Support blending global fog color to match zdoom behavior when flag 512 'fade' is not set on 3d floor

A current limitation is that when a 3d floor does not have this flag set the control sector's fog color is disabled. This is because the sector id is used to index the color to render so it's not possible to both render the fog color in the control sector and not render it through a 3d floor since they reference the same id.

This feature is likely practically useless but prevents the scenario where the fade color is rendered out to all 3d floors in Helion but it wouldn't work in UZDoom when the flag is not set.