### PR TITLE
Add always on/always off to compatibility options

### DIFF
--- a/Client/Client.Demo.cs
+++ b/Client/Client.Demo.cs
@@ -114,7 +114,7 @@ public partial class Client
 
     private void Player_PlaybackEnded(object? sender, EventArgs e)
     {
-        m_config.ApplyConfiguration(m_userConfigValues, writeToConfig: false);
+        m_config.ApplyConfiguration(m_userConfigValues);
         m_userConfigValues.Clear();
     }
 
@@ -155,7 +155,7 @@ public partial class Client
             m_userConfigValues.Add(new ConfigValueModel("game.rng", m_config.Game.Rng.Value));
         }
 
-        m_config.ApplyConfiguration(m_demoModel.ConfigValues, writeToConfig: false);
+        m_config.ApplyConfiguration(m_demoModel.ConfigValues);
     }
 
     private void SetDefaultDemoValues(Dictionary<string, ConfigComponent> components)

--- a/Core/Layer/Worlds/WorldLayer.cs
+++ b/Core/Layer/Worlds/WorldLayer.cs
@@ -252,7 +252,7 @@ public partial class WorldLayer : IGameLayerParent
         if (worldModel == null)
             return;
 
-        config.ApplyConfiguration(worldModel.ConfigValues, writeToConfig: false);
+        config.ApplyConfiguration(worldModel.ConfigValues);
     }
 
     public static SinglePlayerWorld? CreateWorldGeometry(GlobalData globalData, IConfig config, IAudioSystem audioSystem,

--- a/Core/Resources/Definitions/CompLevelDefinition.cs
+++ b/Core/Resources/Definitions/CompLevelDefinition.cs
@@ -58,21 +58,21 @@ public class CompLevelDefinition
         switch (CompLevel)
         {
             case CompLevel.Vanilla:
-                compat.AllowItemDropoff.Set(false, writeToConfig: false);
-                compat.Doom2ProjectileWalkTriggers.Set(true, writeToConfig: false);
-                compat.InfinitelyTallThings.Set(true, writeToConfig: false);
-                compat.MissileClip.Set(true, writeToConfig: false);
-                compat.OriginalExplosion.Set(true, writeToConfig: false);
-                compat.PainElementalLostSoulLimit.Set(true, writeToConfig: false);
-                compat.Stairs.Set(true, writeToConfig: false);
-                compat.VanillaMovementPhysics.Set(true, writeToConfig: false);
-                compat.VanillaSectorPhysics.Set(true, writeToConfig: false);
-                compat.VanillaSectorSound.Set(true, writeToConfig: false);
-                compat.VanillaShortestTexture.Set(true, writeToConfig: false);
-                compat.VileGhosts.Set(true, writeToConfig: false);
-                compat.MbfTelefrag.Set(false, writeToConfig: false);
+                compat.AllowItemDropoff.SetIfMutable(false);
+                compat.Doom2ProjectileWalkTriggers.SetIfMutable(true);
+                compat.InfinitelyTallThings.SetIfMutable(true);
+                compat.MissileClip.SetIfMutable(true);
+                compat.OriginalExplosion.SetIfMutable(true);
+                compat.PainElementalLostSoulLimit.SetIfMutable(true);
+                compat.Stairs.SetIfMutable(true);
+                compat.VanillaMovementPhysics.SetIfMutable(true);
+                compat.VanillaSectorPhysics.SetIfMutable(true);
+                compat.VanillaSectorSound.SetIfMutable(true);
+                compat.VanillaShortestTexture.SetIfMutable(true);
+                compat.VileGhosts.SetIfMutable(true);
+                compat.MbfTelefrag.SetIfMutable(false);
 
-                compat.Mbf21.Set(false, writeToConfig: false);
+                compat.Mbf21.SetIfMutable(false);
                 break;
             case CompLevel.Boom:
                 SetBoomCompat(compat, mbf21: false, mbfTelefrag: false);
@@ -90,12 +90,12 @@ public class CompLevelDefinition
 
     private static void SetBoomCompat(ConfigCompat compat, bool mbf21, bool mbfTelefrag)
     {
-        compat.AllowItemDropoff.Set(true, writeToConfig: false);
-        compat.Stairs.Set(false, writeToConfig: false);
-        compat.VanillaSectorPhysics.Set(false, writeToConfig: false);
-        compat.VanillaShortestTexture.Set(false, writeToConfig: false);
+        compat.AllowItemDropoff.SetIfMutable(true);
+        compat.Stairs.SetIfMutable(false);
+        compat.VanillaSectorPhysics.SetIfMutable(false);
+        compat.VanillaShortestTexture.SetIfMutable(false);
 
-        compat.MbfTelefrag.Set(mbfTelefrag, writeToConfig: false);
-        compat.Mbf21.Set(mbf21, writeToConfig: false);
+        compat.MbfTelefrag.SetIfMutable(mbfTelefrag);
+        compat.Mbf21.SetIfMutable(mbf21);
     }
 }

--- a/Core/Resources/Definitions/DefinitionEntries.cs
+++ b/Core/Resources/Definitions/DefinitionEntries.cs
@@ -95,7 +95,7 @@ public class DefinitionEntries
     private bool m_parseLegacyMapInfo;
     private bool m_parseWeapons;
 
-    private bool ShouldParseWeapons => m_parseWeapons || !ConfigCompatibility.PreferDehacked;
+    private bool ShouldParseWeapons => m_parseWeapons || !ConfigCompatibility.PreferDehacked.Value.ToBool();
 
     /// <summary>
     /// Creates a definition entries data structure which has no tracked
@@ -286,9 +286,9 @@ public class DefinitionEntries
         m_parseLegacyMapInfo = true;
 
         bool hasBoth = archive.AnyEntryByName("DEHACKED") && archive.AnyEntryByName("DECORATE");
-        if (ConfigCompatibility.PreferDehacked && hasBoth)
+        if (ConfigCompatibility.PreferDehacked.Value.ToBool() && hasBoth)
             m_parseDecorate = false;
-        else if (!ConfigCompatibility.PreferDehacked && hasBoth)
+        else if (!ConfigCompatibility.PreferDehacked.Value.ToBool() && hasBoth)
             m_parseDehacked = false;
 
         var ZMapInfo = archive.AnyEntryByName("ZMAPINFO");

--- a/Core/Util/Configs/Components/CompatSetting.cs
+++ b/Core/Util/Configs/Components/CompatSetting.cs
@@ -1,10 +1,16 @@
-﻿namespace Helion.Util.Configs.Components;
+﻿using System.ComponentModel;
+
+namespace Helion.Util.Configs.Components;
 
 public enum CompatSetting
 {
+    [Description("Off")]
     False,
+    [Description("On")]
     True,
+    [Description("Always On")]
     Always,
+    [Description("Always Off")]
     Never
 }
 

--- a/Core/Util/Configs/Components/CompatSetting.cs
+++ b/Core/Util/Configs/Components/CompatSetting.cs
@@ -1,0 +1,21 @@
+﻿namespace Helion.Util.Configs.Components;
+
+public enum CompatSetting
+{
+    False,
+    True,
+    Always,
+    Never
+}
+
+public static class CompatSettingExtensions
+{
+    public static bool ToBool(this CompatSetting setting)
+    {
+        return setting switch
+        {
+            CompatSetting.True or CompatSetting.Always => true,
+            _ => false,
+        };
+    }
+}

--- a/Core/Util/Configs/Components/ConfigCompat.cs
+++ b/Core/Util/Configs/Components/ConfigCompat.cs
@@ -13,71 +13,71 @@ public class ConfigCompat: ConfigElement<ConfigCompat>
 
     [ConfigInfo("Use vanilla method for finding shortest texture. Emulates bug with AASHITTY.", save: false, serialize: true, demo: true)]
     [OptionMenu(OptionSectionType.Compatibility, "Find Shortest Texture", spacer: true)]
-    public readonly ConfigValue<bool> VanillaShortestTexture = new(true);
+    public readonly ConfigCompatValue VanillaShortestTexture = new(CompatSetting.True);
 
     [ConfigInfo("Use DeHackEd over DECORATE if both are available.", demo: true)]
     [OptionMenu(OptionSectionType.Compatibility, "Use DeHackEd over DECORATE")]
-    public readonly ConfigValue<bool> PreferDehacked = new(true);
+    public readonly ConfigCompatValue PreferDehacked = new(CompatSetting.True);
 
     [ConfigInfo("Allow items to drop off tall ledges.", serialize: true, demo: true)]
     [OptionMenu(OptionSectionType.Compatibility, "Items Drop Off Ledges")]
-    public readonly ConfigValue<bool> AllowItemDropoff = new(true);
+    public readonly ConfigCompatValue AllowItemDropoff = new(CompatSetting.True);
 
     [ConfigInfo("Use vanilla sector physics. Floors can move through ceilings. Only one move special per sector at a time.", serialize: true, demo: true)]
     [OptionMenu(OptionSectionType.Compatibility, "Vanilla Sector Physics")]
-    public readonly ConfigValue<bool> VanillaSectorPhysics = new(false);
+    public readonly ConfigCompatValue VanillaSectorPhysics = new(CompatSetting.False);
 
     [ConfigInfo("Use vanilla movement physics. Velocity is maintained when hitting things.", serialize: true, demo: true)]
     [OptionMenu(OptionSectionType.Compatibility, "Vanilla Movement Physics")]
-    public readonly ConfigValue<bool> VanillaMovementPhysics = new(true);
+    public readonly ConfigCompatValue VanillaMovementPhysics = new(CompatSetting.True);
 
     [ConfigInfo("Use vanilla sector sound calculation. Sound is calculated from the center of the sector's bounding box.", serialize: true, demo: true)]
     [OptionMenu(OptionSectionType.Compatibility, "Vanilla Sector Sound")]
-    public readonly ConfigValue<bool> VanillaSectorSound = new(false);
+    public readonly ConfigCompatValue VanillaSectorSound = new(CompatSetting.False);
 
     [ConfigInfo("Emulate vanilla infinitely tall things.", serialize: true, demo: true)]
     [OptionMenu(OptionSectionType.Compatibility, "Infinitely Tall Things")]
-    public readonly ConfigValue<bool> InfinitelyTallThings = new(false);
+    public readonly ConfigCompatValue InfinitelyTallThings = new(CompatSetting.False);
 
     [ConfigInfo("Things use their original vanilla heights for projectile collision checks.", serialize: true, demo: true)]
     [OptionMenu(OptionSectionType.Compatibility, "Vanilla Missile Height Collision")]
-    public readonly ConfigValue<bool> MissileClip = new(false);
+    public readonly ConfigCompatValue MissileClip = new(CompatSetting.False);
 
     [ConfigInfo("Limit lost souls spawned by pain elementals to 21.", serialize: true, demo: true)]
     [OptionMenu(OptionSectionType.Compatibility, "Limit Pain Elemental Lost Souls to 21")]
-    public readonly ConfigValue<bool> PainElementalLostSoulLimit = new(false);
+    public readonly ConfigCompatValue PainElementalLostSoulLimit = new(CompatSetting.False);
 
     [ConfigInfo("Disable item drop tossing.", serialize: true, demo: true)]
     [OptionMenu(OptionSectionType.Compatibility, "Disable Item Drop Tossing")]
-    public readonly ConfigValue<bool> NoTossDrops = new(false);
+    public readonly ConfigCompatValue NoTossDrops = new(CompatSetting.False);
 
     [ConfigInfo("Use Doom's bugged stair building.", serialize: true, demo: true)]
     [OptionMenu(OptionSectionType.Compatibility, "Use Bugged Stair Building")]
-    public readonly ConfigValue<bool> Stairs = new(false);
+    public readonly ConfigCompatValue Stairs = new(CompatSetting.False);
 
     [ConfigInfo("Enable Doom 2 projectiles triggering walk specials.", serialize: true, demo: true)]
     [OptionMenu(OptionSectionType.Compatibility, "Doom 2 Projectiles Trigger Walk Specials")]
-    public readonly ConfigValue<bool> Doom2ProjectileWalkTriggers = new(false);
+    public readonly ConfigCompatValue Doom2ProjectileWalkTriggers = new(CompatSetting.False);
 
     [ConfigInfo("Use original Doom explosion behavior.", serialize: true, demo: true)]
     [OptionMenu(OptionSectionType.Compatibility, "Use Original Doom Explosion Behavior")]
-    public readonly ConfigValue<bool> OriginalExplosion = new(false);
+    public readonly ConfigCompatValue OriginalExplosion = new(CompatSetting.False);
 
     [ConfigInfo("Enable vile ghosts.", serialize: true, demo: true)]
     [OptionMenu(OptionSectionType.Compatibility, "Vile Ghosts")]
-    public readonly ConfigValue<bool> VileGhosts = new(false);
+    public readonly ConfigCompatValue VileGhosts = new(CompatSetting.False);
 
     [ConfigInfo("Enable Final Doom teleports. Disables forcing to floor.", serialize: true, demo: true)]
     [OptionMenu(OptionSectionType.Compatibility, "Final Doom Teleport")]
-    public readonly ConfigValue<bool> FinalDoomTeleport = new(false);
+    public readonly ConfigCompatValue FinalDoomTeleport = new(CompatSetting.False);
 
     [ConfigInfo("Enable MBF21 features.", serialize: true, demo: true)]
     [OptionMenu(OptionSectionType.Compatibility, "Enable MBF21 Features")]
-    public readonly ConfigValue<bool> Mbf21 = new(true);
+    public readonly ConfigCompatValue Mbf21 = new(CompatSetting.True);
 
     [ConfigInfo("MBF Telefrag Behavior that disables monster telefrags on MAP30 and only allows for icon boss spawns.", serialize: true, demo: true)]
     [OptionMenu(OptionSectionType.Compatibility, "Mbf Telefrag Behavior")]
-    public readonly ConfigValue<bool> MbfTelefrag = new(true);
+    public readonly ConfigCompatValue MbfTelefrag = new(CompatSetting.True);
 
     public void ResetToUserValues()
     {
@@ -96,5 +96,6 @@ public class ConfigCompat: ConfigElement<ConfigCompat>
         VanillaShortestTexture.ResetToUserValue();
         VileGhosts.ResetToUserValue();
         Mbf21.ResetToUserValue();
+        MbfTelefrag.ResetToUserValue();
     }
 }

