### PR TITLE
Music entry read fix

### DIFF
--- a/Client/Music/MusicPlayer.cs
+++ b/Client/Music/MusicPlayer.cs
@@ -184,6 +184,11 @@ public class MusicPlayer : IMusicPlayer
         m_musicLookup.Clear();
     }
 
+    public void CacheMusicEntry(Entry entry)
+    {
+        GetMusicData(entry);
+    }
+
     private void PlayQueueTask()
     {
         while (!m_disposed)
@@ -218,11 +223,7 @@ public class MusicPlayer : IMusicPlayer
         if ((options & MusicPlayerOptions.IgnoreAlreadyPlaying) != 0 && (options & MusicPlayerOptions.Reload) == 0 && fullPath == m_lastEntryPath)
             return;
 
-        if (!m_musicLookup.TryGetValue(fullPath, out var data))
-        {
-            data = playParams.Entry.ReadData();
-            m_musicLookup[fullPath] = data;
-        }
+        var data = GetMusicData(playParams.Entry);
 
         m_lastEntryPath = fullPath;
 
@@ -233,6 +234,18 @@ public class MusicPlayer : IMusicPlayer
 
         m_isMidi = m_zMusicPlayer.IsMIDI(data, out _);
         PlayMusic(playParams, data);
+    }
+
+    private byte[] GetMusicData(Entry entry)
+    {
+        var fullPath = entry.Path.FullPath;
+        if (!m_musicLookup.TryGetValue(fullPath, out var data))
+        {
+            data = entry.ReadDataAsync();
+            m_musicLookup[fullPath] = data;
+        }
+
+        return data;
     }
 
     private void PlayMusic(in PlayParams playParams, byte[] data)

--- a/Core/Audio/IMusicPlayer.cs
+++ b/Core/Audio/IMusicPlayer.cs
@@ -50,4 +50,5 @@ public interface IMusicPlayer : IDisposable
     void OutputChanged();
 
     void ClearCachedData();
+    void CacheMusicEntry(Entry entry);
 }

--- a/Core/Audio/Impl/MockMusicPlayer.cs
+++ b/Core/Audio/Impl/MockMusicPlayer.cs
@@ -40,6 +40,11 @@ namespace Helion.Audio.Impl
 
         }
 
+        public void CacheMusicEntry(Entry entry)
+        {
+
+        }
+
         public bool Enabled { get; set; }
     }
 }

--- a/Core/Resources/Archives/DirectoryArchive/DirectoryArchiveEntry.cs
+++ b/Core/Resources/Archives/DirectoryArchive/DirectoryArchiveEntry.cs
@@ -20,6 +20,11 @@ public class DirectoryArchiveEntry : Entry
         return Parent.ReadData(this);
     }
 
+    public override byte[] ReadDataAsync()
+    {
+        return ReadData();
+    }
+
     public override Stream GetStream()
     {
         return Parent.GetStream(this);

--- a/Core/Resources/Archives/Entries/Entry.cs
+++ b/Core/Resources/Archives/Entries/Entry.cs
@@ -18,6 +18,10 @@ public abstract class Entry
     /// Reads all the raw data for this entry.
     /// </summary>
     public abstract byte[] ReadData();
+    /// <summary>
+    /// Reads all the raw data for this entry. Guarantees that multiple calls to this function asynchronously are safe.
+    /// </summary>
+    public abstract byte[] ReadDataAsync();
     public abstract Stream GetStream();
 
     public string ReadDataAsString() => System.Text.Encoding.UTF8.GetString(ReadData());

--- a/Core/Resources/Archives/PK3/PK3Entry.cs
+++ b/Core/Resources/Archives/PK3/PK3Entry.cs
@@ -27,6 +27,11 @@ public class PK3Entry : Entry
         return data;
     }
 
+    public override byte[] ReadDataAsync()
+    {
+        return ReadData();
+    }
+
     public override Stream GetStream()
     {
         return ZipEntry.Open();

--- a/Core/Resources/Archives/Wad/Wad.cs
+++ b/Core/Resources/Archives/Wad/Wad.cs
@@ -52,9 +52,14 @@ public class Wad : Archive
 
     public Wad(IEntryPath path, IIndexGenerator indexGenerator) : base(path)
     {
-        m_byteReader = new ByteReader(new BinaryReader(File.Open(Path.FullPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)));
+        m_byteReader = new ByteReader(new BinaryReader(GetFileStream()));
         m_indexGenerator = indexGenerator;
         LoadWadEntries();
+    }
+
+    private FileStream GetFileStream()
+    {
+        return File.Open(Path.FullPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
     }
 
     public byte[] ReadData(WadEntry entry)
@@ -65,10 +70,19 @@ public class Wad : Archive
         return m_byteReader.ReadBytes(entry.Size);
     }
 
+    public byte[] ReadDataAsync(WadEntry entry)
+    {
+        Precondition(entry.Parent == this, "Bad entry parent");
+
+        using var byteReader = new ByteReader(new BinaryReader(GetFileStream()));
+        byteReader.Offset(entry.Offset);
+        return byteReader.ReadBytes(entry.Size);
+    }
+
     public Stream GetStream(WadEntry entry)
     {
         Precondition(entry.Parent == this, "Bad entry parent");
-        return new SubStream(m_byteReader.BaseStream, entry.Offset, entry.Size);
+        return new SubStream(GetFileStream(), entry.Offset, entry.Size);
     }
 
     public override void Dispose()

--- a/Core/Resources/Archives/Wad/WadEntry.cs
+++ b/Core/Resources/Archives/Wad/WadEntry.cs
@@ -22,6 +22,11 @@ public class WadEntry : Entry
         return Parent.ReadData(this);
     }
 
+    public override byte[] ReadDataAsync()
+    {
+        return Parent.ReadDataAsync(this);
+    }
+
     public override Stream GetStream()
     {
         return Parent.GetStream(this);

--- a/Core/World/Impl/SinglePlayer/SinglePlayerWorld.cs
+++ b/Core/World/Impl/SinglePlayer/SinglePlayerWorld.cs
@@ -150,7 +150,12 @@ public class SinglePlayerWorld : WorldBase
         CacheSounds();
 
         if (!sameAsPreviousMap)
+        {
             AudioSystem.Music.ClearCachedData();
+            GetMusicEntry(MapInfo.Music, out var lookup, out var entry);
+            if (entry != null)
+                AudioSystem.Music.CacheMusicEntry(entry);
+        }
     }
 
     private void CheckDistanceOverride()


### PR DESCRIPTION
Add entry read functions that explicitly allow for async calls. Fixes issue with wad entries sharing the same base stream that can result in corrupt data reads