### PR TITLE
add new specials to end of the list to match doom behavior

### DIFF
--- a/Core/Audio/IAudioSource.cs
+++ b/Core/Audio/IAudioSource.cs
@@ -39,7 +39,7 @@ public interface IAudioSource : IDisposable
 
     void SetRelative(bool set);
 
-    AudioData AudioData { get; set; }
+    public ref AudioData AudioDataRef();
 
     void Play();
 

--- a/Core/Audio/Impl/MockAudioSource.cs
+++ b/Core/Audio/Impl/MockAudioSource.cs
@@ -5,7 +5,8 @@ namespace Helion.Audio.Impl;
 
 internal sealed class MockAudioSource : IAudioSource
 {
-    public AudioData AudioData { get; set; }
+    private AudioData m_audioData;
+    public ref AudioData AudioDataRef() => ref m_audioData;
     public IAudioSource? Previous { get; set; }
     public IAudioSource? Next { get; set; }
 
@@ -20,7 +21,7 @@ internal sealed class MockAudioSource : IAudioSource
 
     public MockAudioSource(in AudioData audioData, int ticksToPlay)
     {
-        AudioData = audioData;
+        m_audioData = audioData;
         m_playTicks = ticksToPlay;
     }
 
@@ -31,12 +32,12 @@ internal sealed class MockAudioSource : IAudioSource
 
     public void CacheFree()
     {
-        AudioData = default;
+        m_audioData = default;
     }
 
     public void Tick()
     {
-        if (AudioData.Loop)
+        if (m_audioData.Loop)
             return;
 
         if (m_playing)
@@ -116,5 +117,10 @@ internal sealed class MockAudioSource : IAudioSource
     public void Update(in UpdateParams updateParams)
     {
 
+    }
+
+    public override string ToString()
+    {
+        return m_audioData.SoundSource.ToString();
     }
 }

--- a/Core/Audio/Impl/OpenALAudioSource.cs
+++ b/Core/Audio/Impl/OpenALAudioSource.cs
@@ -27,11 +27,8 @@ public class OpenALAudioSource : IAudioSource
 
     public Vec3F Velocity { get; set; }
 
-    public AudioData AudioData
-    {
-        get => m_audioData;
-        set => m_audioData = value;
-    }
+    public ref AudioData AudioDataRef() => ref m_audioData;
+
     public OpenALAudioSourceManager Owner { get; private set; }
     public IAudioSource? Previous { get; set; }
     public IAudioSource? Next { get; set; }
@@ -46,13 +43,13 @@ public class OpenALAudioSource : IAudioSource
     {
         Set(owner, buffer, audioData);
         Owner = owner;
-        AudioData = audioData;
+        m_audioData = audioData;
     }
 
     public void Set(OpenALAudioSourceManager owner, OpenALBuffer buffer, in AudioData audioData)
     {
         Owner = owner;
-        AudioData = audioData;
+        m_audioData = audioData;
         Pitch = 1f;
 
         var rolloffFactor = 1f;
@@ -311,11 +308,11 @@ public class OpenALAudioSource : IAudioSource
 
         Owner.Unlink(this);
         Owner = null!;
-        AudioData = new();
+        m_audioData = new();
         OpenALDebug.Start("Deleting sound source");
         AL.DeleteSource(m_sourceId);
         OpenALDebug.End("Deleting sound source");
     }
 
-    public override string ToString() => AudioData.SoundInfo.Name;
+    public override string ToString() => m_audioData.SoundInfo.Name;
 }

--- a/Core/Audio/Sounds/SoundManager.cs
+++ b/Core/Audio/Sounds/SoundManager.cs
@@ -68,7 +68,7 @@ public class SoundManager : IDisposable
         var node = audioSources.Head;
         while (node != null)
         {
-            if (ReferenceEquals(source, node.AudioData.SoundSource))
+            if (ReferenceEquals(source, node.AudioDataRef().SoundSource))
                 return node;
             node = node.Next;
         }
