### PR TITLE
Auto blood color and fuzz blood options

### DIFF
--- a/Assets/Assets/Actors/Doom/Monsters/Baron.txt
+++ b/Assets/Assets/Actors/Doom/Monsters/Baron.txt
@@ -13,6 +13,7 @@ actor BaronOfHell 3003
     SeeSound "baron/sight"
     SpawnID 3
     Speed 8
+    AutoBloodColor "green"
     
     MONSTER
     +BOSSDEATH

--- a/Assets/Assets/Actors/Doom/Monsters/Cacodemon.txt
+++ b/Assets/Assets/Actors/Doom/Monsters/Cacodemon.txt
@@ -13,6 +13,7 @@ actor Cacodemon 3005
     SeeSound "caco/sight"
     SpawnID 19
     Speed 8
+    AutoBloodColor "blue"
     
     MONSTER
     +FLOAT

--- a/Assets/Assets/Actors/Doom/Monsters/HellKnight.txt
+++ b/Assets/Assets/Actors/Doom/Monsters/HellKnight.txt
@@ -8,6 +8,7 @@ actor HellKnight : BaronOfHell 69
     PainSound "knight/pain"
     SeeSound "knight/sight"
     SpawnID 113
+    AutoBloodColor "green"
     
     -BOSSDEATH
     -E1M8BOSS

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
@@ -201,12 +201,20 @@ public sealed class EntityRenderer : StyleRendererBase, IDisposable
             rotation = CalculateRotation(viewAngle, entityAngle);
         }
 
+        var shadow = entity.Flags.Shadow() || entity.RenderStyle == RenderStyle.Fuzzy;
         var colorMapIndex = entity.Properties.ColormapIndex ?? entity.GetTranslationColorMap();
-        if (WorldStatic.BloodColor && entity.Definition.Type == EntityType.Blood)
+        if (WorldStatic.HasCustomBlood() && entity.Definition.Type == EntityType.Blood)
         {
             var owner = entity.Owner();
-            if (owner != null && owner.Properties.BloodPaletteColor.HasValue)
-                colorMapIndex = m_archiveCollection.Definitions.GetBloodColormap(owner.Properties.BloodPaletteColor.Value).Index;
+            if (owner != null)
+            {
+                if (owner.Properties.BloodPaletteColor.HasValue)
+                    colorMapIndex = m_archiveCollection.Definitions.GetBloodColormap(owner.Properties.BloodPaletteColor.Value).Index;
+                else if (WorldStatic.AutoColoredBlood && owner.Properties.AutoBloodPaletteColor.HasValue)
+                    colorMapIndex = m_archiveCollection.Definitions.GetBloodColormap(owner.Properties.AutoBloodPaletteColor.Value).Index;
+                else if (WorldStatic.FuzzBlood && owner.Flags.Shadow())
+                    shadow = true;
+            }
         }
 
         var shouldMirror = entity.Flags.Mirror();
@@ -233,7 +241,7 @@ public sealed class EntityRenderer : StyleRendererBase, IDisposable
         var disableFullbright = spriteRotation.BrightmapNoFullbright;
         var isFullBright = (entity.Flags.Bright() || entity.FrameState.Frame.Properties.Bright) && !disableFullbright;
         var offsetZ = GetOffsetZ(entity, texture);
-        var shadow = entity.Flags.Shadow() || entity.RenderStyle == RenderStyle.Fuzzy;
+        
 
         int fuzz;
         RenderStyle renderStyle;

--- a/Core/Resources/Definitions/Decorate/DecorateDefinitions.cs
+++ b/Core/Resources/Definitions/Decorate/DecorateDefinitions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Helion.Graphics.Palettes;
 using Helion.Resources.Archives.Collection;
 using Helion.Resources.Archives.Entries;
 using Helion.Resources.Definitions.Decorate.Parser;
