### PR TITLE
ignore zero length behavior marker

### DIFF
--- a/Core/Maps/IMap.cs
+++ b/Core/Maps/IMap.cs
@@ -27,7 +27,7 @@ public interface IMap
     GLComponents? GL { get; }
     byte[]? Reject { get; set; }
     CompatibilityMapDefinition? CompatibilityDefinition { get; set; }
-    bool HasBehavior => Behavior != null;
+    bool HasBehavior => Behavior != null && Behavior.Length > 0;
     byte[]? Behavior { get; set; }
     void ClearAllExceptThings();
     void ClearAll();

--- a/Core/World/WorldBase.cs
+++ b/Core/World/WorldBase.cs
@@ -328,7 +328,22 @@ public abstract partial class WorldBase : IWorld
 
     private void LoadAcsHubMap(IMap map, uint hubId)
     {
-        AcsExecutor.LoadHubMap(hubId, (uint)MapInfo.LevelNumber, map.HasBehavior ? [$"BEHAVIOR:{MapInfo.MapName}"] : []);
+        string[] moduleNames = map.HasBehavior ? [$"BEHAVIOR:{MapInfo.MapName}"] : [];
+        try
+        {
+            AcsExecutor.LoadHubMap(hubId, (uint)MapInfo.LevelNumber, moduleNames);
+        }
+        catch (Exception ex)
+        {
+            throw new Exception($"Failed to load ACS for {GetModuleNames(moduleNames)}", ex);
+        }
+    }
+
+    private static string GetModuleNames(string[] moduleNames)
+    {
+        if (moduleNames.Length == 0)
+            return "[Empty]";
+        return string.Join(", ", moduleNames);
     }
 
     private SpecialManager CreateSpecialManager(bool reuse)


### PR DESCRIPTION
Ignore zero length behavior marker since ACSVM will throw trying to load it.

Log better exception text on errors.

fixes #1742 