### PR TITLE
correct IsMoving check

### DIFF
--- a/Core/World/WorldBase.cs
+++ b/Core/World/WorldBase.cs
@@ -852,9 +852,6 @@ public abstract partial class WorldBase : IWorld
 
     private void SpecialManager_SectorMoveComplete(object? sender, SectorPlane sectorPlane)
     {
-        if (sectorPlane.Sector.IsMoving)
-            return;
-
         sectorPlane.Sector.MoveEventGameTick = Gametick;
         SectorMoveComplete?.Invoke(this, sectorPlane);
 


### PR DESCRIPTION
This was broken in PR 1665 dealing with moving linked sectors. This broke cases where both were flagged to move and cases with transfer heights (first battle in Waffle House 2 MAP14).