### PR TITLE
Always load minimal and detailed HUD layouts

### DIFF
--- a/Assets/Assets/SBARDEF.lmp
+++ b/Assets/Assets/SBARDEF.lmp
@@ -93,6 +93,2077 @@
     ],
     "statusbars": [
       {
+        "name": "Full",
+        "height": 32,
+        "fullscreenrender": false,
+        "fillflat": null,
+        "children": [
+          {
+            "graphic": {
+              "x": 160,
+              "y": 0,
+              "alignment": 1,
+              "tranmap": null,
+              "translation": null,
+              "translucency": false,
+              "conditions": [],
+              "children": [],
+              "patch": "STBAR"
+            }
+          },
+          {
+            "number": {
+              "x": 44,
+              "y": 3,
+              "alignment": 2,
+              "tranmap": null,
+              "translation": null,
+              "translucency": false,
+              "conditions": [],
+              "children": [],
+              "font": "Classic Status Bar",
+              "type": 4,
+              "param": 0,
+              "maxlength": 0
+            }
+          },
+          {
+            "percent": {
+              "x": 104,
+              "y": 3,
+              "alignment": 2,
+              "tranmap": null,
+              "translation": null,
+              "translucency": false,
+              "conditions": [],
+              "children": [],
+              "font": "Classic Status Bar",
+              "type": 0,
+              "param": 0,
+              "maxlength": 0
+            }
+          },
+          {
+            "canvas": {
+              "x": 104,
+              "y": 0,
+              "alignment": 0,
+              "tranmap": null,
+              "translation": null,
+              "translucency": false,
+              "conditions": [
+                {
+                  "condition": 14,
+                  "param": 0,
+                  "param2": 0
+                }
+              ],
+              "children": [
+                {
+                  "graphic": {
+                    "x": 0,
+                    "y": 0,
+                    "alignment": 0,
+                    "tranmap": null,
+                    "translation": null,
+                    "translucency": false,
+                    "conditions": [],
+                    "children": [],
+                    "patch": "STARMS"
+                  }
+                },
+                {
+                  "canvas": {
+                    "x": 0,
+                    "y": 0,
+                    "alignment": 0,
+                    "tranmap": null,
+                    "translation": null,
+                    "translucency": false,
+                    "conditions": [],
+                    "children": [
+                      {
+                        "graphic": {
+                          "x": 7,
+                          "y": 4,
+                          "alignment": 0,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [],
+                          "children": [],
+                          "patch": "STGNUM2"
+                        }
+                      },
+                      {
+                        "graphic": {
+                          "x": 19,
+                          "y": 4,
+                          "alignment": 0,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [],
+                          "children": [],
+                          "patch": "STGNUM3"
+                        }
+                      },
+                      {
+                        "graphic": {
+                          "x": 31,
+                          "y": 4,
+                          "alignment": 0,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [],
+                          "children": [],
+                          "patch": "STGNUM4"
+                        }
+                      },
+                      {
+                        "graphic": {
+                          "x": 7,
+                          "y": 14,
+                          "alignment": 0,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [],
+                          "children": [],
+                          "patch": "STGNUM5"
+                        }
+                      },
+                      {
+                        "graphic": {
+                          "x": 19,
+                          "y": 14,
+                          "alignment": 0,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [],
+                          "children": [],
+                          "patch": "STGNUM6"
+                        }
+                      },
+                      {
+                        "graphic": {
+                          "x": 31,
+                          "y": 14,
+                          "alignment": 0,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [],
+                          "children": [],
+                          "patch": "STGNUM7"
+                        }
+                      },
+                      {
+                        "graphic": {
+                          "x": 7,
+                          "y": 4,
+                          "alignment": 0,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [
+                            {
+                              "condition": 6,
+                              "param": 2,
+                              "param2": 0
+                            }
+                          ],
+                          "children": [],
+                          "patch": "STYSNUM2"
+                        }
+                      },
+                      {
+                        "graphic": {
+                          "x": 19,
+                          "y": 4,
+                          "alignment": 0,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [
+                            {
+                              "condition": 6,
+                              "param": 3,
+                              "param2": 0
+                            }
+                          ],
+                          "children": [],
+                          "patch": "STYSNUM3"
+                        }
+                      },
+                      {
+                        "graphic": {
+                          "x": 31,
+                          "y": 4,
+                          "alignment": 0,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [
+                            {
+                              "condition": 6,
+                              "param": 4,
+                              "param2": 0
+                            }
+                          ],
+                          "children": [],
+                          "patch": "STYSNUM4"
+                        }
+                      },
+                      {
+                        "graphic": {
+                          "x": 7,
+                          "y": 14,
+                          "alignment": 0,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [
+                            {
+                              "condition": 6,
+                              "param": 5,
+                              "param2": 0
+                            }
+                          ],
+                          "children": [],
+                          "patch": "STYSNUM5"
+                        }
+                      },
+                      {
+                        "graphic": {
+                          "x": 19,
+                          "y": 14,
+                          "alignment": 0,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [
+                            {
+                              "condition": 6,
+                              "param": 6,
+                              "param2": 0
+                            }
+                          ],
+                          "children": [],
+                          "patch": "STYSNUM6"
+                        }
+                      },
+                      {
+                        "graphic": {
+                          "x": 31,
+                          "y": 14,
+                          "alignment": 0,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [
+                            {
+                              "condition": 6,
+                              "param": 7,
+                              "param2": 0
+                            }
+                          ],
+                          "children": [],
+                          "patch": "STYSNUM7"
+                        }
+                      }
+                    ]
+                  },
+                  "_cacoco_name": "Weapon Slot Group"
+                }
+              ]
+            },
+            "_cacoco_name": "STARMS Cluster"
+          },
+          {
+            "canvas": {
+              "x": 0,
+              "y": 0,
+              "alignment": 0,
+              "tranmap": null,
+              "translation": null,
+              "translucency": false,
+              "conditions": [
+                {
+                  "condition": 14,
+                  "param": 2,
+                  "param2": 0
+                }
+              ],
+              "children": [
+                {
+                  "number": {
+                    "x": 138,
+                    "y": 3,
+                    "alignment": 2,
+                    "tranmap": null,
+                    "translation": null,
+                    "translucency": false,
+                    "conditions": [],
+                    "children": [],
+                    "font": "Classic Status Bar",
+                    "type": 2,
+                    "param": 0,
+                    "maxlength": 0
+                  }
+                },
+                {
+                  "facebackground": {
+                    "x": 143,
+                    "y": 1,
+                    "alignment": 0,
+                    "tranmap": null,
+                    "translation": null,
+                    "translucency": false,
+                    "conditions": [],
+                    "children": [],
+                    "width": 0,
+                    "height": 0,
+                    "topoffset": 0,
+                    "leftoffset": 0,
+                    "midoffset": 0
+                  }
+                }
+              ]
+            },
+            "_cacoco_name": "Deathmatch Group"
+          },
+          {
+            "face": {
+              "x": 143,
+              "y": 0,
+              "alignment": 0,
+              "tranmap": null,
+              "translation": null,
+              "translucency": false,
+              "conditions": [],
+              "children": [],
+              "width": 0,
+              "height": 0,
+              "topoffset": 0,
+              "leftoffset": 0,
+              "midoffset": 0
+            }
+          },
+          {
+            "canvas": {
+              "x": 239,
+              "y": 0,
+              "alignment": 0,
+              "tranmap": null,
+              "translation": null,
+              "translucency": false,
+              "conditions": [],
+              "children": [
+                {
+                  "canvas": {
+                    "x": 0,
+                    "y": 3,
+                    "alignment": 0,
+                    "tranmap": null,
+                    "translation": null,
+                    "translucency": false,
+                    "conditions": [],
+                    "children": [
+                      {
+                        "graphic": {
+                          "x": 0,
+                          "y": 0,
+                          "alignment": 0,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [
+                            {
+                              "condition": 10,
+                              "param": 1,
+                              "param2": 0
+                            },
+                            {
+                              "condition": 11,
+                              "param": 4,
+                              "param2": 0
+                            }
+                          ],
+                          "children": [],
+                          "patch": "STKEYS0"
+                        }
+                      },
+                      {
+                        "graphic": {
+                          "x": 0,
+                          "y": 0,
+                          "alignment": 0,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [
+                            {
+                              "condition": 11,
+                              "param": 1,
+                              "param2": 0
+                            },
+                            {
+                              "condition": 10,
+                              "param": 4,
+                              "param2": 0
+                            }
+                          ],
+                          "children": [],
+                          "patch": "STKEYS3"
+                        }
+                      },
+                      {
+                        "graphic": {
+                          "x": 0,
+                          "y": 0,
+                          "alignment": 0,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [
+                            {
+                              "condition": 10,
+                              "param": 1,
+                              "param2": 0
+                            },
+                            {
+                              "condition": 10,
+                              "param": 4,
+                              "param2": 0
+                            }
+                          ],
+                          "children": [],
+                          "patch": "STKEYS6"
+                        }
+                      }
+                    ]
+                  },
+                  "_cacoco_name": "Blue Keys"
+                },
+                {
+                  "canvas": {
+                    "x": 0,
+                    "y": 13,
+                    "alignment": 0,
+                    "tranmap": null,
+                    "translation": null,
+                    "translucency": false,
+                    "conditions": [],
+                    "children": [
+                      {
+                        "graphic": {
+                          "x": 0,
+                          "y": 0,
+                          "alignment": 0,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [
+                            {
+                              "condition": 10,
+                              "param": 2,
+                              "param2": 0
+                            },
+                            {
+                              "condition": 11,
+                              "param": 5,
+                              "param2": 0
+                            }
+                          ],
+                          "children": [],
+                          "patch": "STKEYS1"
+                        }
+                      },
+                      {
+                        "graphic": {
+                          "x": 0,
+                          "y": 0,
+                          "alignment": 0,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [
+                            {
+                              "condition": 11,
+                              "param": 2,
+                              "param2": 0
+                            },
+                            {
+                              "condition": 10,
+                              "param": 5,
+                              "param2": 0
+                            }
+                          ],
+                          "children": [],
+                          "patch": "STKEYS4"
+                        }
+                      },
+                      {
+                        "graphic": {
+                          "x": 0,
+                          "y": 0,
+                          "alignment": 0,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [
+                            {
+                              "condition": 10,
+                              "param": 2,
+                              "param2": 0
+                            },
+                            {
+                              "condition": 10,
+                              "param": 5,
+                              "param2": 0
+                            }
+                          ],
+                          "children": [],
+                          "patch": "STKEYS7"
+                        }
+                      }
+                    ]
+                  },
+                  "_cacoco_name": "Yellow Keys"
+                },
+                {
+                  "canvas": {
+                    "x": 0,
+                    "y": 23,
+                    "alignment": 0,
+                    "tranmap": null,
+                    "translation": null,
+                    "translucency": false,
+                    "conditions": [],
+                    "children": [
+                      {
+                        "graphic": {
+                          "x": 0,
+                          "y": 0,
+                          "alignment": 0,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [
+                            {
+                              "condition": 10,
+                              "param": 3,
+                              "param2": 0
+                            },
+                            {
+                              "condition": 11,
+                              "param": 6,
+                              "param2": 0
+                            }
+                          ],
+                          "children": [],
+                          "patch": "STKEYS2"
+                        }
+                      },
+                      {
+                        "graphic": {
+                          "x": 0,
+                          "y": 0,
+                          "alignment": 0,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [
+                            {
+                              "condition": 11,
+                              "param": 3,
+                              "param2": 0
+                            },
+                            {
+                              "condition": 10,
+                              "param": 6,
+                              "param2": 0
+                            }
+                          ],
+                          "children": [],
+                          "patch": "STKEYS5"
+                        }
+                      },
+                      {
+                        "graphic": {
+                          "x": 0,
+                          "y": 0,
+                          "alignment": 0,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [
+                            {
+                              "condition": 10,
+                              "param": 3,
+                              "param2": 0
+                            },
+                            {
+                              "condition": 10,
+                              "param": 6,
+                              "param2": 0
+                            }
+                          ],
+                          "children": [],
+                          "patch": "STKEYS8"
+                        }
+                      }
+                    ]
+                  },
+                  "_cacoco_name": "Red Keys"
+                }
+              ]
+            },
+            "_cacoco_name": "Keys Cluster"
+          },
+          {
+            "percent": {
+              "x": 235,
+              "y": 3,
+              "alignment": 2,
+              "tranmap": null,
+              "translation": null,
+              "translucency": false,
+              "conditions": [],
+              "children": [],
+              "font": "Classic Status Bar",
+              "type": 1,
+              "param": 0,
+              "maxlength": 0
+            }
+          },
+          {
+            "canvas": {
+              "x": 288,
+              "y": 0,
+              "alignment": 0,
+              "tranmap": null,
+              "translation": null,
+              "translucency": false,
+              "conditions": [],
+              "children": [
+                {
+                  "number": {
+                    "x": 0,
+                    "y": 5,
+                    "alignment": 2,
+                    "tranmap": null,
+                    "translation": null,
+                    "translucency": false,
+                    "conditions": [],
+                    "children": [],
+                    "font": "Classic Yellow",
+                    "type": 3,
+                    "param": 0,
+                    "maxlength": 0
+                  }
+                },
+                {
+                  "number": {
+                    "x": 0,
+                    "y": 11,
+                    "alignment": 2,
+                    "tranmap": null,
+                    "translation": null,
+                    "translucency": false,
+                    "conditions": [],
+                    "children": [],
+                    "font": "Classic Yellow",
+                    "type": 3,
+                    "param": 1,
+                    "maxlength": 0
+                  }
+                },
+                {
+                  "number": {
+                    "x": 0,
+                    "y": 17,
+                    "alignment": 2,
+                    "tranmap": null,
+                    "translation": null,
+                    "translucency": false,
+                    "conditions": [],
+                    "children": [],
+                    "font": "Classic Yellow",
+                    "type": 3,
+                    "param": 3,
+                    "maxlength": 0
+                  }
+                },
+                {
+                  "number": {
+                    "x": 0,
+                    "y": 23,
+                    "alignment": 2,
+                    "tranmap": null,
+                    "translation": null,
+                    "translucency": false,
+                    "conditions": [],
+                    "children": [],
+                    "font": "Classic Yellow",
+                    "type": 3,
+                    "param": 2,
+                    "maxlength": 0
+                  }
+                }
+              ]
+            },
+            "_cacoco_name": "Current Ammo Group"
+          },
+          {
+            "canvas": {
+              "x": 314,
+              "y": 0,
+              "alignment": 0,
+              "tranmap": null,
+              "translation": null,
+              "translucency": false,
+              "conditions": [],
+              "children": [
+                {
+                  "number": {
+                    "x": 0,
+                    "y": 5,
+                    "alignment": 2,
+                    "tranmap": null,
+                    "translation": null,
+                    "translucency": false,
+                    "conditions": [],
+                    "children": [],
+                    "font": "Classic Yellow",
+                    "type": 5,
+                    "param": 0,
+                    "maxlength": 0
+                  }
+                },
+                {
+                  "number": {
+                    "x": 0,
+                    "y": 11,
+                    "alignment": 2,
+                    "tranmap": null,
+                    "translation": null,
+                    "translucency": false,
+                    "conditions": [],
+                    "children": [],
+                    "font": "Classic Yellow",
+                    "type": 5,
+                    "param": 1,
+                    "maxlength": 0
+                  }
+                },
+                {
+                  "number": {
+                    "x": 0,
+                    "y": 17,
+                    "alignment": 2,
+                    "tranmap": null,
+                    "translation": null,
+                    "translucency": false,
+                    "conditions": [],
+                    "children": [],
+                    "font": "Classic Yellow",
+                    "type": 5,
+                    "param": 3,
+                    "maxlength": 0
+                  }
+                },
+                {
+                  "number": {
+                    "x": 0,
+                    "y": 23,
+                    "alignment": 2,
+                    "tranmap": null,
+                    "translation": null,
+                    "translucency": false,
+                    "conditions": [],
+                    "children": [],
+                    "font": "Classic Yellow",
+                    "type": 5,
+                    "param": 2,
+                    "maxlength": 0
+                  }
+                }
+              ]
+            },
+            "_cacoco_name": "Max Ammo Group"
+          }
+        ]
+      },
+      {
+        "name": "FullNoBackground",
+        "height": 200,
+        "fullscreenrender": true,
+        "fillflat": null,
+        "children": [
+          {
+            "canvas": {
+              "x": 0,
+              "y": 168,
+              "alignment": 0,
+              "tranmap": null,
+              "translation": null,
+              "translucency": false,
+              "conditions": [],
+              "children": [
+                {
+                  "number": {
+                    "x": 44,
+                    "y": 3,
+                    "alignment": 2,
+                    "tranmap": null,
+                    "translation": null,
+                    "translucency": false,
+                    "conditions": [],
+                    "children": [],
+                    "font": "Classic Status Bar",
+                    "type": 4,
+                    "param": 0,
+                    "maxlength": 0
+                  }
+                },
+                {
+                  "percent": {
+                    "x": 104,
+                    "y": 3,
+                    "alignment": 2,
+                    "tranmap": null,
+                    "translation": null,
+                    "translucency": false,
+                    "conditions": [],
+                    "children": [],
+                    "font": "Classic Status Bar",
+                    "type": 0,
+                    "param": 0,
+                    "maxlength": 0
+                  }
+                },
+                {
+                  "canvas": {
+                    "x": 104,
+                    "y": 0,
+                    "alignment": 0,
+                    "tranmap": null,
+                    "translation": null,
+                    "translucency": false,
+                    "conditions": [
+                      {
+                        "condition": 14,
+                        "param": 0,
+                        "param2": 0
+                      }
+                    ],
+                    "children": [
+                      {
+                        "canvas": {
+                          "x": 0,
+                          "y": 0,
+                          "alignment": 0,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [],
+                          "children": [
+                            {
+                              "graphic": {
+                                "x": 7,
+                                "y": 4,
+                                "alignment": 0,
+                                "tranmap": null,
+                                "translation": null,
+                                "translucency": false,
+                                "conditions": [],
+                                "children": [],
+                                "patch": "STGNUM2"
+                              }
+                            },
+                            {
+                              "graphic": {
+                                "x": 19,
+                                "y": 4,
+                                "alignment": 0,
+                                "tranmap": null,
+                                "translation": null,
+                                "translucency": false,
+                                "conditions": [],
+                                "children": [],
+                                "patch": "STGNUM3"
+                              }
+                            },
+                            {
+                              "graphic": {
+                                "x": 31,
+                                "y": 4,
+                                "alignment": 0,
+                                "tranmap": null,
+                                "translation": null,
+                                "translucency": false,
+                                "conditions": [],
+                                "children": [],
+                                "patch": "STGNUM4"
+                              }
+                            },
+                            {
+                              "graphic": {
+                                "x": 7,
+                                "y": 14,
+                                "alignment": 0,
+                                "tranmap": null,
+                                "translation": null,
+                                "translucency": false,
+                                "conditions": [],
+                                "children": [],
+                                "patch": "STGNUM5"
+                              }
+                            },
+                            {
+                              "graphic": {
+                                "x": 19,
+                                "y": 14,
+                                "alignment": 0,
+                                "tranmap": null,
+                                "translation": null,
+                                "translucency": false,
+                                "conditions": [],
+                                "children": [],
+                                "patch": "STGNUM6"
+                              }
+                            },
+                            {
+                              "graphic": {
+                                "x": 31,
+                                "y": 14,
+                                "alignment": 0,
+                                "tranmap": null,
+                                "translation": null,
+                                "translucency": false,
+                                "conditions": [],
+                                "children": [],
+                                "patch": "STGNUM7"
+                              }
+                            },
+                            {
+                              "graphic": {
+                                "x": 7,
+                                "y": 4,
+                                "alignment": 0,
+                                "tranmap": null,
+                                "translation": null,
+                                "translucency": false,
+                                "conditions": [
+                                  {
+                                    "condition": 6,
+                                    "param": 2,
+                                    "param2": 0
+                                  }
+                                ],
+                                "children": [],
+                                "patch": "STYSNUM2"
+                              }
+                            },
+                            {
+                              "graphic": {
+                                "x": 19,
+                                "y": 4,
+                                "alignment": 0,
+                                "tranmap": null,
+                                "translation": null,
+                                "translucency": false,
+                                "conditions": [
+                                  {
+                                    "condition": 6,
+                                    "param": 3,
+                                    "param2": 0
+                                  }
+                                ],
+                                "children": [],
+                                "patch": "STYSNUM3"
+                              }
+                            },
+                            {
+                              "graphic": {
+                                "x": 31,
+                                "y": 4,
+                                "alignment": 0,
+                                "tranmap": null,
+                                "translation": null,
+                                "translucency": false,
+                                "conditions": [
+                                  {
+                                    "condition": 6,
+                                    "param": 4,
+                                    "param2": 0
+                                  }
+                                ],
+                                "children": [],
+                                "patch": "STYSNUM4"
+                              }
+                            },
+                            {
+                              "graphic": {
+                                "x": 7,
+                                "y": 14,
+                                "alignment": 0,
+                                "tranmap": null,
+                                "translation": null,
+                                "translucency": false,
+                                "conditions": [
+                                  {
+                                    "condition": 6,
+                                    "param": 5,
+                                    "param2": 0
+                                  }
+                                ],
+                                "children": [],
+                                "patch": "STYSNUM5"
+                              }
+                            },
+                            {
+                              "graphic": {
+                                "x": 19,
+                                "y": 14,
+                                "alignment": 0,
+                                "tranmap": null,
+                                "translation": null,
+                                "translucency": false,
+                                "conditions": [
+                                  {
+                                    "condition": 6,
+                                    "param": 6,
+                                    "param2": 0
+                                  }
+                                ],
+                                "children": [],
+                                "patch": "STYSNUM6"
+                              }
+                            },
+                            {
+                              "graphic": {
+                                "x": 31,
+                                "y": 14,
+                                "alignment": 0,
+                                "tranmap": null,
+                                "translation": null,
+                                "translucency": false,
+                                "conditions": [
+                                  {
+                                    "condition": 6,
+                                    "param": 7,
+                                    "param2": 0
+                                  }
+                                ],
+                                "children": [],
+                                "patch": "STYSNUM7"
+                              }
+                            }
+                          ]
+                        },
+                        "_cacoco_name": "Weapon Slot Group"
+                      }
+                    ]
+                  },
+                  "_cacoco_name": "STARMS Cluster"
+                },
+                {
+                  "canvas": {
+                    "x": 239,
+                    "y": 0,
+                    "alignment": 0,
+                    "tranmap": null,
+                    "translation": null,
+                    "translucency": false,
+                    "conditions": [],
+                    "children": [
+                      {
+                        "canvas": {
+                          "x": 0,
+                          "y": 3,
+                          "alignment": 0,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [],
+                          "children": [
+                            {
+                              "graphic": {
+                                "x": 0,
+                                "y": 0,
+                                "alignment": 0,
+                                "tranmap": null,
+                                "translation": null,
+                                "translucency": false,
+                                "conditions": [
+                                  {
+                                    "condition": 10,
+                                    "param": 1,
+                                    "param2": 0
+                                  },
+                                  {
+                                    "condition": 11,
+                                    "param": 4,
+                                    "param2": 0
+                                  }
+                                ],
+                                "children": [],
+                                "patch": "STKEYS0"
+                              }
+                            },
+                            {
+                              "graphic": {
+                                "x": 0,
+                                "y": 0,
+                                "alignment": 0,
+                                "tranmap": null,
+                                "translation": null,
+                                "translucency": false,
+                                "conditions": [
+                                  {
+                                    "condition": 11,
+                                    "param": 1,
+                                    "param2": 0
+                                  },
+                                  {
+                                    "condition": 10,
+                                    "param": 4,
+                                    "param2": 0
+                                  }
+                                ],
+                                "children": [],
+                                "patch": "STKEYS3"
+                              }
+                            },
+                            {
+                              "graphic": {
+                                "x": 0,
+                                "y": 0,
+                                "alignment": 0,
+                                "tranmap": null,
+                                "translation": null,
+                                "translucency": false,
+                                "conditions": [
+                                  {
+                                    "condition": 10,
+                                    "param": 1,
+                                    "param2": 0
+                                  },
+                                  {
+                                    "condition": 10,
+                                    "param": 4,
+                                    "param2": 0
+                                  }
+                                ],
+                                "children": [],
+                                "patch": "STKEYS6"
+                              }
+                            }
+                          ]
+                        },
+                        "_cacoco_name": "Blue Keys"
+                      },
+                      {
+                        "canvas": {
+                          "x": 0,
+                          "y": 13,
+                          "alignment": 0,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [],
+                          "children": [
+                            {
+                              "graphic": {
+                                "x": 0,
+                                "y": 0,
+                                "alignment": 0,
+                                "tranmap": null,
+                                "translation": null,
+                                "translucency": false,
+                                "conditions": [
+                                  {
+                                    "condition": 10,
+                                    "param": 2,
+                                    "param2": 0
+                                  },
+                                  {
+                                    "condition": 11,
+                                    "param": 5,
+                                    "param2": 0
+                                  }
+                                ],
+                                "children": [],
+                                "patch": "STKEYS1"
+                              }
+                            },
+                            {
+                              "graphic": {
+                                "x": 0,
+                                "y": 0,
+                                "alignment": 0,
+                                "tranmap": null,
+                                "translation": null,
+                                "translucency": false,
+                                "conditions": [
+                                  {
+                                    "condition": 11,
+                                    "param": 2,
+                                    "param2": 0
+                                  },
+                                  {
+                                    "condition": 10,
+                                    "param": 5,
+                                    "param2": 0
+                                  }
+                                ],
+                                "children": [],
+                                "patch": "STKEYS4"
+                              }
+                            },
+                            {
+                              "graphic": {
+                                "x": 0,
+                                "y": 0,
+                                "alignment": 0,
+                                "tranmap": null,
+                                "translation": null,
+                                "translucency": false,
+                                "conditions": [
+                                  {
+                                    "condition": 10,
+                                    "param": 2,
+                                    "param2": 0
+                                  },
+                                  {
+                                    "condition": 10,
+                                    "param": 5,
+                                    "param2": 0
+                                  }
+                                ],
+                                "children": [],
+                                "patch": "STKEYS7"
+                              }
+                            }
+                          ]
+                        },
+                        "_cacoco_name": "Yellow Keys"
+                      },
+                      {
+                        "canvas": {
+                          "x": 0,
+                          "y": 23,
+                          "alignment": 0,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [],
+                          "children": [
+                            {
+                              "graphic": {
+                                "x": 0,
+                                "y": 0,
+                                "alignment": 0,
+                                "tranmap": null,
+                                "translation": null,
+                                "translucency": false,
+                                "conditions": [
+                                  {
+                                    "condition": 10,
+                                    "param": 3,
+                                    "param2": 0
+                                  },
+                                  {
+                                    "condition": 11,
+                                    "param": 6,
+                                    "param2": 0
+                                  }
+                                ],
+                                "children": [],
+                                "patch": "STKEYS2"
+                              }
+                            },
+                            {
+                              "graphic": {
+                                "x": 0,
+                                "y": 0,
+                                "alignment": 0,
+                                "tranmap": null,
+                                "translation": null,
+                                "translucency": false,
+                                "conditions": [
+                                  {
+                                    "condition": 11,
+                                    "param": 3,
+                                    "param2": 0
+                                  },
+                                  {
+                                    "condition": 10,
+                                    "param": 6,
+                                    "param2": 0
+                                  }
+                                ],
+                                "children": [],
+                                "patch": "STKEYS5"
+                              }
+                            },
+                            {
+                              "graphic": {
+                                "x": 0,
+                                "y": 0,
+                                "alignment": 0,
+                                "tranmap": null,
+                                "translation": null,
+                                "translucency": false,
+                                "conditions": [
+                                  {
+                                    "condition": 10,
+                                    "param": 3,
+                                    "param2": 0
+                                  },
+                                  {
+                                    "condition": 10,
+                                    "param": 6,
+                                    "param2": 0
+                                  }
+                                ],
+                                "children": [],
+                                "patch": "STKEYS8"
+                              }
+                            }
+                          ]
+                        },
+                        "_cacoco_name": "Red Keys"
+                      }
+                    ]
+                  },
+                  "_cacoco_name": "Keys Cluster"
+                },
+                {
+                  "percent": {
+                    "x": 235,
+                    "y": 3,
+                    "alignment": 2,
+                    "tranmap": null,
+                    "translation": null,
+                    "translucency": false,
+                    "conditions": [],
+                    "children": [],
+                    "font": "Classic Status Bar",
+                    "type": 1,
+                    "param": 0,
+                    "maxlength": 0
+                  }
+                },
+                {
+                  "canvas": {
+                    "x": 288,
+                    "y": 0,
+                    "alignment": 0,
+                    "tranmap": null,
+                    "translation": null,
+                    "translucency": false,
+                    "conditions": [],
+                    "children": [
+                      {
+                        "number": {
+                          "x": 0,
+                          "y": 5,
+                          "alignment": 2,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [],
+                          "children": [],
+                          "font": "Classic Yellow",
+                          "type": 3,
+                          "param": 0,
+                          "maxlength": 0
+                        }
+                      },
+                      {
+                        "number": {
+                          "x": 0,
+                          "y": 11,
+                          "alignment": 2,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [],
+                          "children": [],
+                          "font": "Classic Yellow",
+                          "type": 3,
+                          "param": 1,
+                          "maxlength": 0
+                        }
+                      },
+                      {
+                        "number": {
+                          "x": 0,
+                          "y": 17,
+                          "alignment": 2,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [],
+                          "children": [],
+                          "font": "Classic Yellow",
+                          "type": 3,
+                          "param": 3,
+                          "maxlength": 0
+                        }
+                      },
+                      {
+                        "number": {
+                          "x": 0,
+                          "y": 23,
+                          "alignment": 2,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [],
+                          "children": [],
+                          "font": "Classic Yellow",
+                          "type": 3,
+                          "param": 2,
+                          "maxlength": 0
+                        }
+                      }
+                    ]
+                  },
+                  "_cacoco_name": "Current Ammo Group"
+                },
+                {
+                  "canvas": {
+                    "x": 314,
+                    "y": 0,
+                    "alignment": 0,
+                    "tranmap": null,
+                    "translation": null,
+                    "translucency": false,
+                    "conditions": [],
+                    "children": [
+                      {
+                        "number": {
+                          "x": 0,
+                          "y": 5,
+                          "alignment": 2,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [],
+                          "children": [],
+                          "font": "Classic Yellow",
+                          "type": 5,
+                          "param": 0,
+                          "maxlength": 0
+                        }
+                      },
+                      {
+                        "number": {
+                          "x": 0,
+                          "y": 11,
+                          "alignment": 2,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [],
+                          "children": [],
+                          "font": "Classic Yellow",
+                          "type": 5,
+                          "param": 1,
+                          "maxlength": 0
+                        }
+                      },
+                      {
+                        "number": {
+                          "x": 0,
+                          "y": 17,
+                          "alignment": 2,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [],
+                          "children": [],
+                          "font": "Classic Yellow",
+                          "type": 5,
+                          "param": 3,
+                          "maxlength": 0
+                        }
+                      },
+                      {
+                        "number": {
+                          "x": 0,
+                          "y": 23,
+                          "alignment": 2,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [],
+                          "children": [],
+                          "font": "Classic Yellow",
+                          "type": 5,
+                          "param": 2,
+                          "maxlength": 0
+                        }
+                      }
+                    ]
+                  },
+                  "_cacoco_name": "Max Ammo Group"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "name": "Minimal",
+        "height": 200,
+        "fullscreenrender": true,
+        "fillflat": null,
+        "children": [
+          {
+            "native": {
+              "x": 0,
+              "y": 0,
+              "alignment": 64,
+              "tranmap": null,
+              "translation": null,
+              "translucency": false,
+              "conditions": [],
+              "children": [
+                {
+                  "component": {
+                    "x": 0,
+                    "y": 0,
+                    "alignment": 0,
+                    "tranmap": null,
+                    "translation": null,
+                    "translucency": false,
+                    "conditions": [],
+                    "children": [],
+                    "type": "message",
+                    "font": "Classic HUD",
+                    "vertical": false,
+                    "duration": 4
+                  }
+                }
+              ]
+            },
+            "_cacoco_name": "Top Left"
+          },
+          {
+            "native": {
+              "x": 0,
+              "y": 160,
+              "alignment": 72,
+              "tranmap": null,
+              "translation": null,
+              "translucency": false,
+              "conditions": [],
+              "children": [
+                {
+                  "component": {
+                    "x": 0,
+                    "y": 0,
+                    "alignment": 0,
+                    "tranmap": null,
+                    "translation": null,
+                    "translucency": false,
+                    "conditions": [
+                      {
+                        "condition": 19,
+                        "param": 1,
+                        "param2": 0
+                      }
+                    ],
+                    "children": [],
+                    "type": "level_title",
+                    "font": "Classic HUD",
+                    "vertical": false,
+                    "duration": 4
+                  }
+                }
+              ]
+            },
+            "_cacoco_name": "Bottom Left Automap"
+          },
+          {
+            "native": {
+              "x": 5,
+              "y": 197,
+              "alignment": 72,
+              "tranmap": null,
+              "translation": null,
+              "translucency": false,
+              "conditions": [],
+              "children": [
+                {
+                  "face": {
+                    "x": 90,
+                    "y": -2,
+                    "alignment": 56,
+                    "tranmap": null,
+                    "translation": null,
+                    "translucency": false,
+                    "conditions": [],
+                    "children": [],
+                    "width": 0,
+                    "height": 0,
+                    "topoffset": 0,
+                    "leftoffset": 0,
+                    "midoffset": 0
+                  }
+                },
+                {
+                  "canvas": {
+                    "x": 0,
+                    "y": 0,
+                    "alignment": 8,
+                    "tranmap": null,
+                    "translation": null,
+                    "translucency": false,
+                    "conditions": [],
+                    "children": [
+                      {
+                        "canvas": {
+                          "x": -1,
+                          "y": -23,
+                          "alignment": 8,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [],
+                          "children": [
+                            {
+                              "graphic": {
+                                "x": 0,
+                                "y": 0,
+                                "alignment": 56,
+                                "tranmap": null,
+                                "translation": null,
+                                "translucency": false,
+                                "conditions": [
+                                  {
+                                    "condition": 11,
+                                    "param": 15,
+                                    "param2": 0
+                                  },
+                                  {
+                                    "condition": 27,
+                                    "param": 1,
+                                    "param2": 0
+                                  }
+                                ],
+                                "children": [],
+                                "patch": "ARM1A0"
+                              }
+                            },
+                            {
+                              "graphic": {
+                                "x": 0,
+                                "y": 0,
+                                "alignment": 56,
+                                "tranmap": null,
+                                "translation": null,
+                                "translucency": false,
+                                "conditions": [
+                                  {
+                                    "condition": 10,
+                                    "param": 15,
+                                    "param2": 0
+                                  },
+                                  {
+                                    "condition": 27,
+                                    "param": 1,
+                                    "param2": 0
+                                  }
+                                ],
+                                "children": [],
+                                "patch": "ARM2A0"
+                              }
+                            }
+                          ]
+                        },
+                        "_cacoco_name": "Armor"
+                      },
+                      {
+                        "graphic": {
+                          "x": 0,
+                          "y": 0,
+                          "alignment": 56,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [
+                            {
+                              "condition": 11,
+                              "param": 18,
+                              "param2": 0
+                            }
+                          ],
+                          "children": [],
+                          "patch": "MEDIA0"
+                        }
+                      },
+                      {
+                        "graphic": {
+                          "x": 0,
+                          "y": 0,
+                          "alignment": 56,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [
+                            {
+                              "condition": 10,
+                              "param": 18,
+                              "param2": 0
+                            }
+                          ],
+                          "children": [],
+                          "patch": "PSTRA0"
+                        }
+                      },
+                      {
+                        "number": {
+                          "x": 34,
+                          "y": -23,
+                          "alignment": 8,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [
+                            {
+                              "condition": 27,
+                              "param": 1,
+                              "param2": 0
+                            }
+                          ],
+                          "children": [],
+                          "font": "Classic Status Bar",
+                          "type": 1,
+                          "param": 0,
+                          "maxlength": 3
+                        }
+                      },
+                      {
+                        "number": {
+                          "x": 34,
+                          "y": -1,
+                          "alignment": 8,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [],
+                          "children": [],
+                          "font": "Classic Status Bar",
+                          "type": 0,
+                          "param": 0,
+                          "maxlength": 3
+                        }
+                      }
+                    ]
+                  },
+                  "_cacoco_name": "Health Cluster"
+                }
+              ]
+            },
+            "_cacoco_name": "Bottom Left"
+          },
+          {
+            "native": {
+              "x": 317,
+              "y": 197,
+              "alignment": 138,
+              "tranmap": null,
+              "translation": null,
+              "translucency": false,
+              "conditions": [],
+              "children": [
+                {
+                  "list": {
+                    "x": -1,
+                    "y": -26,
+                    "alignment": 6,
+                    "tranmap": null,
+                    "translation": null,
+                    "translucency": false,
+                    "conditions": [],
+                    "children": [
+                      {
+                        "list": {
+                          "x": 0,
+                          "y": 0,
+                          "alignment": 0,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [],
+                          "children": [
+                            {
+                              "graphic": {
+                                "x": 0,
+                                "y": 0,
+                                "alignment": 0,
+                                "tranmap": null,
+                                "translation": null,
+                                "translucency": false,
+                                "conditions": [
+                                  {
+                                    "condition": 10,
+                                    "param": 1,
+                                    "param2": 0
+                                  }
+                                ],
+                                "children": [],
+                                "patch": "STKEYS0"
+                              }
+                            },
+                            {
+                              "graphic": {
+                                "x": 0,
+                                "y": 0,
+                                "alignment": 0,
+                                "tranmap": null,
+                                "translation": null,
+                                "translucency": false,
+                                "conditions": [
+                                  {
+                                    "condition": 10,
+                                    "param": 2,
+                                    "param2": 0
+                                  }
+                                ],
+                                "children": [],
+                                "patch": "STKEYS1"
+                              }
+                            },
+                            {
+                              "graphic": {
+                                "x": 0,
+                                "y": 0,
+                                "alignment": 0,
+                                "tranmap": null,
+                                "translation": null,
+                                "translucency": false,
+                                "conditions": [
+                                  {
+                                    "condition": 10,
+                                    "param": 3,
+                                    "param2": 0
+                                  }
+                                ],
+                                "children": [],
+                                "patch": "STKEYS2"
+                              }
+                            }
+                          ],
+                          "horizontal": true,
+                          "spacing": 4
+                        }
+                      },
+                      {
+                        "list": {
+                          "x": 0,
+                          "y": 0,
+                          "alignment": 0,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [],
+                          "children": [
+                            {
+                              "graphic": {
+                                "x": 0,
+                                "y": 0,
+                                "alignment": 0,
+                                "tranmap": null,
+                                "translation": null,
+                                "translucency": false,
+                                "conditions": [
+                                  {
+                                    "condition": 10,
+                                    "param": 4,
+                                    "param2": 0
+                                  }
+                                ],
+                                "children": [],
+                                "patch": "STKEYS3"
+                              }
+                            },
+                            {
+                              "graphic": {
+                                "x": 0,
+                                "y": 0,
+                                "alignment": 0,
+                                "tranmap": null,
+                                "translation": null,
+                                "translucency": false,
+                                "conditions": [
+                                  {
+                                    "condition": 10,
+                                    "param": 5,
+                                    "param2": 0
+                                  }
+                                ],
+                                "children": [],
+                                "patch": "STKEYS4"
+                              }
+                            },
+                            {
+                              "graphic": {
+                                "x": 0,
+                                "y": 0,
+                                "alignment": 0,
+                                "tranmap": null,
+                                "translation": null,
+                                "translucency": false,
+                                "conditions": [
+                                  {
+                                    "condition": 10,
+                                    "param": 6,
+                                    "param2": 0
+                                  }
+                                ],
+                                "children": [],
+                                "patch": "STKEYS5"
+                              }
+                            }
+                          ],
+                          "horizontal": true,
+                          "spacing": 4
+                        }
+                      }
+                    ],
+                    "horizontal": false,
+                    "spacing": 4
+                  }
+                },
+                {
+                  "canvas": {
+                    "x": -55,
+                    "y": 0,
+                    "alignment": 10,
+                    "tranmap": null,
+                    "translation": null,
+                    "translucency": false,
+                    "conditions": [],
+                    "children": [
+                      {
+                        "graphic": {
+                          "x": 0,
+                          "y": 0,
+                          "alignment": 58,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [
+                            {
+                              "condition": 5,
+                              "param": 0,
+                              "param2": 0
+                            }
+                          ],
+                          "children": [],
+                          "patch": "CLIPA0"
+                        }
+                      },
+                      {
+                        "graphic": {
+                          "x": 0,
+                          "y": 0,
+                          "alignment": 58,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [
+                            {
+                              "condition": 5,
+                              "param": 1,
+                              "param2": 0
+                            }
+                          ],
+                          "children": [],
+                          "patch": "SHELA0"
+                        }
+                      },
+                      {
+                        "graphic": {
+                          "x": 0,
+                          "y": 0,
+                          "alignment": 58,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [
+                            {
+                              "condition": 5,
+                              "param": 3,
+                              "param2": 0
+                            }
+                          ],
+                          "children": [],
+                          "patch": "ROCKA0"
+                        }
+                      },
+                      {
+                        "graphic": {
+                          "x": 0,
+                          "y": 0,
+                          "alignment": 58,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [
+                            {
+                              "condition": 5,
+                              "param": 2,
+                              "param2": 0
+                            }
+                          ],
+                          "children": [],
+                          "patch": "CELLA0"
+                        }
+                      }
+                    ]
+                  },
+                  "_cacoco_name": "Ammo"
+                },
+                {
+                  "number": {
+                    "x": 0,
+                    "y": 0,
+                    "alignment": 10,
+                    "tranmap": null,
+                    "translation": null,
+                    "translucency": false,
+                    "conditions": [
+                      {
+                        "condition": 9,
+                        "param": 1,
+                        "param2": 0
+                      }
+                    ],
+                    "children": [],
+                    "font": "Classic Status Bar",
+                    "type": 4,
+                    "param": 0,
+                    "maxlength": 3
+                  }
+                }
+              ]
+            },
+            "_cacoco_name": "Bottom Right"
+          }
+        ]
+      },
+      {
         "name": "Detailed",
         "height": 200,
         "fullscreenrender": true,
@@ -137,7 +2208,7 @@
                           "type": "message",
                           "font": "Classic HUD",
                           "vertical": false,
-                          "duration": 4.0
+                          "duration": 4
                         }
                       },
                       {
@@ -169,7 +2240,7 @@
                                 "type": "stat_totals",
                                 "font": "Boom HUD",
                                 "vertical": true,
-                                "duration": 0.0
+                                "duration": 0
                               }
                             },
                             {
@@ -185,7 +2256,7 @@
                                 "type": "time",
                                 "font": "Boom HUD",
                                 "vertical": false,
-                                "duration": 0.0
+                                "duration": 0
                               }
                             }
                           ]
@@ -225,7 +2296,7 @@
                           "type": "level_title",
                           "font": "Classic HUD",
                           "vertical": false,
-                          "duration": 4.0
+                          "duration": 4
                         }
                       }
                     ]