@@ -10,6 +11,8 @@ namespace Helion.Resources.Definitions.Decorate;
 
 public class DecorateDefinitions
 {
+    public readonly HashSet<PaletteColor> BloodColors = [];
+
     private readonly Dictionary<string, ActorDefinition> m_definitions = new(StringComparer.OrdinalIgnoreCase);
 
     private readonly Dictionary<string, ActorDefinition>.AlternateLookup<ReadOnlySpan<char>> m_definitionsBySpan;
@@ -30,12 +33,15 @@ public class DecorateDefinitions
 
     public void AddDecorateDefinitions(Entry entry)
     {
-        DecorateParser parser = new DecorateParser(entry.Path.FullPath, MakeIncludeLocator());
+        var parser = new DecorateParser(entry.Path.FullPath, MakeIncludeLocator());
         if (parser.Parse(entry))
         {
             foreach (var def in parser.ActorDefinitions)
                 AddDefinition(def);
         }
+
+        foreach (var color in parser.BloodColors)
+            BloodColors.Add(color);
     }
 
     private Func<string, string?> MakeIncludeLocator()

--- a/Core/Resources/Definitions/Decorate/Parser/DecorateParser.cs
+++ b/Core/Resources/Definitions/Decorate/Parser/DecorateParser.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Helion.Graphics.Palettes;
 using Helion.Util.Parser;
 using NLog;
 
@@ -12,13 +13,15 @@ public partial class DecorateParser : ParserBase
 {
     private static readonly Logger Log = LogManager.GetCurrentClassLogger();
 
-    public readonly IList<ActorDefinition> ActorDefinitions = new List<ActorDefinition>();
+    public readonly IList<ActorDefinition> ActorDefinitions = [];
     public readonly Dictionary<string, double> Variables = new(StringComparer.OrdinalIgnoreCase);
     protected readonly string Path;
     protected readonly Func<string, string?> IncludeResolver;
-    private ActorDefinition m_currentDefinition = new ActorDefinition("none", null, null, null);
+    private ActorDefinition m_currentDefinition = new("none", null, null, null);
     private int m_frameIndex;
     private string? m_immediatelySeenLabel;
+
+    public readonly HashSet<PaletteColor> BloodColors = [];
 
     public DecorateParser(string path, Func<string, string?> includeResolver)
     {
@@ -59,22 +62,19 @@ public partial class DecorateParser : ParserBase
             ActorDefinitions.Add(def);
         foreach (var pair in parser.Variables)
             Variables[pair.Key] = pair.Value;
+
+        foreach (var color in parser.BloodColors)
+            BloodColors.Add(color);
     }
 
     private void ConsumeInclude()
     {
-        Token? token = GetCurrentToken();
-        if (token == null)
-            throw MakeException("Expected value to follow preprocessor include symbol");
-
+        Token? token = GetCurrentToken() ?? throw MakeException("Expected value to follow preprocessor include symbol");
         Consume("include");
-        string includePath = ConsumeString();
+        var includePath = ConsumeString();
+        var includeText = IncludeResolver.Invoke(includePath) ?? throw new ParserException(token.Value, $"Could not locate include at {includePath}");
 
-        string? includeText = IncludeResolver.Invoke(includePath);
-        if (includeText == null)
-            throw new ParserException(token.Value, $"Could not locate include at {includePath}");
-
-        DecorateParser parser = new DecorateParser(includePath, IncludeResolver);
+        var parser = new DecorateParser(includePath, IncludeResolver);
         if (!parser.Parse(includeText))
             throw new ParserException(token.Value, $"Failed to parse include path at {includePath}");
 

--- a/Core/Resources/Definitions/Decorate/Parser/DecoratePropertyParser.cs
+++ b/Core/Resources/Definitions/Decorate/Parser/DecoratePropertyParser.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Helion.Graphics;
+using Helion.Graphics.Palettes;
 using Helion.Maps.Specials;
 using Helion.Resources.Definitions.Decorate.Properties;
 using Helion.Resources.Definitions.Decorate.Properties.Enums;
@@ -1341,8 +1342,22 @@ public partial class DecorateParser
             case "RIPSOUND":
                 m_currentDefinition.Properties.RipSound = ConsumeString();
                 break;
+            case "AUTOBLOODCOLOR":
+                m_currentDefinition.Properties.AutoBloodPaletteColor = GetPaletteColor(ConsumeString());
+                break;
             default:
                 throw MakeException($"Unknown property '{property}' on actor '{m_currentDefinition.Name}'");
         }
     }
+
+    private PaletteColor? GetPaletteColor(string value)
+    {
+        if (Enum.TryParse(value, true, out PaletteColor color) && color != PaletteColor.None)
+        {
+            BloodColors.Add(color);
+            return color;
+        }
+        return null;
+    }
 }
+    

--- a/Core/Resources/Definitions/Decorate/Properties/ActorProperties.cs
+++ b/Core/Resources/Definitions/Decorate/Properties/ActorProperties.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Helion.Graphics;
+using Helion.Graphics.Palettes;
 using Helion.Maps.Specials;
 using Helion.Resources.Definitions.Decorate.Properties.Enums;
 
@@ -121,4 +122,5 @@ public class ActorProperties
     public double? XScale;
     public double? YScale;
     public string? RipSound;
