### PR TITLE
Enable fully static-linked AOT builds on MacOS ARM64

### DIFF
--- a/Client/Client.cs
+++ b/Client/Client.cs
@@ -784,6 +784,7 @@ public partial class Client : IDisposable, IInputManagement
         // Force OpenTK to load OpenAL-Soft instead of the Apple implementation of OpenAL on MacOS
         if (OperatingSystem.IsMacOS())
         {
+            #if !AOT
             // In "published" builds or other contexts where a Runtime ID (RID) was specified, the .dylib will be
             // in the same directory as the executable.  In "any platform" builds, it'll be in runtimes/osx-arm64/native.
             string runtimePath = Path.Combine(AppContext.BaseDirectory, "runtimes/osx-arm64/native/libopenal.dylib");
@@ -792,6 +793,7 @@ public partial class Client : IDisposable, IInputManagement
             OpenALLibraryNameContainer.OverridePath = Path.Exists(runtimePath)
                 ? runtimePath
                 : noRuntimePath;
+            #endif
         }
     }
 }

--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -72,13 +72,40 @@
   </ItemGroup>
 
   <ItemGroup Condition="('$(PublishAot)' == 'true') AND ('$(RuntimeIdentifier)'=='osx-arm64')">
-    <!-- OS-level dependencies -->
+    <!-- OS-level dependencies attributable to OpenAL-Soft -->
     <LinkerArg Include="-framework AudioToolbox" />
     <LinkerArg Include="-framework AudioUnit" />
     <LinkerArg Include="-framework ApplicationServices" />
     <LinkerArg Include="-framework CoreAudio" />
     <LinkerArg Include="-framework CoreFoundation" />
     <LinkerArg Include="-lstdc++" />
+
+    <!-- OS-level dependencies attributable to SDL2 -->
+    <!-- <LinkerArg Include="-framework AudioToolbox" /> -->
+    <!-- <LinkerArg Include="-framework CoreAudio" /> -->
+    <LinkerArg Include="-framework AVFoundation" />
+    <LinkerArg Include="-framework AppKit" />
+    <LinkerArg Include="-framework Carbon" />
+    <LinkerArg Include="-framework Cocoa" />
+    <LinkerArg Include="-framework CoreHaptics" />
+    <LinkerArg Include="-framework CoreServices" />
+    <LinkerArg Include="-framework CoreVideo" />
+    <LinkerArg Include="-framework ForceFeedback" />
+    <LinkerArg Include="-framework GameController" />
+    <LinkerArg Include="-framework IOKit" />
+    <LinkerArg Include="-framework Metal" />
+    <LinkerArg Include="-framework QuartzCore" />
+    <LinkerArg Include="-lobjc" />
+
+    <!-- OS-level dependencies attributable to GLFW -->
+    <!-- <LinkerArg Include="-framework AudioToolbox" /> -->
+    <!-- <LinkerArg Include="-framework CoreFoundation" /> -->
+    <!-- <LinkerArg Include="-framework CoreServices" /> -->
+    <!-- <LinkerArg Include="-framework Cocoa" /> -->
+    <!-- <LinkerArg Include="-framework IOKit" /> -->
+    <!-- <LinkerArg Include="-lobjc" -->
+    <LinkerArg Include="-framework AppKit" />
+    <LinkerArg Include="-framework CoreGraphics" />
 
     <!-- Transitive dependencies of ZMusic; assumes Homebrew installed, libsndfile and mpg123 installed via Homebrew -->
     <LinkerArg Include="/opt/homebrew/opt/flac/lib/libFLAC.a" />

--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Helion.OpenALSoft" Version="1.25.2.2" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(AOT)' == 'true'">
+  <ItemGroup Condition="'$(PublishAot)' == 'true'">
     <DirectPInvoke Include="zmusic.dll" />
     <DirectPInvoke Include="glfw3.dll" />
     <DirectPInvoke Include="SDL2.dll" />
@@ -48,7 +48,7 @@
     <DirectPInvoke Include="HelionACS-native" />
   </ItemGroup>
 