@@ -271,7 +2342,7 @@
                                 "type": "time",
                                 "font": "Boom HUD",
                                 "vertical": false,
-                                "duration": 0.0
+                                "duration": 0
                               }
                             },
                             {
@@ -293,7 +2364,7 @@
                                 "type": "stat_totals",
                                 "font": "Boom HUD",
                                 "vertical": false,
-                                "duration": 0.0
+                                "duration": 0
                               }
                             }
                           ],
@@ -7390,2077 +9461,6 @@
                 }
               ]
             }
-          }
-        ]
-      },
-      {
-        "name": "Minimal",
-        "height": 200,
-        "fullscreenrender": true,
-        "fillflat": null,
-        "children": [
-          {
-            "native": {
-              "x": 0,
-              "y": 0,
-              "alignment": 64,
-              "tranmap": null,
-              "translation": null,
-              "translucency": false,
-              "conditions": [],
-              "children": [
-                {
-                  "component": {
-                    "x": 0,
-                    "y": 0,
-                    "alignment": 0,
-                    "tranmap": null,
-                    "translation": null,
-                    "translucency": false,
-                    "conditions": [],
-                    "children": [],
-                    "type": "message",
-                    "font": "Classic HUD",
-                    "vertical": false,
-                    "duration": 4.0
-                  }
-                }
-              ]
-            },
-            "_cacoco_name": "Top Left"
-          },
-          {
-            "native": {
-              "x": 0,
-              "y": 160,
-              "alignment": 72,
-              "tranmap": null,
-              "translation": null,
-              "translucency": false,
-              "conditions": [],
-              "children": [
-                {
-                  "component": {
-                    "x": 0,
-                    "y": 0,
-                    "alignment": 0,
-                    "tranmap": null,
-                    "translation": null,
-                    "translucency": false,
-                    "conditions": [
-                      {
-                        "condition": 19,
-                        "param": 1,
-                        "param2": 0
-                      }
-                    ],
-                    "children": [],
-                    "type": "level_title",
-                    "font": "Classic HUD",
-                    "vertical": false,
-                    "duration": 4.0
-                  }
-                }
-              ]
-            },
-            "_cacoco_name": "Bottom Left Automap"
-          },
-          {
-            "native": {
-              "x": 5,
-              "y": 197,
-              "alignment": 72,
-              "tranmap": null,
-              "translation": null,
-              "translucency": false,
-              "conditions": [],
-              "children": [
-                {
-                  "face": {
-                    "x": 90,
-                    "y": -2,
-                    "alignment": 56,
-                    "tranmap": null,
-                    "translation": null,
-                    "translucency": false,
-                    "conditions": [],
-                    "children": [],
-                    "width": 0,
-                    "height": 0,
-                    "topoffset": 0,
-                    "leftoffset": 0,
-                    "midoffset": 0
-                  }
-                },
-                {
-                  "canvas": {
-                    "x": 0,
-                    "y": 0,
-                    "alignment": 8,
-                    "tranmap": null,
-                    "translation": null,
-                    "translucency": false,
-                    "conditions": [],
-                    "children": [
-                      {
-                        "canvas": {
-                          "x": -1,
-                          "y": -23,
-                          "alignment": 8,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [],
-                          "children": [
-                            {
-                              "graphic": {
-                                "x": 0,
-                                "y": 0,
-                                "alignment": 56,
-                                "tranmap": null,
-                                "translation": null,
-                                "translucency": false,
-                                "conditions": [
-                                  {
-                                    "condition": 11,
-                                    "param": 15,
-                                    "param2": 0
-                                  },
-                                  {
-                                    "condition": 27,
-                                    "param": 1,
-                                    "param2": 0
-                                  }
-                                ],
-                                "children": [],
-                                "patch": "ARM1A0"
-                              }
-                            },
-                            {
-                              "graphic": {
-                                "x": 0,
-                                "y": 0,
-                                "alignment": 56,
-                                "tranmap": null,
-                                "translation": null,
-                                "translucency": false,
-                                "conditions": [
-                                  {
-                                    "condition": 10,
-                                    "param": 15,
-                                    "param2": 0
-                                  },
-                                  {
-                                    "condition": 27,
-                                    "param": 1,
-                                    "param2": 0
-                                  }
-                                ],
-                                "children": [],
-                                "patch": "ARM2A0"
-                              }
-                            }
-                          ]
-                        },
-                        "_cacoco_name": "Armor"
-                      },
-                      {
-                        "graphic": {
-                          "x": 0,
-                          "y": 0,
-                          "alignment": 56,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [
-                            {
-                              "condition": 11,
-                              "param": 18,
-                              "param2": 0
-                            }
-                          ],
-                          "children": [],
-                          "patch": "MEDIA0"
-                        }
-                      },
-                      {
-                        "graphic": {
-                          "x": 0,
-                          "y": 0,
-                          "alignment": 56,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [
-                            {
-                              "condition": 10,
-                              "param": 18,
-                              "param2": 0
-                            }
-                          ],
-                          "children": [],
-                          "patch": "PSTRA0"
-                        }
-                      },
-                      {
-                        "number": {
-                          "x": 34,
-                          "y": -23,
-                          "alignment": 8,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [
-                            {
-                              "condition": 27,
-                              "param": 1,
-                              "param2": 0
-                            }
-                          ],
-                          "children": [],
-                          "font": "Classic Status Bar",
-                          "type": 1,
-                          "param": 0,
-                          "maxlength": 3
-                        }
-                      },
-                      {
-                        "number": {
-                          "x": 34,
-                          "y": -1,
-                          "alignment": 8,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [],
-                          "children": [],
-                          "font": "Classic Status Bar",
-                          "type": 0,
-                          "param": 0,
-                          "maxlength": 3
-                        }
-                      }
-                    ]
-                  },
-                  "_cacoco_name": "Health Cluster"
-                }
-              ]
-            },
-            "_cacoco_name": "Bottom Left"
-          },
-          {
-            "native": {
-              "x": 317,
-              "y": 197,
-              "alignment": 138,
-              "tranmap": null,
-              "translation": null,
-              "translucency": false,
-              "conditions": [],
-              "children": [
-                {
-                  "list": {
-                    "x": -1,
-                    "y": -26,
-                    "alignment": 6,
-                    "tranmap": null,
-                    "translation": null,
-                    "translucency": false,
-                    "conditions": [],
-                    "children": [
-                      {
-                        "list": {
-                          "x": 0,
-                          "y": 0,
-                          "alignment": 0,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [],
-                          "children": [
-                            {
-                              "graphic": {
-                                "x": 0,
-                                "y": 0,
-                                "alignment": 0,
-                                "tranmap": null,
-                                "translation": null,
-                                "translucency": false,
-                                "conditions": [
-                                  {
-                                    "condition": 10,
-                                    "param": 1,
-                                    "param2": 0
-                                  }
-                                ],
-                                "children": [],
-                                "patch": "STKEYS0"
-                              }
-                            },
-                            {
-                              "graphic": {
-                                "x": 0,
-                                "y": 0,
-                                "alignment": 0,
-                                "tranmap": null,
-                                "translation": null,
-                                "translucency": false,
-                                "conditions": [
-                                  {
-                                    "condition": 10,
-                                    "param": 2,
-                                    "param2": 0
-                                  }
-                                ],
-                                "children": [],
-                                "patch": "STKEYS1"
-                              }
-                            },
-                            {
-                              "graphic": {
-                                "x": 0,
-                                "y": 0,
-                                "alignment": 0,
-                                "tranmap": null,
-                                "translation": null,
-                                "translucency": false,
-                                "conditions": [
-                                  {
-                                    "condition": 10,
-                                    "param": 3,
-                                    "param2": 0
-                                  }
-                                ],
-                                "children": [],
-                                "patch": "STKEYS2"
-                              }
-                            }
-                          ],
-                          "horizontal": true,
-                          "spacing": 4
-                        }
-                      },
-                      {
-                        "list": {
-                          "x": 0,
-                          "y": 0,
-                          "alignment": 0,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [],
-                          "children": [
-                            {
-                              "graphic": {
-                                "x": 0,
-                                "y": 0,
-                                "alignment": 0,
-                                "tranmap": null,
-                                "translation": null,
-                                "translucency": false,
-                                "conditions": [
-                                  {
-                                    "condition": 10,
-                                    "param": 4,
-                                    "param2": 0
-                                  }
-                                ],
-                                "children": [],
-                                "patch": "STKEYS3"
-                              }
-                            },
-                            {
-                              "graphic": {
-                                "x": 0,
-                                "y": 0,
-                                "alignment": 0,
-                                "tranmap": null,
-                                "translation": null,
-                                "translucency": false,
-                                "conditions": [
-                                  {
-                                    "condition": 10,
-                                    "param": 5,
-                                    "param2": 0
-                                  }
-                                ],
-                                "children": [],
-                                "patch": "STKEYS4"
-                              }
-                            },
-                            {
-                              "graphic": {
-                                "x": 0,
-                                "y": 0,
-                                "alignment": 0,
-                                "tranmap": null,
-                                "translation": null,
-                                "translucency": false,
-                                "conditions": [
-                                  {
-                                    "condition": 10,
-                                    "param": 6,
-                                    "param2": 0
-                                  }
-                                ],
-                                "children": [],
-                                "patch": "STKEYS5"
-                              }
-                            }
-                          ],
-                          "horizontal": true,
-                          "spacing": 4
-                        }
-                      }
-                    ],
-                    "horizontal": false,
-                    "spacing": 4
-                  }
-                },
-                {
-                  "canvas": {
-                    "x": -55,
-                    "y": 0,
-                    "alignment": 10,
-                    "tranmap": null,
-                    "translation": null,
-                    "translucency": false,
-                    "conditions": [],
-                    "children": [
-                      {
-                        "graphic": {
-                          "x": 0,
-                          "y": 0,
-                          "alignment": 58,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [
-                            {
-                              "condition": 5,
-                              "param": 0,
-                              "param2": 0
-                            }
-                          ],
-                          "children": [],
-                          "patch": "CLIPA0"
-                        }
-                      },
-                      {
-                        "graphic": {
-                          "x": 0,
-                          "y": 0,
-                          "alignment": 58,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [
-                            {
-                              "condition": 5,
-                              "param": 1,
-                              "param2": 0
-                            }
-                          ],
-                          "children": [],
-                          "patch": "SHELA0"
-                        }
-                      },
-                      {
-                        "graphic": {
-                          "x": 0,
-                          "y": 0,
-                          "alignment": 58,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [
-                            {
-                              "condition": 5,
-                              "param": 3,
-                              "param2": 0
-                            }
-                          ],
-                          "children": [],
-                          "patch": "ROCKA0"
-                        }
-                      },
-                      {
-                        "graphic": {
-                          "x": 0,
-                          "y": 0,
-                          "alignment": 58,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [
-                            {
-                              "condition": 5,
-                              "param": 2,
-                              "param2": 0
-                            }
-                          ],
-                          "children": [],
-                          "patch": "CELLA0"
-                        }
-                      }
-                    ]
-                  },
-                  "_cacoco_name": "Ammo"
-                },
-                {
-                  "number": {
-                    "x": 0,
-                    "y": 0,
-                    "alignment": 10,
-                    "tranmap": null,
-                    "translation": null,
-                    "translucency": false,
-                    "conditions": [
-                      {
-                        "condition": 9,
-                        "param": 1,
-                        "param2": 0
-                      }
-                    ],
-                    "children": [],
-                    "font": "Classic Status Bar",
-                    "type": 4,
-                    "param": 0,
-                    "maxlength": 3
-                  }
-                }
-              ]
-            },
-            "_cacoco_name": "Bottom Right"
-          }
-        ]
-      },
-      {
-        "name": "FullNoBackground",
-        "height": 200,
-        "fullscreenrender": true,
-        "fillflat": null,
-        "children": [
-          {
-            "canvas": {
-              "x": 0,
-              "y": 168,
-              "alignment": 0,
-              "tranmap": null,
-              "translation": null,
-              "translucency": false,
-              "conditions": [],
-              "children": [
-                {
-                  "number": {
-                    "x": 44,
-                    "y": 3,
-                    "alignment": 2,
-                    "tranmap": null,
-                    "translation": null,
-                    "translucency": false,
-                    "conditions": [],
-                    "children": [],
-                    "font": "Classic Status Bar",
-                    "type": 4,
-                    "param": 0,
-                    "maxlength": 0
-                  }
-                },
-                {
-                  "percent": {
-                    "x": 104,
-                    "y": 3,
-                    "alignment": 2,
-                    "tranmap": null,
-                    "translation": null,
-                    "translucency": false,
-                    "conditions": [],
-                    "children": [],
-                    "font": "Classic Status Bar",
-                    "type": 0,
-                    "param": 0,
-                    "maxlength": 0
-                  }
-                },
-                {
-                  "canvas": {
-                    "x": 104,
-                    "y": 0,
-                    "alignment": 0,
-                    "tranmap": null,
-                    "translation": null,
-                    "translucency": false,
-                    "conditions": [
-                      {
-                        "condition": 14,
-                        "param": 0,
-                        "param2": 0
-                      }
-                    ],
-                    "children": [
-                      {
-                        "canvas": {
-                          "x": 0,
-                          "y": 0,
-                          "alignment": 0,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [],
-                          "children": [
-                            {
-                              "graphic": {
-                                "x": 7,
-                                "y": 4,
-                                "alignment": 0,
-                                "tranmap": null,
-                                "translation": null,
-                                "translucency": false,
-                                "conditions": [],
-                                "children": [],
-                                "patch": "STGNUM2"
-                              }
-                            },
-                            {
-                              "graphic": {
-                                "x": 19,
-                                "y": 4,
-                                "alignment": 0,
-                                "tranmap": null,
-                                "translation": null,
-                                "translucency": false,
-                                "conditions": [],
-                                "children": [],
-                                "patch": "STGNUM3"
-                              }
-                            },
-                            {
-                              "graphic": {
-                                "x": 31,
-                                "y": 4,
-                                "alignment": 0,
-                                "tranmap": null,
-                                "translation": null,
-                                "translucency": false,
-                                "conditions": [],
-                                "children": [],
-                                "patch": "STGNUM4"
-                              }
-                            },
-                            {
-                              "graphic": {
-                                "x": 7,
-                                "y": 14,
-                                "alignment": 0,
-                                "tranmap": null,
-                                "translation": null,
-                                "translucency": false,
-                                "conditions": [],
-                                "children": [],
-                                "patch": "STGNUM5"
-                              }
-                            },
-                            {
-                              "graphic": {
-                                "x": 19,
-                                "y": 14,
-                                "alignment": 0,
-                                "tranmap": null,
-                                "translation": null,
-                                "translucency": false,
-                                "conditions": [],
-                                "children": [],
-                                "patch": "STGNUM6"
-                              }
-                            },
-                            {
-                              "graphic": {
-                                "x": 31,
-                                "y": 14,
-                                "alignment": 0,
-                                "tranmap": null,
-                                "translation": null,
-                                "translucency": false,
-                                "conditions": [],
-                                "children": [],
-                                "patch": "STGNUM7"
-                              }
-                            },
-                            {
-                              "graphic": {
-                                "x": 7,
-                                "y": 4,
-                                "alignment": 0,
-                                "tranmap": null,
-                                "translation": null,
-                                "translucency": false,
-                                "conditions": [
-                                  {
-                                    "condition": 6,
-                                    "param": 2,
-                                    "param2": 0
-                                  }
-                                ],
-                                "children": [],
-                                "patch": "STYSNUM2"
-                              }
-                            },
-                            {
-                              "graphic": {
-                                "x": 19,
-                                "y": 4,
-                                "alignment": 0,
-                                "tranmap": null,
-                                "translation": null,
-                                "translucency": false,
-                                "conditions": [
-                                  {
-                                    "condition": 6,
-                                    "param": 3,
-                                    "param2": 0
-                                  }
-                                ],
-                                "children": [],
-                                "patch": "STYSNUM3"
-                              }
-                            },
-                            {
-                              "graphic": {
-                                "x": 31,
-                                "y": 4,
-                                "alignment": 0,
-                                "tranmap": null,
-                                "translation": null,
-                                "translucency": false,
-                                "conditions": [
-                                  {
-                                    "condition": 6,
-                                    "param": 4,
-                                    "param2": 0
-                                  }
-                                ],
-                                "children": [],
-                                "patch": "STYSNUM4"
-                              }
-                            },
-                            {
-                              "graphic": {
-                                "x": 7,
-                                "y": 14,
-                                "alignment": 0,
-                                "tranmap": null,
-                                "translation": null,
-                                "translucency": false,
-                                "conditions": [
-                                  {
-                                    "condition": 6,
-                                    "param": 5,
-                                    "param2": 0
-                                  }
-                                ],
-                                "children": [],
-                                "patch": "STYSNUM5"
-                              }
-                            },
-                            {
-                              "graphic": {
-                                "x": 19,
-                                "y": 14,
-                                "alignment": 0,
-                                "tranmap": null,
-                                "translation": null,
-                                "translucency": false,
-                                "conditions": [
-                                  {
-                                    "condition": 6,
-                                    "param": 6,
-                                    "param2": 0
-                                  }
-                                ],
-                                "children": [],
-                                "patch": "STYSNUM6"
-                              }
-                            },
-                            {
-                              "graphic": {
-                                "x": 31,
-                                "y": 14,
-                                "alignment": 0,
-                                "tranmap": null,
-                                "translation": null,
-                                "translucency": false,
-                                "conditions": [
-                                  {
-                                    "condition": 6,
-                                    "param": 7,
-                                    "param2": 0
-                                  }
-                                ],
-                                "children": [],
-                                "patch": "STYSNUM7"
-                              }
-                            }
-                          ]
-                        },
-                        "_cacoco_name": "Weapon Slot Group"
-                      }
-                    ]
-                  },
-                  "_cacoco_name": "STARMS Cluster"
-                },
-                {
-                  "canvas": {
-                    "x": 239,
-                    "y": 0,
-                    "alignment": 0,
-                    "tranmap": null,
-                    "translation": null,
-                    "translucency": false,
-                    "conditions": [],
-                    "children": [
-                      {
-                        "canvas": {
-                          "x": 0,
-                          "y": 3,
-                          "alignment": 0,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [],
-                          "children": [
-                            {
-                              "graphic": {
-                                "x": 0,
-                                "y": 0,
-                                "alignment": 0,
-                                "tranmap": null,
-                                "translation": null,
-                                "translucency": false,
-                                "conditions": [
-                                  {
-                                    "condition": 10,
-                                    "param": 1,
-                                    "param2": 0
-                                  },
-                                  {
-                                    "condition": 11,
-                                    "param": 4,
-                                    "param2": 0
-                                  }
-                                ],
-                                "children": [],
-                                "patch": "STKEYS0"
-                              }
-                            },
-                            {
-                              "graphic": {
-                                "x": 0,
-                                "y": 0,
-                                "alignment": 0,
-                                "tranmap": null,
-                                "translation": null,
-                                "translucency": false,
-                                "conditions": [
-                                  {
-                                    "condition": 11,
-                                    "param": 1,
-                                    "param2": 0
-                                  },
-                                  {
-                                    "condition": 10,
-                                    "param": 4,
-                                    "param2": 0
-                                  }
-                                ],
-                                "children": [],
-                                "patch": "STKEYS3"
-                              }
-                            },
-                            {
-                              "graphic": {
-                                "x": 0,
-                                "y": 0,
-                                "alignment": 0,
-                                "tranmap": null,
-                                "translation": null,
-                                "translucency": false,
-                                "conditions": [
-                                  {
-                                    "condition": 10,
-                                    "param": 1,
-                                    "param2": 0
-                                  },
-                                  {
-                                    "condition": 10,
-                                    "param": 4,
-                                    "param2": 0
-                                  }
-                                ],
-                                "children": [],
-                                "patch": "STKEYS6"
-                              }
-                            }
-                          ]
-                        },
-                        "_cacoco_name": "Blue Keys"
-                      },
-                      {
-                        "canvas": {
-                          "x": 0,
-                          "y": 13,
-                          "alignment": 0,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [],
-                          "children": [
-                            {
-                              "graphic": {
-                                "x": 0,
-                                "y": 0,
-                                "alignment": 0,
-                                "tranmap": null,
-                                "translation": null,
-                                "translucency": false,
-                                "conditions": [
-                                  {
-                                    "condition": 10,
-                                    "param": 2,
-                                    "param2": 0
-                                  },
-                                  {
-                                    "condition": 11,
-                                    "param": 5,
-                                    "param2": 0
-                                  }
-                                ],
-                                "children": [],
-                                "patch": "STKEYS1"
-                              }
-                            },
-                            {
-                              "graphic": {
-                                "x": 0,
-                                "y": 0,
-                                "alignment": 0,
-                                "tranmap": null,
-                                "translation": null,
-                                "translucency": false,
-                                "conditions": [
-                                  {
-                                    "condition": 11,
-                                    "param": 2,
-                                    "param2": 0
-                                  },
-                                  {
-                                    "condition": 10,
-                                    "param": 5,
-                                    "param2": 0
-                                  }
-                                ],
-                                "children": [],
-                                "patch": "STKEYS4"
-                              }
-                            },
-                            {
-                              "graphic": {
-                                "x": 0,
-                                "y": 0,
-                                "alignment": 0,
-                                "tranmap": null,
-                                "translation": null,
-                                "translucency": false,
-                                "conditions": [
-                                  {
-                                    "condition": 10,
-                                    "param": 2,
-                                    "param2": 0
-                                  },
-                                  {
-                                    "condition": 10,
-                                    "param": 5,
-                                    "param2": 0
-                                  }
-                                ],
-                                "children": [],
-                                "patch": "STKEYS7"
-                              }
-                            }
-                          ]
-                        },
-                        "_cacoco_name": "Yellow Keys"
-                      },
-                      {
-                        "canvas": {
-                          "x": 0,
-                          "y": 23,
-                          "alignment": 0,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [],
-                          "children": [
-                            {
-                              "graphic": {
-                                "x": 0,
-                                "y": 0,
-                                "alignment": 0,
-                                "tranmap": null,
-                                "translation": null,
-                                "translucency": false,
-                                "conditions": [
-                                  {
-                                    "condition": 10,
-                                    "param": 3,
-                                    "param2": 0
-                                  },
-                                  {
-                                    "condition": 11,
-                                    "param": 6,
-                                    "param2": 0
-                                  }
-                                ],
-                                "children": [],
-                                "patch": "STKEYS2"
-                              }
-                            },
-                            {
-                              "graphic": {
-                                "x": 0,
-                                "y": 0,
-                                "alignment": 0,
-                                "tranmap": null,
-                                "translation": null,
-                                "translucency": false,
-                                "conditions": [
-                                  {
-                                    "condition": 11,
-                                    "param": 3,
-                                    "param2": 0
-                                  },
-                                  {
-                                    "condition": 10,
-                                    "param": 6,
-                                    "param2": 0
-                                  }
-                                ],
-                                "children": [],
-                                "patch": "STKEYS5"
-                              }
-                            },
-                            {
-                              "graphic": {
-                                "x": 0,
-                                "y": 0,
-                                "alignment": 0,
-                                "tranmap": null,
-                                "translation": null,
-                                "translucency": false,
-                                "conditions": [
-                                  {
-                                    "condition": 10,
-                                    "param": 3,
-                                    "param2": 0
-                                  },
-                                  {
-                                    "condition": 10,
-                                    "param": 6,
-                                    "param2": 0
-                                  }
-                                ],
-                                "children": [],
-                                "patch": "STKEYS8"
-                              }
-                            }
-                          ]
-                        },
-                        "_cacoco_name": "Red Keys"
-                      }
-                    ]
-                  },
-                  "_cacoco_name": "Keys Cluster"
-                },
-                {
-                  "percent": {
-                    "x": 235,
-                    "y": 3,
-                    "alignment": 2,
-                    "tranmap": null,
-                    "translation": null,
-                    "translucency": false,
-                    "conditions": [],
-                    "children": [],
-                    "font": "Classic Status Bar",
-                    "type": 1,
-                    "param": 0,
-                    "maxlength": 0
-                  }
-                },
-                {
-                  "canvas": {
-                    "x": 288,
-                    "y": 0,
-                    "alignment": 0,
-                    "tranmap": null,
-                    "translation": null,
-                    "translucency": false,
-                    "conditions": [],
-                    "children": [
-                      {
-                        "number": {
-                          "x": 0,
-                          "y": 5,
-                          "alignment": 2,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [],
-                          "children": [],
-                          "font": "Classic Yellow",
-                          "type": 3,
-                          "param": 0,
-                          "maxlength": 0
-                        }
-                      },
-                      {
-                        "number": {
-                          "x": 0,
-                          "y": 11,
-                          "alignment": 2,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [],
-                          "children": [],
-                          "font": "Classic Yellow",
-                          "type": 3,
-                          "param": 1,
-                          "maxlength": 0
-                        }
-                      },
-                      {
-                        "number": {
-                          "x": 0,
-                          "y": 17,
-                          "alignment": 2,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [],
-                          "children": [],
-                          "font": "Classic Yellow",
-                          "type": 3,
-                          "param": 3,
-                          "maxlength": 0
-                        }
-                      },
-                      {
-                        "number": {
-                          "x": 0,
-                          "y": 23,
-                          "alignment": 2,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [],
-                          "children": [],
-                          "font": "Classic Yellow",
-                          "type": 3,
-                          "param": 2,
-                          "maxlength": 0
-                        }
-                      }
-                    ]
-                  },
-                  "_cacoco_name": "Current Ammo Group"
-                },
-                {
-                  "canvas": {
-                    "x": 314,
-                    "y": 0,
-                    "alignment": 0,
-                    "tranmap": null,
-                    "translation": null,
-                    "translucency": false,
-                    "conditions": [],
-                    "children": [
-                      {
-                        "number": {
-                          "x": 0,
-                          "y": 5,
-                          "alignment": 2,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [],
-                          "children": [],
-                          "font": "Classic Yellow",
-                          "type": 5,
-                          "param": 0,
-                          "maxlength": 0
-                        }
-                      },
-                      {
-                        "number": {
-                          "x": 0,
-                          "y": 11,
-                          "alignment": 2,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [],
-                          "children": [],
-                          "font": "Classic Yellow",
-                          "type": 5,
-                          "param": 1,
-                          "maxlength": 0
-                        }
-                      },
-                      {
-                        "number": {
-                          "x": 0,
-                          "y": 17,
-                          "alignment": 2,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [],
-                          "children": [],
-                          "font": "Classic Yellow",
-                          "type": 5,
-                          "param": 3,
-                          "maxlength": 0
-                        }
-                      },
-                      {
-                        "number": {
-                          "x": 0,
-                          "y": 23,
-                          "alignment": 2,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [],
-                          "children": [],
-                          "font": "Classic Yellow",
-                          "type": 5,
-                          "param": 2,
-                          "maxlength": 0
-                        }
-                      }
-                    ]
-                  },
-                  "_cacoco_name": "Max Ammo Group"
-                }
-              ]
-            }
-          }
-        ]
-      },
-      {
-        "name": "Full",
-        "height": 32,
-        "fullscreenrender": false,
-        "fillflat": null,
-        "children": [
-          {
-            "graphic": {
-              "x": 160,
-              "y": 0,
-              "alignment": 1,
-              "tranmap": null,
-              "translation": null,
-              "translucency": false,
-              "conditions": [],
-              "children": [],
-              "patch": "STBAR"
-            }
-          },
-          {
-            "number": {
-              "x": 44,
-              "y": 3,
-              "alignment": 2,
-              "tranmap": null,
-              "translation": null,
-              "translucency": false,
-              "conditions": [],
-              "children": [],
-              "font": "Classic Status Bar",
-              "type": 4,
-              "param": 0,
-              "maxlength": 0
-            }
-          },
-          {
-            "percent": {
-              "x": 104,
-              "y": 3,
-              "alignment": 2,
-              "tranmap": null,
-              "translation": null,
-              "translucency": false,
-              "conditions": [],
-              "children": [],
-              "font": "Classic Status Bar",
-              "type": 0,
-              "param": 0,
-              "maxlength": 0
-            }
-          },
-          {
-            "canvas": {
-              "x": 104,
-              "y": 0,
-              "alignment": 0,
-              "tranmap": null,
-              "translation": null,
-              "translucency": false,
-              "conditions": [
-                {
-                  "condition": 14,
-                  "param": 0,
-                  "param2": 0
-                }
-              ],
-              "children": [
-                {
-                  "graphic": {
-                    "x": 0,
-                    "y": 0,
-                    "alignment": 0,
-                    "tranmap": null,
-                    "translation": null,
-                    "translucency": false,
-                    "conditions": [],
-                    "children": [],
-                    "patch": "STARMS"
-                  }
-                },
-                {
-                  "canvas": {
-                    "x": 0,
-                    "y": 0,
-                    "alignment": 0,
-                    "tranmap": null,
-                    "translation": null,
-                    "translucency": false,
-                    "conditions": [],
-                    "children": [
-                      {
-                        "graphic": {
-                          "x": 7,
-                          "y": 4,
-                          "alignment": 0,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [],
-                          "children": [],
-                          "patch": "STGNUM2"
-                        }
-                      },
-                      {
-                        "graphic": {
-                          "x": 19,
-                          "y": 4,
-                          "alignment": 0,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [],
-                          "children": [],
-                          "patch": "STGNUM3"
-                        }
-                      },
-                      {
-                        "graphic": {
-                          "x": 31,
-                          "y": 4,
-                          "alignment": 0,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [],
-                          "children": [],
-                          "patch": "STGNUM4"
-                        }
-                      },
-                      {
-                        "graphic": {
-                          "x": 7,
-                          "y": 14,
-                          "alignment": 0,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [],
-                          "children": [],
-                          "patch": "STGNUM5"
-                        }
-                      },
-                      {
-                        "graphic": {
-                          "x": 19,
-                          "y": 14,
-                          "alignment": 0,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [],
-                          "children": [],
-                          "patch": "STGNUM6"
-                        }
-                      },
-                      {
-                        "graphic": {
-                          "x": 31,
-                          "y": 14,
-                          "alignment": 0,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [],
-                          "children": [],
-                          "patch": "STGNUM7"
-                        }
-                      },
-                      {
-                        "graphic": {
-                          "x": 7,
-                          "y": 4,
-                          "alignment": 0,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [
-                            {
-                              "condition": 6,
-                              "param": 2,
-                              "param2": 0
-                            }
-                          ],
-                          "children": [],
-                          "patch": "STYSNUM2"
-                        }
-                      },
-                      {
-                        "graphic": {
-                          "x": 19,
-                          "y": 4,
-                          "alignment": 0,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [
-                            {
-                              "condition": 6,
-                              "param": 3,
-                              "param2": 0
-                            }
-                          ],
-                          "children": [],
-                          "patch": "STYSNUM3"
-                        }
-                      },
-                      {
-                        "graphic": {
-                          "x": 31,
-                          "y": 4,
-                          "alignment": 0,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [
-                            {
-                              "condition": 6,
-                              "param": 4,
-                              "param2": 0
-                            }
-                          ],
-                          "children": [],
-                          "patch": "STYSNUM4"
-                        }
-                      },
-                      {
-                        "graphic": {
-                          "x": 7,
-                          "y": 14,
-                          "alignment": 0,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [
-                            {
-                              "condition": 6,
-                              "param": 5,
-                              "param2": 0
-                            }
-                          ],
-                          "children": [],
-                          "patch": "STYSNUM5"
-                        }
-                      },
-                      {
-                        "graphic": {
-                          "x": 19,
-                          "y": 14,
-                          "alignment": 0,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [
-                            {
-                              "condition": 6,
-                              "param": 6,
-                              "param2": 0
-                            }
-                          ],
-                          "children": [],
-                          "patch": "STYSNUM6"
-                        }
-                      },
-                      {
-                        "graphic": {
-                          "x": 31,
-                          "y": 14,
-                          "alignment": 0,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [
-                            {
-                              "condition": 6,
-                              "param": 7,
-                              "param2": 0
-                            }
-                          ],
-                          "children": [],
-                          "patch": "STYSNUM7"
-                        }
-                      }
-                    ]
-                  },
-                  "_cacoco_name": "Weapon Slot Group"
-                }
-              ]
-            },
-            "_cacoco_name": "STARMS Cluster"
-          },
-          {
-            "canvas": {
-              "x": 0,
-              "y": 0,
-              "alignment": 0,
-              "tranmap": null,
-              "translation": null,
-              "translucency": false,
-              "conditions": [
-                {
-                  "condition": 14,
-                  "param": 2,
-                  "param2": 0
-                }
-              ],
-              "children": [
-                {
-                  "number": {
-                    "x": 138,
-                    "y": 3,
-                    "alignment": 2,
-                    "tranmap": null,
-                    "translation": null,
-                    "translucency": false,
-                    "conditions": [],
-                    "children": [],
-                    "font": "Classic Status Bar",
-                    "type": 2,
-                    "param": 0,
-                    "maxlength": 0
-                  }
-                },
-                {
-                  "facebackground": {
-                    "x": 143,
-                    "y": 1,
-                    "alignment": 0,
-                    "tranmap": null,
-                    "translation": null,
-                    "translucency": false,
-                    "conditions": [],
-                    "children": [],
-                    "width": 0,
-                    "height": 0,
-                    "topoffset": 0,
-                    "leftoffset": 0,
-                    "midoffset": 0
-                  }
-                }
-              ]
-            },
-            "_cacoco_name": "Deathmatch Group"
-          },
-          {
-            "face": {
-              "x": 143,
-              "y": 0,
-              "alignment": 0,
-              "tranmap": null,
-              "translation": null,
-              "translucency": false,
-              "conditions": [],
-              "children": [],
-              "width": 0,
-              "height": 0,
-              "topoffset": 0,
-              "leftoffset": 0,
-              "midoffset": 0
-            }
-          },
-          {
-            "canvas": {
-              "x": 239,
-              "y": 0,
-              "alignment": 0,
-              "tranmap": null,
-              "translation": null,
-              "translucency": false,
-              "conditions": [],
-              "children": [
-                {
-                  "canvas": {
-                    "x": 0,
-                    "y": 3,
-                    "alignment": 0,
-                    "tranmap": null,
-                    "translation": null,
-                    "translucency": false,
-                    "conditions": [],
-                    "children": [
-                      {
-                        "graphic": {
-                          "x": 0,
-                          "y": 0,
-                          "alignment": 0,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [
-                            {
-                              "condition": 10,
-                              "param": 1,
-                              "param2": 0
-                            },
-                            {
-                              "condition": 11,
-                              "param": 4,
-                              "param2": 0
-                            }
-                          ],
-                          "children": [],
-                          "patch": "STKEYS0"
-                        }
-                      },
-                      {
-                        "graphic": {
-                          "x": 0,
-                          "y": 0,
-                          "alignment": 0,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [
-                            {
-                              "condition": 11,
-                              "param": 1,
-                              "param2": 0
-                            },
-                            {
-                              "condition": 10,
-                              "param": 4,
-                              "param2": 0
-                            }
-                          ],
-                          "children": [],
-                          "patch": "STKEYS3"
-                        }
-                      },
-                      {
-                        "graphic": {
-                          "x": 0,
-                          "y": 0,
-                          "alignment": 0,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [
-                            {
-                              "condition": 10,
-                              "param": 1,
-                              "param2": 0
-                            },
-                            {
-                              "condition": 10,
-                              "param": 4,
-                              "param2": 0
-                            }
-                          ],
-                          "children": [],
-                          "patch": "STKEYS6"
-                        }
-                      }
-                    ]
-                  },
-                  "_cacoco_name": "Blue Keys"
-                },
-                {
-                  "canvas": {
-                    "x": 0,
-                    "y": 13,
-                    "alignment": 0,
-                    "tranmap": null,
-                    "translation": null,
-                    "translucency": false,
-                    "conditions": [],
-                    "children": [
-                      {
-                        "graphic": {
-                          "x": 0,
-                          "y": 0,
-                          "alignment": 0,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [
-                            {
-                              "condition": 10,
-                              "param": 2,
-                              "param2": 0
-                            },
-                            {
-                              "condition": 11,
-                              "param": 5,
-                              "param2": 0
-                            }
-                          ],
-                          "children": [],
-                          "patch": "STKEYS1"
-                        }
-                      },
-                      {
-                        "graphic": {
-                          "x": 0,
-                          "y": 0,
-                          "alignment": 0,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [
-                            {
-                              "condition": 11,
-                              "param": 2,
-                              "param2": 0
-                            },
-                            {
-                              "condition": 10,
-                              "param": 5,
-                              "param2": 0
-                            }
-                          ],
-                          "children": [],
-                          "patch": "STKEYS4"
-                        }
-                      },
-                      {
-                        "graphic": {
-                          "x": 0,
-                          "y": 0,
-                          "alignment": 0,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [
-                            {
-                              "condition": 10,
-                              "param": 2,
-                              "param2": 0
-                            },
-                            {
-                              "condition": 10,
-                              "param": 5,
-                              "param2": 0
-                            }
-                          ],
-                          "children": [],
-                          "patch": "STKEYS7"
-                        }
-                      }
-                    ]
-                  },
-                  "_cacoco_name": "Yellow Keys"
-                },
-                {
-                  "canvas": {
-                    "x": 0,
-                    "y": 23,
-                    "alignment": 0,
-                    "tranmap": null,
-                    "translation": null,
-                    "translucency": false,
-                    "conditions": [],
-                    "children": [
-                      {
-                        "graphic": {
-                          "x": 0,
-                          "y": 0,
-                          "alignment": 0,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [
-                            {
-                              "condition": 10,
-                              "param": 3,
-                              "param2": 0
-                            },
-                            {
-                              "condition": 11,
-                              "param": 6,
-                              "param2": 0
-                            }
-                          ],
-                          "children": [],
-                          "patch": "STKEYS2"
-                        }
-                      },
-                      {
-                        "graphic": {
-                          "x": 0,
-                          "y": 0,
-                          "alignment": 0,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [
-                            {
-                              "condition": 11,
-                              "param": 3,
-                              "param2": 0
-                            },
-                            {
-                              "condition": 10,
-                              "param": 6,
-                              "param2": 0
-                            }
-                          ],
-                          "children": [],
-                          "patch": "STKEYS5"
-                        }
-                      },
-                      {
-                        "graphic": {
-                          "x": 0,
-                          "y": 0,
-                          "alignment": 0,
-                          "tranmap": null,
-                          "translation": null,
-                          "translucency": false,
-                          "conditions": [
-                            {
-                              "condition": 10,
-                              "param": 3,
-                              "param2": 0
-                            },
-                            {
-                              "condition": 10,
-                              "param": 6,
-                              "param2": 0
-                            }
-                          ],
-                          "children": [],
-                          "patch": "STKEYS8"
-                        }
-                      }
-                    ]
-                  },
-                  "_cacoco_name": "Red Keys"
-                }
-              ]
-            },
-            "_cacoco_name": "Keys Cluster"
-          },
-          {
-            "percent": {
-              "x": 235,
-              "y": 3,
-              "alignment": 2,
-              "tranmap": null,
-              "translation": null,
-              "translucency": false,
-              "conditions": [],
-              "children": [],
-              "font": "Classic Status Bar",
-              "type": 1,
-              "param": 0,
-              "maxlength": 0
-            }
-          },
-          {
-            "canvas": {
-              "x": 288,
-              "y": 0,
-              "alignment": 0,
-              "tranmap": null,
-              "translation": null,
-              "translucency": false,
-              "conditions": [],
-              "children": [
-                {
-                  "number": {
-                    "x": 0,
-                    "y": 5,
-                    "alignment": 2,
-                    "tranmap": null,
-                    "translation": null,
-                    "translucency": false,
-                    "conditions": [],
-                    "children": [],
-                    "font": "Classic Yellow",
-                    "type": 3,
-                    "param": 0,
-                    "maxlength": 0
-                  }
-                },
-                {
-                  "number": {
-                    "x": 0,
-                    "y": 11,
-                    "alignment": 2,
-                    "tranmap": null,
-                    "translation": null,
-                    "translucency": false,
-                    "conditions": [],
-                    "children": [],
-                    "font": "Classic Yellow",
-                    "type": 3,
-                    "param": 1,
-                    "maxlength": 0
-                  }
-                },
-                {
-                  "number": {
-                    "x": 0,
-                    "y": 17,
-                    "alignment": 2,
-                    "tranmap": null,
-                    "translation": null,
-                    "translucency": false,
-                    "conditions": [],
-                    "children": [],
-                    "font": "Classic Yellow",
-                    "type": 3,
-                    "param": 3,
-                    "maxlength": 0
-                  }
-                },
-                {
-                  "number": {
-                    "x": 0,
-                    "y": 23,
-                    "alignment": 2,
-                    "tranmap": null,
-                    "translation": null,
-                    "translucency": false,
-                    "conditions": [],
-                    "children": [],
-                    "font": "Classic Yellow",
-                    "type": 3,
-                    "param": 2,
-                    "maxlength": 0
-                  }
-                }
-              ]
-            },
-            "_cacoco_name": "Current Ammo Group"
-          },
-          {
-            "canvas": {
-              "x": 314,
-              "y": 0,
-              "alignment": 0,
-              "tranmap": null,
-              "translation": null,
-              "translucency": false,
-              "conditions": [],
-              "children": [
-                {
-                  "number": {
-                    "x": 0,
-                    "y": 5,
-                    "alignment": 2,
-                    "tranmap": null,
-                    "translation": null,
-                    "translucency": false,
-                    "conditions": [],
-                    "children": [],
-                    "font": "Classic Yellow",
-                    "type": 5,
-                    "param": 0,
-                    "maxlength": 0
-                  }
-                },
-                {
-                  "number": {
-                    "x": 0,
-                    "y": 11,
-                    "alignment": 2,
-                    "tranmap": null,
-                    "translation": null,
-                    "translucency": false,
-                    "conditions": [],
-                    "children": [],
-                    "font": "Classic Yellow",
-                    "type": 5,
-                    "param": 1,
-                    "maxlength": 0
-                  }
-                },
-                {
-                  "number": {
-                    "x": 0,
-                    "y": 17,
-                    "alignment": 2,
-                    "tranmap": null,
-                    "translation": null,
-                    "translucency": false,
-                    "conditions": [],
-                    "children": [],
-                    "font": "Classic Yellow",
-                    "type": 5,
-                    "param": 3,
-                    "maxlength": 0
-                  }
-                },
-                {
-                  "number": {
-                    "x": 0,
-                    "y": 23,
-                    "alignment": 2,
-                    "tranmap": null,
-                    "translation": null,
-                    "translucency": false,
-                    "conditions": [],
-                    "children": [],
-                    "font": "Classic Yellow",
-                    "type": 5,
-                    "param": 2,
-                    "maxlength": 0
-                  }
-                }
-              ]
-            },
-            "_cacoco_name": "Max Ammo Group"
           }
         ]
       }

