### PR TITLE
Monster closet load fix

### DIFF
--- a/Core/World/Geometry/Islands/ClosetClassifier.cs
+++ b/Core/World/Geometry/Islands/ClosetClassifier.cs
@@ -9,35 +9,25 @@ namespace Helion.World.Geometry.Islands;
 
 public static class ClosetClassifier
 {
-    // Assumes entities and geometry have been populated. Should be done as
-    // a final post-processing step.
-    public static void Classify(WorldBase world, BspTreeNew bspTree, bool isFromSave)
+    public static void ClassifySameMap(WorldBase world)
     {
-        if (world.SameAsPreviousMap)
+        for (var entity = world.EntityManager.Head; entity != null; entity = entity.Next)
         {
-            for (var entity = world.EntityManager.Head; entity != null; entity = entity.Next)
-            {
-                if (entity.Flags.Friendly())
-                    continue;
+            if (entity.Flags.Friendly())
+                continue;
 
-                var subsector = bspTree.Subsectors[entity.SubsectorId];
-                if (subsector.IslandId < 0 || subsector.IslandId >= world.Geometry.IslandGeometry.Islands.Count)
-                    continue;
-                var island = world.Geometry.IslandGeometry.Islands[subsector.IslandId];
-                if (!isFromSave)
-                {
-                    if (island.IsMonsterCloset)
-                        entity.ClosetFlags |= ClosetFlags.MonsterCloset;
-                    continue;
-                }
+            var islandId = world.Geometry.SubsectorToIslandId[entity.SubsectorId];
+            if (islandId < 0 || islandId >= world.Geometry.IslandGeometry.Islands.Count)
+                continue;
 
-                // Saved misclassification?
-                if (!island.IsMonsterCloset && entity.ClosetFlags != ClosetFlags.None)
-                    entity.ClearMonsterCloset();
-            }
-            return;
+            var island = world.Geometry.IslandGeometry.Islands[islandId];
+            if (island.IsMonsterCloset)
+                entity.ClosetFlags |= ClosetFlags.MonsterCloset;
         }
+    }
 
+    public static void Classify(WorldBase world, BspTreeNew bspTree)
+    {
         PopulateLookups(world, bspTree, out var islandToEntities, out var entityToSubsector);
 
         for (int i = 0; i < world.Geometry.IslandGeometry.Islands.Count; i++)

--- a/Core/World/Impl/SinglePlayer/SinglePlayerWorld.cs
+++ b/Core/World/Impl/SinglePlayer/SinglePlayerWorld.cs
@@ -129,10 +129,11 @@ public class SinglePlayerWorld : WorldBase
         EnsureEntityModelSize(EntityManager.EntityCount + (int)(EntityManager.EntityCount * 0.25));
 
         var bspTree = Geometry.GetBspTree();
-        if (config.Game.MonsterCloset.Value && bspTree != null)
-            ClosetClassifier.Classify(this, bspTree, worldModel != null);
-        else if (worldModel != null)
-            ClearMonsterClosets();
+        // Entities clear closet flags on dispose. If the same map islands have been flagged as closets so they can be reset without using the tree.
+        if (sameAsPreviousMap)
+            ClosetClassifier.ClassifySameMap(this);
+        else if (config.Game.MonsterCloset.Value && bspTree != null)
+            ClosetClassifier.Classify(this, bspTree);
 
         CheatManager.CheatActivationChanged += Instance_CheatActivationChanged;
 
@@ -213,16 +214,6 @@ public class SinglePlayerWorld : WorldBase
             return;
 
         m_musicLookup[name] = entry.ReadData();
-    }
-
-    private void ClearMonsterClosets()
-    {
-        for (var entity = EntityManager.Head; entity != null; entity = entity.Next)
-        {
-            if ((entity.ClosetFlags & ClosetFlags.MonsterCloset) == 0)
-                continue;
-            entity.ClearMonsterCloset();
-        }
     }
 
     private void MarkSpecials_OnChanged(object? sender, bool e)

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -40,6 +40,7 @@
 - Fix cycling order with SBARDEF.
 - Fix mono spaced font width rendering in SBARDEF.
 - Fix hud transparency config option not working with SBARDEF.
+- Fix monster closet setting for monsters resetting on map loads.
 
 ## Misc:
 - Refactor of old Status Bar renderer to data-driven SBARDEF format.

--- a/Tests/Unit/GameAction/MonsterCloset.cs
+++ b/Tests/Unit/GameAction/MonsterCloset.cs
@@ -1,8 +1,10 @@
 ﻿using FluentAssertions;
+using Helion.Models;
 using Helion.Resources.IWad;
 using Helion.World.Entities;
 using Helion.World.Entities.Players;
 using Helion.World.Impl.SinglePlayer;
+using System;
 using Xunit;
 
 namespace Helion.Tests.Unit.GameAction;
@@ -10,12 +12,12 @@ namespace Helion.Tests.Unit.GameAction;
 [Collection("GameActions")]
 public class MonsterCloset
 {
-    private readonly SinglePlayerWorld World;
+    private SinglePlayerWorld World;
     private Player Player => World.Player;
 
     public MonsterCloset()
     {
-        World = WorldAllocator.LoadMap("Resources/monstercloset.zip", "monstercloset.WAD", "MAP01", GetType().Name, (world) => { }, IWadType.Doom2);
+        World = LoadMap(null, disposeExistingWorld: true);
     }
 
     [Fact(DisplayName = "Monster closets")]
@@ -49,5 +51,69 @@ public class MonsterCloset
         imp1.FrameState.Frame.ActionFunction!.Method.Name.Should().Be("A_Chase");
         // Should not play sight sound
         GameActions.AssertNoSound(World, imp1);
+    }
+
+    [Fact(DisplayName = "Monster closet serialize")]
+    public void MonsterClosetSerialize()
+    {
+        var imp1 = GameActions.GetEntity(World, 1);
+        var imp2 = GameActions.GetEntity(World, 3);
+
+        imp1.ClosetFlags.Should().Be(ClosetFlags.MonsterCloset);
+        imp2.ClosetFlags.Should().Be(ClosetFlags.None);
+
+        var model = World.ToWorldModel();
+        World = LoadMap(model, disposeExistingWorld: true);
+
+        imp1 = GameActions.GetEntity(World, 1);
+        imp2 = GameActions.GetEntity(World, 3);
+
+        imp1.ClosetFlags.Should().Be(ClosetFlags.MonsterCloset);
+        imp2.ClosetFlags.Should().Be(ClosetFlags.None);
+
+        GameActions.SetEntityPosition(World, imp1, (-256, -256));
+        imp1.ClearMonsterCloset();
+        imp1.ClosetFlags.Should().Be(ClosetFlags.None);
+
+        model = World.ToWorldModel();
+        World = LoadMap(model, disposeExistingWorld: true);
+
+        imp1 = GameActions.GetEntity(World, 1);
+        imp2 = GameActions.GetEntity(World, 3);
+
+        imp1.ClosetFlags.Should().Be(ClosetFlags.None);
+        imp2.ClosetFlags.Should().Be(ClosetFlags.None);
+    }
+
+    [Fact(DisplayName = "Monster reload same map")]
+    public void MonsterClosetReloadSameMap()
+    {
+        var imp1 = GameActions.GetEntity(World, 1);
+        var imp2 = GameActions.GetEntity(World, 3);
+
+        imp1.ClosetFlags.Should().Be(ClosetFlags.MonsterCloset);
+        imp2.ClosetFlags.Should().Be(ClosetFlags.None);
+
+        GameActions.SetEntityPosition(World, imp1, (-256, -256));
+        imp1.ClearMonsterCloset();
+        imp1.ClosetFlags.Should().Be(ClosetFlags.None);
+
+        World = LoadMap(null, disposeExistingWorld: true);
+
+        imp1 = GameActions.GetEntity(World, 1);
+        imp2 = GameActions.GetEntity(World, 3);
+
+        imp1.ClosetFlags.Should().Be(ClosetFlags.MonsterCloset);
+        imp2.ClosetFlags.Should().Be(ClosetFlags.None);
+    }
+
+    private SinglePlayerWorld LoadMap(WorldModel? worldModel, bool disposeExistingWorld = false)
+    {
+        // Need to dispose the first world's archive collection because it locks the file
+        if (worldModel != null && !World.ArchiveCollection.IsDisposed)
+            World.ArchiveCollection.Dispose();
+
+        return WorldAllocator.LoadMap("Resources/monstercloset.zip", "monstercloset.WAD", "MAP01", Guid.NewGuid().ToString(), (world) => { }, IWadType.Doom2,
+            worldModel: worldModel, disposeExistingWorld: disposeExistingWorld, sameAsPreviousMap: worldModel != null);
     }
 }

