### PR TITLE
add reading of user_ properties & add ACS Get*UDMF* functions

### DIFF
--- a/Core/ACS/WorldExecutor.cs
+++ b/Core/ACS/WorldExecutor.cs
@@ -5,8 +5,10 @@ using Helion.Resources.Definitions.MapInfo;
 using Helion.Util;
 using Helion.Util.Extensions;
 using Helion.World;
+using Helion.World.Geometry.Lines;
 using Helion.World.Geometry.Sectors;
 using Helion.World.Geometry.Walls;
+using Helion.World.Geometry.Sides;
 using Helion.World.Special.Specials;
 using HelionACS;
 using NLog;
@@ -233,14 +235,14 @@ public class WorldExecutor : Executor
         // 
 
         // 0-0: ACSVM internal funcs.
-        //AddFuncDataACS0I(  1, CF_GetLineUDMFInt);
-        //AddFuncDataACS0F(  2, CF_GetLineUDMFFixed);
-        //AddFuncDataACS0I(  3, CF_GetThingUDMFInt);
-        //AddFuncDataACS0F(  4, CF_GetThingUDMFFixed);
-        //AddFuncDataACS0I(  5, CF_GetSectorUDMFInt);
-        //AddFuncDataACS0F(  6, CF_GetSectorUDMFFixed);
-        //AddFuncDataACS0I(  7, CF_GetSideUDMFInt);
-        //AddFuncDataACS0F(  8, CF_GetSideUDMFFixed);
+        AddFuncDataACS0I(  1, CF_GetLineUDMFInt);
+        AddFuncDataACS0F(  2, CF_GetLineUDMFFixed);
+        AddFuncDataACS0I(  3, CF_GetThingUDMFInt);
+        AddFuncDataACS0F(  4, CF_GetThingUDMFFixed);
+        AddFuncDataACS0I(  5, CF_GetSectorUDMFInt);
+        AddFuncDataACS0F(  6, CF_GetSectorUDMFFixed);
+        AddFuncDataACS0I(  7, CF_GetSideUDMFInt);
+        AddFuncDataACS0F(  8, CF_GetSideUDMFFixed);
         AddFuncDataACS0F(  9, CF_GetActorVelX);
         AddFuncDataACS0F( 10, CF_GetActorVelY);
         AddFuncDataACS0F( 11, CF_GetActorVelZ);
@@ -842,6 +844,49 @@ public class WorldExecutor : Executor
         var y = args.Get(2);
         return GetSectorForTagOrPoint(tag, x, y)?.Ceiling?.Plane.ToZ(new Vec2D(x, y)) ?? 0.0;
     }
+
+    public int CF_GetLineUDMFInt(ThreadHandle thread, uint[] args) =>
+        m_world.FindByLineId(args.Get(0))
+            .First()
+            ?.UserProperties.GetInteger(args.GetStringSpan(thread, 1))
+            ?? 0;
+    public double CF_GetLineUDMFFixed(ThreadHandle thread, uint[] args) =>
+        m_world.FindByLineId(args.Get(0))
+            .First()
+            ?.UserProperties.GetDecimal(args.GetStringSpan(thread, 1))
+            ?? 0;
+
+    public int CF_GetThingUDMFInt(ThreadHandle thread, uint[] args) =>
+        m_world.FindByTid(args.Get(0))
+            .First()
+            ?.UserProperties.GetInteger(args.GetStringSpan(thread, 1))
+            ?? 0;
+    public double CF_GetThingUDMFFixed(ThreadHandle thread, uint[] args) =>
+        m_world.FindByTid(args.Get(0))
+        .First()
+        ?.UserProperties.GetDecimal(args.GetStringSpan(thread, 1))
+        ?? 0;
+
+    public int CF_GetSectorUDMFInt(ThreadHandle thread, uint[] args) =>
+        m_world.FindBySectorTag(args.Get(0))
+        .First()
+        ?.UserProperties.GetInteger(args.GetStringSpan(thread, 1))
+        ?? 0;
+    public double CF_GetSectorUDMFFixed(ThreadHandle thread, uint[] args) =>
+        m_world.FindBySectorTag(args.Get(0))
+        .First()
+        ?.UserProperties.GetDecimal(args.GetStringSpan(thread, 1))
+        ?? 0;
+
+    private static Side? GetLineSide(Line? line, bool back) => back ? line?.Back : line?.Front;
+    public int CF_GetSideUDMFInt(ThreadHandle thread, uint[] args) =>
+        GetLineSide(m_world.FindByLineId(args.Get(0)).First(), args.GetBool(1))
+            ?.UserProperties.GetInteger(args.GetStringSpan(thread, 2))
+            ?? 0;
+    public double CF_GetSideUDMFFixed(ThreadHandle thread, uint[] args) =>
+        GetLineSide(m_world.FindByLineId(args.Get(0)).First(), args.GetBool(1))
+            ?.UserProperties.GetDecimal(args.GetStringSpan(thread, 2))
+            ?? 0;
 
     private int GetThingCount(int type, int tid)
     {

--- a/Core/Maps/Components/IThing.cs
+++ b/Core/Maps/Components/IThing.cs
@@ -21,4 +21,6 @@ public interface IThing
     float? Alpha { get; }
     float Gravity { get; }
     int? Health { get; }
+
+    MapUserProperties GetUserProperties() { return new(); }
 }

