### PR TITLE
add AnyEntityAlive to short on the first alive entity

### DIFF
--- a/Core/World/Entities/Definition/States/EntityActionFunctions.cs
+++ b/Core/World/Entities/Definition/States/EntityActionFunctions.cs
@@ -1497,7 +1497,7 @@ public static class EntityActionFunctions
         A_Fall(entity);
 
         var world = WorldStatic.World;
-        if (world.EntityAliveCount(entity.Definition.Id, EntityManager.NoTid, Sector.NoTag, entity) == 0)
+        if (!world.AnyEntityAlive(entity.Definition.Id, EntityManager.NoTid, Sector.NoTag, entity))
         {
             var sectors = world.FindBySectorTag(666);
             foreach (var sector in sectors)

--- a/Core/World/IWorld.cs
+++ b/Core/World/IWorld.cs
@@ -179,6 +179,7 @@ public interface IWorld : IDisposable
     bool IsLineIdValid(int lineId) => lineId >= 0 && lineId < Lines.Count;
     int EntityCount(int entityDefinitionId);
     int EntityAliveCount(int entityDefinitionId, int tid, int sectorTag, Entity? ignoreEntity = null);
+    bool AnyEntityAlive(int entityDefinitionId, int tid, int sectorTag, Entity? ignoreEntity = null);
     void NoiseAlert(Entity target, Entity source);
     void BossDeath(Entity entity);
     Player? GetLineOfSightPlayer(Entity entity, bool allAround);

--- a/Core/World/Special/BossActionMonsterCount.cs
+++ b/Core/World/Special/BossActionMonsterCount.cs
@@ -26,7 +26,7 @@ public class BossActionMonsterCount : IMonsterCounterSpecial
 
     public SpecialTickStatus Tick(Entity? ignoreEntity)
     {
-        if (m_world.EntityAliveCount(EntityDefinitionId, EntityManager.NoTid, Sector.NoTag, ignoreEntity) == 0)
+        if (!m_world.AnyEntityAlive(EntityDefinitionId, EntityManager.NoTid, Sector.NoTag, ignoreEntity))
             ExecuteSpecial();
 
         return SpecialTickStatus.Continue;

--- a/Core/World/WorldBase.cs
+++ b/Core/World/WorldBase.cs
@@ -3930,7 +3930,10 @@ public abstract partial class WorldBase : IWorld
     public int EntityAliveCount(int entityDefinitionId, int tid, int sectorTag, Entity? ignoreEntity = null) =>
         EntityCount(entityDefinitionId, tid, sectorTag, true, ignoreEntity);
 
-    private int EntityCount(int entityDefinitionId, int tid, int sectorTag, bool checkAlive, Entity? ignoreEntity = null)
+    public bool AnyEntityAlive(int entityDefinitionId, int tid, int sectorTag, Entity? ignoreEntity = null) =>
+        EntityCount(entityDefinitionId, tid, sectorTag, true, ignoreEntity, stopOnFirstAlive: true) > 0;
+
+    private int EntityCount(int entityDefinitionId, int tid, int sectorTag, bool checkAlive, Entity? ignoreEntity = null, bool stopOnFirstAlive = false)
     {
         int count = 0;
         if (sectorTag != Sector.NoTag)
@@ -3939,7 +3942,11 @@ public abstract partial class WorldBase : IWorld
             foreach (var sector in sectors)
             {
                 for (var node = sector.Entities.Head; node != null; node = node.Next)
+                {
                     CountEntity(node.Value, entityDefinitionId, tid, checkAlive, ignoreEntity, ref count);
+                    if (stopOnFirstAlive && count > 0)
+                        return count;
+                }
             }
 
             return count;
@@ -3950,13 +3957,21 @@ public abstract partial class WorldBase : IWorld
             // If searching by thing id then pre-filter by tid list.
             var entities = EntityManager.FindByTid(tid);
             for (var node = entities.Head; node != null; node = node.Next)
+            {
                 CountEntity(node.Value, entityDefinitionId, tid, checkAlive, ignoreEntity, ref count);
+                if (stopOnFirstAlive && count > 0)
+                    return count;
+            }
 
             return count;
         }
 
         for (var entity = EntityManager.Head; entity != null; entity = entity.Next)
+        {
             CountEntity(entity, entityDefinitionId, tid, checkAlive, ignoreEntity, ref count);
+            if (stopOnFirstAlive && count > 0)
+                return count;
+        }
 
         return count;
     }

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -69,3 +69,4 @@
 - Update SDL dependency to 2.32.10
 - Update OpenAL-Soft dependency to 1.25.2
 - Update SDL controller database support file (for button mappings, etc.)
+- Improved performance for A_KeenDie and A_BossDeath functions for extreme cases like 100krevs.wad.


### PR DESCRIPTION
A_KeenDie and A_BossDeath functions only care when everything is dead. Added a second function that doesn't rely on counting everything. This mostly doesn't matter but there are extreme cases where 100krevs.wad works using A_KeenDie on every revenant causing Helion to traverse 100k+ entities on each death.