--- a/Core/Layer/Worlds/WorldLayer.Input.cs
+++ b/Core/Layer/Worlds/WorldLayer.Input.cs
@@ -319,17 +319,22 @@ public partial class WorldLayer
             return;
 
         var currentLayoutName = m_config.Hud.StatusBarLayout.Value;
-        int currentIndex = -1;
+        int currentIndex = 0;
 
         for (int i = 0; i < sbarDef.StatusBars.Count; i++)
         {
-            if (!sbarDef.StatusBars[i].Name.Equals(currentLayoutName, StringComparison.OrdinalIgnoreCase)) continue;
+            if (!sbarDef.StatusBars[i].Name.Equals(currentLayoutName, StringComparison.OrdinalIgnoreCase))
+                continue;
+
             currentIndex = i;
             break;
         }
 
-        int step = increase ? 1 : -1;
-        int nextIndex = (currentIndex + step + sbarDef.StatusBars.Count) % sbarDef.StatusBars.Count;
+        // First index is the 'largest'. Generally full-sized status bar.
+        int step = increase ? -1 : 1;
+        int nextIndex = (currentIndex + step) % sbarDef.StatusBars.Count;
+        if (nextIndex < 0)
+            nextIndex = sbarDef.StatusBars.Count - 1;
         
         while (string.IsNullOrEmpty(sbarDef.StatusBars[nextIndex].Name) && nextIndex != currentIndex)
         {

--- a/Core/Layer/Worlds/WorldLayer.Input.cs
+++ b/Core/Layer/Worlds/WorldLayer.Input.cs
@@ -9,7 +9,6 @@ using Helion.World;
 using Helion.World.Entities.Players;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using static Helion.Util.Constants;
 
 namespace Helion.Layer.Worlds;

--- a/Core/Resources/Definitions/DefinitionEntries.cs
+++ b/Core/Resources/Definitions/DefinitionEntries.cs
@@ -88,6 +88,7 @@ public class DefinitionEntries
     private readonly Dictionary<Color, Colormap> m_levelSectorColormaps = [];
     private readonly PnamesTextureXCollection m_pnamesTextureXCollection = new();
     private readonly LookupArray<Colormap> m_bloodColorMaps = new();
+    private readonly List<StatusBarLayoutDef> m_protectedStatusBars = [];
     private bool m_parseDehacked;
     private bool m_parseDecorate;
     private bool m_parseZDoomMapInfo;
@@ -123,7 +124,7 @@ public class DefinitionEntries
         m_entryNameToAction["COMPLVL"] = entry => ParseEntry(ParseCompLevel, entry);
         m_entryNameToAction["OPTIONS"] = OptionsDefinition.Parse;
         m_entryNameToAction["MUSINFO"] = entry => ParseEntry(ParseMusInfo, entry);
-        m_entryNameToAction["SBARDEF"] = entry => ParseEntry(ParseSBarDef, entry);
+        m_entryNameToAction["SBARDEF"] = entry => ParseSBarDef(entry);
         m_entryNameToAction["SKYDEFS"] = Id24SkyDefinition.Parse;
         m_entryNameToAction["GAMECONF"] = GameConfDefinition.Parse;
         m_entryNameToAction["GAMEINFO"] = entry => ParseEntry(GameInfoDefinition.Parse, entry);
@@ -186,8 +187,31 @@ public class DefinitionEntries
     private void ParseLanguageCompatibility(string text) => Language.ParseCompatibility(text);
     private void ParseCompLevel(string data) => CompLevelDefinition.Parse(data);
     private void ParseMusInfo(string text) => MusInfoDefinition.Parse(text);
-    private void ParseSBarDef(string text) => StatusBarDefinition.Parse(text);
     private void ParseGldefs(Entry entry) => GldefsDefinition.Parse(entry, m_archiveCollection.IWadInfo.IWadBaseType);
+
+    private void ParseSBarDef(Entry entry)
+    {
+        try
+        {
+            StatusBarDefinition.Parse(entry.ReadDataAsString(), m_protectedStatusBars);
+
+            if (entry.Parent == m_archiveCollection.Assets && m_protectedStatusBars.Count == 0)
+            {
+                AddProtectedStatusBarLayout(m_protectedStatusBars, StatusBarDefinition.MinimalLayoutName);
+                AddProtectedStatusBarLayout(m_protectedStatusBars, StatusBarDefinition.DetailedLayoutName);
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+        }
+    }
+
+    private void AddProtectedStatusBarLayout(List<StatusBarLayoutDef> layouts, string name)
+    {
+        if (StatusBarDefinition.TryGetLayoutByProtectedName(name, out var layout))
+            layouts.Add(layout);
+    }
 
     private void ParseZMapInfo(string text)
     {

--- a/Core/Resources/Definitions/StatusBar/StatusBarDefinition.cs
+++ b/Core/Resources/Definitions/StatusBar/StatusBarDefinition.cs
@@ -1,8 +1,10 @@
-using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Helion.Layer.Worlds.StatusBar;
+using Helion.Util.Extensions;
 using Helion.Util.Parser;
 
 namespace Helion.Resources.Definitions.StatusBar;
@@ -24,8 +26,11 @@ public class StatusBarDefinition
     private List<StatusBarNumberFontDef> m_numberFonts = [];
     private List<StatusBarHudFontDef> m_hudFonts = [];
     private List<StatusBarLayoutDef> m_statusBars = [];
+    private int m_statusBarId;
 
     public const string HiddenLayoutName = "Hidden";
+    public const string MinimalLayoutName = "Minimal";
+    public const string DetailedLayoutName = "Detailed";
 
     [JsonPropertyName("numberfonts")]
     public List<StatusBarNumberFontDef> NumberFonts
@@ -49,24 +54,18 @@ public class StatusBarDefinition
         set => m_statusBars = value ?? [];
     }
 
-    public void Parse(string data)
+    public void Parse(string data, List<StatusBarLayoutDef> protectedLayouts)
     {
-        try 
+        m_statusBarId++;
+
+        try
         {
+            StatusBarDeserializeContext.Prefix = $"{m_statusBarId}";
             var file = JsonSerializer.Deserialize(data, StatusBarJsonContext.Default.StatusBarFileDef);
 
             if (!string.IsNullOrEmpty(file?.Type))
             {
-                NumberFonts.Clear();
-                HudFonts.Clear();
-                StatusBars.Clear();
-
-                NumberFonts.AddRange(file.Data.NumberFonts);
-                HudFonts.AddRange(file.Data.HudFonts);
-                StatusBars.AddRange(file.Data.StatusBars);
-                
-                EnsureValidNames();
-                AddHiddenLayout();
+                LoadDefinition(file.Data, protectedLayouts);
             }
             else
             {
@@ -80,24 +79,26 @@ public class StatusBarDefinition
             {
                 var loaded = JsonSerializer.Deserialize(data, StatusBarJsonContext.Default.StatusBarDefinition);
                 if (loaded != null)
-                {
-                    NumberFonts.Clear();
-                    HudFonts.Clear();
-                    StatusBars.Clear();
-
-                    NumberFonts.AddRange(loaded.NumberFonts);
-                    HudFonts.AddRange(loaded.HudFonts);
-                    StatusBars.AddRange(loaded.StatusBars);
-                    
-                    EnsureValidNames();
-                    AddHiddenLayout();
-                }
+                    LoadDefinition(loaded, protectedLayouts);
             }
             catch (JsonException ex)
             {
                 throw new ParserException(0, 0, 0, $"SBARDEF JSON Error: {ex.Message}");
             }
         }
+    }
+
+    private void LoadDefinition(StatusBarDefinition def, List<StatusBarLayoutDef> protectedLayouts)
+    {
+        StatusBars.Clear();
+
+        EnsureValidNames(def.StatusBars);
+        NumberFonts.AddRange(def.NumberFonts);
+        HudFonts.AddRange(def.HudFonts);
+        StatusBars.AddRange(def.StatusBars.Where(x => x.Children.Length > 0));
+        StatusBars.AddRange(protectedLayouts);
+        
+        AddHiddenLayout();
     }
     
     private void AddHiddenLayout()
@@ -111,27 +112,42 @@ public class StatusBarDefinition
         });
     }
     
