### PR TITLE
refactor ThingId so that setting it automatically syncs up the lookup dict

### DIFF
--- a/Core/World/Entities/Entity.cs
+++ b/Core/World/Entities/Entity.cs
@@ -104,7 +104,7 @@ public partial class Entity : IDisposable, ITickable, ISoundSource, IFloorCeilin
     public double HighestFloorZ;
     public DynamicArray<Sector> IntersectSectors = new(arrayPool: true);
     public int Id;
-    public int ThingId;
+    public int ThingId { get; private set; }
     // Index in Blockmap.BlockLines
     public int BlockingBlockLineIndex;
     public Entity? BlockingEntity;
@@ -201,7 +201,7 @@ public partial class Entity : IDisposable, ITickable, ISoundSource, IFloorCeilin
         World = world;
         Index = index;
         Id = id;
-        ThingId = thingId;
+        world.EntityManager.SetThingId(this, thingId);
         Definition = definition;
         Flags = definition.Flags;
         Properties = definition.Properties;
@@ -242,7 +242,7 @@ public partial class Entity : IDisposable, ITickable, ISoundSource, IFloorCeilin
         Index = index;
         IsDisposed = false;
         Id = entityModel.Id;
-        ThingId = entityModel.ThingId;
+        world.EntityManager.SetThingId(this, entityModel.ThingId);
         Definition = definition;
         Flags = new EntityFlags(entityModel.Flags);
         Properties = definition.Properties;
@@ -1236,6 +1236,7 @@ public partial class Entity : IDisposable, ITickable, ISoundSource, IFloorCeilin
 
         Id = int.MinValue;
         IsDisposed = true;
+        ThingId = EntityManager.NoTid;
         UnlinkFromWorld();
         Unlink();
 
@@ -1410,5 +1411,11 @@ public partial class Entity : IDisposable, ITickable, ISoundSource, IFloorCeilin
             return false;
 
         return true;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void SetThingIdWithoutAddingToList(int thingId)
+    {
+        ThingId = thingId;
     }
 }

--- a/Core/World/Entities/EntityManager.cs
+++ b/Core/World/Entities/EntityManager.cs
@@ -123,14 +123,9 @@ public class EntityManager : IDisposable
         return entity;
     }
 
-    public void Destroy(Entity entity, bool removeFromIdList = true)
+    private void RemoveEntityFromThingLookup(Entity entity)
     {
-        if (entity.IsDisposed)
-            return;
-
-        EntityCount--;
-
-        if (removeFromIdList && TidToEntity.TryGetValue(entity.ThingId, out var entities))
+        if (TidToEntity.TryGetValue(entity.ThingId, out var entities))
         {
             var node = entities.Find(entity);
             if (node != null)
@@ -138,6 +133,19 @@ public class EntityManager : IDisposable
                 World.DataCache.FreeLinkedListNodeEntity(node);
                 entities.Remove(node);
             }
+        }
+    }
+
+    public void Destroy(Entity entity, bool removeFromIdList = true)
+    {
+        if (entity.IsDisposed)
+            return;
+
+        EntityCount--;
+
+        if (removeFromIdList)
+        {
+            RemoveEntityFromThingLookup(entity);
         }
 
         if (entity.Flags.IsTeleportSpot())
@@ -304,7 +312,7 @@ public class EntityManager : IDisposable
                 relinkEntities.Add(entity);
 
             if (isMusicChanger)
-                entity.ThingId = mapThing.EditorNumber - (int)EditorId.MusicChangerStart;
+                SetThingId(entity, mapThing.EditorNumber - (int)EditorId.MusicChangerStart);
         }
 
         //Relink entities with a z-height only, this way they can properly stack with other things in the map now that everything exists
@@ -618,9 +626,6 @@ public class EntityManager : IDisposable
     {
         SpawnLocations.AddPossibleSpawnLocation(entity);
 
-        if (entity.ThingId != NoTid)
-            AddToThingLookup(entity, entity.ThingId);
-
         if (entity.PlayerObj != null && !entity.PlayerObj.IsVooDooDoll)
             AddToThingLookup(entity, 0);
 
@@ -641,6 +646,20 @@ public class EntityManager : IDisposable
             var list = new LinkedList<Entity>();
             list.AddFirst(World.DataCache.GetLinkedListNodeEntity(entity));
             TidToEntity.Add(thingId, list);
+        }
+    }
+
+    public void SetThingId(Entity entity, int thingId)
+    {
+        if (entity.ThingId == thingId) return;
+        if (entity.ThingId != NoTid)
+        {
+            RemoveEntityFromThingLookup(entity);
+        }
+        entity.SetThingIdWithoutAddingToList(thingId);
+        if (entity.ThingId != NoTid)
+        {
+            AddToThingLookup(entity, entity.ThingId);
         }
     }
 

--- a/Core/World/Special/Specials/ActionSpecials.cs
+++ b/Core/World/Special/Specials/ActionSpecials.cs
@@ -98,7 +98,7 @@ public static class ActionSpecials
             if (entity == null)
                 continue;
 
-            entity.ThingId = newTid;
+            world.EntityManager.SetThingId(entity, newTid);
             var xy = Vec2D.UnitCircle(angle) * speedXY;
             entity.Velocity.X = xy.X;
             entity.Velocity.Y = xy.Y;
@@ -142,7 +142,7 @@ public static class ActionSpecials
                 continue;
 
             entity.Velocity = Vec3D.UnitSphere(angle, pitch) * speed;
-            entity.ThingId = newTid;
+            world.EntityManager.SetThingId(entity, newTid);
             success = true;
         }
 
@@ -377,7 +377,7 @@ public static class ActionSpecials
     {
         var targets = GetActivatorOrEntities(activator, world, args.Arg0);
         for (var target = targets.Current(); target != null; target = targets.Advance())
-            target.ThingId = args.Arg1;
+            world.EntityManager.SetThingId(target, args.Arg1);
         return true;
     }
 
@@ -599,7 +599,7 @@ public static class ActionSpecials
         }
 
         entity.AngleRadians = angle;
-        entity.ThingId = tid;
+        world.EntityManager.SetThingId(entity, tid);
         return true;
     }
 

--- a/Tests/Unit/GameAction/ACS/AcsScripts.cs
+++ b/Tests/Unit/GameAction/ACS/AcsScripts.cs
@@ -58,7 +58,7 @@ public class AcsScripts
             messages.Count.Should().Be(1);
             messages[0].Args.Message.Should().Be("Script 3 0");
 
-            Player.ThingId = 69;
+            World.EntityManager.SetThingId(Player, 69);
             GameActions.ActivateLine(World, Player, 9, ActivationContext.CrossLine).Should().BeTrue();
             World.Tick();
             messages.Count.Should().Be(2);

--- a/Tests/Unit/GameAction/Udmf/UdmfThingSpecials.cs
+++ b/Tests/Unit/GameAction/Udmf/UdmfThingSpecials.cs
@@ -415,7 +415,7 @@ public class UdmfThingSpecials : IDisposable
         Player.ThingId.Should().Be(0);
         GameActions.ActivateLine(World, Player, 118, ActivationContext.UseLine).Should().BeTrue();
         Player.ThingId.Should().Be(420);
-        Player.ThingId = 0;
+        World.EntityManager.SetThingId(Player, 0);
     }
 
     [Fact(DisplayName = "Thing set special")]


### PR DESCRIPTION
Not entirely convinced this is the best way to implement this, but without it functions like Spawn, Thing_ChangeTID etc were just setting the ThingId and not actually ensuring that the EntityManager was aware of that, so the lookups by TID would fail