### PR TITLE
Mac OS AARCH64 support

### DIFF
--- a/.github/workflows/Nightly.yml
+++ b/.github/workflows/Nightly.yml
@@ -23,28 +23,23 @@ jobs:
       run: dotnet restore
     - name: Build
       run: dotnet build --no-restore
-    - name: Dotnet Publish Linux
-      run: dotnet publish -c Release -r linux-x64 Client/Client.csproj
-    - name: Dotnet Publish Windows
-      run: dotnet publish -c Release -r win-x64 Client/Client.csproj
     - name: Dotnet Publish Linux Self-Contained
       run: dotnet publish -c Release -r linux-x64 -p:SelfContainedRelease=true Client/Client.csproj
     - name: Dotnet Publish Windows Self-Contained
       run: dotnet publish -c Release -r win-x64 -p:SelfContainedRelease=true Client/Client.csproj
+    - name: Dotnet Publish MacOS Self-Contained
+      run: dotnet publish -c Release -r osx-arm64 -p:SelfContainedRelease=true Client/Client.csproj
     - name: Install zip
       uses: montudor/action-zip@v1
-    - name: Zip Linux
-      run: zip -r ../../Helion-${{ github.ref_name }}-linux-x64.zip *
-      working-directory: Publish/linux-x64
     - name: Zip Linux Self-Contained
       run: zip -r ../../Helion-${{ github.ref_name }}-linux-x64_SelfContained.zip *
       working-directory: Publish/linux-x64_SelfContained
-    - name: Zip Windows
-      run: zip -r ../../Helion-${{ github.ref_name }}-win-x64.zip *
-      working-directory: Publish/win-x64
     - name: Zip Windows Self-Contained
       run: zip -r ../../Helion-${{ github.ref_name }}-win-x64_SelfContained.zip *
       working-directory: Publish/win-x64_SelfContained
+    - name: Zip MacOS Self-Contained
+      run: zip -r ../../Helion-${{ github.ref_name }}-osx-arm64_SelfContained.zip *
+      working-directory: Publish/osx-arm64_SelfContained
     - name: Update nightly release
       uses: pyTooling/Actions/releaser@r0
       with:

--- a/Client/Client.cs
+++ b/Client/Client.cs
@@ -28,6 +28,7 @@ using Helion.World;
 using Helion.World.Entities.Players;
 using Helion.World.Save;
 using NLog;
+using OpenTK.Audio.OpenAL;
 using OpenTK.Windowing.Common;
 using OpenTK.Windowing.Desktop;
 using OpenTK.Windowing.GraphicsLibraryFramework;
@@ -720,6 +721,8 @@ public partial class Client : IDisposable, IInputManagement
             ArchiveCollection archiveCollection = new(new FilesystemArchiveLocator(pathsManager, config, []), config, ArchiveCollection.StaticDataCache);
             using HelionConsole console = new(archiveCollection.DataCache, config, commandLineArgs);
             LogClientInfo();
+            InitOpenAL();
+
             using IMusicPlayer musicPlayer = commandLineArgs.NoMusic ?
                 new MockMusicPlayer() :
                 new MusicPlayer(pathsManager, config.Audio, archiveCollection);
@@ -774,5 +777,21 @@ public partial class Client : IDisposable, IInputManagement
         if (map != null)
             return map.GetDisplayNameWithPrefix(m_archiveCollection.Language);
         return null;
+    }
+
+    private static void InitOpenAL()
+    {
+        // Force OpenTK to load OpenAL-Soft instead of the Apple implementation of OpenAL on MacOS
+        if (OperatingSystem.IsMacOS())
+        {
+            // In "published" builds or other contexts where a Runtime ID (RID) was specified, the .dylib will be
+            // in the same directory as the executable.  In "any platform" builds, it'll be in runtimes/osx-arm64/native.
+            string runtimePath = Path.Combine(AppContext.BaseDirectory, "runtimes/osx-arm64/native/libopenal.dylib");
+            string noRuntimePath = Path.Combine(AppContext.BaseDirectory, "libopenal.dylib");
+
+            OpenALLibraryNameContainer.OverridePath = Path.Exists(runtimePath)
+                ? runtimePath
+                : noRuntimePath;
+        }
     }
 }

--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -32,9 +32,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Helion.SDLControllerWrapper" Version="3.0.0" />
-    <PackageReference Include="Helion.GLFW" Version="3.4.0" />
-    <PackageReference Include="Helion.OpenALSoft" Version="1.25.2" />
+    <PackageReference Include="Helion.SDLControllerWrapper" Version="3.0.0.1" />
+    <PackageReference Include="Helion.GLFW" Version="3.4.0.1" />
+    <PackageReference Include="Helion.OpenALSoft" Version="1.25.2.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(AOT)' == 'true'">

--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Helion.SDLControllerWrapper" Version="3.0.0.1" />
+    <PackageReference Include="Helion.SDLControllerWrapper" Version="3.0.0.2" />
     <PackageReference Include="Helion.GLFW" Version="3.4.0.1" />
     <PackageReference Include="Helion.OpenALSoft" Version="1.25.2.1" />
   </ItemGroup>