--- a/Core/Maps/Shared/MapUserProperties.cs
+++ b/Core/Maps/Shared/MapUserProperties.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Helion.Util;
+
+namespace Helion.Maps.Shared;
+
+/// <summary>The mapped value of a UDMF user property, which can unconditionally be accessed as an integer, decimal or text.</summary>
+readonly struct MapUserValue {
+    public readonly int Integer;
+    public readonly double Decimal;
+    public readonly string Text;
+
+    public MapUserValue(string val) {
+        Text = val;
+        if (val.Equals("true", StringComparison.OrdinalIgnoreCase))
+        {
+            Integer = 1;
+            Decimal = 1.0;
+            return;
+        }
+        if (val.Equals("false", StringComparison.OrdinalIgnoreCase))
+        {
+            Integer = 0;
+            Decimal = 0.0;
+            return;
+        }
+
+        if (!Parsing.TryParseDouble(val, out var doubleValue)) doubleValue = 0.0;
+        if (!int.TryParse(val, out var intValue)) intValue = (int)doubleValue;
+        Integer = intValue;
+        Decimal = doubleValue;
+    }
+}
+
+/// <summary>Dictionary-like struct for UDMF properties which only accepts keys starting with `user_`, mapping to an integer, decimal and text.</summary>
+public struct MapUserProperties {
+    private Dictionary<string, MapUserValue>? m_keyValues;
+    private Dictionary<string, MapUserValue>.AlternateLookup<ReadOnlySpan<char>>? m_keyValuesLookup;
+
+    const string UserPrefix = "user_";
+
+    void AddInternal(string key, MapUserValue value) {
+        if (!key.StartsWith(UserPrefix, StringComparison.OrdinalIgnoreCase)) return;
+        var actualKey = key.ToLower(CultureInfo.InvariantCulture);
+        if (m_keyValues == null) {
+            m_keyValues = new(StringComparer.OrdinalIgnoreCase);
+            m_keyValuesLookup = m_keyValues.GetAlternateLookup<ReadOnlySpan<char>>();
+        }
+        m_keyValues[actualKey] = value;
+    }
+    public void Add(ReadOnlySpan<char> key, ReadOnlySpan<char> value) => AddInternal(key.ToString(), new MapUserValue(value.ToString()));
+
+    public readonly int? GetInteger(ReadOnlySpan<char> key) {
+        if (m_keyValuesLookup == null) return null;
+        if (!m_keyValuesLookup.Value.TryGetValue(key, out var value)) return null;
+        return value.Integer;
+    }
+    public readonly double? GetDecimal(ReadOnlySpan<char> key) {
+        if (m_keyValuesLookup == null) return null;
+        if (!m_keyValuesLookup.Value.TryGetValue(key, out var value)) return null;
+        return value.Decimal;
+    }
+    public readonly string? GetText(ReadOnlySpan<char> key) {
+        if (m_keyValuesLookup == null) return null;
+        if (!m_keyValuesLookup.Value.TryGetValue(key, out var value)) return null;
+        return value.Text;
+    }
+}