--- a/Core/Util/Configs/Components/ConfigCompatValue.cs
+++ b/Core/Util/Configs/Components/ConfigCompatValue.cs
@@ -4,6 +4,7 @@ namespace Helion.Util.Configs.Components;
 
 public class ConfigCompatValue(CompatSetting value) : ConfigValue<CompatSetting>(value)
 {
+    // Save files only store true/false — Always/Never are user config pins
     public override object ObjectValueSerialize => Value.ToBool();
 
     public override ConfigSetResult Set(object newValue, bool writeToConfig = true, bool fireChangeEvents = true)

--- a/Core/Util/Configs/Components/ConfigCompatValue.cs
+++ b/Core/Util/Configs/Components/ConfigCompatValue.cs
@@ -1,0 +1,36 @@
+﻿using Helion.Util.Configs.Values;
+
+namespace Helion.Util.Configs.Components;
+
+public class ConfigCompatValue(CompatSetting value) : ConfigValue<CompatSetting>(value)
+{
+    public override object ObjectValueSerialize => Value.ToBool();
+
+    public override ConfigSetResult Set(object newValue, bool writeToConfig = true, bool fireChangeEvents = true)
+    {
+        if (writeToConfig)
+            return base.Set(newValue, writeToConfig, fireChangeEvents);
+
+        if (!TryConvertInternal(newValue, out var converted))
+            return ConfigSetResult.NotSetByBadConversion;
+
+        if (this.IsMutable())
+            return base.Set(converted, writeToConfig, fireChangeEvents);
+
+        return ConfigSetResult.Unchanged;
+    }
+}
+
+public static class ConfigValueCompatSettingExtensions
+{
+    public static void SetIfMutable(this ConfigCompatValue configValue, bool newValue)
+    {
+        if (configValue.IsMutable())
+            configValue.Set(newValue, writeToConfig: false);
+    }
+
+    public static bool IsMutable(this ConfigCompatValue configValue)
+    {
+        return configValue.UserValue != CompatSetting.Always && configValue.UserValue != CompatSetting.Never;
+    }
+}

--- a/Core/Util/Configs/ConfigEnums.cs
+++ b/Core/Util/Configs/ConfigEnums.cs
@@ -49,6 +49,7 @@ namespace Helion.Util.Configs
             { typeof(RenderContrastMode), Enum.GetValues<RenderContrastMode>() },
             { typeof(WeaponSwitch), Enum.GetValues<WeaponSwitch>() },
             { typeof(ConfigRenderMode), Enum.GetValues<ConfigRenderMode>() },
+            { typeof(CompatSetting), Enum.GetValues<CompatSetting>() },
         };
 
         public static Dictionary<Type, Dictionary<Enum, string>> KnownEnumLabels { get; } = new Dictionary<Type, Dictionary<Enum, string>>()