--- a/Tests/Unit/GameAction/MonsterCloset.cs
+++ b/Tests/Unit/GameAction/MonsterCloset.cs
@@ -17,7 +17,7 @@ public class MonsterCloset
 
     public MonsterCloset()
     {
-        World = LoadMap(null, disposeExistingWorld: true);
+        World = LoadMap(null, disposeExistingWorld: true, sameAsPreviousMap: false);
     }
 
     [Fact(DisplayName = "Monster closets")]
@@ -63,7 +63,7 @@ public class MonsterCloset
         imp2.ClosetFlags.Should().Be(ClosetFlags.None);
 
         var model = World.ToWorldModel();
-        World = LoadMap(model, disposeExistingWorld: true);
+        World = LoadMap(model, disposeExistingWorld: true, sameAsPreviousMap: true);
 
         imp1 = GameActions.GetEntity(World, 1);
         imp2 = GameActions.GetEntity(World, 3);
@@ -76,7 +76,7 @@ public class MonsterCloset
         imp1.ClosetFlags.Should().Be(ClosetFlags.None);
 
         model = World.ToWorldModel();
-        World = LoadMap(model, disposeExistingWorld: true);
+        World = LoadMap(model, disposeExistingWorld: true, sameAsPreviousMap: true);
 
         imp1 = GameActions.GetEntity(World, 1);
         imp2 = GameActions.GetEntity(World, 3);
