### PR TITLE
Fix "compact HUD" (Tate/Portrait Mode) behavior for SBARDEF

### DIFF
--- a/Core/Layer/Worlds/WorldLayer.Render.Hud.cs
+++ b/Core/Layer/Worlds/WorldLayer.Render.Hud.cs
@@ -456,6 +456,7 @@ public partial class WorldLayer
             return;
 
         bool isWidescreen = hud.WindowDimension.AspectRatio > 4.0f / 3.0f;
+        bool isCompact = hud.WindowDimension.AspectRatio < 4.0f / 3.0f;
         int fps = (int)Math.Round(m_fpsTracker.AverageFramesPerSecond);
 
         string? consoleMsg = null;
@@ -484,8 +485,8 @@ public partial class WorldLayer
             }
         }
 
-        var context = new StatusBarContext(World, Player, World.MapInfo, activeLayout, automapVisible, isWidescreen, fps, consoleMsg,
-            isCentered, Player.Inventory.HasItemOfClass(Inventory.BackPackBaseClassName), HasTicks);
+        var context = new StatusBarContext(World, Player, World.MapInfo, activeLayout, automapVisible, isWidescreen, isCompact, fps,
+            consoleMsg, isCentered, Player.Inventory.HasItemOfClass(Inventory.BackPackBaseClassName), HasTicks);
         m_statusBarRenderer.Draw(hud, activeLayout, context, m_hudPaddingX);
     }
     

--- a/Core/World/StatusBar/StatusBarConditionResolver.cs
+++ b/Core/World/StatusBar/StatusBarConditionResolver.cs
@@ -342,7 +342,7 @@ public static class StatusBarConditionResolver
 
     private static bool CheckHudMode(StatusBarContext context, int param)
     {
-        int mode = context.ActiveLayout?.FullscreenRender == true ? 1 : 0;
+        int mode = context.IsCompact ? 1 : 0;
         return mode == param;
     }
     

--- a/Core/World/StatusBar/StatusBarContext.cs
+++ b/Core/World/StatusBar/StatusBarContext.cs
@@ -11,6 +11,7 @@ public readonly record struct StatusBarContext(
     StatusBarLayoutDef? ActiveLayout,
     bool AutomapVisible, 
     bool Widescreen,
+    bool IsCompact,
     int Fps,
     string? ConsoleMessage,
     bool IsMessageCentered,

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -35,6 +35,7 @@
 - Fix to match boom behavior to parsing dehacked integers with failures defaulting to zero.
 - Fix SBARDEF crash when children element was explicity set to null.
 - Fix dehacked dropped ammo types only giving half ammo.
+- Fix "Compact HUD" (Tate/Portrait Window) behavior for SBARDEF
 
 ## Misc:
 - Refactor of old Status Bar renderer to data-driven SBARDEF format.


### PR DESCRIPTION
Fixes #1615.

<img width="656" height="476" alt="fixcompact" src="https://github.com/user-attachments/assets/b7e6f6a7-e9fe-40c1-83a7-6ae448765f19" />