@@ -319,15 +319,17 @@ public class SoundManager : IDisposable
     private bool StopSound(ISoundSource source, SoundInfo soundInfo, in SoundParams soundParams, StopSoundOption option, double sourceDistanceSquared,
         SoundList audioSources, string? sound = null)
     {
-        bool soundStopped = false;
+        var furthestDistanceSquared = double.MinValue;
         var priority = GetPriority(source, soundInfo, soundParams);
         var node = audioSources.Head;
         var gametick = GetGameTick();
         IAudioSource? nextNode;
+        IAudioSource? furthestNode = null;
+
         while (node != null)
         {
             nextNode = node.Next;
-            var audioData = node.AudioData;
+            ref var audioData = ref node.AudioDataRef();
             if (!ShouldStopSound(source, priority, soundParams.Channel, sound,
                 audioData.SoundSource, audioData.SoundChannelType, audioData.SoundInfo.Name, audioData.Priority, option))
             {
@@ -335,31 +337,39 @@ public class SoundManager : IDisposable
                 continue;
             }
 
-            if (option == StopSoundOption.BySound)
+            if (option == StopSoundOption.ByFurthestSound)
             {
-                if (sourceDistanceSquared > GetDistanceSquared(node.AudioData.SoundSource))
+                var currentDistanceSquared = GetDistanceSquared(node.AudioDataRef().SoundSource);
+                if (sourceDistanceSquared < currentDistanceSquared && currentDistanceSquared > furthestDistanceSquared)
                 {
-                    node = nextNode;
-                    continue;
+                    furthestNode = node;
+                    furthestDistanceSquared = currentDistanceSquared;
                 }
             }
-
-            if (option == StopSoundOption.BySound && node.AudioData.Loop)
+            else
             {
-                var stopSoundSource = node.AudioData.SoundSource;
-                var stopSoundParams = new SoundParams(stopSoundSource, node.AudioData.Loop, node.AudioData.Attenuation, node.AudioData.Volume);
-                CreateWaitingLoopSound(stopSoundSource, node.GetPosition().Double, node.GetVelocity().Double, 
-                    node.AudioData.SoundInfo, node.AudioData.Priority, node.GetOffsetSeconds(), gametick, stopSoundParams);
+                furthestNode = node;
+                break;
             }
 
-            node.Stop();
-            audioSources.RemoveAndFree(node, ArchiveCollection.DataCache);
-            soundStopped = true;
-
-            break;
+            node = nextNode;
         }
 
-        return soundStopped;
+        if (furthestNode == null)
+            return false;
+
+        ref var furthestAudioData = ref furthestNode.AudioDataRef();
+        if (option == StopSoundOption.ByFurthestSound && furthestAudioData.Loop)
+        {
+            var stopSoundSource = furthestAudioData.SoundSource;
+            var stopSoundParams = new SoundParams(stopSoundSource, furthestAudioData.Loop, furthestAudioData.Attenuation, furthestAudioData.Volume);
+            CreateWaitingLoopSound(stopSoundSource, furthestNode.GetPosition().Double, furthestNode.GetVelocity().Double,
+                furthestAudioData.SoundInfo, furthestAudioData.Priority, furthestNode.GetOffsetSeconds(), gametick, stopSoundParams);
+        }
+
+        furthestNode.Stop();
+        audioSources.RemoveAndFree(furthestNode, ArchiveCollection.DataCache);
+        return true;
     }
 
     private bool StopSound(ISoundSource source, SoundInfo soundInfo, in SoundParams soundParams, WaitingSoundList waitingSounds, string? sound = null)