-  <ItemGroup Condition="('$(AOT)' == 'true') AND ('$(RuntimeIdentifier)'=='win-x64')">
+  <ItemGroup Condition="('$(PublishAot)' == 'true') AND ('$(RuntimeIdentifier)'=='win-x64')">
     <!-- These are all .libs that would normally get included if we were building DLLs from one or more of our native deps using CMake;
     All of these come from the Windows SDK, e.g. C:\Program Files (x86)\Windows Kits\10\Lib\10.0.26100.0\um\x64 -->
     <LinkerArg Include="Gdi32.lib" />
@@ -63,7 +63,7 @@
     <LinkerArg Include="Setupapi.lib" />
   </ItemGroup>
 
-  <ItemGroup Condition="('$(AOT)' == 'true') AND ('$(RuntimeIdentifier)'=='linux-x64')">
+  <ItemGroup Condition="('$(PublishAot)' == 'true') AND ('$(RuntimeIdentifier)'=='linux-x64')">
     <LinkerArg Include="-lstdc++" />
     <LinkerArg Include="-lsndfile" />
     <LinkerArg Include="-lmpg123" />
@@ -123,7 +123,7 @@
   </ItemGroup>
 
   <Target Name="HandleNativeLibraries" BeforeTargets="ResolveLockFileCopyLocalFiles">
-    <ItemGroup Condition="('$(AOT)' == 'true')">
+    <ItemGroup Condition="('$(PublishAot)' == 'true')">
       <NativeLibrary Include="@(NativeCopyLocalItems)" Condition="('%(Extension)'=='.lib') AND ('$(RuntimeIdentifier)'=='win-x64')" />
       <NativeLibrary Include="@(NativeCopyLocalItems)" Condition="('%(Extension)'=='.a') AND ('$(RuntimeIdentifier)'=='linux-x64')" />
       <NativeLibrary Include="@(NativeCopyLocalItems)" Condition="('%(Extension)'=='.a') AND ('$(RuntimeIdentifier)'=='osx-arm64')" />
@@ -165,8 +165,8 @@
   <Target Name="SetPublishDir" BeforeTargets="Build">
     <PropertyGroup>
       <PublishDir Condition="'$(SelfContainedRelease)' == 'true'">$(HelionRootDir)\Publish\$(RuntimeIdentifier)_SelfContained\</PublishDir>
-      <PublishDir Condition="'$(AOT)' == 'true'">$(HelionRootDir)\Publish\$(RuntimeIdentifier)_AOT\</PublishDir>
-      <PublishDir Condition="'$(SelfContainedRelease)' != 'true' AND '$(AOT)' != 'true'">$(HelionRootDir)\Publish\$(RuntimeIdentifier)\</PublishDir>
+      <PublishDir Condition="'$(PublishAot)' == 'true'">$(HelionRootDir)\Publish\$(RuntimeIdentifier)_AOT\</PublishDir>
+      <PublishDir Condition="'$(SelfContainedRelease)' != 'true' AND '$(PublishAot)' != 'true'">$(HelionRootDir)\Publish\$(RuntimeIdentifier)\</PublishDir>
     </PropertyGroup>
   </Target>
 

--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -19,12 +19,15 @@
     <PublishTrimmed>true</PublishTrimmed>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(AOT)' == 'true'">
+  <PropertyGroup Condition="'$(AOT)' == 'true' OR '$(PublishAot)' == 'true'">
     <PublishAot>true</PublishAot>
     <OptimizationPreference>Speed</OptimizationPreference>
     <!-- See https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/optimizing.md for instruction set info -->
     <!-- x86-x64-v3: Haswell and newer (~2013) with FMA and AVX2.  x86-64-v4: AVX-512 required. -->
     <!--<IlcInstructionSet>x86-x64-v3</IlcInstructionSet>-->