--- a/Core/Maps/Udmf/Components/UdmfLine.cs
+++ b/Core/Maps/Udmf/Components/UdmfLine.cs
@@ -36,6 +36,8 @@ public class UdmfLine : ILine
     public bool DeathSpecial;
     public bool WrapMidTex;
 
+    public MapUserProperties UserProperties;
+
     public ISide GetFront() => Front;
 
     public ISide? GetBack() => Back;

--- a/Core/Maps/Udmf/Components/UdmfSector.cs
+++ b/Core/Maps/Udmf/Components/UdmfSector.cs
@@ -1,4 +1,5 @@
 ﻿using Helion.Maps.Components;
+using Helion.Maps.Shared;
 using Helion.Util;
 
 namespace Helion.Maps.Udmf.Components;
@@ -39,4 +40,6 @@ public class UdmfSector : ISector
     public int FogDensity;
     public string SkyFloor = string.Empty;
     public string SkyCeiling = string.Empty;
+
+    public MapUserProperties UserProperties;
 }

--- a/Core/Maps/Udmf/Components/UdmfSide.cs
+++ b/Core/Maps/Udmf/Components/UdmfSide.cs
@@ -1,5 +1,6 @@
 ﻿using Helion.Geometry.Vectors;
 using Helion.Maps.Components;
+using Helion.Maps.Shared;
 using Helion.Util;
 
 namespace Helion.Maps.Udmf.Components;
@@ -41,4 +42,6 @@ public class UdmfSide : ISide
     public UdmfSector Sector = null!;
 
     public ISector GetSector() => Sector;
+
+    public MapUserProperties UserProperties;
 }

--- a/Core/Maps/Udmf/Components/UdmfThing.cs
+++ b/Core/Maps/Udmf/Components/UdmfThing.cs
@@ -26,4 +26,7 @@ public class UdmfThing : IThing
     public float? Alpha { get; set; }
     public float Gravity { get; set; } = 1f;
     public int? Health { get; set; }
+
+    public MapUserProperties UserProperties;
+    public MapUserProperties GetUserProperties() { return UserProperties; }
 }

