### PR TITLE
Fix issue with berserk taking priority over damage when berserk intensity is zero with palettes

### DIFF
--- a/Core/Graphics/Palettes/PaletteUtil.cs
+++ b/Core/Graphics/Palettes/PaletteUtil.cs
@@ -28,24 +28,23 @@ public static class PaletteUtil
     {
         var palette = PaletteIndex.Normal;
         var powerup = player.Inventory.PowerupEffectColor;
-        int damageCount = player.DamageCount;
+        var damageCount = player.DamageCount;
+        var damageIntensity = (float)config.Game.PainIntensity.Value;
 
         if (powerup != null && powerup.PowerupType == PowerupType.Strength)
-            damageCount = Math.Max(damageCount, 12 - (powerup.Ticks >> 6));
+        {
+            var berserkAmount = 12 - (powerup.Ticks >> 6);
+            var berserkIntensity = (float)config.Game.BerserkIntensity.Value;
+
+            if (berserkAmount * berserkIntensity > damageCount * damageIntensity)
+            {
+                damageCount = berserkAmount;
+                damageIntensity = berserkIntensity;
+            }
+        }
 
         if (damageCount > 0)
         {
-            float damageIntensity;
-            if (damageCount == player.DamageCount)
-            {
-                damageIntensity = (float)config.Game.PainIntensity;
-                damageCount = player.DamageCount;
-            }
-            else
-            {
-                damageIntensity = (float)config.Game.BerserkIntensity;
-            }
-
             palette = GetDamagePalette(damageCount, damageIntensity);
         }
         else if (player.BonusCount > 0)

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -51,6 +51,7 @@
 - Fix monsters not activating secret door lines.
 - Add new specials to the end of the list to match Doom behavior.
 - Fix issues with negative Y scaling for middle textures.
+- Fix issue with berserk taking priority over damage when berserk intensity is zero with palettes.
 
 ## Misc:
 - Refactor of old Status Bar renderer to data-driven SBARDEF format.


### PR DESCRIPTION
compare berserk amount with damage amount with intensities to fix damage not showing when berserk intensity is zero

fixes #1667 