+    public PaletteColor? AutoBloodPaletteColor;
 }

--- a/Core/Resources/Definitions/DefinitionEntries.cs
+++ b/Core/Resources/Definitions/DefinitionEntries.cs
@@ -434,12 +434,17 @@ public class DefinitionEntries
 
         if (DehackedDefinition != null && DehackedDefinition.HasBloodColor)
             CreateBloodColorMaps(palette, dataEntries.PaletteColorLookup, colormapBytes, DehackedDefinition.BloodColors);
+
+        CreateBloodColorMaps(palette, dataEntries.PaletteColorLookup, colormapBytes, Decorate.BloodColors);
     }
 
     private void CreateBloodColorMaps(Palette palette, PaletteColorLookup paletteColorLookup, byte[] colormapBytes, IEnumerable<PaletteColor> paletteColors)
     {
         foreach (var paletteColor in paletteColors)
         {
+            if (m_bloodColorMaps.TryGetValue((int)paletteColor, out _))
+                continue;
+
             var colormap = Colormap.TranslateToNearestMatch(palette, paletteColorLookup, colormapBytes, paletteColor);
             if (colormap == null)
                 continue;

--- a/Core/Util/Configs/Components/ConfigRender.cs
+++ b/Core/Util/Configs/Components/ConfigRender.cs
@@ -150,11 +150,11 @@ public class ConfigRender: ConfigElement<ConfigRender>
 
     [ConfigInfo("Automatically colors blood for Cacodemons, Hell Knights and Barons. Does not affect custom blood definitions.")]
     [OptionMenu(OptionSectionType.Render, "Colored Blood")]
-    public readonly ConfigValue<bool> AutoColoredBlood = new(true);
+    public readonly ConfigValue<bool> AutoColoredBlood = new(false);
 
     [ConfigInfo("Sets blood to shadow for shadow monsters like spectres.")]
     [OptionMenu(OptionSectionType.Render, "Fuzz Blood")]
-    public readonly ConfigValue<bool> FuzzBlood = new(true);
+    public readonly ConfigValue<bool> FuzzBlood = new(false);
 
     [ConfigInfo("Enable sprite transparency.")]
     [OptionMenu(OptionSectionType.Render, "Sprite Transparency")]

--- a/Core/Util/Configs/Components/ConfigRender.cs
+++ b/Core/Util/Configs/Components/ConfigRender.cs
@@ -148,6 +148,14 @@ public class ConfigRender: ConfigElement<ConfigRender>
     [OptionMenu(OptionSectionType.Render, "Fuzz Amount", sliderMin: 0, sliderMax: 5.0, sliderStep: .1)]
     public readonly ConfigValue<double> FuzzAmount = new(1);
 
+    [ConfigInfo("Automatically colors blood for Cacodemons, Hell Knights and Barons. Does not affect custom blood definitions.")]
+    [OptionMenu(OptionSectionType.Render, "Colored Blood")]
+    public readonly ConfigValue<bool> AutoColoredBlood = new(true);
+
+    [ConfigInfo("Sets blood to shadow for shadow monsters like spectres.")]
+    [OptionMenu(OptionSectionType.Render, "Fuzz Blood")]
+    public readonly ConfigValue<bool> FuzzBlood = new(true);
+
     [ConfigInfo("Enable sprite transparency.")]
     [OptionMenu(OptionSectionType.Render, "Sprite Transparency")]
     public readonly ConfigValue<bool> SpriteTransparency = new(true);

--- a/Core/World/Entities/Definition/Composer/DefinitionPropertyApplier.cs
+++ b/Core/World/Entities/Definition/Composer/DefinitionPropertyApplier.cs
@@ -205,5 +205,7 @@ public static class DefinitionPropertyApplier
         }
 
         definition.Properties.RenderStyle = properties.RenderStyle;
+
+        definition.Properties.AutoBloodPaletteColor = properties.AutoBloodPaletteColor;
     }
 }

--- a/Core/World/Entities/Definition/Properties/EntityProperties.cs
+++ b/Core/World/Entities/Definition/Properties/EntityProperties.cs
@@ -66,6 +66,7 @@ public class EntityProperties
     public string? TranslationEntry;
     public int? ColormapIndex;
     public PaletteColor? BloodPaletteColor;
+    public PaletteColor? AutoBloodPaletteColor;
     public int HealthBarOffset;
     public int HealthBarWidth;
     public RenderStyle RenderStyle = RenderStyle.Normal;

