### PR TITLE
Use defaults for mbf21 dehacked parameters when not specified in dehacked

### DIFF
--- a/Core/Dehacked/DehackedConstants.cs
+++ b/Core/Dehacked/DehackedConstants.cs
@@ -4832,6 +4832,8 @@ public partial class DehackedDefinition
 
     public static readonly Dictionary<ActionFunction, DefaultArgs> DefaultFrameArgs = new()
     {
+        { A_MonsterBulletAttack, new DefaultArgs() { Args3 = 1, Args4 = 5, Args5 = 3} },
+        { A_MonsterMeleeAttack, new DefaultArgs() { Args1 = 3, Args2 = 8} },
         { A_WeaponBulletAttack, new DefaultArgs() { Args3 = 1, Args4 = 5, Args5 = 3 } },
         { A_WeaponMeleeAttack, new DefaultArgs() { Args1 = 2, Args2 = 10, Args3 = 65536 } },
     };

--- a/Core/World/Entities/Definition/States/EntityActionFunctions.cs
+++ b/Core/World/Entities/Definition/States/EntityActionFunctions.cs
@@ -2961,9 +2961,9 @@ public static class EntityActionFunctions
 
         var spreadAngle = MathHelper.ToRadians(MathHelper.FromFixed(frame.DehackedArgs1));
         var spreadPitch = MathHelper.ToRadians(MathHelper.FromFixed(frame.DehackedArgs2));
-        var bullets = GetArgOrDefault(frame.DehackedArgs3, 1);
-        var damage = GetArgOrDefault(frame.DehackedArgs4, 5);
-        var mod = Math.Max(GetArgOrDefault(frame.DehackedArgs5, 3), 0);
+        var bullets = frame.DehackedArgs3;
+        var damage = frame.DehackedArgs4;
+        var mod = Math.Max(frame.DehackedArgs5, 1);
 
         WorldStatic.World.FirePlayerHitscanBullets(entity.PlayerObj, bullets, spreadAngle, spreadPitch, entity.PlayerObj.PitchRadians, Constants.EntityShootDistance,
             WorldStatic.World.Config.Game.AutoAim, DamageAttackFunction, new DamageFuncParams(true, entity, damage, mod));
@@ -2974,9 +2974,9 @@ public static class EntityActionFunctions
         if (entity.PlayerObj == null || !GetPlayerWeaponFrame(entity, out EntityFrame? frame))
             return;
 
-        var damage = GetArgOrDefault(frame.DehackedArgs1, 2);
-        var mod = Math.Max(GetArgOrDefault(frame.DehackedArgs2, 10), 1);
-        var berserkFactor = MathHelper.FromFixed(GetArgOrDefault(frame.DehackedArgs3, 1));
+        var damage = frame.DehackedArgs1;
+        var mod = Math.Max(frame.DehackedArgs2, 1);
+        var berserkFactor = MathHelper.FromFixed(frame.DehackedArgs3);
         var sound = frame.DehackedArgs4;
         var range = frame.DehackedArgs5 == 0 ? entity.Properties.MeleeRange : MathHelper.FromFixed(frame.DehackedArgs5);
 
@@ -3195,16 +3195,16 @@ public static class EntityActionFunctions
         projectile?.SetTracer(target);
     }
 
-    private static void A_MonsterBulletAttack(Entity entity)
+    public static void A_MonsterBulletAttack(Entity entity)
     {
         if (entity.Target() == null)
             return;
 
         var spreadAngle = MathHelper.ToRadians(MathHelper.FromFixed(entity.FrameState.Frame.DehackedArgs1));
         var spreadPitch = MathHelper.ToRadians(MathHelper.FromFixed(entity.FrameState.Frame.DehackedArgs2));
-        var bullets = GetArgOrDefault(entity.FrameState.Frame.DehackedArgs3, 1);
-        var damage = GetArgOrDefault(entity.FrameState.Frame.DehackedArgs4, 3);
-        var mod = Math.Max(GetArgOrDefault(entity.FrameState.Frame.DehackedArgs5, 5), 0);
+        var bullets = entity.FrameState.Frame.DehackedArgs3;
+        var damage = entity.FrameState.Frame.DehackedArgs4;
+        var mod = Math.Max(entity.FrameState.Frame.DehackedArgs5, 0);
 
         A_FaceTarget(entity);
         entity.PlayAttackSound();
@@ -3219,14 +3219,14 @@ public static class EntityActionFunctions
         }
     }
 