-    private void EnsureValidNames()
+    private static void EnsureValidNames(List<StatusBarLayoutDef> layouts)
     {
-        for (int i = 0; i < StatusBars.Count; i++)
+        for (int i = 0; i < layouts.Count; i++)
         {
-            var layout = StatusBars[i];
+            var layout = layouts[i];
             if (string.IsNullOrWhiteSpace(layout.Name))
             {
                 layout.Name = $"Layout {i}";
             }
-            else if (string.Equals(layout.Name, HiddenLayoutName, StringComparison.OrdinalIgnoreCase))
+            else if (layout.Name.EqualsIgnoreCase(HiddenLayoutName) || layout.Name.EqualsIgnoreCase(DetailedLayoutName))
             {
                 layout.Name += "*";
             }
         }
     }
+
+    public bool TryGetLayoutByProtectedName(string name, [NotNullWhen(true)] out StatusBarLayoutDef? layout)
+    {
+        layout = StatusBars.FirstOrDefault(x => x.Name.StartsWithIgnoreCase(name));
+        if (layout == null)
+            return false;
+
+        return layout.Name.EqualsIgnoreCase(name) || (layout.Name.Length == name.Length + 1 && layout.Name[^1] == '*');
+    }
 }
 
 public class StatusBarNumberFontDef
 {
+    private string m_name = string.Empty;
+
     [JsonPropertyName("name")]
-    public string Name { get; set; } = string.Empty;
+    public string Name
+    {
+        get => m_name;
+        set => m_name = StatusBarDeserializeContext.GetName(value);
+    }
 
     [JsonPropertyName("type")]
     public int Type { get; set; }
@@ -142,8 +158,14 @@ public class StatusBarNumberFontDef
 
 public class StatusBarHudFontDef
 {
+    private string m_name = string.Empty;
+
     [JsonPropertyName("name")]
-    public string Name { get; set; } = string.Empty;
+    public string Name
+    {
+        get => m_name;
+        set => m_name = StatusBarDeserializeContext.GetName(value);
+    }
 
     [JsonPropertyName("type")]
     public int Type { get; set; }
@@ -180,6 +202,8 @@ public class StatusBarLayoutDef
 
     [JsonIgnore]
     public StatusBarCoverage Coverage { get; set; }
+
+    public override string ToString() => Name;
 }
 
 [JsonSourceGenerationOptions(

--- a/Core/Resources/Definitions/StatusBar/StatusBarDeserializeContext.cs
+++ b/Core/Resources/Definitions/StatusBar/StatusBarDeserializeContext.cs
@@ -1,0 +1,7 @@
+﻿namespace Helion.Resources.Definitions.StatusBar;
+
+public static class StatusBarDeserializeContext
+{
+    public static string Prefix = string.Empty;
+    public static string GetName(string name) => $"[{Prefix}].{name}";
+}

--- a/Core/Resources/Definitions/StatusBar/StatusBarElementDef.cs
+++ b/Core/Resources/Definitions/StatusBar/StatusBarElementDef.cs
@@ -1,5 +1,4 @@
 using Helion.Geometry.Vectors;
-using Helion.Render.Common.Enums;
 using Helion.Render.Common.Textures;
 using Helion.Resources.Definitions.StatusBar.Enums;
 using System;

--- a/Core/Resources/Definitions/StatusBar/StatusBarElementDef.cs
+++ b/Core/Resources/Definitions/StatusBar/StatusBarElementDef.cs
@@ -155,8 +155,15 @@ public class StatusBarListDef : StatusBarBaseDef
 
 public class StatusBarStringDef : StatusBarBaseDef
 {
+    private string m_font = "";
+
+    // Update this
     [JsonPropertyName("font")]
-    public string Font { get; set; } = string.Empty;
+    public string Font
+    {
+        get => m_font;
+        set => m_font = StatusBarDeserializeContext.GetName(value);
+    }
 
     [JsonPropertyName("type")]
     public int Type { get; set; }
@@ -200,6 +207,7 @@ public class StatusBarFaceDef : StatusBarBaseDef
 public class StatusBarComponentDef : StatusBarBaseDef 
 {
     private string m_type = string.Empty;
+    private string m_font = string.Empty;
 
     [JsonPropertyName("type")]
     public string Type 
@@ -215,8 +223,12 @@ public class StatusBarComponentDef : StatusBarBaseDef
     public StatusBarComponentType ComponentType { get; private set; }
 
     [JsonPropertyName("font")]
-    public string Font { get; set; } = string.Empty;
-    
+    public string Font
+    {
+        get => m_font;
+        set => m_font = StatusBarDeserializeContext.GetName(value);
+    }
+
     // v1.1
     [JsonPropertyName("vertical")]
     public bool Vertical { get; set; }
@@ -257,8 +269,6 @@ public class StatusBarCarouselDef : StatusBarBaseDef
     [JsonPropertyName("translucency")]
     public bool Translucency { get; set; }
 }
-
-
 
 public class StatusBarGraphicDef : StatusBarBaseDef
 {
@@ -303,8 +313,14 @@ public class StatusBarAnimationDef : StatusBarBaseDef
 
 public class StatusBarNumberDef : StatusBarBaseDef
 {
+    private string m_font = string.Empty;
+
     [JsonPropertyName("font")]
-    public string Font { get; set; } = string.Empty;
+    public string Font
+    {
+        get => m_font;
+        set => m_font = StatusBarDeserializeContext.GetName(value);
+    }
 
     [JsonPropertyName("type")]
     public StatusBarNumberType Type { get; set; }

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -35,7 +35,8 @@
 - Fix to match boom behavior to parsing dehacked integers with failures defaulting to zero.
 - Fix SBARDEF crash when children element was explicity set to null.
 - Fix dehacked dropped ammo types only giving half ammo.
-- Fix "Compact HUD" (Tate/Portrait Window) behavior for SBARDEF
+- Fix "Compact HUD" (Tate/Portrait Window) behavior for SBARDEF.
+- Fix cycling order with SBARDEF.
 
 ## Misc:
 - Refactor of old Status Bar renderer to data-driven SBARDEF format.
@@ -51,3 +52,4 @@
 - Add pool for entity sprite VBO/VAOs to fix stutter when encountering a new sprite to render.
 - Update order independent transparency weight to be more stable across a higher range.
 - Use ColorAdd render style for Revenant fireball to match UZDoom.
+- Always load Helion's minimal and detailed HUDs when loading a mod that loads an SBARDEF.


### PR DESCRIPTION
Always load minimal and detailed HUD layouts when loading a custom SBARDEF.

Fix cycle order.

Fix needing to cycle twice to get past the first layout when the configuration setting isn't in the loaded SBARDEF.