### PR TITLE
Sector load state fixes

### DIFF
--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
@@ -48,7 +48,6 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
 
     private readonly SkyGeometryManager m_skyGeometry = new();
     private readonly LookupArray<List<Sector>?> m_transferHeightsLookup = new();
-    private readonly List<Sector> m_initMoveSectors = [];
     private readonly GeometryRenderer.RenderCoverWallAction m_renderCoverWallAction;
     private readonly DynamicVertex[] m_coverWallVertices3D = new DynamicVertex[6];
 
@@ -134,9 +133,6 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
                 AddSectorPlane(sector, SectorPlaneFace.Floor, true);
             if ((sector.Ceiling.Dynamic & IgnoreFlags) == 0)
                 AddSectorPlane(sector, SectorPlaneFace.Ceiling, false);
-
-            if (sector.IsMoving)
-                m_initMoveSectors.Add(sector);
         }
 
         if (WorldStatic.Sector3D)
@@ -162,19 +158,6 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
 
             AddLine(line);
         }
-
-        // Sectors can be actively moving loading a save game.
-        WorldBase worldBase = (WorldBase)world;
-        for (int i = 0; i < m_initMoveSectors.Count; i++)
-        {
-            var sector = world.Sectors[i];
-            if (sector.ActiveFloorMove != null)
-                HandleSectorMoveStart(worldBase, sector.Floor);
-            if (sector.ActiveCeilingMove != null)
-                HandleSectorMoveStart(worldBase, sector.Ceiling);
-        }
-
-        m_initMoveSectors.Clear();
 
         foreach (var list in m_geometry.GetAllGeometry())
         {

--- a/Core/World/Geometry/Sectors/Sector3D.cs
+++ b/Core/World/Geometry/Sectors/Sector3D.cs
@@ -469,6 +469,7 @@ public sealed class Sector3D
 
         FakeBottom.Reset(0);
         FakeTop.Reset(0);
+        FakeSector.Reset();
     }
 
     public bool IsInvertedByContext(SolidContext context)

--- a/Core/World/Geometry/Sectors/Sector3D.cs
+++ b/Core/World/Geometry/Sectors/Sector3D.cs
@@ -465,7 +465,11 @@ public sealed class Sector3D
     public void Reset()
     {
         for (int i = 0; i < FakeSector.Lines.Length; i++)
-            FakeSector.Lines[i].Front.Reset();
+        {
+            var line = FakeSector.Lines[i];
+            line.Front.Reset();
+            line.Back?.Reset();
+        }
 
         FakeBottom.Reset(0);
         FakeTop.Reset(0);


### PR DESCRIPTION
Add missing resets for the fake sector and back side if used in 3D sectors.

Remove incorrect/unnecessary code that was attempting to remove moving sectors from static geometry on world load.