--- a/Core/World/WorldBase.cs
+++ b/Core/World/WorldBase.cs
@@ -566,6 +566,8 @@ public abstract partial class WorldBase : IWorld
         Config.Game.DamageApplyMultiplier.OnChanged += DamageApplyMultiplier_OnChanged;
         Config.Game.DamageReceiveMultiplier.OnChanged += DamageReceiveMultiplier_OnChanged;
         Config.Game.MirrorCorpse.OnChanged += MirrorCorpse_OnChanged;
+        Config.Render.AutoColoredBlood.OnChanged += AutoColoredBlood_OnChanged;
+        Config.Render.FuzzBlood.OnChanged += FuzzBlood_OnChanged;
     }
 
     private void UnRegisterConfigChanges()
@@ -593,6 +595,9 @@ public abstract partial class WorldBase : IWorld
         Config.Game.DamageApplyMultiplier.OnChanged -= DamageApplyMultiplier_OnChanged;
         Config.Game.DamageReceiveMultiplier.OnChanged -= DamageReceiveMultiplier_OnChanged;
         Config.Game.MirrorCorpse.OnChanged -= MirrorCorpse_OnChanged;
+        
+        Config.Render.AutoColoredBlood.OnChanged -= AutoColoredBlood_OnChanged;
+        Config.Render.FuzzBlood.OnChanged -= FuzzBlood_OnChanged;
     }
 
     private void SetWorldStatic()
@@ -658,6 +663,8 @@ public abstract partial class WorldBase : IWorld
         WorldStatic.SectorFriction = false;
         WorldStatic.BloodColor = ArchiveCollection.Dehacked != null && ArchiveCollection.Dehacked.HasBloodColor;
         WorldStatic.MirrorCorpse = Config.Game.MirrorCorpse;
+        WorldStatic.AutoColoredBlood = Config.Render.AutoColoredBlood;
+        WorldStatic.AutoColoredBlood = Config.Render.FuzzBlood;
 
         if (!SameAsPreviousMap)
             WorldStatic.Sector3D = false;
@@ -669,7 +676,6 @@ public abstract partial class WorldBase : IWorld
         if (soulSphere != null)
             WorldStatic.MaxSoulsphere = soulSphere.Properties.Inventory.MaxAmount;
     }
-
 
     private void MbfTelefrag_OnChanged(object? sender, CompatSetting enabled) =>
         WorldStatic.MbfTelefrag = enabled.ToBool();
@@ -716,6 +722,10 @@ public abstract partial class WorldBase : IWorld
         IsFastMonsters = SkillDefinition.IsFastMonsters(Config);
         WorldStatic.IsFastMonsters = IsFastMonsters;
     }
+    private void FuzzBlood_OnChanged(object? sender, bool enabled) =>
+        WorldStatic.FuzzBlood = enabled;
+    private void AutoColoredBlood_OnChanged(object? sender, bool enabled) =>
+        WorldStatic.AutoColoredBlood = enabled;
 
     private List<MapInfoDef> GetVisitedMaps(IList<string> visitedMaps)
     {

--- a/Core/World/WorldStatic.cs
+++ b/Core/World/WorldStatic.cs
@@ -7,6 +7,7 @@ using Helion.World.Entities.Definition.States;
 using Helion.World.Physics.Blockmap;
 using Helion.World.Sound;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace Helion.World;
 
@@ -42,6 +43,8 @@ public static class WorldStatic
     public static bool Udmf;
     public static bool SectorFriction;
     public static bool BloodColor;
+    public static bool AutoColoredBlood;
+    public static bool FuzzBlood;
     public static bool MirrorCorpse;
     public static bool Sector3D;
     public static bool MbfTelefrag;
@@ -57,6 +60,9 @@ public static class WorldStatic
     public static float DamageApplyMultiplier = 1;
     public static float DamageReceiveMultiplier = 1;
     public static int MaxSoulsphere = 200;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool HasCustomBlood() => BloodColor || AutoColoredBlood || FuzzBlood;
 
     public static EntityDefinition DoomImpBall = EntityDefinition.Default;
     public static EntityDefinition ArachnotronPlasma = EntityDefinition.Default;

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,6 +2,7 @@
 
 ## Features:
 - Add Radsuit intensity.
+- Automatic blood color and fuzz blood options.
 
 ## Bug Fixes:
 


### PR DESCRIPTION
Automatic blood color automatically colors barons and hell knights blood to green and cacodemons to blue.

Fuzz blood sets blood spawned from monster with shadow flag to inherit like spectres.

implements #1499 