### PR TITLE
Refactor renderable string cache handling

### DIFF
--- a/Core/Layer/Worlds/WorldLayer.Render.Hud.cs
+++ b/Core/Layer/Worlds/WorldLayer.Render.Hud.cs
@@ -772,7 +772,7 @@ public partial class WorldLayer
         if (!HasTicks)
             return renderableString;
 
-        renderableString.Set(World.ArchiveCollection.DataCache, charSpan, GetFontOrDefault(font),
+        renderableString.Set(charSpan, GetFontOrDefault(font),
             fontSize, drawColor: drawColor);
         if (useDoomScale)
             renderableString.DrawArea = new(renderableString.DrawArea.Width, (int)(renderableString.DrawArea.Height * DoomVerticalScale));

--- a/Core/Layer/Worlds/WorldLayer.cs
+++ b/Core/Layer/Worlds/WorldLayer.cs
@@ -147,7 +147,7 @@ public partial class WorldLayer : IGameLayerParent
     }
 
     private RenderableString InitRenderableString(TextAlign align = TextAlign.Left) =>
-        new(World.ArchiveCollection.DataCache, string.Empty, DefaultFont, 12, align: align, shouldFree: false);
+        new(string.Empty, DefaultFont, 12, align: align, shouldFree: false);
 
     private Font GetFontOrDefault(string name)
     {

--- a/Core/Render/OpenGL/GLHudRenderContext.cs
+++ b/Core/Render/OpenGL/GLHudRenderContext.cs
@@ -207,7 +207,7 @@ public class GLHudRenderContext : IHudRenderContext
             return;
 
         int scaledFontSize = (int)(fontSize * scale);
-        RenderableString renderableString = m_archiveCollection.DataCache.GetRenderableString(text, fontObject, scaledFontSize, textAlign, maxWidth);
+        var renderableString = RenderableString.Get(text, fontObject, scaledFontSize, textAlign, maxWidth);
         drawArea = renderableString.DrawArea;
 
         Vec2I pos = GetDrawingCoordinateFromAlign(origin.X, origin.Y, drawArea.Width, drawArea.Height,
@@ -234,7 +234,7 @@ public class GLHudRenderContext : IHudRenderContext
 
         int scaledFontSize = (int)(fontSize * scale);
 
-        RenderableString renderableString = m_archiveCollection.DataCache.GetRenderableString(text, fontObject, scaledFontSize, textAlign, maxWidth, color);
+        var renderableString = RenderableString.Get(text, fontObject, scaledFontSize, textAlign, maxWidth, color);
         drawArea = renderableString.DrawArea;
 
         Vec2I pos = GetDrawingCoordinateFromAlign(origin.X, origin.Y, drawArea.Width, drawArea.Height,
@@ -257,9 +257,9 @@ public class GLHudRenderContext : IHudRenderContext
             return default;
 
         int scaledFontSize = (int)(fontSize * scale);
-        RenderableString renderableString = m_archiveCollection.DataCache.GetRenderableString(text, fontObject, scaledFontSize, TextAlign.Left, maxWidth);
+        var renderableString = RenderableString.Get(text, fontObject, scaledFontSize, TextAlign.Left, maxWidth);
         var drawArea = renderableString.DrawArea;
-        m_archiveCollection.DataCache.FreeRenderableString(renderableString);
+        renderableString.Free();
         return drawArea;
     }
 

--- a/Core/Render/OpenGL/Texture/Fonts/RenderableString.Cache.cs
+++ b/Core/Render/OpenGL/Texture/Fonts/RenderableString.Cache.cs
@@ -1,0 +1,110 @@
+﻿using Helion.Graphics;
+using Helion.Graphics.Fonts;
+using Helion.Render.Common.Enums;
+using Helion.Util.Container;
+using System;
+
+namespace Helion.Render.OpenGL.Texture.Fonts;
+
+public partial class RenderableString
+{
+    private static readonly DynamicArray<RenderableString> StringCache = new(64);
+    private static readonly DynamicArray<DynamicArray<ColorRange>> ColorRangeCache = new(32);
+    private static readonly DynamicArray<DynamicArray<RenderableGlyph>> GlyphsCache = new(256);
+    private static readonly DynamicArray<DynamicArray<RenderableSentence>> SentencesCache = new(64);
+
+    public static RenderableString Get(ReadOnlySpan<char> str, Font font, int fontSize, TextAlign align = TextAlign.Left,
+        int maxWidth = int.MaxValue, Color? drawColor = null)
+    {
+        lock (StringCache)
+        {
+            if (StringCache.Length > 0)
+            {
+                var renderableString = StringCache.RemoveLast();
+                renderableString.Set(str, font, fontSize, align, maxWidth, drawColor);
+                return renderableString;
+            }
+        }
+
+        return new RenderableString(str, font, fontSize, align, maxWidth, drawColor);
+    }
+
+    public void Free()
+    {
+        if (!ShouldFree)
+            return;
+
+        FreeData();
+        StringCache.Add(this);
+    }
+
+    private void FreeData()
+    {
+        for (int i = 0; i < Sentences.Length; i++)
+            FreeGlyphs(Sentences[i].Glyphs);
+        FreeSentences(Sentences);
+
+        Sentences = null!;
+        Font = null!;
+    }
+
+    private static DynamicArray<ColorRange> GetColorRange()
+    {
+        lock (ColorRangeCache)
+        {
+            if (ColorRangeCache.Length > 0)
+                return ColorRangeCache.RemoveLast();
+        }
+
+        return new DynamicArray<ColorRange>(32);
+    }
+
+    private static void FreeColorRange(DynamicArray<ColorRange> colors)
+    {
+        colors.Clear();
+        lock (ColorRangeCache)
+        {
+            ColorRangeCache.Add(colors);
+        }
+    }
+
+    private static DynamicArray<RenderableSentence> GetSentences()
+    {
+        lock (SentencesCache)
+        {
+            if (SentencesCache.Length > 0)
+                return SentencesCache.RemoveLast();
+        }
+
+        return new DynamicArray<RenderableSentence>();
+    }
+
+    private static void FreeSentences(DynamicArray<RenderableSentence> list)
+    {
+        list.Clear();
+        lock (SentencesCache)
+        {
+            SentencesCache.Add(list);
+        }
+    }
+
+    private static DynamicArray<RenderableGlyph> GetGlyphs()
+    {
+        lock (GlyphsCache)
+        {
+            if (GlyphsCache.Length > 0)
+                return GlyphsCache.RemoveLast();
+        }
+
+        return new DynamicArray<RenderableGlyph>(256);
+    }
+
+    private static void FreeGlyphs(DynamicArray<RenderableGlyph> list)
+    {
+        list.Clear();
+        lock (GlyphsCache)
+        {
+            GlyphsCache.Add(list);
+        }
+    }
+}

--- a/Core/Render/OpenGL/Texture/Fonts/RenderableString.cs
+++ b/Core/Render/OpenGL/Texture/Fonts/RenderableString.cs
@@ -1,12 +1,10 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using Helion.Geometry;
 using Helion.Geometry.Boxes;
 using Helion.Geometry.Vectors;
 using Helion.Graphics;
 using Helion.Graphics.Fonts;
-using Helion.Graphics.Geometry;
 using Helion.Render.Common.Enums;
 using Helion.Util;
 using Helion.Util.Container;
@@ -16,11 +14,9 @@ namespace Helion.Render.OpenGL.Texture.Fonts;
 /// <summary>
 /// A collection of render information that can be used to draw a string.
 /// </summary>
-public class RenderableString
+public partial class RenderableString
 {
     public static readonly Color DefaultColor = Color.White;
-
-    private static readonly DynamicArray<ColorRange> ColorRanges = new();
 
     /// <summary>
     /// The font used when rendering this.
@@ -42,7 +38,6 @@ public class RenderableString
     /// <summary>
     /// Creates a rendered string that is ready to be passed to a renderer.
     /// </summary>
-    /// <param name="dataCache">The DataCache to use.</param>
     /// <param name="font">The font to use.</param>
     /// <param name="str">The colored string to process.</param>
     /// <param name="fontSize">The height of the characters, in pixels. If
@@ -52,32 +47,32 @@ public class RenderableString
     /// <param name="align">Alignment (only needed if there are multiple
     /// lines, otherwise it does not matter).</param>
     /// <param name="maxWidth">How wide before wrapping around.</param>
-    public RenderableString(DataCache dataCache, ReadOnlySpan<char> str, Font font, int fontSize, TextAlign align = TextAlign.Left,
+    public RenderableString(ReadOnlySpan<char> str, Font font, int fontSize, TextAlign align = TextAlign.Left,
         int maxWidth = int.MaxValue, Color? drawColor = null, bool shouldFree = true)
     {
         ShouldFree = shouldFree;
         Font = font;
-        Sentences = PopulateSentences(dataCache, str, font, fontSize, maxWidth, drawColor);
+        Sentences = PopulateSentences(str, font, fontSize, maxWidth, drawColor);
         DrawArea = CalculateDrawArea(Sentences);
         AlignTo(align);
         RecalculateGlyphLocations();
     }
 
-    public void Set(DataCache dataCache, ReadOnlySpan<char> str, Font font, int fontSize, TextAlign align = TextAlign.Left,
+    public void Set(ReadOnlySpan<char> str, Font font, int fontSize, TextAlign align = TextAlign.Left,
         int maxWidth = int.MaxValue, Color? drawColor = null)
     {
         // This is kind of a hack. If reusing this string the underlying data needs to freed.
         if (!ShouldFree)
-            dataCache.FreeRenderableStringData(this);
+            FreeData();
 
         Font = font;
-        Sentences = PopulateSentences(dataCache, str, font, fontSize, maxWidth, drawColor);
+        Sentences = PopulateSentences(str, font, fontSize, maxWidth, drawColor);
         DrawArea = CalculateDrawArea(Sentences);
         AlignTo(align);
         RecalculateGlyphLocations();
     }
 
-    public static DynamicArray<RenderableSentence> PopulateSentences(DataCache dataCache, ReadOnlySpan<char> str, Font font, int fontSize,
+    public static DynamicArray<RenderableSentence> PopulateSentences(ReadOnlySpan<char> str, Font font, int fontSize,
         int maxWidth, Color? drawColor)
     {
         int currentWidth = 0;
@@ -85,7 +80,7 @@ public class RenderableString
         int drawAreaWidth = 0;
         int drawAreaHeight = 0;
 
-        var sentences = dataCache.GetRenderableSentences();
+        var sentences = GetSentences();
         if (str.Length == 0)
             return sentences;
 
@@ -132,7 +127,7 @@ public class RenderableString
 
                 if (currentSentence == null)
                 {
-                    currentSentence = dataCache.GetRenderableGlyphs();
+                    currentSentence = GetGlyphs();
                     currentSentence.EnsureCapacity(str.Length);
                 }
 
@@ -149,6 +144,8 @@ public class RenderableString
                     currentWidth = endX;
             }
         }
+
+        FreeColorRange(colorRanges);
 
         CreateAndAddSentenceIfPossible(sentences, ref currentSentence, ref drawAreaWidth, ref drawAreaHeight, ref currentWidth, ref currentHeight);
         return sentences;
@@ -172,38 +169,38 @@ public class RenderableString
 
     private static DynamicArray<ColorRange> GetColorRanges(ReadOnlySpan<char> str, Color? drawColor)
     {
-        ColorRanges.Clear();
+        var colorRanges = GetColorRange();
         if (drawColor != null)
         {
-            ColorRanges.Add(new ColorRange(0, str.Length, drawColor.Value));
-            return ColorRanges;
+            colorRanges.Add(new ColorRange(0, str.Length, drawColor.Value));
+            return colorRanges;
         }
 
-        ColorRanges.Add(new ColorRange(0, DefaultColor));
+        colorRanges.Add(new ColorRange(0, DefaultColor));
 
         bool success = FindNextColorIndex(str, 0, out int startIndex, out int endIndex);
         while (success)
         {
-            ColorRange currentColorInfo = ColorRanges[ColorRanges.Length - 1];
+            ColorRange currentColorInfo = colorRanges[colorRanges.Length - 1];
             currentColorInfo.EndIndex = startIndex;
-            ColorRanges[ColorRanges.Length - 1] = currentColorInfo;
+            colorRanges[colorRanges.Length - 1] = currentColorInfo;
 
             Color color = ColorDefinitionToColor(str.Slice(startIndex, endIndex - startIndex));
-            ColorRanges.Add(new ColorRange(endIndex, color));
+            colorRanges.Add(new ColorRange(endIndex, color));
             startIndex = endIndex + 1;
             success = FindNextColorIndex(str, startIndex, out startIndex, out endIndex);
         }
 
         // Since we never set the very last element's ending point due to
         // the loop invariant, we do that now.
-        var last = ColorRanges[ColorRanges.Length - 1];
+        var last = colorRanges[colorRanges.Length - 1];
         last.EndIndex = str.Length;
-        ColorRanges[ColorRanges.Length - 1] = last;
+        colorRanges[colorRanges.Length - 1] = last;
 
         if (last.StartIndex == last.EndIndex)
-            ColorRanges.Length--;
+            colorRanges.Length--;
 
-        return ColorRanges;
+        return colorRanges;
     }
 
     private static bool FindNextColorIndex(ReadOnlySpan<char> str, int index, out int startIndex, out int endIndex)

--- a/Core/Render/Renderer.cs
+++ b/Core/Render/Renderer.cs
@@ -17,6 +17,7 @@ using Helion.Render.OpenGL.Renderers.Legacy.World;
 using Helion.Render.OpenGL.Renderers.Legacy.World.Automap;
 using Helion.Render.OpenGL.Renderers.Legacy.World.Shader;
 using Helion.Render.OpenGL.Shared;
+using Helion.Render.OpenGL.Texture.Fonts;
 using Helion.Render.OpenGL.Texture.Legacy;
 using Helion.Render.OpenGL.Util;
 using Helion.Resources.Archives.Collection;
@@ -847,8 +848,7 @@ public partial class Renderer : IDisposable
     private void HandleDrawText(DrawTextCommand cmd)
     {
         m_hudRenderer.DrawText(cmd.Text, cmd.DrawArea, cmd.Alpha, cmd.DrawColorMap);
-        var dataCache = m_archiveCollection.DataCache;
-        dataCache.FreeRenderableString(cmd.Text);
+        cmd.Text.Free();
     }
 
     private void HandleRenderAutomapCommand(DrawWorldCommand cmd, Rectangle viewport)

--- a/Core/Util/DataCache.cs
+++ b/Core/Util/DataCache.cs
@@ -10,12 +10,9 @@ using Helion.Render.OpenGL.Texture.Legacy;
 using Helion.World.Entities.Definition;
 using Helion.Models;
 using Helion.Geometry.Vectors;
-using Helion.Render.OpenGL.Texture.Fonts;
 using Helion.Render.OpenGL.Renderers.Legacy.Hud;
-using Helion.Render.Common.Enums;
 using Helion.World.Special.Specials;
 using Helion.World;
-using Font = Helion.Graphics.Fonts.Font;
 using Helion.Graphics;
 using System;
 using Helion.World.Special;
@@ -42,9 +39,6 @@ public class DataCache
     private readonly DynamicArray<int> m_entities = new(DefaultLength);
     private readonly DynamicArray<IAudioSource> m_audioSources = new(64);
     private readonly DynamicArray<DynamicArray<Entity>> m_entityLists = new();
-    private readonly DynamicArray<DynamicArray<RenderableGlyph>> m_glyphs = new(256);
-    private readonly DynamicArray<DynamicArray<RenderableSentence>> m_sentences = new(64);
-    private readonly DynamicArray<RenderableString> m_strings = new(64);
     private readonly DynamicArray<HudDrawBufferData> m_hudDrawBufferData = new(64);
     private readonly DynamicArray<LinkedListNode<WaitingSound>> m_waitingSoundNodes = new();
     private readonly DynamicArray<LinkedListNode<ISpecial>> m_specialNodes = new();
@@ -225,66 +219,6 @@ public class DataCache
     {
         list.Clear();
         m_entityLists.Add(list);
-    }
-
-    public DynamicArray<RenderableSentence> GetRenderableSentences()
-    {
-        if (m_sentences.Length > 0)
-            return m_sentences.RemoveLast();
-
-        return new DynamicArray<RenderableSentence>();
-    }
-
-    private void FreeRenderableSentences(DynamicArray<RenderableSentence> list)
-    {
-        list.Clear();
-        m_sentences.Add(list);
-    }
-
-    public DynamicArray<RenderableGlyph> GetRenderableGlyphs()
-    {
-        if (m_glyphs.Length > 0)
-            return m_glyphs.RemoveLast();
-
-        return new DynamicArray<RenderableGlyph>(256);
-    }
-
-    private void FreeRenderableGlyphs(DynamicArray<RenderableGlyph> list)
-    {
-        list.Clear();
-        m_glyphs.Add(list);
-    }
-
-    public RenderableString GetRenderableString(ReadOnlySpan<char> str, Font font, int fontSize, TextAlign align = TextAlign.Left,
-        int maxWidth = int.MaxValue, Color? drawColor = null)
-    {
-        if (m_strings.Length > 0)
-        {
-            var renderableString = m_strings.RemoveLast();
-            renderableString.Set(this, str, font, fontSize, align, maxWidth, drawColor);
-            return renderableString;
-        }
-
-        return new RenderableString(this, str, font, fontSize, align, maxWidth, drawColor);
-    }
-
-    public void FreeRenderableString(RenderableString renderableString)
-    {
-        if (!renderableString.ShouldFree)
-            return;
-
-        FreeRenderableStringData(renderableString);
-        m_strings.Add(renderableString);
-    }
-
-    public void FreeRenderableStringData(RenderableString renderableString)
-    {
-        for (int i = 0; i < renderableString.Sentences.Length; i++)
-            FreeRenderableGlyphs(renderableString.Sentences[i].Glyphs);
-        FreeRenderableSentences(renderableString.Sentences);
-
-        renderableString.Sentences = null!;
-        renderableString.Font = null!;
     }
 
     public HudDrawBufferData GetDrawHudBufferData(GLLegacyTexture texture, GLLegacyTexture? brightmapTexture = null)

--- a/Tests/Unit/Graphics/String/RGBColoredStringDecoderTest.cs
+++ b/Tests/Unit/Graphics/String/RGBColoredStringDecoderTest.cs
@@ -13,11 +13,10 @@ public class RGBColoredStringDecoderTest
 {
     private static void AssertMatches(string rawString, params Tuple<string, Color>[] expectedColors)
     {
-        DataCache dataCache = new();
         var image = new Image((16, 16), ImageType.Argb);
         var glyphs = new Dictionary<char, Glyph>() { { 'A', new Glyph() } };
         var font = new Font("test", glyphs, image);
-        RenderableString colorStr = new(dataCache, rawString, font, 12);
+        RenderableString colorStr = new(rawString, font, 12);
 
         int startIndex = 0;
         int endIndex = 0;


### PR DESCRIPTION
Refactor out of data cache and keep it contained into the class itself. Add locks around cache objects since there are places where it's called when loading maps.