+
+    <!-- Define a constant we can use in source code #if statements -->
+    <DefineConstants>AOT</DefineConstants>
 
     <!-- Avoid copying symbols for release AOT builds, as these are miserable to debug even with symbols (and the files are huge) -->
     <CopyOutputSymbolsToPublishDirectory Condition="'$(Configuration)'=='Release'">false</CopyOutputSymbolsToPublishDirectory>
@@ -68,10 +71,35 @@
     <LinkerArg Include="-lglib-2.0" />
   </ItemGroup>
 
+  <ItemGroup Condition="('$(PublishAot)' == 'true') AND ('$(RuntimeIdentifier)'=='osx-arm64')">
+    <!-- OS-level dependencies -->
+    <LinkerArg Include="-framework AudioToolbox" />
+    <LinkerArg Include="-framework AudioUnit" />
+    <LinkerArg Include="-framework ApplicationServices" />
+    <LinkerArg Include="-framework CoreAudio" />
+    <LinkerArg Include="-framework CoreFoundation" />
+    <LinkerArg Include="-lstdc++" />
+
+    <!-- Transitive dependencies of ZMusic; assumes Homebrew installed, libsndfile and mpg123 installed via Homebrew -->
+    <LinkerArg Include="/opt/homebrew/opt/flac/lib/libFLAC.a" />
+    <LinkerArg Include="/opt/homebrew/opt/glib/lib/libglib-2.0.a" />
+    <LinkerArg Include="/opt/homebrew/opt/gettext/lib/libintl.a" />
+    <LinkerArg Include="/opt/homebrew/opt/lame/lib/libmp3lame.a" />
+    <LinkerArg Include="/opt/homebrew/opt/mpg123/lib/libmpg123.a" />
+    <LinkerArg Include="/opt/homebrew/opt/libogg/lib/libogg.a" />
+    <LinkerArg Include="/opt/homebrew/opt/opus/lib/libopus.a" />
+    <LinkerArg Include="/opt/homebrew/opt/pcre2/lib/libpcre2-8.a" />
+    <LinkerArg Include="/opt/homebrew/opt/libsndfile/lib/libsndfile.a" />
+    <LinkerArg Include="/opt/homebrew/opt/libvorbis/lib/libvorbis.a" />
+    <LinkerArg Include="/opt/homebrew/opt/libvorbis/lib/libvorbisenc.a" />
+    <LinkerArg Include="-liconv" />
+  </ItemGroup>
+
   <Target Name="HandleNativeLibraries" BeforeTargets="ResolveLockFileCopyLocalFiles">
     <ItemGroup Condition="('$(AOT)' == 'true')">
       <NativeLibrary Include="@(NativeCopyLocalItems)" Condition="('%(Extension)'=='.lib') AND ('$(RuntimeIdentifier)'=='win-x64')" />
       <NativeLibrary Include="@(NativeCopyLocalItems)" Condition="('%(Extension)'=='.a') AND ('$(RuntimeIdentifier)'=='linux-x64')" />
+      <NativeLibrary Include="@(NativeCopyLocalItems)" Condition="('%(Extension)'=='.a') AND ('$(RuntimeIdentifier)'=='osx-arm64')" />
 
       <!-- Don't copy shared libs if we're doing an AOT build, we are doing static linking here -->
       <RuntimeTargetsCopyLocalItems Remove="@(RuntimeTargetsCopyLocalItems)" />

--- a/INSTALL.adoc
+++ b/INSTALL.adoc
@@ -28,7 +28,11 @@ Note that we have provided copies of various binaries we depend upon.  If you ex
 
 ## Mac
 
-M-series ARM64 Macintosh is supported.  Install Homebrew, install .NET SDK 10.0, and then do a normal build as you would on the other supported platforms.  AOT builds are not supported yet.  Intel-based Macintosh machines are not supported, nor do we intend to do so in the future.
+M-series ARM64 Macintosh is supported. Intel-based Macintosh machines are not supported, nor do we intend to do so in the future.  Status of ARM64 other than M-series (e.g. Macbook Neo with A18 Pro SoC) unknown.
+
+If you wish to build Helion on an ARM Mac, you will need to install link:https://brew.sh/[Homebrew].  Then `brew install --cask dotnet-sdk`.
+
+If you wish to do AOT builds (see explanation below) on Macintosh Arm64, you will need to `brew install libsndfile` and `brew install mpg123` to get the necessary `.a` files for linking.  Clang must also be installed on your system (it seems to be present by default on OS 26.x).  Note that these steps are ONLY necessary for AOT builds.
 
 ## Command Line Build
 
