### PR TITLE
Fix scrolling floors/ceilings not rendering movement after loading a game in non-UDMF maps

### DIFF
--- a/Core/Maps/Udmf/UdmfMap.cs
+++ b/Core/Maps/Udmf/UdmfMap.cs
@@ -123,7 +123,6 @@ public sealed class UdmfMap : IMap, IMapSpecials
             if ((flags & UdmfScrollSectorFlags.Texture) != 0 && scrollSpeeds.ScrollSpeed.HasValue)
             {
                 world.SpecialManager.AddSpecial(new ScrollSpecial(ScrollPlaneOptions.Textures | carryOptions, plane, scrollSpeeds.ScrollSpeed.Value));
-                StaticDataApplier.SetSectorDynamic(world, sector, plane.Facing.ToSectorPlanes(), SectorDynamic.Scroll);
             }
 
             flags &= ~UdmfScrollSectorFlags.Texture;

--- a/Core/World/Special/SectorBaseSpecialType.cs
+++ b/Core/World/Special/SectorBaseSpecialType.cs
@@ -5,4 +5,5 @@ public enum SectorBaseSpecialType
     Default,
     Move,
     Light,
+    ScrollPlane,
 }

--- a/Core/World/Special/SpecialManager.cs
+++ b/Core/World/Special/SpecialManager.cs
@@ -243,7 +243,7 @@ public sealed class SpecialManager : ITickable, IDisposable
     private void AddSpecialNodeNotNull(ISpecial? special)
     {
         if (special != null)
-            AddSpecialNode(special);
+            AddSpecial(special);
     }
 
     public void ResetInterpolation()
@@ -450,12 +450,19 @@ public sealed class SpecialManager : ITickable, IDisposable
     public SectorMoveSpecial AddDelayedSpecial(SectorMoveSpecial special, int delayTics)
     {
         special.SetDelayTics(delayTics);
-        AddSpecialNode(special);
+        AddSpecial(special);
         return special;
     }
 
     public void AddSpecial(ISpecial special)
     {
+        if (special.SectorBaseSpecialType == SectorBaseSpecialType.ScrollPlane && special is ScrollSpecial scrollSpecial &&
+            scrollSpecial.SectorPlane != null && (scrollSpecial.Options & ScrollPlaneOptions.Textures) != 0)
+        {
+            StaticDataApplier.SetSectorDynamic(m_world, scrollSpecial.SectorPlane.Sector, 
+                scrollSpecial.SectorPlane.Facing.ToSectorPlanes(), SectorDynamic.Scroll);
+        }
+
         m_specials.AddLast(m_world.DataCache.GetSpecialNode(special));
     }
 
@@ -1260,7 +1267,6 @@ public sealed class SpecialManager : ITickable, IDisposable
                 if (!replace || !FindAndSetScroller(sectorPlane, ScrollPlaneOptions.Textures, speeds.ScrollSpeed.Value))
                 {
                     AddSpecial(new ScrollSpecial(ScrollPlaneOptions.Textures | carryOptions, sectorPlane, speeds.ScrollSpeed.Value, changeScroll, flags));
-                    StaticDataApplier.SetSectorDynamic(m_world, sector, sectorPlane.Facing.ToSectorPlanes(), SectorDynamic.Scroll);
                 }
             }
             else if(replace)
@@ -2282,9 +2288,9 @@ public sealed class SpecialManager : ITickable, IDisposable
             floor = CreateFloorLowerSpecial(sector, SectorDest.LowestAdjacentFloor, floorSpeed);
 
         if (floor != null)
-            AddSpecialNode(floor);
+            AddSpecial(floor);
         if (ceiling != null)
-            AddSpecialNode(ceiling);
+            AddSpecial(ceiling);
 
         return floor != null || ceiling != null;
     }
@@ -2575,11 +2581,6 @@ public sealed class SpecialManager : ITickable, IDisposable
     {
         Sector? destSector = sector.GetHighestAdjacentCeiling();
         return destSector?.Ceiling.Z ?? MinDest;
-    }
-
-    private void AddSpecialNode(ISpecial special)
-    {
-        m_specials.AddFirst(m_world.DataCache.GetSpecialNode(special));
     }
 
     private void RemoveSpecialNode(LinkedListNode<ISpecial> node)

--- a/Core/World/Special/Specials/ScrollSpecial.cs
+++ b/Core/World/Special/Specials/ScrollSpecial.cs
@@ -46,9 +46,12 @@ public class ScrollSpecial : ISpecial
 
     public ScrollPlaneOptions Options => m_options;
 
+    public SectorBaseSpecialType SectorBaseSpecialType => m_baseType;
+
     private readonly ScrollPlaneOptions m_options;
     private readonly AccelScrollSpeed? m_accelScrollSpeed;
     private readonly ZDoomLineScroll m_lineScroll;
+    private readonly SectorBaseSpecialType m_baseType;
     private ScrollSides m_scrollSides;
     private SideScrollData? m_frontScroll;
     private SideScrollData? m_backScroll;
@@ -86,6 +89,7 @@ public class ScrollSpecial : ISpecial
     public ScrollSpecial(ScrollPlaneOptions flags, SectorPlane sectorPlane, in Vec2D speed, Sector? accelSector = null,
         ZDoomScroll scrollFlags = ZDoomScroll.None)
     {
+        m_baseType = SectorBaseSpecialType.ScrollPlane;
         m_options = flags;
         SectorPlane = sectorPlane;
         Speed = speed;

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -7,6 +7,7 @@
 ## Bug Fixes:
 - Do not clear player velocity when slide movement fails. Matches vanilla doom behavior where players can move out of lines with enough momentum to pass clip checks. (Fixes Hellevator MAP06 start)
 - Fix paths where checkered null texture would be used for brightmaps on sprites with null texture option.
+- Fix scrolling floors/ceilings not rendering movement after loading a game in non-UDMF maps.
 
 ## Misc:
 - Use modern OpenGL functions for VAO attributes when supported.


### PR DESCRIPTION
move check to add scrolling plane specials to dynamic render block in AddSpecial to fix cases where it's not added

fixes #1715