--- a/Core/Maps/Udmf/UdmfMap.cs
+++ b/Core/Maps/Udmf/UdmfMap.cs
@@ -283,7 +283,9 @@ public sealed class UdmfMap : IMap, IMapSpecials
         while (!IsBlockComplete(parser))
         {
             var prop = ParseProperty(parser, typeArray, valueArray);
-            if (prop.Name.EqualsIgnoreCase("x"))
+            if (prop.Name.StartsWithIgnoreCase("user_"))
+                thing.UserProperties.Add(prop.Name, prop.Value);
+            else if (prop.Name.EqualsIgnoreCase("x"))
                 x = parser.ParseDouble(prop.Value);
             else if (prop.Name.EqualsIgnoreCase("y"))
                 y = parser.ParseDouble(prop.Value);
@@ -381,7 +383,9 @@ public sealed class UdmfMap : IMap, IMapSpecials
         while (!IsBlockComplete(parser))
         {
             var prop = ParseProperty(parser, typeArray, valueArray);
-            if (prop.Name.EqualsIgnoreCase("sector"))
+            if (prop.Name.StartsWithIgnoreCase("user_"))
+                side.UserProperties.Add(prop.Name, prop.Value);
+            else if (prop.Name.EqualsIgnoreCase("sector"))
                 side.SectorId = parser.ParseInt(prop.Value);
             else if (prop.Name.EqualsIgnoreCase("texturetop"))
                 side.UpperTexture = GetString(stringLookup, prop.Value);
@@ -451,7 +455,9 @@ public sealed class UdmfMap : IMap, IMapSpecials
         while (!IsBlockComplete(parser))
         {
             var prop = ParseProperty(parser, typeArray, valueArray);
-            if (prop.Name.EqualsIgnoreCase("heightfloor"))
+            if (prop.Name.StartsWithIgnoreCase("user_"))
+                sector.UserProperties.Add(prop.Name, prop.Value);
+            else if (prop.Name.EqualsIgnoreCase("heightfloor"))
                 sector.FloorZ = (short)parser.ParseInt(prop.Value);
             else if (prop.Name.EqualsIgnoreCase("heightceiling"))
                 sector.CeilingZ = (short)parser.ParseInt(prop.Value);
@@ -566,7 +572,9 @@ public sealed class UdmfMap : IMap, IMapSpecials
         while (!IsBlockComplete(parser))
         {
             var prop = ParseProperty(parser, typeArray, valueArray);
-            if (prop.Name.EqualsIgnoreCase("v1"))
+            if (prop.Name.StartsWithIgnoreCase("user_"))
+                line.UserProperties.Add(prop.Name, prop.Value);
+            else if (prop.Name.EqualsIgnoreCase("v1"))
                 line.StartVertex = parser.ParseInt(prop.Value);
             else if (prop.Name.EqualsIgnoreCase("v2"))
                 line.EndVertex = parser.ParseInt(prop.Value);

--- a/Core/Util/Extensions/StringExtensions.cs
+++ b/Core/Util/Extensions/StringExtensions.cs
@@ -56,6 +56,12 @@ public static class StringExtensions
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool StartsWithIgnoreCase(this ReadOnlySpan<char> text, string other)
+    {
+        return text.StartsWith(other, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool EndsWithIgnoreCase(this string text, string other)
     {
         return text.EndsWith(other, StringComparison.OrdinalIgnoreCase);

--- a/Core/World/Entities/Entity.cs
+++ b/Core/World/Entities/Entity.cs
@@ -3,6 +3,7 @@ using Helion.Geometry.Vectors;
 using Helion.Graphics.Palettes;
 using Helion.Maps.Specials;
 using Helion.Maps.Specials.ZDoom;
+using Helion.Maps.Shared;
 using Helion.Models;
 using Helion.Resources.Definitions.Decorate.Properties.Enums;
 using Helion.Resources.Definitions.MapInfo;
@@ -151,6 +152,8 @@ public partial class Entity : IDisposable, ITickable, ISoundSource, IFloorCeilin
     public int MaxTargetRange;
     public int MinMissileChance;
     public int MeleeThreshold;
+
+    public MapUserProperties UserProperties;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool IsFrozen() => FrozenTics > 0;
@@ -1291,6 +1294,7 @@ public partial class Entity : IDisposable, ITickable, ISoundSource, IFloorCeilin
         Special = ZDoomLineSpecialType.None;
         WaterSubmersionLevel = SubmersionLevel.None;
         WaterControlSector = null;
+        UserProperties = new();
     }
 
     private void FreeToDataCache()

--- a/Core/World/Entities/EntityManager.cs
+++ b/Core/World/Entities/EntityManager.cs
@@ -277,6 +277,8 @@ public class EntityManager : IDisposable
             entity.Special = mapThing.Special;
             entity.Gravity = mapThing.Gravity;
 
+            entity.UserProperties = mapThing.GetUserProperties();
+
             if (mapThing.Alpha.HasValue)
                 entity.Alpha = mapThing.Alpha.Value;
 

--- a/Core/World/Geometry/Builder/UdmfGeometryBuilder.cs
+++ b/Core/World/Geometry/Builder/UdmfGeometryBuilder.cs
@@ -78,7 +78,8 @@ public class UdmfGeometryBuilder
                 SkyFloor = mapSector.SkyFloor,
                 SkyCeiling = mapSector.SkyCeiling,
                 DamageInterval = mapSector.DamageInterval == 0 ? SectorDamageSpecial.DefaultDamageInterval : mapSector.DamageInterval,
-                MoreTags = mapSector.MoreTags
+                MoreTags = mapSector.MoreTags,
+                UserProperties = mapSector.UserProperties
             };
 
             if (mapSector.DamageAmount != 0)
@@ -129,7 +130,8 @@ public class UdmfGeometryBuilder
             var line = new Line(mapLine.Id, seg, front, back, flags, special, mapLine.Args)
             {
                 LockNumber = mapLine.LockNumber,
-                MapLineId = mapLine.LineId
+                MapLineId = mapLine.LineId,
+                UserProperties = mapLine.UserProperties
             };
 
             if (needsTranslation)
@@ -224,7 +226,10 @@ public class UdmfGeometryBuilder
         Wall lower = new(lowerTexture.Index, WallLocation.Lower, side.LightLevelLower, side.LightLevelLowerAbsolute, side.BottomOffset, side.BottomScale);
 
         Side addSide = new(nextSideId, side.Offset, upper, middle, lower, facingSector, side.LightLevel, side.LightLevelAbsolute, side.NoFakeConstrast, side.SmoothLighting, 
-            line.WrapMidTex || side.WrapMidTex);
+            line.WrapMidTex || side.WrapMidTex)
+        {
+            UserProperties = side.UserProperties
+        };
         builder.Sides.Add(addSide);
 
 

--- a/Core/World/Geometry/Lines/Line.cs
+++ b/Core/World/Geometry/Lines/Line.cs
@@ -2,6 +2,7 @@ using Helion.Geometry.Segments;
 using Helion.Geometry.Vectors;
 using Helion.Maps.Specials;
 using Helion.Maps.Specials.ZDoom;
+using Helion.Maps.Shared;
 using Helion.Models;
 using Helion.Render.OpenGL.Renderers.Legacy.World.Geometry;
 using Helion.Resources;
@@ -44,6 +45,8 @@ public sealed class Line
     public string? MusicChangeBack;
     public LineBlockFlags InitialLineBlockFlags;
     public float InitialAlpha;
+
+    public MapUserProperties UserProperties;
 
     public bool HasSpecial => Special.LineSpecialType != ZDoomLineSpecialType.None;
     public bool HasSectorTag => SectorTag > 0;

--- a/Core/World/Geometry/Sectors/Sector.cs
+++ b/Core/World/Geometry/Sectors/Sector.cs
@@ -2,6 +2,7 @@ using Helion.Geometry.Boxes;
 using Helion.Geometry.Vectors;
 using Helion.Graphics;
 using Helion.Graphics.Palettes;
+using Helion.Maps.Shared;
 using Helion.Maps.Specials;
 using Helion.Maps.Specials.ZDoom;
 using Helion.Models;
@@ -103,6 +104,8 @@ public sealed class Sector : IFloorCeilingAnchor
     public Sector TransferCeilingLightSector;
     public Sector SetTransferFloorLightSector;
     public Sector SetTransferCeilingLightSector;
+
+    public MapUserProperties UserProperties;
 
 #if DEBUG
     public SectorDamageSpecial? SectorDamageSpecial { get; private set; }

--- a/Core/World/Geometry/Sides/Side.cs
+++ b/Core/World/Geometry/Sides/Side.cs
@@ -1,5 +1,6 @@
 using Helion.Geometry.Vectors;
 using Helion.Graphics.Palettes;
+using Helion.Maps.Shared;
 using Helion.Maps.Specials;
 using Helion.Render.OpenGL.Renderers.Legacy.World.Data;
 using Helion.Render.OpenGL.Renderers.Legacy.World.Geometry.Static;
@@ -67,6 +68,8 @@ public sealed class Side
     public SideFlags Flags;
     public float Alpha = 1f;
     public RenderDataStyle RenderDataStyle;
+
+    public MapUserProperties UserProperties;
 
     public Side(int id, Vec2I offset, Wall upper, Wall middle, Wall lower, Sector sector)
         : this(id, offset, upper, middle, lower, sector, 0, false, false, false, false)


### PR DESCRIPTION
dictionary only gets stored when user properties are actually in use, + should be avoiding allocations on case-insensitive lookups using `StringComparer.OrdinalIgnoreCase` & `GetAlternateLookup`