--- a/Client/Window.cs
+++ b/Client/Window.cs
@@ -73,6 +73,7 @@ public class Window : GameWindow, IWindow
         base(MakeGameWindowSettings(), MakeNativeWindowSettings(config, title, glMajor, glMinor, flags))
     {
         Log.Debug("Creating client window");
+        OpenTK.Graphics.OpenGL.GL.LoadBindings(new GLFWBindingsContext());
         onCreate();
         m_config = config;
         m_renderWindowState = config.Window.State;
@@ -191,6 +192,7 @@ public class Window : GameWindow, IWindow
             Title = title,
             WindowBorder = config.Window.Border,
             WindowState = GetWindowState(config.Window.State.Value),
+            AutoLoadBindings = false
         };
 
         SetDisplay(config.Window.Display.Value, settings);

--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="GlmSharp-netstandard" Version="0.9.8.1" />
-    <PackageReference Include="Helion.ZMusic" Version="3.0.0.2" />
+    <PackageReference Include="Helion.ZMusic" Version="3.0.0.3" />
     <PackageReference Include="NAudio.Core" Version="2.2.1" />
     <PackageReference Include="NLog" Version="6.0.0" />
     <PackageReference Include="OpenTK" Version="4.9.4" ExcludeAssets="native" />

--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="GlmSharp-netstandard" Version="0.9.8.1" />
-    <PackageReference Include="Helion.ZMusic" Version="3.0.0.1" />
+    <PackageReference Include="Helion.ZMusic" Version="3.0.0.2" />
     <PackageReference Include="NAudio.Core" Version="2.2.1" />
     <PackageReference Include="NLog" Version="6.0.0" />
     <PackageReference Include="OpenTK" Version="4.9.4" ExcludeAssets="native" />

--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="GlmSharp-netstandard" Version="0.9.8.1" />
-    <PackageReference Include="Helion.ZMusic" Version="3.0.0" />
+    <PackageReference Include="Helion.ZMusic" Version="3.0.0.1" />
     <PackageReference Include="NAudio.Core" Version="2.2.1" />
     <PackageReference Include="NLog" Version="6.0.0" />
     <PackageReference Include="OpenTK" Version="4.9.4" ExcludeAssets="native" />
@@ -30,6 +30,6 @@
     <PackageReference Include="ini-parser-net8" Version="2.6.2.1" />
     <PackageReference Include="xBRZNet" Version="1.2.0" />
     <PackageReference Include="zdbspSharp" Version="1.0.9" />
-    <PackageReference Include="Helion.HelionACS" Version="0.1.1-pre.49" />
+    <PackageReference Include="Helion.HelionACS" Version="0.1.1-pre.50" />
   </ItemGroup>
 </Project>

--- a/Core/Util/PathsManager.cs
+++ b/Core/Util/PathsManager.cs
@@ -206,6 +206,16 @@ public class PathsManager
             }
         }
 
+        else if (OperatingSystem.IsMacOS())
+        {
+            var configHome = Environment.GetEnvironmentVariable("HOME");
+            if (!string.IsNullOrWhiteSpace(configHome))
+            {
+                folder = Path.Combine(configHome, "Library/Application Support/Helion");
+            }
+            
+        }
+
         // ensure the folder exists
         if (folder != null)
         {

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -10,6 +10,7 @@
 
     <DefineConstants Condition="'$(RuntimeIdentifier)' == 'linux-x64'">LINUX</DefineConstants>
     <DefineConstants Condition="'$(RuntimeIdentifier)' == 'win-x64'">WINDOWS</DefineConstants>
+    <DefineConstants Condition="'$(RuntimeIdentifier)' == 'osx-arm64'">MACOS</DefineConstants>
   </PropertyGroup>
 
   <!-- Configure code analysis (debug builds only) -->

--- a/INSTALL.adoc
+++ b/INSTALL.adoc
@@ -28,7 +28,7 @@ Note that we have provided copies of various binaries we depend upon.  If you ex
 
 ## Mac
 
-Macintosh is not supported at this time.
+M-series ARM64 Macintosh is supported.  Install Homebrew, install .NET SDK 10.0, and then do a normal build as you would on the other supported platforms.  AOT builds are not supported yet.  Intel-based Macintosh machines are not supported, nor do we intend to do so in the future.
 
 ## Command Line Build
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -3,6 +3,7 @@
 ## Features:
 - Add Radsuit intensity.
 - Automatic blood color and fuzz blood options.
+- Initial support for MacOS ARM64 builds.
 
 ## Bug Fixes:
 - Do not clear player velocity when slide movement fails. Matches vanilla doom behavior where players can move out of lines with enough momentum to pass clip checks. (Fixes Hellevator MAP06 start)


### PR DESCRIPTION
Initial support for doing local debug builds of MacOS AARCH64 (runtime ID: osx-arm64), as well as self-contained publish builds.  Video and audio output, ACS, music, and gamepad input all seem to be working.  

AOT support not yet implemented; we're building the `.a` files for all of these libraries in addition to the `.dylib` files, I just need to set aside some time to wrestle with `ld`.

This required changes in most of our packages because we were not previously building MacOS versions of the native libraries upon which we depend.