@@ -76,6 +77,7 @@ namespace Helion.Util.Configs
             { typeof(SkyRenderMode), GetDescriptions<SkyRenderMode>()},
             { typeof(WeaponSwitch), GetDescriptions<WeaponSwitch>()},
             { typeof(ConfigRenderMode), GetDescriptions<ConfigRenderMode>()},
+            { typeof(CompatSetting), GetDescriptions<CompatSetting>() },
         };
 
         private static Dictionary<Enum, string> GetDescriptions<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] T>() where T : struct, Enum

--- a/Core/Util/Configs/IConfig.cs
+++ b/Core/Util/Configs/IConfig.cs
@@ -48,7 +48,7 @@ public interface IConfig
     void ApplyQueuedChanges(ConfigSetFlags setFlags);
 
     Dictionary<string, ConfigComponent> GetComponents();
-    void ApplyConfiguration(IList<ConfigValueModel> configValues, bool writeToConfig = true);
+    void ApplyConfiguration(IList<ConfigValueModel> configValues);
 
     List<(IConfigValue, OptionMenuAttribute, ConfigInfoAttribute)> GetAllConfigFields();
 }

--- a/Core/Util/Configs/Impl/Config.cs
+++ b/Core/Util/Configs/Impl/Config.cs
@@ -116,7 +116,7 @@ public class Config : ConfigElement<Config>, IConfig
 
     public Dictionary<string, ConfigComponent> GetComponents() => Components;
 
