### PR TITLE
Update Windows version for release builds

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -58,7 +58,7 @@ jobs:
         bodyFile: "RELEASENOTES.md"
   
   buildReleaseWindows:
-    runs-on: windows-2022
+    runs-on: windows-2025-vs2026
     needs: buildReleaseLinux
 
     steps:


### PR DESCRIPTION
Bump Windows (and Visual Studio) version for Release builds because OpenAL-Soft is built using a newer toolchain