-    private static void A_MonsterMeleeAttack(Entity entity)
+    public static void A_MonsterMeleeAttack(Entity entity)
     {
         var target = entity.Target();
         if (target == null)
             return;
 
-        var damage = GetArgOrDefault(entity.FrameState.Frame.DehackedArgs1, 3);
-        var mod = Math.Max(GetArgOrDefault(entity.FrameState.Frame.DehackedArgs2, 8), 1);
+        var damage = entity.FrameState.Frame.DehackedArgs1;
+        var mod = Math.Max(entity.FrameState.Frame.DehackedArgs2, 1);
         var sound = entity.FrameState.Frame.DehackedArgs3;
         var range = entity.FrameState.Frame.DehackedArgs4 == 0 ? entity.Properties.MeleeRange : MathHelper.FromFixed(entity.FrameState.Frame.DehackedArgs4);
 
@@ -3551,8 +3551,4 @@ public static class EntityActionFunctions
     {
         return damageParams.Arg0 * ((WorldStatic.World.Random.NextByte() % damageParams.Arg1) + 1);
     }
-
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static int GetArgOrDefault(int value, int def) => value == 0 ? def : value;
 }

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -45,6 +45,7 @@
 - Fix monster closet setting for monsters resetting on map loads.
 - Support multiple boss death triggers. Fixes Crate Expectations MAP07.
 - Fix new dehacked definitions to default height to zero. Fixes Eye Juice ceiling light offsets.
+- Fix A_MonsterBulletAttack, A_MonsterMeleeAttack, A_WeaponBulletAttack, and A_WeaponMeleeAttack to use default parameters when not specified from dehacked instead of checking for zero to match other ports.
 
 ## Misc:
 - Refactor of old Status Bar renderer to data-driven SBARDEF format.

