### PR TITLE
statically link nuget-provided HelionACS for AOT

### DIFF
--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -31,6 +31,17 @@
     <AllowedReferenceRelatedFileExtensions Condition="'$(Configuration)'=='Release'">none</AllowedReferenceRelatedFileExtensions>
   </PropertyGroup>
 
+  <Target Name="ResolveNative" BeforeTargets="Build">
+    <MSBuild Projects="..\Core\Core.csproj" Targets="GetNativePaths" BuildInParallel="false">
+      <Output TaskParameter="TargetOutputs" ItemName="NativeLibraryPath" />
+    </MSBuild>
+
+    <ItemGroup Condition="'$(AOT)' == 'true'">
+      <DirectPInvoke Include="HelionACS-native" />
+      <NativeLibrary Include="@(NativeLibraryPath)" />
+    </ItemGroup>
+  </Target>
+
   <ItemGroup Condition="'$(AOT)' == 'true'">
     <DirectPInvoke Include="zmusic.dll" />
     <DirectPInvoke Include="glfw3.dll" />

--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -31,6 +31,13 @@
     <PackageReference Include="ini-parser-net8" Version="2.6.2.1" />
     <PackageReference Include="xBRZNet" Version="1.2.0" />
     <PackageReference Include="zdbspSharp" Version="1.0.8" />
-    <PackageReference Include="Gutawer.HelionACS" Version="0.1.1-pre.29" GeneratePathProperty="true" />
+    <PackageReference Include="Gutawer.HelionACS" Version="0.1.1-pre.38" GeneratePathProperty="true" />
   </ItemGroup>
+
+  <Target Name="GetNativePaths" Returns="@(NativeLibraryPath)">
+    <ItemGroup>
+      <NativeLibraryPath Condition="'$(RuntimeIdentifier)'=='win-x64'" Include="$(PkgGutawer_HelionACS)\runtimes\win-x64\native\HelionACS-native-static.lib" />
+      <NativeLibraryPath Condition="'$(RuntimeIdentifier)'=='linux-x64'" Include="$(PkgGutawer_HelionACS)\runtimes\linux-x64\native\libHelionACS-native-static.a" />
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
since HelionACS is depended on by Core but needs static linking in Client, there's a target for passing the to-be-linked paths upwards. i'm really not familiar with MSBuild so let me know if there's an easier way of doing this!

tested both `dotnet publish -c Release -r linux-x64 Client/Client.csproj -p:SelfContainedRelease=true` and `dotnet publish -c Release -r linux-x64 Client/Client.csproj -p:AOT=true` to function correctly in an Ubuntu 22.04 Distrobox, using `LD_DEBUG=libs` to ensure AOT build isn't doing dynamic lookups