### PR TITLE
Fix ACS crash when using nextmap command

### DIFF
--- a/Client/Client.Commands.cs
+++ b/Client/Client.Commands.cs
@@ -839,6 +839,8 @@ public partial class Client
 
     private void NewGame(MapInfoDef mapInfo)
     {
+        // Must stop world. GlobalData disposes the global AcsExecutor.
+        m_layerManager.WorldLayer?.Stop();
         m_globalData?.Dispose();
         m_globalData = new();
         QueueLoadMap(mapInfo, null, null, LevelChangeEvent.Default);

--- a/Core/World/GlobalData.cs
+++ b/Core/World/GlobalData.cs
@@ -11,6 +11,8 @@ public class GlobalData : IDisposable
     public int TotalTime { get; set; }
     private ACS.WorldExecutor? AcsExecutor;
 
+    public ACS.WorldExecutor? GetCurrentAcsExecutor() => AcsExecutor;
+
     public ACS.WorldExecutor GetOrCreateAcsExecutor(IWorld world, bool reallocate)
     {
         if (AcsExecutor == null || reallocate)
@@ -54,6 +56,7 @@ public class GlobalData : IDisposable
     public void Dispose()
     {
         AcsExecutor?.Dispose();
+        AcsExecutor = null;
         GC.SuppressFinalize(this);
     }
 }

--- a/Core/World/WorldBase.cs
+++ b/Core/World/WorldBase.cs
@@ -25,6 +25,7 @@ using Helion.Resources.Definitions.MusInfo;
 using Helion.Resources.Definitions.SoundInfo;
 using Helion.Resources.IWad;
 using Helion.Util;
+using Helion.Util.Assertion;
 using Helion.Util.Configs;
 using Helion.Util.Configs.Components;
 using Helion.Util.Container;
@@ -167,7 +168,7 @@ public abstract partial class WorldBase : IWorld
     public CompatibilityMapDefinition? CompatibilityMapDefinition { get; private set; }
     public MapType MapType { get; private set; }
 
-    public ACS.WorldExecutor AcsExecutor { get; private set; }
+    public WorldExecutor AcsExecutor { get; private set; }
     public byte[]? Behavior => m_map.Behavior;
 
     public bool HasDehacked;
@@ -1054,6 +1055,7 @@ public abstract partial class WorldBase : IWorld
         }
         else if (WorldState == WorldState.Normal)
         {
+            Precondition(GlobalData.GetCurrentAcsExecutor() == AcsExecutor, "Trying to tick world with disposed WorldExecutor");
             TickPlayers();
             TickEntities();
             AcsExecutor.Exec();


### PR DESCRIPTION
Ensure world is stopped when loading new game to fix potential ACS crash accessing disposed executor

fixes #1743 