--- a/Tests/Unit/Dehacked/DehackedDefaultsMbf21.cs
+++ b/Tests/Unit/Dehacked/DehackedDefaultsMbf21.cs
@@ -1,0 +1,143 @@
+﻿using FluentAssertions;
+using Helion.Dehacked;
+using Helion.Resources.Archives.Collection;
+using Helion.Resources.Archives.Locator;
+using Helion.Resources.Definitions;
+using Helion.World.Entities.Definition.States;
+using Xunit;
+
+namespace Helion.Tests.Unit.Dehacked;
+
+public class DehackedDefaultsMbf21
+{
+    [Fact(DisplayName = "A_MonsterBulletAttack defaults")]
+    public void A_MonsterBulletAttackDefaults()
+    {
+        var definitionEntries = CreateAndApply(ParseDehacked("MonsterBulletAttack"));
+        var frame = definitionEntries.EntityFrameTable.Frames[0];
+        AssertArgs(frame, [0, 0, 1, 5, 3, 0, 0, 0]);
+        frame.ActionFunction.Should().NotBeNull();
+        frame.ActionFunction.Method.Name.Should().Be("A_MonsterBulletAttack");
+    }
+
+    [Fact(DisplayName = "A_MonsterBulletAttack")]
+    public void A_MonsterBulletAttack()
+    {
+        var definitionEntries = CreateAndApply(ParseDehacked("MonsterBulletAttack", noArgs: false));
+        var frame = definitionEntries.EntityFrameTable.Frames[0];
+        AssertArgs(frame, [10, 20, 30, 40, 50, 60, 70, 80]);
+        frame.ActionFunction.Should().NotBeNull();
+        frame.ActionFunction.Method.Name.Should().Be("A_MonsterBulletAttack");
+    }
+
+    [Fact(DisplayName = "A_MonsterMeleeAttack defaults")]
+    public void A_MonsterMeleeAttackDefaults()
+    {
+        var definitionEntries = CreateAndApply(ParseDehacked("MonsterMeleeAttack"));
+        var frame = definitionEntries.EntityFrameTable.Frames[0];
+        AssertArgs(frame, [3, 8, 0, 0, 0, 0, 0, 0]);
+        frame.ActionFunction.Should().NotBeNull();
+        frame.ActionFunction.Method.Name.Should().Be("A_MonsterMeleeAttack");
+    }
+
+    [Fact(DisplayName = "A_MonsterMeleeAttack")]
+    public void A_MonsterMeleeAttack()
+    {
+        var definitionEntries = CreateAndApply(ParseDehacked("MonsterMeleeAttack", noArgs: false));
+        var frame = definitionEntries.EntityFrameTable.Frames[0];
+        AssertArgs(frame, [10, 20, 30, 40, 50, 60, 70, 80]);
+        frame.ActionFunction.Should().NotBeNull();
+        frame.ActionFunction.Method.Name.Should().Be("A_MonsterMeleeAttack");
+    }
+
+    [Fact(DisplayName = "A_WeaponBulletAttack defaults")]
+    public void A_WeaponBulletAttackDefaults()
+    {
+        var definitionEntries = CreateAndApply(ParseDehacked("WeaponBulletAttack"));
+        var frame = definitionEntries.EntityFrameTable.Frames[0];
+        AssertArgs(frame, [0, 0, 1, 5, 3, 0, 0, 0]);
+        frame.ActionFunction.Should().NotBeNull();
+        frame.ActionFunction.Method.Name.Should().Be("A_WeaponBulletAttack");
+    }
+
+    [Fact(DisplayName = "A_WeaponBulletAttack")]
+    public void A_WeaponBulletAttac()
+    {
+        var definitionEntries = CreateAndApply(ParseDehacked("WeaponBulletAttack", noArgs: false));
+        var frame = definitionEntries.EntityFrameTable.Frames[0];
+        AssertArgs(frame, [10, 20, 30, 40, 50, 60, 70, 80]);
+        frame.ActionFunction.Should().NotBeNull();
+        frame.ActionFunction.Method.Name.Should().Be("A_WeaponBulletAttack");
+    }
+
+    [Fact(DisplayName = "A_WeaponMeleeAttack defaults")]
+    public void A_WeaponMeleeAttackDefaults()
+    {
+        var definitionEntries = CreateAndApply(ParseDehacked("WeaponMeleeAttack"));
+        var frame = definitionEntries.EntityFrameTable.Frames[0];
+        AssertArgs(frame, [2, 10, 65536, 0, 0, 0, 0, 0]);
+        frame.ActionFunction.Should().NotBeNull();
+        frame.ActionFunction.Method.Name.Should().Be("A_WeaponMeleeAttack");
+    }
+
+    [Fact(DisplayName = "A_WeaponMeleeAttack defaults")]
+    public void A_WeaponMeleeAttack()
+    {
+        var definitionEntries = CreateAndApply(ParseDehacked("WeaponMeleeAttack", noArgs: false));
+        var frame = definitionEntries.EntityFrameTable.Frames[0];
+        AssertArgs(frame, [10, 20, 30, 40, 50, 60, 70, 80]);
+        frame.ActionFunction.Should().NotBeNull();
+        frame.ActionFunction.Method.Name.Should().Be("A_WeaponMeleeAttack");
+    }
+
+    private static void AssertArgs(EntityFrame frame, params int[] args)
+    {
+        frame.DehackedArgs1.Should().Be(args[0]);
+        frame.DehackedArgs2.Should().Be(args[1]);
+        frame.DehackedArgs3.Should().Be(args[2]);
+        frame.DehackedArgs4.Should().Be(args[3]);
+        frame.DehackedArgs5.Should().Be(args[4]);
+        frame.DehackedArgs6.Should().Be(args[5]);
+        frame.DehackedArgs7.Should().Be(args[6]);
+        frame.DehackedArgs8.Should().Be(args[7]);
+    }
+    private static DefinitionEntries CreateAndApply(DehackedDefinition definition)
+    {
+        var archiveCollection = new ArchiveCollection(new FilesystemArchiveLocator(), new(), new());
+        var definitionEntries = new DefinitionEntries(archiveCollection, new());
+        var applier = new DehackedApplier(definitionEntries, definition);
+        applier.Apply(definition, definitionEntries, new(archiveCollection));
+        return definitionEntries;
+    }
+
+    private static DehackedDefinition ParseDehacked(string functionName, bool noArgs = true)
+    {
+        var dehacked = GetDehacked(functionName, noArgs);
+        var def = new DehackedDefinition();
+        def.Parse(dehacked);
+        return def;
+    }
+
+    private static string GetDehacked(string functionName, bool noArgs = true)
+    {
+        return $@"
+[CodePtr]
+Frame 1234 = {functionName}
+
+Frame 1234
+Sprite number = 1
+Sprite subnumber = 2
+Duration = 3
+Next frame = 4
+" +
+(noArgs ? "" :
+@"Args1 = 10
+Args2 = 20
+Args3 = 30
+Args4 = 40
+Args5 = 50
+Args6 = 60
+Args7 = 70
+Args8 = 80");
+    }
+}

--- a/Tests/Unit/GameAction/Mbf21/MonsterAttack.cs
+++ b/Tests/Unit/GameAction/Mbf21/MonsterAttack.cs
@@ -46,7 +46,7 @@ public class MonsterAttack
     public void MonsterBulletAttackDefaults()
     {
         CreateEntityAndSetState(177);
-        Player.Health.Should().Be(994);
+        Player.Health.Should().Be(1000);
     }
 
     [Fact(DisplayName = "MonsterBulletAttack")]

--- a/Tests/Unit/GameAction/Mbf21/PlayerAttack.cs
+++ b/Tests/Unit/GameAction/Mbf21/PlayerAttack.cs
@@ -46,7 +46,7 @@ public class PlayerAttack
     {
         var monster = CreateMonster();
         SetState(177);
-        monster.Health.Should().Be(985);
+        monster.Health.Should().Be(1000);
     }
 
     [Fact(DisplayName = "WeaponBulletAttack")]


### PR DESCRIPTION
Fix A_MonsterBulletAttack, A_MonsterMeleeAttack, A_WeaponBulletAttack, and A_WeaponMeleeAttack to use default parameters when not specified from dehacked. Matches behavior from other ports. 

dsda-doom implemented two different types of defaults in the same function. Most are handled at parse time where if not specified they get a default parameter. For example, this means that if a user specifies 0 for an argument that it will be used. This is a problem for the modulus parameters and Helion will still force them to 1. The others are checked in the function for zero, which means that if the user doesn't specify the value or sets it to 0 this is interpreted as the default value either way. This is how the range parameters were functioning and would use the MeleeRange property when 0.