-    public void ApplyConfiguration(IList<ConfigValueModel> configValues, bool writeToConfig = true)
+    public void ApplyConfiguration(IList<ConfigValueModel> configValues)
     {
         foreach (var configModel in configValues)
         {
@@ -126,7 +126,7 @@ public class Config : ConfigElement<Config>, IConfig
                 continue;
             }
 
-            if (component.Value.Set(configModel.Value, writeToConfig) == ConfigSetResult.NotSetByBadConversion)
+            if (component.Value.Set(configModel.Value, false) == ConfigSetResult.NotSetByBadConversion)
                 Log.Error($"Bad configuration value '{configModel.Value}' for '{configModel.Key}'.");
         }
     }

--- a/Core/Util/Configs/Values/ConfigValue.cs
+++ b/Core/Util/Configs/Values/ConfigValue.cs
@@ -5,13 +5,10 @@ using System.Diagnostics.CodeAnalysis;
 using Helion.Util.Extensions;
 using static Helion.Util.Assertion.Assert;
 using static Helion.Util.Configs.Values.ConfigConverters;
-
 namespace Helion.Util.Configs.Values;
 
 public class ConfigValue<T> : IConfigValue where T : notnull
 {
-
-
     // This value could be passed any type. To avoid many creations, this
     // is cached between different generic types.
     private static readonly Func<object, T> ObjectToTypeConverterOrThrow;
@@ -29,6 +26,7 @@ public class ConfigValue<T> : IConfigValue where T : notnull
     }
 
     public object ObjectValue => Value;
+    public virtual object ObjectValueSerialize => Value;
     public object ObjectDefaultValue => DefaultValue;
     public object ObjectUserValue => UserValue;
     public bool HasTemporaryValue { get; private set; }
@@ -91,7 +89,7 @@ public class ConfigValue<T> : IConfigValue where T : notnull
 
     public static implicit operator T(ConfigValue<T> val) => val.Value;
 
-    public ConfigSetResult Set(object newValue, bool writeToConfig = true, bool fireChangeEvents = true)
+    public virtual ConfigSetResult Set(object newValue, bool writeToConfig = true, bool fireChangeEvents = true)
     {
         return TryConvertInternal(newValue, out var convertedValue)
             ? Set(convertedValue, writeToConfig, fireChangeEvents)
@@ -121,7 +119,7 @@ public class ConfigValue<T> : IConfigValue where T : notnull
         return success;
     }
 