@@ -98,7 +98,7 @@ public class MonsterCloset
         imp1.ClearMonsterCloset();
         imp1.ClosetFlags.Should().Be(ClosetFlags.None);
 
-        World = LoadMap(null, disposeExistingWorld: true);
+        World = LoadMap(null, disposeExistingWorld: true, sameAsPreviousMap: false);
 
         imp1 = GameActions.GetEntity(World, 1);
         imp2 = GameActions.GetEntity(World, 3);
@@ -107,13 +107,13 @@ public class MonsterCloset
         imp2.ClosetFlags.Should().Be(ClosetFlags.None);
     }
 
-    private SinglePlayerWorld LoadMap(WorldModel? worldModel, bool disposeExistingWorld = false)
+    private SinglePlayerWorld LoadMap(WorldModel? worldModel, bool disposeExistingWorld, bool sameAsPreviousMap)
     {
         // Need to dispose the first world's archive collection because it locks the file
         if (worldModel != null && !World.ArchiveCollection.IsDisposed)
             World.ArchiveCollection.Dispose();
 
         return WorldAllocator.LoadMap("Resources/monstercloset.zip", "monstercloset.WAD", "MAP01", Guid.NewGuid().ToString(), (world) => { }, IWadType.Doom2,
-            worldModel: worldModel, disposeExistingWorld: disposeExistingWorld, sameAsPreviousMap: worldModel != null);
+            worldModel: worldModel, disposeExistingWorld: disposeExistingWorld, sameAsPreviousMap: sameAsPreviousMap);
     }
 }

--- a/Tests/Unit/GameAction/WorldAllocator.cs
+++ b/Tests/Unit/GameAction/WorldAllocator.cs
@@ -40,7 +40,7 @@ internal static class WorldAllocator
     public static SinglePlayerWorld LoadMap(string resourceZip, string fileName, string mapName, string testKey, Action<SinglePlayerWorld> onInit,
         IWadType iwadType = IWadType.Doom2, SkillLevel skillLevel = SkillLevel.Medium, Player? existingPlayer = null, WorldModel? worldModel = null,
         bool disposeExistingWorld = true, bool cacheWorld = true, bool gameConf = false,
-        Action<ArchiveCollection>? onBeforeInit = null, Config? config = null, string? dehackedPatch = null)
+        Action<ArchiveCollection>? onBeforeInit = null, Config? config = null, string? dehackedPatch = null, bool sameAsPreviousMap = false)
     {
         if (disposeExistingWorld && UseExistingWorld(resourceZip, fileName, mapName, testKey, cacheWorld, out SinglePlayerWorld? existingWorld))
             return existingWorld;
@@ -104,7 +104,7 @@ internal static class WorldAllocator
 
         DoomRandom random = worldModel == null ? new() : new(worldModel.RandomIndex);
         SinglePlayerWorld? world = WorldLayer.CreateWorldGeometry(new GlobalData(), config, audioSystem, archiveCollection, profiler, mapDef,
-            skillDef, outputMap, existingPlayer, worldModel, random, unitTest: true) ?? throw new Exception("Failed to create world");
+            skillDef, outputMap, existingPlayer, worldModel, random, unitTest: true, sameAsPreviousMap: sameAsPreviousMap) ?? throw new Exception("Failed to create world");
         StaticWorld = world;
         world.OnTick += World_OnTick;
         world.Start(worldModel);


### PR DESCRIPTION
Correct setting entity monster closet flags when reloading a map.

Removes unnecessary clear in SinglePlayerWorld likely missed during refactoring/changes around the loading functionality.

Adds tests for loading states and reloading the map. Adds flag to WorldAllocator to support sending same as previous map flag to better match how it works in the engine for the user.

fixes #1635 