@@ -37,7 +41,7 @@ Once any platform-specific prerequisites are installed, you can build or publish
 Note that it only makes sense to run the following from the `Client` subdirectory, as this is the only one that actually builds an executable (and can therefore be published).
 
 .Common Build Parameters
-* `-r <runtimeID>`:  Build an executable for the specific runtime.  Tested choices include `win-x64`, `win-x86`, and `linux-x64`.
+* `-r <runtimeID>`:  Build an executable for a specific runtime.  Tested choices include `win-x64`, `osx-arm64`, and `linux-x64`.
 * `--self-contained=true`:  Includes support files for the specified runtime, so that you do not need to install the .NET runtime onto the machine where you're going to run this (helps to make installs more portable)
 * `-p:PublishSingleFile=true`:  Bundles all of the .NET dependencies into a single file, resulting in fewer files in the output directory.  Can be combined with `--self-contained=true`.
 * `-p:EnableCompressionInSingleFile=true`:  When combined with single-file publish, this will also compress the resulting executable file.  This can result in a much smaller file size, but may result in the app taking longer to start.
@@ -63,8 +67,8 @@ Similarly, the output would be published to `(repo root)\Publish\linux-x64_AOT`.
 
 The .NET SDK normally builds assemblies (libraries or programs) that require Just-In-Time compilation when run.  The JIT compiler in modern .NET will first do a "fast" pass just to get the program running, and will later do an "optimized" pass to generate faster code, swapping the relevant code segments out at runtime.
 
-We also maintain compatibility with .NET Native AOT, which produces full native code **Ahead-Of-Time.**.  We do have to pick a lowest-common-denominator instruction set for these, which means that the generated binaries _may_ be slightly slower than the native tuning possible in a JIT environment, but the performance and memory behaviors are more stable and consistent, and the startup is instantaneous.
+We also maintain compatibility with .NET Native AOT, which produces full native code **Ahead-Of-Time.**.  We do have to pick a lowest-common-denominator instruction set for these, which means that the generated binaries _may_ be slightly slower than the native tuning possible in a JIT environment, but the performance and memory behaviors are more stable and consistent, and the startup is instantaneous because there is no JIT and many of the dependencies are statically linked and thus do not need to be resolved at runtime.
 
 Another advantage of Native AOT, and one that is _very_ relevant for Linux users, is that we can remove code that dynamically loads dependent libraries (.NET P/Invoke) and instead _link_ to those libraries.  This means that our Native AOT builds will fully honor normal Linux loader semantics-editing RPATH with tools, changing LD_LIBRARY_PATH, etc.-making it more feasible to package Helion in an AppImage, run it in a "jail", run it in a container, etc.
 
-Note that cross-compilation (building for Windows on Linux or vice-versa) is possible for normal builds but not for AOT builds, as these require the native toolchains for the respective platforms.
+Note that cross-compilation (building for Windows on Linux or vice-versa) is possible for normal builds (including "self contained publish") but not for AOT builds, as these require the native linkers for their respective platforms (typically some flavor of `ld` on Linux and MacOS).


### PR DESCRIPTION
Add the necessary linker directives to get AOT working on MacOS.  Note that this _requires_ whoever builds this to use Homebrew to install `libmpg123` and `libsndfile`, because we do not pack the necessary `.a` files with the ZMusic wrapper.

I have tested `-p:SelfContainedRelease=true` and `-p:AOT=true` publishing on all three supported environments (Win/Linux x64, MacOS ARM64) with this change.

I will update our GitHub actions sometime before our next major release to ensure that this is included in the set of things we build.