@@ -432,7 +442,7 @@ public class SoundManager : IDisposable
         var hitSoundLimit =  IsMaxSoundCount || HitSoundLimit(soundInfo, gametick);
         if (hitSoundLimit && !StopSounds(source, soundInfo, soundParams, distanceSquared, StopSoundOption.BySource))
         {
-            if (!StopSounds(source, soundInfo, soundParams, distanceSquared, StopSoundOption.BySound))
+            if (!StopSounds(source, soundInfo, soundParams, distanceSquared, StopSoundOption.ByFurthestSound))
             {
                 if (soundParams.Loop)
                     CreateWaitingLoopSound(source, pos, velocity, soundInfo, priority, 0, gametick, soundParams);
@@ -539,13 +549,14 @@ public class SoundManager : IDisposable
         while (node != null)
         {
             nextNode = node.Next;
-            if (node.AudioData.Attenuation != Attenuation.None && node.AudioData.Priority > lowestPriority)
+            ref var audioData = ref node.AudioDataRef();
+            if (audioData.Attenuation != Attenuation.None && audioData.Priority > lowestPriority)
             {
-                var checkDistanceSquared = GetDistanceSquared(node.AudioData.SoundSource);
+                var checkDistanceSquared = GetDistanceSquared(audioData.SoundSource);
                 if (checkDistanceSquared > farthestDistanceSquared)
                 {
                     lowestPriorityNode = node;
-                    lowestPriority = node.AudioData.Priority;
+                    lowestPriority = audioData.Priority;
                     farthestDistanceSquared = checkDistanceSquared;
                 }
             }
@@ -566,12 +577,13 @@ public class SoundManager : IDisposable
 
     protected void AddWaitingSoundFromBumpedSound(IAudioSource audioSource)
     {
-        if (!audioSource.AudioData.Loop)
+        ref var audioData = ref audioSource.AudioDataRef();
+        if (!audioData.Loop)
             return;
 
-        var soundParams = new SoundParams(audioSource.AudioData.SoundSource, true, audioSource.AudioData.Attenuation);
-        CreateWaitingLoopSound(audioSource.AudioData.SoundSource, audioSource.GetPosition().Double, audioSource.GetVelocity().Double, audioSource.AudioData.SoundInfo,
-            audioSource.AudioData.Priority, audioSource.GetOffsetSeconds(), GetGameTick(), soundParams);
+        var soundParams = new SoundParams(audioData.SoundSource, true, audioData.Attenuation);
+        CreateWaitingLoopSound(audioData.SoundSource, audioSource.GetPosition().Double, audioSource.GetVelocity().Double, audioData.SoundInfo,
+            audioData.Priority, audioSource.GetOffsetSeconds(), GetGameTick(), soundParams);
     }
 
     protected virtual int GetPriority(ISoundSource soundSource, SoundInfo soundInfo, SoundParams soundParams)
@@ -599,7 +611,7 @@ public class SoundManager : IDisposable
 
         while (node != null)
         {
-            if (soundInfo == node.AudioData.SoundInfo && CheckSoundWindow(node, gametick))
+            if (soundInfo == node.AudioDataRef().SoundInfo && CheckSoundWindow(node, gametick))
                 count++;
 
             node = node.Next;
@@ -608,7 +620,7 @@ public class SoundManager : IDisposable
         node = m_soundsToPlay.Head;
         while (node != null)
         {
-            if (soundInfo == node.AudioData.SoundInfo && CheckSoundWindow(node, gametick))
+            if (soundInfo == node.AudioDataRef().SoundInfo && CheckSoundWindow(node, gametick))
                 count++;
 
             node = node.Next;
@@ -622,7 +634,7 @@ public class SoundManager : IDisposable
         if (m_sameSoundWindow == 0)
             return true;
 
-        if (gametick - audio.AudioData.GameTick <= m_sameSoundWindow)
+        if (gametick - audio.AudioDataRef().GameTick <= m_sameSoundWindow)
             return true;
 
         return false;

--- a/Core/Audio/Sounds/StopSoundOption.cs
+++ b/Core/Audio/Sounds/StopSoundOption.cs
@@ -3,5 +3,5 @@
 enum StopSoundOption
 {
     BySource,
-    BySound
+    ByFurthestSound
 }

--- a/Core/Util/DataCache.cs
+++ b/Core/Util/DataCache.cs
@@ -193,7 +193,7 @@ public class DataCache
     {
         if (audioSource is not OpenALAudioSource)
         {
-            audioSource.AudioData.SoundSource.ClearSound(audioSource, audioSource.AudioData.SoundChannelType);
+            audioSource.AudioDataRef().SoundSource.ClearSound(audioSource, audioSource.AudioDataRef().SoundChannelType);
             audioSource.CacheFree();
             return;
         }
@@ -202,7 +202,7 @@ public class DataCache
         audioSource.SetVelocity(0, 0, 0);
         audioSource.SetPosition(0, 0, 0);
 
-        audioSource.AudioData.SoundSource.ClearSound(audioSource, audioSource.AudioData.SoundChannelType);
+        audioSource.AudioDataRef().SoundSource.ClearSound(audioSource, audioSource.AudioDataRef().SoundChannelType);
         audioSource.CacheFree();
         m_audioSources.Add(audioSource);
     }

--- a/Core/World/Entities/Entity.cs
+++ b/Core/World/Entities/Entity.cs
@@ -1231,10 +1231,10 @@ public partial class Entity : IDisposable, ITickable, ISoundSource, IFloorCeilin
         WaitSoundDispose = AudioSource != null;
 
         // If the sound looping then kill it since it will play indefinitely.
-        if (AudioSource != null && AudioSource.AudioData.Loop)
+        if (AudioSource != null && AudioSource.AudioDataRef().Loop)
         {
             WaitSoundDispose = false;
-            World.SoundManager.StopSoundBySource(this, AudioSource.AudioData.SoundChannelType, AudioSource.AudioData.SoundInfo.Name);
+            World.SoundManager.StopSoundBySource(this, AudioSource.AudioDataRef().SoundChannelType, AudioSource.AudioDataRef().SoundInfo.Name);
         }        
 
         Id = int.MinValue;
@@ -1384,7 +1384,7 @@ public partial class Entity : IDisposable, ITickable, ISoundSource, IFloorCeilin
 
     public virtual bool HasSound(string sound, SoundChannel channel)
     {
-        return AudioSource != null && AudioSource.AudioData.SoundInfo.Name.EqualsIgnoreCase(sound);
+        return AudioSource != null && AudioSource.AudioDataRef().SoundInfo.Name.EqualsIgnoreCase(sound);
     }
 
     public virtual void ClearSound(IAudioSource audioSource, SoundChannel channel)

--- a/Core/World/Entities/Players/Player.cs
+++ b/Core/World/Entities/Players/Player.cs
@@ -485,7 +485,7 @@ public class Player : Entity
             CheckIcyBounceLineAngle(World.Blockmap.BlockLines[BlockingBlockLineIndex].Segment, velocity))
         {
             var existingSound = SoundChannels[(int)SoundChannel.Default];
-            if (existingSound == null || !existingSound.AudioData.SoundInfo.Name.EndsWithIgnoreCase("*grunt"))
+            if (existingSound == null || !existingSound.AudioDataRef().SoundInfo.Name.EndsWithIgnoreCase("*grunt"))
                 PlayGruntSound();
             var bounceVelocity = MathHelper.BounceVelocity(velocity.XY);
             Velocity.X = bounceVelocity.X / 2;
@@ -784,7 +784,7 @@ public class Player : Entity
     public override bool HasSound(string sound, SoundChannel channel)
     {
         var audioSource = SoundChannels[(int)channel];
-        return audioSource != null && audioSource.AudioData.SoundInfo.Name.EqualsIgnoreCase(sound);
+        return audioSource != null && audioSource.AudioDataRef().SoundInfo.Name.EqualsIgnoreCase(sound);
     }
 
     public override void ClearSound(IAudioSource audioSource, SoundChannel channel)

--- a/Core/World/Sound/DefaultSoundSource.cs
+++ b/Core/World/Sound/DefaultSoundSource.cs
@@ -57,7 +57,7 @@ public class DefaultSoundSource : ISoundSource
 
     public bool HasSound(string sound, SoundChannel channel)
     {
-        return m_audioSource != null && m_audioSource.AudioData.SoundInfo.Name.EqualsIgnoreCase(sound);
+        return m_audioSource != null && m_audioSource.AudioDataRef().SoundInfo.Name.EqualsIgnoreCase(sound);
     }
 
     public bool CanMakeSound() => true;

--- a/Core/World/Sound/WorldSoundManager.cs
+++ b/Core/World/Sound/WorldSoundManager.cs
@@ -225,7 +225,7 @@ public class WorldSoundManager : SoundManager, ITickable
         var playingSound = PlayingSounds.Head;
         while (playingSound != null)
         {
-            if (playingSound.AudioData.SoundSource == source)
+            if (playingSound.AudioDataRef().SoundSource == source)
                 playingSound.SetRelative(false);
             playingSound = playingSound.Next;
         }
@@ -255,16 +255,17 @@ public class WorldSoundManager : SoundManager, ITickable
         while (node != null)
         {
             nextNode = node.Next;
+            ref var audioData = ref node.AudioDataRef();
             if (node.IsFinished())
             {
-                node.AudioData.SoundSource.TryClearSound(node.AudioData.SoundInfo.Name, SoundChannel.Default, out _);
+                audioData.SoundSource.TryClearSound(audioData.SoundInfo.Name, SoundChannel.Default, out _);
                 PlayingSounds.RemoveAndFree(node, m_world.DataCache);
                 node = nextNode;
                 continue;
             }
 
-            var distanceSquared = node.AudioData.SoundSource.GetDistanceSquaredFrom(listener.Entity);
-            if (!CheckDistance(distanceSquared, node.AudioData.Attenuation))
+            var distanceSquared = audioData.SoundSource.GetDistanceSquaredFrom(listener.Entity);
+            if (!CheckDistance(distanceSquared, audioData.Attenuation))
             {
                 AddWaitingSoundFromBumpedSound(node);
                 node.Stop();
@@ -274,7 +275,7 @@ public class WorldSoundManager : SoundManager, ITickable
             {
                 node.Update(new((float)Math.Sqrt(distanceSquared)));
                 node.SetPitch(node.Pitch * GetWaterLevelPitch(listener.Entity));
-                var position = node.AudioData.SoundSource.GetSoundPosition(listener.Entity);
+                var position = audioData.SoundSource.GetSoundPosition(listener.Entity);
                 if (position != null)
                     node.SetPosition((float)position.Value.X, (float)position.Value.Y, (float)position.Value.Z);
             }

--- a/Core/World/Special/SpecialManager.cs
+++ b/Core/World/Special/SpecialManager.cs
@@ -455,7 +455,7 @@ public sealed class SpecialManager : ITickable, IDisposable
 
     public void AddSpecial(ISpecial special)
     {
-        m_specials.AddFirst(m_world.DataCache.GetSpecialNode(special));
+        m_specials.AddLast(m_world.DataCache.GetSpecialNode(special));
     }
 
     public ISpecial? FindSpecialBySector(Sector sector)

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -49,6 +49,7 @@
 - Fix rendering issue with vertical scrolling two-sided middle textures.
 - Fix line scrolling using boom accel model not loading correctly from save.
 - Fix monsters not activating secret door lines.
+- Add new specials to the end of the list to match Doom behavior.
 
 ## Misc:
 - Refactor of old Status Bar renderer to data-driven SBARDEF format.

--- a/Tests/Unit/GameAction/ACS/AcsScripts.cs
+++ b/Tests/Unit/GameAction/ACS/AcsScripts.cs
@@ -568,7 +568,7 @@ public class AcsScripts
         GameActions.ActivateLine(World, Player, 243, ActivationContext.UseLine).Should().BeTrue();
         World.Tick();
         var sound = GameActions.GetSoundBySoundInfo(World, "plats/pt1_strt");
-        sound.AudioData.Volume.Should().Be(0.503937f);
+        sound.AudioDataRef().Volume.Should().Be(0.503937f);
 
         World.SoundManager.ClearSounds();
 
@@ -576,7 +576,7 @@ public class AcsScripts
         GameActions.ActivateLine(World, imp, 221, ActivationContext.UseLine).Should().BeTrue();
         World.Tick();
         sound = GameActions.GetSoundBySoundInfo(World, "plats/pt1_strt");
-        sound.AudioData.Volume.Should().Be(0.503937f);
+        sound.AudioDataRef().Volume.Should().Be(0.503937f);
     }
 
     [Fact(DisplayName = "LocalAmbientSound")]
@@ -586,7 +586,7 @@ public class AcsScripts
         GameActions.ActivateLine(World, Player, 234, ActivationContext.UseLine).Should().BeTrue();
         World.Tick();
         var sound = GameActions.GetSoundBySoundInfo(World, "plats/pt1_stop");
-        sound.AudioData.Volume.Should().Be(0.503937f);
+        sound.AudioDataRef().Volume.Should().Be(0.503937f);
 
         World.SoundManager.ClearSounds();
 
@@ -605,8 +605,8 @@ public class AcsScripts
         GameActions.ActivateLine(World, Player, 227, ActivationContext.CrossLine).Should().BeTrue();
         World.Tick();
         var sound = GameActions.GetSoundBySoundInfo(World, "plats/pt1_strt");
-        sound.AudioData.SoundSource.Should().Be(sector);
-        sound.AudioData.Volume.Should().Be(0.503937f);
+        sound.AudioDataRef().SoundSource.Should().Be(sector);
+        sound.AudioDataRef().Volume.Should().Be(0.503937f);
     }
 
     [Fact(DisplayName = "ThingSound")]
@@ -618,8 +618,8 @@ public class AcsScripts
         GameActions.ActivateLine(World, Player, 222, ActivationContext.UseLine).Should().BeTrue();
         World.Tick();
         var sound = GameActions.GetSoundBySoundInfo(World, "plats/pt1_strt");
-        sound.AudioData.SoundSource.Should().Be(candle);
-        sound.AudioData.Volume.Should().Be(0.503937f);
+        sound.AudioDataRef().SoundSource.Should().Be(candle);
+        sound.AudioDataRef().Volume.Should().Be(0.503937f);
     }
 
     [Fact(DisplayName = "ActivatorSound")]
@@ -630,8 +630,8 @@ public class AcsScripts
         GameActions.ActivateLine(World, Player, 243, ActivationContext.UseLine).Should().BeTrue();
         World.Tick();
         var sound = GameActions.GetSoundBySoundInfo(World, "plats/pt1_strt");
-        sound.AudioData.SoundSource.Should().Be(Player);
-        sound.AudioData.Volume.Should().Be(0.503937f);
+        sound.AudioDataRef().SoundSource.Should().Be(Player);
+        sound.AudioDataRef().Volume.Should().Be(0.503937f);
     }
 
     [Fact(DisplayName = "SetGravity")]

--- a/Tests/Unit/GameAction/Id24/Scroll.cs
+++ b/Tests/Unit/GameAction/Id24/Scroll.cs
@@ -65,10 +65,11 @@ public class Scroll
         int count = 0;
         GameActions.RunSectorPlaneSpecial(World, GameActions.GetSectorByTag(World, 4), () =>
         {
-            count++;
             AssertTwoSidedScroll(line, (-1 * count, 0.5 * count));
+            count++;
         });
 
+        GameActions.TickWorld(World, 1);
         var offset = line.Front.ScrollData!.Offset(WallLocation.Middle, ScrollOffsetType.Current);
         GameActions.TickWorld(World, 1);
         // Sector has completed movement so scrolling stops
@@ -91,11 +92,12 @@ public class Scroll
         Vec2D current = Vec2D.Zero;
         GameActions.RunSectorPlaneSpecial(World, GameActions.GetSectorByTag(World, 5), () =>
         {
-            count++;
             current += (-count, count * 0.5);
             AssertTwoSidedScroll(line, current);
+            count++;
         });
 
+        GameActions.TickWorld(World, 1);
         var offset = line.Front.ScrollData!.Offset(WallLocation.Middle, ScrollOffsetType.Current);
         GameActions.TickWorld(World, 1);
         // Scroll keeps moving even though sector has stopped

--- a/Tests/Unit/GameAction/Physics/BoomPhysics.cs
+++ b/Tests/Unit/GameAction/Physics/BoomPhysics.cs
@@ -87,8 +87,8 @@ namespace Helion.Tests.Unit.GameAction
         public void LiftAndCeilingMoveBlock()
         {
             var sector = GameActions.GetSectorByTag(World, 3);
-            GameActions.ActivateLine(World, Player, 24, ActivationContext.UseLine).Should().BeTrue();
             GameActions.ActivateLine(World, Player, 6, ActivationContext.UseLine).Should().BeTrue();
+            GameActions.ActivateLine(World, Player, 24, ActivationContext.UseLine).Should().BeTrue();
             sector.ActiveCeilingMove.Should().NotBeNull();
             sector.ActiveFloorMove.Should().NotBeNull();
 
@@ -112,8 +112,8 @@ namespace Helion.Tests.Unit.GameAction
             sector.ActiveFloorMove.Should().NotBeNull();
 
             GameActions.RunSectorPlaneSpecial(World, sector);
-            sector.Floor.Z.Should().Be(113);
-            sector.Ceiling.Z.Should().Be(113);
+            sector.Floor.Z.Should().Be(112);
+            sector.Ceiling.Z.Should().Be(112);
         }
 
         [Fact(DisplayName = "Activate two lines with use through flag")]

--- a/Tests/Unit/GameAction/Physics/Physics_Player.cs
+++ b/Tests/Unit/GameAction/Physics/Physics_Player.cs
@@ -225,7 +225,7 @@ namespace Helion.Tests.Unit.GameAction
 
             var audio = World.SoundManager.FindBySource(Player);
             audio.Should().NotBeNull();
-            audio!.AudioData.SoundInfo.EntryName.EqualsIgnoreCase("dsoof").Should().BeTrue();
+            audio!.AudioDataRef().SoundInfo.EntryName.EqualsIgnoreCase("dsoof").Should().BeTrue();
 
             double[] values = new[] { 39.625, 38.5, 37.625, 37, 36.625, 36.5, 36.625, 37, 37.625, 38.5, 39.625 };
             int index = 0;
@@ -258,7 +258,7 @@ namespace Helion.Tests.Unit.GameAction
 
             var audio = World.SoundManager.FindBySource(Player);
             audio.Should().NotBeNull();
-            audio!.AudioData.SoundInfo.EntryName.EqualsIgnoreCase("dsoof").Should().BeTrue();
+            audio!.AudioDataRef().SoundInfo.EntryName.EqualsIgnoreCase("dsoof").Should().BeTrue();
 
             double[] values = new[] { 39.25, 37.75, 36.5, 35.5, 34.75, 34.25, 34, 34, 34.25, 34.75, 35.5, 36.5, 37.75, 39.25 };
             int index = 0;
@@ -290,7 +290,7 @@ namespace Helion.Tests.Unit.GameAction
 
             var audio = World.SoundManager.FindBySource(Player);
             audio.Should().NotBeNull();
-            audio!.AudioData.SoundInfo.EntryName.EqualsIgnoreCase("dsoof").Should().BeTrue();
+            audio!.AudioDataRef().SoundInfo.EntryName.EqualsIgnoreCase("dsoof").Should().BeTrue();
 
             double[] values = new[] { 33, 25.25, 20.5, 20.75, 21.25, 22, 23, 24.25, 25.75, 27.5, 29.5, 31.75, 34.25, 37, 40 };
             int index = 0;
@@ -372,7 +372,7 @@ namespace Helion.Tests.Unit.GameAction
 
             var audio = World.SoundManager.FindBySource(Player);
             audio.Should().NotBeNull();
-            audio!.AudioData.SoundInfo.EntryName.EqualsIgnoreCase("dsnoway").Should().BeTrue();
+            audio!.AudioDataRef().SoundInfo.EntryName.EqualsIgnoreCase("dsnoway").Should().BeTrue();
 
             GameActions.TickWorld(World, 70);
             World.SoundManager.FindBySource(Player).Should().BeNull();
@@ -387,7 +387,7 @@ namespace Helion.Tests.Unit.GameAction
 
             var audio = World.SoundManager.FindBySource(Player);
             audio.Should().NotBeNull();
-            audio!.AudioData.SoundInfo.EntryName.EqualsIgnoreCase("dsnoway").Should().BeTrue();
+            audio!.AudioDataRef().SoundInfo.EntryName.EqualsIgnoreCase("dsnoway").Should().BeTrue();
 
             GameActions.TickWorld(World, 70);
             World.SoundManager.FindBySource(Player).Should().BeNull();
@@ -414,7 +414,7 @@ namespace Helion.Tests.Unit.GameAction
 
             var audio = World.SoundManager.FindBySource(Player);
             audio.Should().NotBeNull();
-            audio!.AudioData.SoundInfo.EntryName.EqualsIgnoreCase("dsnoway").Should().BeTrue();
+            audio!.AudioDataRef().SoundInfo.EntryName.EqualsIgnoreCase("dsnoway").Should().BeTrue();
 
             var sector = GameActions.GetSectorByTag(World, 3);
             sector.ActiveFloorMove.Should().BeNull();

--- a/Tests/Unit/GameAction/SoundInfo/AmbientSound.cs
+++ b/Tests/Unit/GameAction/SoundInfo/AmbientSound.cs
@@ -35,10 +35,10 @@ public class AmbientSounds
         sounds.Count.Should().Be(1);
 
         var sound = sounds.First!.Value;
-        sound.AudioData.Loop.Should().BeTrue();
-        sound.AudioData.Volume.Should().Be(0.5f);
-        sound.AudioData.AttenuationFactor.Should().Be(2f);
-        sound.AudioData.Attenuation.Should().Be(Attenuation.Default);
+        sound.AudioDataRef().Loop.Should().BeTrue();
+        sound.AudioDataRef().Volume.Should().Be(0.5f);
+        sound.AudioDataRef().AttenuationFactor.Should().Be(2f);
+        sound.AudioDataRef().Attenuation.Should().Be(Attenuation.Default);
 
         GameActions.TickWorld(world, 35);
         sounds = world.SoundManager.GetPlayingSounds();
@@ -68,10 +68,10 @@ public class AmbientSounds
         sounds.Count.Should().Be(1);
 
         var sound = sounds.First!.Value;
-        sound.AudioData.Loop.Should().BeTrue();
-        sound.AudioData.Volume.Should().Be(1f);
-        sound.AudioData.AttenuationFactor.Should().Be(1f);
-        sound.AudioData.Attenuation.Should().Be(Attenuation.None);
+        sound.AudioDataRef().Loop.Should().BeTrue();
+        sound.AudioDataRef().Volume.Should().Be(1f);
+        sound.AudioDataRef().AttenuationFactor.Should().Be(1f);
+        sound.AudioDataRef().Attenuation.Should().Be(Attenuation.None);
 
         GameActions.TickWorld(world, 35);
         sounds = world.SoundManager.GetPlayingSounds();
@@ -116,10 +116,10 @@ public class AmbientSounds
         sounds.Count.Should().Be(1);
 
         var sound = sounds.First!.Value;
-        sound.AudioData.Loop.Should().BeFalse();
-        sound.AudioData.Volume.Should().Be(1f);
-        sound.AudioData.AttenuationFactor.Should().Be(1f);
-        sound.AudioData.Attenuation.Should().Be(Attenuation.Default);
+        sound.AudioDataRef().Loop.Should().BeFalse();
+        sound.AudioDataRef().Volume.Should().Be(1f);
+        sound.AudioDataRef().AttenuationFactor.Should().Be(1f);
+        sound.AudioDataRef().Attenuation.Should().Be(Attenuation.Default);
 
         GameActions.TickWorld(world, () => { return world.SoundManager.GetPlayingSounds().Count > 0; }, () => { });
 

--- a/Tests/Unit/GameAction/SoundManager.cs
+++ b/Tests/Unit/GameAction/SoundManager.cs
@@ -116,11 +116,11 @@ public class SoundManager
 
         GameActions.TickWorld(World, 35, () =>
         {
-            sound.Value.AudioData.Attenuation.Should().Be(Attenuation.Default);
-            sound.Value.AudioData.SoundChannelType.Should().Be(SoundChannel.Default);
-            sound.Value.AudioData.Loop.Should().BeTrue();
-            sound.Value.AudioData.SoundInfo.EntryName.Should().Be("dsstnmov");
-            sound.Value.AudioData.SoundSource.Should().Be(GameActions.GetSectorByTag(World, 1).Floor);
+            sound.Value.AudioDataRef().Attenuation.Should().Be(Attenuation.Default);
+            sound.Value.AudioDataRef().SoundChannelType.Should().Be(SoundChannel.Default);
+            sound.Value.AudioDataRef().Loop.Should().BeTrue();
+            sound.Value.AudioDataRef().SoundInfo.EntryName.Should().Be("dsstnmov");
+            sound.Value.AudioDataRef().SoundSource.Should().Be(GameActions.GetSectorByTag(World, 1).Floor);
         });
     }
 
@@ -143,17 +143,17 @@ public class SoundManager
 
         GameActions.TickWorld(World, 35, () =>
         {
-            sound.Value.AudioData.Attenuation.Should().Be(Attenuation.Default);
-            sound.Value.AudioData.SoundChannelType.Should().Be(SoundChannel.Default);
-            sound.Value.AudioData.Loop.Should().BeTrue();
-            sound.Value.AudioData.SoundInfo.EntryName.Should().Be("dsstnmov");
-            sound.Value.AudioData.SoundSource.Should().Be(GameActions.GetSectorByTag(World, 1).Floor);
+            sound.Value.AudioDataRef().Attenuation.Should().Be(Attenuation.Default);
+            sound.Value.AudioDataRef().SoundChannelType.Should().Be(SoundChannel.Default);
+            sound.Value.AudioDataRef().Loop.Should().BeTrue();
+            sound.Value.AudioDataRef().SoundInfo.EntryName.Should().Be("dsstnmov");
+            sound.Value.AudioDataRef().SoundSource.Should().Be(GameActions.GetSectorByTag(World, 1).Floor);
 
-            secondSound.Value.AudioData.Attenuation.Should().Be(Attenuation.Default);
-            secondSound.Value.AudioData.SoundChannelType.Should().Be(SoundChannel.Default);
-            secondSound.Value.AudioData.Loop.Should().BeTrue();
-            secondSound.Value.AudioData.SoundInfo.EntryName.Should().Be("dsstnmov");
-            secondSound.Value.AudioData.SoundSource.Should().Be(GameActions.GetSectorByTag(World, 2).Floor);
+            secondSound.Value.AudioDataRef().Attenuation.Should().Be(Attenuation.Default);
+            secondSound.Value.AudioDataRef().SoundChannelType.Should().Be(SoundChannel.Default);
+            secondSound.Value.AudioDataRef().Loop.Should().BeTrue();
+            secondSound.Value.AudioDataRef().SoundInfo.EntryName.Should().Be("dsstnmov");
+            secondSound.Value.AudioDataRef().SoundSource.Should().Be(GameActions.GetSectorByTag(World, 2).Floor);
         });
     }
 
@@ -462,8 +462,8 @@ public class SoundManager
         sounds = World.SoundManager.GetPlayingSounds();
         sounds.Count.Should().Be(3);
 
-        // Sector 6 should be bumped since it's now the furthest away
-        closestSector2 = GameActions.GetSector(World, 9);
+        // Sector 5 should be bumped since it's now the furthest away
+        closestSector1 = GameActions.GetSector(World, 9);
         AssertSound(sounds, closestSector1.Floor);
         AssertSound(sounds, closestSector2.Floor);
         AssertSound(sounds, "dspistol");
@@ -544,7 +544,7 @@ public class SoundManager
         var node = list.First;
         while (node != null)
         {
-            if (node.Value.AudioData.SoundSource == sectorPlane)
+            if (node.Value.AudioDataRef().SoundSource == sectorPlane)
             {
                 found = true;
                 break;
@@ -562,7 +562,7 @@ public class SoundManager
         var node = list.First;
         while (node != null)
         {
-            if (node.Value.AudioData.SoundInfo.EntryName.Equals(soundName, StringComparison.OrdinalIgnoreCase))
+            if (node.Value.AudioDataRef().SoundInfo.EntryName.Equals(soundName, StringComparison.OrdinalIgnoreCase))
             {
                 found = true;
                 break;
@@ -577,7 +577,7 @@ public class SoundManager
     private static void AssertSoundSource(LinkedListNode<IAudioSource>? node, object source)
     {
         node.Should().NotBeNull();
-        ReferenceEquals(node!.Value.AudioData.SoundSource, source).Should().BeTrue();
+        ReferenceEquals(node!.Value.AudioDataRef().SoundSource, source).Should().BeTrue();
     }
 
     private static void AssertSound(LinkedListNode<WaitingSound>? node, string soundName)

--- a/Tests/Unit/GameAction/Util/GameAction_Crusher.cs
+++ b/Tests/Unit/GameAction/Util/GameAction_Crusher.cs
@@ -98,7 +98,7 @@ namespace Helion.Tests.Unit.GameAction
             var node = playingSounds.First;
             while (node != null)
             {
-                if (node.Value.AudioData.SoundSource == plane)
+                if (node.Value.AudioDataRef().SoundSource == plane)
                     return;
                 node = node.Next;
             }

--- a/Tests/Unit/GameAction/Util/GameAction_Sound.cs
+++ b/Tests/Unit/GameAction/Util/GameAction_Sound.cs
@@ -13,20 +13,20 @@ public partial class GameActions
     {
         var sound = world.SoundManager.FindBySource(soundSource);
         sound.Should().NotBeNull();
-        sound.AudioData.SoundInfo.Name.EqualsIgnoreCase(soundInfoName);
+        sound.AudioDataRef().SoundInfo.Name.EqualsIgnoreCase(soundInfoName);
     }
 
     public static void AssertNoSoundInfo(WorldBase world, string soundInfoName)
     {
-        world.SoundManager.GetPlayingSounds().Any(x => x.AudioData.SoundInfo.Name.EqualsIgnoreCase(soundInfoName)).Should().BeFalse();
-        world.SoundManager.GetSoundsToPlay().Any(x => x.AudioData.SoundInfo.Name.EqualsIgnoreCase(soundInfoName)).Should().BeFalse();
+        world.SoundManager.GetPlayingSounds().Any(x => x.AudioDataRef().SoundInfo.Name.EqualsIgnoreCase(soundInfoName)).Should().BeFalse();
+        world.SoundManager.GetSoundsToPlay().Any(x => x.AudioDataRef().SoundInfo.Name.EqualsIgnoreCase(soundInfoName)).Should().BeFalse();
     }
 
     public static IAudioSource GetSoundBySoundInfo(WorldBase world, string soundInfoName)
     {
         return world.SoundManager.GetPlayingSounds()
             .Union(world.SoundManager.GetSoundsToPlay())
-            .Single(x => x.AudioData.SoundInfo.Name.EqualsIgnoreCase(soundInfoName));
+            .Single(x => x.AudioDataRef().SoundInfo.Name.EqualsIgnoreCase(soundInfoName));
     }
 
     public static void AssertAnySound(WorldBase world, object soundSource) => AssertSound(world, soundSource, null);
@@ -36,7 +36,7 @@ public partial class GameActions
         var sound = world.SoundManager.FindBySource(soundSource);
         sound.Should().NotBeNull();
         if (entrySoundName != null)
-            sound!.AudioData.SoundInfo.EntryName.EqualsIgnoreCase(entrySoundName).Should().BeTrue();
+            sound!.AudioDataRef().SoundInfo.EntryName.EqualsIgnoreCase(entrySoundName).Should().BeTrue();
 
         ((MockAudioSourceManager)world.SoundManager.AudioManager).CreateSound = false;
         TickWorld(world, () => { return world.SoundManager.FindBySource(soundSource) != null; }, () => { });


### PR DESCRIPTION
Add new specials to end of the list to match doom behavior

Fixes StopSound to stop the furthest matching sound instead of first one that is further away as originally intended.

Refactor AudioData to return a reference since the original property call through the interface was unintentionally copying the entire struct.