-    private bool TryConvertInternal(object value, [NotNullWhen(true)] out T? converted)
+    protected bool TryConvertInternal(object value, [NotNullWhen(true)] out T? converted)
     {
         try
         {

--- a/Core/Util/Configs/Values/IConfigValue.cs
+++ b/Core/Util/Configs/Values/IConfigValue.cs
@@ -13,6 +13,11 @@ public interface IConfigValue
     object ObjectValue { get; }
 
     /// <summary>
+    /// The value to use when serializing this config value.
+    /// </summary>
+    object ObjectValueSerialize { get; }
+
+    /// <summary>
     /// Whether this config value has been temporarily set (such as by COMPLVL loaded from a WAD file)
     /// </summary>
     bool HasTemporaryValue { get; }

--- a/Core/Util/SerializationContexts/WorldModelSerializationContext.cs
+++ b/Core/Util/SerializationContexts/WorldModelSerializationContext.cs
@@ -1,35 +1,28 @@
-﻿using Helion.Util.Container;
-using System;
-using System.Text.Json;
+﻿using Helion.Models;
+using Helion.Util.RandomGenerators;
+using System.Text.Json.Serialization;
 
-namespace Helion.Util.SerializationContexts
+namespace Helion.Util.SerializationContexts;
+
+[JsonSourceGenerationOptions(
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull | JsonIgnoreCondition.WhenWritingDefault,
+    PropertyNameCaseInsensitive = true,
+    IncludeFields = true
+)]
+[JsonSerializable(typeof(WorldModel), TypeInfoPropertyName = "WorldModel")]
+[JsonSerializable(typeof(ISpecialModel), TypeInfoPropertyName = "ISpecialModel")]
+[JsonSerializable(typeof(ElevatorSpecialModel), TypeInfoPropertyName = "ElevatorSpecialModel")]
+[JsonSerializable(typeof(LightChangeSpecialModel), TypeInfoPropertyName = "LightChangeSpecialModel")]
+[JsonSerializable(typeof(LightFireFlickerDoomModel), TypeInfoPropertyName = "LightFireFlickerDoomModel")]
+[JsonSerializable(typeof(LightFlickerDoomSpecialModel), TypeInfoPropertyName = "LightFlickerDoomSpecialModel")]
+[JsonSerializable(typeof(LightPulsateSpecialModel), TypeInfoPropertyName = "LightPulsateSpecialModel")]
+[JsonSerializable(typeof(LightStrobeSpecialModel), TypeInfoPropertyName = "LightStrobeSpecialModel")]
+[JsonSerializable(typeof(PushSpecialModel), TypeInfoPropertyName = "PushSpecialModel")]
+[JsonSerializable(typeof(ScrollSpecialModel), TypeInfoPropertyName = "ScrollSpecialModel")]
+[JsonSerializable(typeof(SectorMoveSpecialModel), TypeInfoPropertyName = "SectorMoveSpecialModel")]
+[JsonSerializable(typeof(StairSpecialModel), TypeInfoPropertyName = "StairSpecialModel")]
+[JsonSerializable(typeof(SwitchChangeSpecialModel), TypeInfoPropertyName = "SwitchChangeSpecialModel")]
+[JsonSerializable(typeof(RngMethod), TypeInfoPropertyName = "RandomMethod")]
+public partial class WorldModelSerializationContext : JsonSerializerContext
 {
-    using Helion.Models;
-    using Helion.Util.RandomGenerators;
-    using System.Collections.Generic;
-    using System.Text.Json.Serialization;
-
-    [JsonSourceGenerationOptions(
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull | JsonIgnoreCondition.WhenWritingDefault,
-        PropertyNameCaseInsensitive = true,
-        IncludeFields = true
-    )]
-    [JsonSerializable(typeof(WorldModel), TypeInfoPropertyName = "WorldModel")]
-    [JsonSerializable(typeof(ISpecialModel), TypeInfoPropertyName = "ISpecialModel")]
-    [JsonSerializable(typeof(ElevatorSpecialModel), TypeInfoPropertyName = "ElevatorSpecialModel")]
-    [JsonSerializable(typeof(LightChangeSpecialModel), TypeInfoPropertyName = "LightChangeSpecialModel")]
-    [JsonSerializable(typeof(LightFireFlickerDoomModel), TypeInfoPropertyName = "LightFireFlickerDoomModel")]
-    [JsonSerializable(typeof(LightFlickerDoomSpecialModel), TypeInfoPropertyName = "LightFlickerDoomSpecialModel")]
-    [JsonSerializable(typeof(LightPulsateSpecialModel), TypeInfoPropertyName = "LightPulsateSpecialModel")]
-    [JsonSerializable(typeof(LightStrobeSpecialModel), TypeInfoPropertyName = "LightStrobeSpecialModel")]
-    [JsonSerializable(typeof(PushSpecialModel), TypeInfoPropertyName = "PushSpecialModel")]
-    [JsonSerializable(typeof(ScrollSpecialModel), TypeInfoPropertyName = "ScrollSpecialModel")]
-    [JsonSerializable(typeof(SectorMoveSpecialModel), TypeInfoPropertyName = "SectorMoveSpecialModel")]
-    [JsonSerializable(typeof(StairSpecialModel), TypeInfoPropertyName = "StairSpecialModel")]
-    [JsonSerializable(typeof(SwitchChangeSpecialModel), TypeInfoPropertyName = "SwitchChangeSpecialModel")]
-    [JsonSerializable(typeof(RngMethod), TypeInfoPropertyName = "RandomMethod")]
-    public partial class WorldModelSerializationContext : JsonSerializerContext
-    {
-    }
 }
-

--- a/Core/World/Entities/Definition/States/EntityActionFunctions.cs
+++ b/Core/World/Entities/Definition/States/EntityActionFunctions.cs
@@ -8,6 +8,7 @@ using Helion.Maps.Specials.Vanilla;
 using Helion.Maps.Specials.ZDoom;
 using Helion.Resources.Definitions.MapInfo;
 using Helion.Util;
+using Helion.Util.Configs.Components;
 using Helion.Util.RandomGenerators;
 using Helion.World.Entities.Inventories;
 using Helion.World.Entities.Inventories.Powerups;
@@ -1714,7 +1715,7 @@ public static class EntityActionFunctions
 
     private static void A_PainShootSkull(Entity entity, double angle)
     {
-        if (WorldStatic.World.Config.Compatibility.PainElementalLostSoulLimit)
+        if (WorldStatic.World.Config.Compatibility.PainElementalLostSoulLimit.Value.ToBool())
         {
             var def = WorldStatic.EntityManager.DefinitionComposer.GetByName("LostSoul");
             if (def != null && WorldStatic.World.EntityCount(def.Id) > 20)

--- a/Core/World/Geometry/Sectors/Sector.cs
+++ b/Core/World/Geometry/Sectors/Sector.cs
@@ -1020,12 +1020,12 @@ public sealed class Sector : SectorSoundSource, IFloorCeilingAnchor
             if (line.Back != null)
             {
                 Side side = line.Front;
-                min = GetShortestTextureHeight(textureManager, side, byLowerTx, config.VanillaShortestTexture, min);
+                min = GetShortestTextureHeight(textureManager, side, byLowerTx, config.VanillaShortestTexture.Value.ToBool(), min);
 
                 if (line.Back != null)
                 {
                     side = line.Back;
-                    min = GetShortestTextureHeight(textureManager, side, byLowerTx, config.VanillaShortestTexture, min);
+                    min = GetShortestTextureHeight(textureManager, side, byLowerTx, config.VanillaShortestTexture.Value.ToBool(), min);
                 }
             }
         }

--- a/Core/World/Physics/PhysicsManager.cs
+++ b/Core/World/Physics/PhysicsManager.cs
@@ -4,6 +4,7 @@ using Helion.Geometry.Vectors;
 using Helion.Maps.Specials;
 using Helion.Maps.Specials.ZDoom;
 using Helion.Util;
+using Helion.Util.Configs.Components;
 using Helion.Util.Container;
 using Helion.Util.RandomGenerators;
 using Helion.World.Blockmap;
@@ -193,7 +194,7 @@ public sealed partial class PhysicsManager
         var moveData = moveSpecial.MoveData;
         var moveType = moveSpecial.MoveData.SectorMoveType;
         var startZ = sectorPlane.Z;
-        if (!m_world.Config.Compatibility.VanillaSectorPhysics && IsSectorMovementBlocked(sector, startZ, destZ, moveSpecial))
+        if (!m_world.Config.Compatibility.VanillaSectorPhysics.Value.ToBool() && IsSectorMovementBlocked(sector, startZ, destZ, moveSpecial))
             return SectorMoveStatus.Blocked | SectorMoveStatus.Stop;
 
         // Move lower entities first to handle stacked entities
@@ -212,7 +213,7 @@ public sealed partial class PhysicsManager
 
         bool isCompleted = moveSpecial.IsFinalDestination(destZ);
         // Doors can't be part of the clip check. Maps are reliant on this behavior (e.g. Going Down Turbo MAP23 invul)
-        if (!moveSpecial.IsDoor && !m_world.Config.Compatibility.VanillaSectorPhysics && IsSectorMovementBlocked(sector, startZ, destZ, moveSpecial))
+        if (!moveSpecial.IsDoor && !m_world.Config.Compatibility.VanillaSectorPhysics.Value.ToBool() && IsSectorMovementBlocked(sector, startZ, destZ, moveSpecial))
         {
             if ((moveData.Flags & SectorMoveFlags.NoFixClip) == 0)
                 FixPlaneClip(sector, sectorPlane, moveType);

--- a/Core/World/Special/SpecialManager.cs
+++ b/Core/World/Special/SpecialManager.cs
@@ -10,6 +10,7 @@ using Helion.Resources;
 using Helion.Resources.Definitions;
 using Helion.Util;
 using Helion.Util.Assertion;
+using Helion.Util.Configs.Components;
 using Helion.Util.Container;
 using Helion.Util.RandomGenerators;
 using Helion.World.Entities;
@@ -1634,7 +1635,7 @@ public sealed class SpecialManager : ITickable, IDisposable
 
     private bool CanActivateSectorSpecial(LineSpecial special, Sector sector)
     {
-        if (m_world.Config.Compatibility.VanillaSectorPhysics)
+        if (m_world.Config.Compatibility.VanillaSectorPhysics.Value.ToBool())
             return !sector.IsMoving;
 
         if (sector.ActiveCeilingMove != null && special.IsCeilingMove())

--- a/Core/World/Special/Specials/StairSpecial.cs
+++ b/Core/World/Special/Specials/StairSpecial.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Helion.Audio;
 using Helion.Models;
 using Helion.Util;
+using Helion.Util.Configs.Components;
 using Helion.World.Geometry.Lines;
 using Helion.World.Geometry.Sectors;
 using Helion.World.Special.SectorMovement;
@@ -50,7 +51,7 @@ public class StairSpecial : SectorMoveSpecial
     {
         base.Set(world, sector, 0, 0, new SectorMoveData(SectorPlaneFace.Floor, direction, MoveRepetition.None, speed, 0),
             new SectorSoundData(null, null, Constants.PlatStopSound));
-        m_buggedStairs = world.Config.Compatibility.Stairs;
+        m_buggedStairs = world.Config.Compatibility.Stairs.Value.ToBool();
         m_init = true;
         m_stairDelay = delay;
         m_resetTics = resetTicks == 0 ? -1 : resetTicks;

--- a/Core/World/WorldBase.Serialize.cs
+++ b/Core/World/WorldBase.Serialize.cs
@@ -116,7 +116,7 @@ public partial class WorldBase
             if (!component.Attribute.Serialize)
                 continue;
 
-            s_configValueModels.Add(new ConfigValueModel(path, component.Value.ObjectValue));
+            s_configValueModels.Add(new ConfigValueModel(path, component.Value.ObjectValueSerialize));
         }
         return s_configValueModels;
     }

--- a/Core/World/WorldBase.cs
+++ b/Core/World/WorldBase.cs
@@ -26,6 +26,7 @@ using Helion.Resources.Definitions.SoundInfo;
 using Helion.Resources.IWad;
 using Helion.Util;
 using Helion.Util.Configs;
+using Helion.Util.Configs.Components;
 using Helion.Util.Container;
 using Helion.Util.Extensions;
 using Helion.Util.Loggers;
@@ -616,18 +617,18 @@ public abstract partial class WorldBase : IWorld
         WorldStatic.SlowTickTracerMultiplier = (short)Config.SlowTick.TracerMultiplier;
         WorldStatic.IsFastMonsters = IsFastMonsters;
         WorldStatic.IsSlowMonsters = SkillDefinition.SlowMonsters;
-        WorldStatic.InfinitelyTallThings = Config.Compatibility.InfinitelyTallThings;
-        WorldStatic.MissileClip = Config.Compatibility.MissileClip;
-        WorldStatic.AllowItemDropoff = Config.Compatibility.AllowItemDropoff;
-        WorldStatic.NoTossDrops = Config.Compatibility.NoTossDrops;
-        WorldStatic.VanillaMovementPhysics = Config.Compatibility.VanillaMovementPhysics;
+        WorldStatic.InfinitelyTallThings = Config.Compatibility.InfinitelyTallThings.Value.ToBool();
+        WorldStatic.MissileClip = Config.Compatibility.MissileClip.Value.ToBool();
+        WorldStatic.AllowItemDropoff = Config.Compatibility.AllowItemDropoff.Value.ToBool();
+        WorldStatic.NoTossDrops = Config.Compatibility.NoTossDrops.Value.ToBool();
+        WorldStatic.VanillaMovementPhysics = Config.Compatibility.VanillaMovementPhysics.Value.ToBool();
         WorldStatic.Dehacked = ArchiveCollection.Definitions.DehackedDefinition != null;
-        WorldStatic.Mbf21 = Config.Compatibility.Mbf21;
-        WorldStatic.MbfTelefrag = Config.Compatibility.MbfTelefrag;
-        WorldStatic.Doom2ProjectileWalkTriggers = Config.Compatibility.Doom2ProjectileWalkTriggers;
-        WorldStatic.OriginalExplosion = Config.Compatibility.OriginalExplosion;
-        WorldStatic.FinalDoomTeleport = Config.Compatibility.FinalDoomTeleport;
-        WorldStatic.VanillaSectorSound = Config.Compatibility.VanillaSectorSound;
+        WorldStatic.Mbf21 = Config.Compatibility.Mbf21.Value.ToBool();
+        WorldStatic.MbfTelefrag = Config.Compatibility.MbfTelefrag.Value.ToBool();
+        WorldStatic.Doom2ProjectileWalkTriggers = Config.Compatibility.Doom2ProjectileWalkTriggers.Value.ToBool();
+        WorldStatic.OriginalExplosion = Config.Compatibility.OriginalExplosion.Value.ToBool();
+        WorldStatic.FinalDoomTeleport = Config.Compatibility.FinalDoomTeleport.Value.ToBool();
+        WorldStatic.VanillaSectorSound = Config.Compatibility.VanillaSectorSound.Value.ToBool();
         WorldStatic.RespawnTicks = SkillDefinition.RespawnTime.Seconds * (int)Constants.TicksPerSecond;
         WorldStatic.ClosetLookFrameIndex = ArchiveCollection.EntityFrameTable.ClosetLookFrameIndex;
         WorldStatic.ClosetChaseFrameIndex = ArchiveCollection.EntityFrameTable.ClosetChaseFrameIndex;
@@ -670,28 +671,28 @@ public abstract partial class WorldBase : IWorld
     }
 
 
-    private void MbfTelefrag_OnChanged(object? sender, bool enabled) =>
-        WorldStatic.MbfTelefrag = enabled;
-    private void VanillaSectorSound_OnChanged(object? sender, bool enabled) =>
-        WorldStatic.VanillaSectorSound = enabled;
-    private void FinalDoomTeleport_OnChanged(object? sender, bool enabled) =>
-        WorldStatic.FinalDoomTeleport = enabled;
-    private void OriginalExplosion_OnChanged(object? sender, bool enabled) =>
-        WorldStatic.OriginalExplosion = enabled;
-    private void Doom2ProjectileWalkTriggers_OnChanged(object? sender, bool enabled) =>
-        WorldStatic.Doom2ProjectileWalkTriggers = enabled;
-    private void Mbf21_OnChanged(object? sender, bool enabled) =>
-       WorldStatic.Mbf21 = enabled;
-    private void VanillaMovementPhysics_OnChanged(object? sender, bool enabled) =>
-        WorldStatic.VanillaMovementPhysics = enabled;
-    private void NoTossDrops_OnChanged(object? sender, bool enabled) =>
-        WorldStatic.NoTossDrops = enabled;
-    private void InfinitelyTallThings_OnChanged(object? sender, bool enabled) =>
-        WorldStatic.InfinitelyTallThings = !WorldStatic.Sector3D && enabled;
-    private void AllowItemDropoff_OnChanged(object? sender, bool enabled) =>
-        WorldStatic.AllowItemDropoff = enabled;
-    private void MissileClip_OnChanged(object? sender, bool enabled) =>
-        WorldStatic.MissileClip = enabled;
+    private void MbfTelefrag_OnChanged(object? sender, CompatSetting enabled) =>
+        WorldStatic.MbfTelefrag = enabled.ToBool();
+    private void VanillaSectorSound_OnChanged(object? sender, CompatSetting enabled) =>
+        WorldStatic.VanillaSectorSound = enabled.ToBool();
+    private void FinalDoomTeleport_OnChanged(object? sender, CompatSetting enabled) =>
+        WorldStatic.FinalDoomTeleport = enabled.ToBool();
+    private void OriginalExplosion_OnChanged(object? sender, CompatSetting enabled) =>
+        WorldStatic.OriginalExplosion = enabled.ToBool();
+    private void Doom2ProjectileWalkTriggers_OnChanged(object? sender, CompatSetting enabled) =>
+        WorldStatic.Doom2ProjectileWalkTriggers = enabled.ToBool();
+    private void Mbf21_OnChanged(object? sender, CompatSetting enabled) =>
+       WorldStatic.Mbf21 = enabled.ToBool();
+    private void VanillaMovementPhysics_OnChanged(object? sender, CompatSetting enabled) =>
+        WorldStatic.VanillaMovementPhysics = enabled.ToBool();
+    private void NoTossDrops_OnChanged(object? sender, CompatSetting enabled) =>
+        WorldStatic.NoTossDrops = enabled.ToBool();
+    private void InfinitelyTallThings_OnChanged(object? sender, CompatSetting enabled) =>
+        WorldStatic.InfinitelyTallThings = !WorldStatic.Sector3D && enabled.ToBool();
+    private void AllowItemDropoff_OnChanged(object? sender, CompatSetting enabled) =>
+        WorldStatic.AllowItemDropoff = enabled.ToBool();
+    private void MissileClip_OnChanged(object? sender, CompatSetting enabled) =>
+        WorldStatic.MissileClip = enabled.ToBool();
     private void SlowTickEnabled_OnChanged(object? sender, bool enabled) =>
         WorldStatic.SlowTickEnabled = enabled;
     private void SlowTickDistance_OnChanged(object? sender, int distance) =>
@@ -4047,7 +4048,7 @@ public abstract partial class WorldBase : IWorld
         if (m_healChaseData.HealSound.Length > 0)
             WorldStatic.SoundManager.CreateSoundOn(entity, m_healChaseData.HealSound, new SoundParams(entity));
 
-        bool setVileGhost = Config.Compatibility.VileGhosts && entity.Flags.CrushGiblets();
+        bool setVileGhost = Config.Compatibility.VileGhosts.Value.ToBool() && entity.Flags.CrushGiblets();
         entity.SetRaiseState(!setVileGhost);
         if (setVileGhost)
         {

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -76,4 +76,4 @@
 - Update OpenAL-Soft dependency to 1.25.2
 - Update SDL controller database support file (for button mappings, etc.)
 - Improved performance for A_KeenDie and A_BossDeath functions for extreme cases like 100krevs.wad.
-- Add support for Always/Never in compatibility options. These values will never be changed by Helion when setting a complvl.
+- Add support for Always On/Always Off in compatibility options. These values will never be changed by Helion when setting a complvl.

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -76,3 +76,4 @@
 - Update OpenAL-Soft dependency to 1.25.2
 - Update SDL controller database support file (for button mappings, etc.)
 - Improved performance for A_KeenDie and A_BossDeath functions for extreme cases like 100krevs.wad.
+- Add support for Always/Never in compatibility options. These values will never be changed by Helion when setting a complvl.

--- a/Tests/Unit/GameAction/Boom/BoomTelefrag.cs
+++ b/Tests/Unit/GameAction/Boom/BoomTelefrag.cs
@@ -2,13 +2,13 @@
 using Helion.Resources.Definitions.MapInfo;
 using Helion.Resources.IWad;
 using Helion.Util.RandomGenerators;
-using Helion.World;
 using Helion.World.Entities;
 using Helion.World.Entities.Definition.States;
 using Helion.World.Impl.SinglePlayer;
 using Helion.World.Physics;
 using System;
 using Xunit;
+using Helion.Util.Configs.Components;
 
 namespace Helion.Tests.Unit.GameAction.Boom;
 
@@ -40,7 +40,7 @@ public class BoomTelefrag : IDisposable
 
     private void WorldInit(SinglePlayerWorld world)
     {
-        world.Config.Compatibility.MbfTelefrag.Value.Should().BeTrue();
+        world.Config.Compatibility.MbfTelefrag.Value.ToBool().Should().BeTrue();
         world.MapInfo.HasOption(MapOptions.AllowMonsterTelefrags).Should().BeTrue();
     }
 

--- a/Tests/Unit/GameAction/DoorClip.cs
+++ b/Tests/Unit/GameAction/DoorClip.cs
@@ -4,6 +4,7 @@ using Helion.World.Entities.Players;
 using Helion.World.Impl.SinglePlayer;
 using Helion.World.Physics;
 using Xunit;
+using Helion.Util.Configs.Components;
 
 namespace Helion.Tests.Unit.GameAction;
 
@@ -25,7 +26,7 @@ public class DoorClip
     [Fact(DisplayName = "Door ceiling clips floor")]
     public void DoorClipsFloor()
     {
-        World.Config.Compatibility.VanillaSectorPhysics.Value.Should().BeFalse();
+        World.Config.Compatibility.VanillaSectorPhysics.Value.ToBool().Should().BeFalse();
         var sector = GameActions.GetSector(World, 2);
         sector.Ceiling.Z.Should().Be(0);
         GameActions.ActivateLine(World, Player, 3, ActivationContext.UseLine).Should().BeTrue();

--- a/Tests/Unit/GameAction/Physics/Physics_MissileClip.cs
+++ b/Tests/Unit/GameAction/Physics/Physics_MissileClip.cs
@@ -2,6 +2,7 @@
 using FluentAssertions;
 using Helion.Util;
 using Xunit;
+using Helion.Util.Configs.Components;
 
 namespace Helion.Tests.Unit.GameAction;
 
@@ -36,7 +37,7 @@ public partial class Physics
     [Fact(DisplayName = "Missile passes hits big tree with projectile pass height of 16")]
     public void MissileClipPassHeightDisabled()
     {
-        World.Config.Compatibility.MissileClip.Value.Should().BeFalse();
+        World.Config.Compatibility.MissileClip.Value.ToBool().Should().BeFalse();
         GameActions.SetEntityPosition(World, Player, (2176, 2048));
 
         const string PlasmaRifle = "PlasmaRifle";

--- a/Tests/Unit/GameAction/Physics/Physics_OriginalExplosion.cs
+++ b/Tests/Unit/GameAction/Physics/Physics_OriginalExplosion.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using Helion.Geometry.Vectors;
 using Xunit;
+using Helion.Util.Configs.Components;
 
 namespace Helion.Tests.Unit.GameAction;
 
@@ -9,7 +10,7 @@ public partial class Physics
     [Fact(DisplayName = "Missile includes z check when original explosion compat is off")]
     public void MissileExplosionWithZ()
     {
-        World.Config.Compatibility.OriginalExplosion.Value.Should().BeFalse();
+        World.Config.Compatibility.OriginalExplosion.Value.ToBool().Should().BeFalse();
 
         var imp = GameActions.GetEntity(World, 70);
         imp.Health.Should().Be(60);
@@ -25,7 +26,7 @@ public partial class Physics
     [Fact(DisplayName = "Missile explosion ignores z when original explosion compat is on")]
     public void MissileOriginalExplosion()
     {
-        World.Config.Compatibility.OriginalExplosion.Value.Should().BeFalse();
+        World.Config.Compatibility.OriginalExplosion.Value.ToBool().Should().BeFalse();
         World.Config.Compatibility.OriginalExplosion.Set(true);
 
         var imp = GameActions.GetEntity(World, 70);

--- a/Tests/Unit/GameAction/Vanilla/TeleportCompat.cs
+++ b/Tests/Unit/GameAction/Vanilla/TeleportCompat.cs
@@ -5,6 +5,7 @@ using Helion.World.Entities.Players;
 using Helion.World.Impl.SinglePlayer;
 using Helion.World.Physics;
 using Xunit;
+using Helion.Util.Configs.Components;
 
 namespace Helion.Tests.Unit.GameAction;
 
@@ -36,7 +37,7 @@ public class TeleportCompat
     [Fact(DisplayName = "Normal teleport")]
     public void NormalTeleport()
     {
-        World.Config.Compatibility.FinalDoomTeleport.Value.Should().Be(false);
+        World.Config.Compatibility.FinalDoomTeleport.Value.ToBool().Should().BeFalse();
         Player.Position.Should().Be(new Vec3D(-224, -288, 128));
         GameActions.ActivateLine(World, Player, 5, ActivationContext.CrossLine);
         Player.Position.Should().Be(new Vec3D(-128, -384, 0));

--- a/Tests/Unit/GameAction/Vanilla/VanillaSectorSound.cs
+++ b/Tests/Unit/GameAction/Vanilla/VanillaSectorSound.cs
@@ -1,12 +1,10 @@
 ﻿using FluentAssertions;
-using Helion.Geometry.Vectors;
 using Helion.Resources.IWad;
-using Helion.World;
 using Helion.World.Entities.Players;
 using Helion.World.Impl.SinglePlayer;
 using Helion.World.Physics;
-using Helion.World.Sound;
 using Xunit;
+using Helion.Util.Configs.Components;
 
 namespace Helion.Tests.Unit.GameAction;
 
@@ -29,7 +27,7 @@ public class VanillaSectorSound
     [Fact(DisplayName = "Vanilla sector sound determined by bounding box")]
     public void VanillaSectorSoundSingleSector()
     {
-        World.Config.Compatibility.VanillaSectorSound.Value.Should().BeTrue();
+        World.Config.Compatibility.VanillaSectorSound.Value.ToBool().Should().BeTrue();
         var soundSector = GameActions.GetSectorByTag(World, 1);
         GameActions.ActivateLine(World, Player, 4, ActivationContext.UseLine);
         GameActions.TickWorld(World, 1);
@@ -53,7 +51,7 @@ public class VanillaSectorSound
     [Fact(DisplayName = "Vanilla sector sound with unconnected sectors")]
     public void VanillaSectorSoundUnconnectedSectors()
     {
-        World.Config.Compatibility.VanillaSectorSound.Value.Should().BeTrue();
+        World.Config.Compatibility.VanillaSectorSound.Value.ToBool().Should().BeTrue();
         var soundSector = GameActions.GetSectorByTag(World, 2);
         GameActions.ActivateLine(World, Player, 10, ActivationContext.UseLine);
         GameActions.TickWorld(World, 1);

--- a/Tests/Unit/GameAction/Vanilla/VileGhostCompat.cs
+++ b/Tests/Unit/GameAction/Vanilla/VileGhostCompat.cs
@@ -6,6 +6,7 @@ using Helion.World.Entities.Players;
 using Helion.World.Impl.SinglePlayer;
 using Helion.World.Physics;
 using Xunit;
+using Helion.Util.Configs.Components;
 
 namespace Helion.Tests.Unit.GameAction;
 
@@ -56,7 +57,7 @@ public class VileGhostCompat
     [Fact(DisplayName = "Monster is resurrected normally")]
     public void VileNormalResurrect()
     {
-        World.Config.Compatibility.VileGhosts.Value.Should().BeFalse();
+        World.Config.Compatibility.VileGhosts.Value.ToBool().Should().BeFalse();
         var imp = CrushAndRaiseImp();
 
         imp.Flags.Solid().Should().BeTrue();


### PR DESCRIPTION
Add support for Always On / Always Off in compatibility options. These values will never be changed by Helion when setting a complvl.

fixes #1652 