### PR TITLE
Sprite clip threshold

### DIFF
--- a/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Entities/EntityRenderer.cs
@@ -7,6 +7,7 @@ using Helion.Render.OpenGL.Texture.Legacy;
 using Helion.Resources;
 using Helion.Resources.Archives.Collection;
 using Helion.Resources.Definitions.Decorate.Properties.Enums;
+using Helion.Util;
 using Helion.Util.Configs;
 using Helion.Util.Container;
 using Helion.World;
@@ -139,11 +140,8 @@ public sealed class EntityRenderer : StyleRendererBase, IDisposable
         if (entity.Sector.Flood || entity.Sector.Floor.NoRender)
             return offsetAmount;
 
-        if (!m_spriteClip)
-            return 0;
-
-        if (texture.Height < m_spriteClipMin || entity.Definition.IsInventory)
-            return 0;
+        if (!m_spriteClip || texture.Height < m_spriteClipMin || entity.Definition.IsInventory)
+            return MathHelper.Max(offsetAmount, -texture.BlankRowsFromBottom);
 
         if (entity.Position.Z - entity.HighestFloorSector.Floor.Z < texture.Offset.Y)
         {
@@ -331,7 +329,7 @@ public sealed class EntityRenderer : StyleRendererBase, IDisposable
         // Prevent small health values from rendering zero pixels
         float min = 1f / (entity.Properties.HealthBarWidth + MinBarWidth - 5);
         // Normalized health percent (0-255)
-        int health = (int)(Math.Max(min, entity.Health / (float)entity.Properties.Health) * 255f);
+        int health = (int)(MathHelper.Max(min, entity.Health / (float)entity.Properties.Health) * 255f);
         vertex.SurfaceOptions = VertexOptions.EntityPackSurface(1, attackFlash ? 1 : 0, 0, entity.Properties.HealthBarWidth, health);
         vertex.Pos = entityVertex.Pos;
         vertex.PrevPos = entityVertex.PrevPos;

--- a/Core/Resources/Images/ArchiveImageRetriever.cs
+++ b/Core/Resources/Images/ArchiveImageRetriever.cs
@@ -143,66 +143,48 @@ public class ArchiveImageRetriever(ArchiveCollection archiveCollection, bool fin
 
     private static void SetSpriteOffset(Image image)
     {
-        int blankRowsFromBottom = GetBlankRowsFromBottom(image);
+        int blankRowsFromBottom = GetBlankRows(image, fromTop: false);
         if (blankRowsFromBottom <= image.Dimension.Height && blankRowsFromBottom >= 0)
             image.BlankRowsFromBottom = blankRowsFromBottom;
 
-        int blankRowsFromTop = GetBlankRowsFromTop(image);
+        int blankRowsFromTop = GetBlankRows(image, fromTop: true);
         if (blankRowsFromTop <= image.Dimension.Height && blankRowsFromTop >= 0)
             image.BlankRowsFromTop = blankRowsFromTop;
-
     }
-    private static int GetBlankRowsFromTop(Image image)
+
+    private static int GetBlankRows(Image image, bool fromTop)
     {
         if (image.ImageType != ImageType.Argb && image.ImageType != ImageType.PaletteWithArgb)
             return 0;
 
-        bool done = false;
-        int y = 0;
-        for (; y < image.Height; y++)
+        int width = image.Width;
+        int height = image.Height;
+
+        int y = fromTop ? 0 : height - 1;
+        int step = fromTop ? 1 : -1;
+        int opaqueThreshold = (int)(width * 0.05f);
+
+        while (y >= 0 && y < height)
         {
-            for (int x = 0; x < image.Width; x++)
+            int opaqueCount = 0;
+            for (int x = 0; x < width; x++)
             {
-                // Did we find a row that has a non-blank pixel?
                 if (image.GetPixel(x, y).A != 0)
                 {
-                    done = true;
-                    break;
+                    opaqueCount++;
+                    if (opaqueCount >= opaqueThreshold)
+                        goto Done;
                 }
             }
 
-            if (done)
-                break;
+            y += step;
         }
 
-        return Math.Max(0, y);
-    }
-
-    private static int GetBlankRowsFromBottom(Image image)
-    {
-        if (image.ImageType != ImageType.Argb && image.ImageType != ImageType.PaletteWithArgb)
-            return 0;
-
-        bool done = false;
-        int y = image.Height - 1;
-        for (; y >= 0; y--)
-        {
-            for (int x = 0; x < image.Width; x++)
-            {
-                // Did we find a row that has a non-blank pixel?
-                if (image.GetPixel(x, y).A != 0)
-                {
-                    done = true;
-                    break;
-                }
-            }
-
-            if (done)
-                break;
-        }
-
-        // Return either the bottom row, or 0 if the entire image is transparent.
-        return Math.Max(0, image.Height - y - 1);
+    Done:
+        if (fromTop)
+            return Math.Max(0, y);
+        else
+            return Math.Max(0, height - y - 1);
     }
 
     // Forces helion graphics like the options background, and brightmaps, to always be true color
@@ -277,6 +259,11 @@ public class ArchiveImageRetriever(ArchiveCollection archiveCollection, bool fin
 
         if (image == null)
             return null;
+
+        if (entry.Path.Name.StartsWith("MED"))
+        {
+            int lol = 1;
+        }
 
         if (entry.Namespace == ResourceNamespace.Sprites)
             SetSpriteOffset(image);

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -21,6 +21,7 @@
 - Fix crash when using nextmap command and the next map has a ACS behavior module to load.
 - Fix A_JumpIfFlagsSet for MBF21 flags that modify entity properties. Fixes Abyssal Apocrypha MAP08 Totem of Resurrection.
 - Fix incosistensies between static/dynamic rendering paths.
+- Add better checks for sprite clipping when not using software sprite emulation. (Fixes Eye Juice Arachnotrons/Medkits floating)
 
 ## Misc:
 - Use DrawArraysInstanced instead of geometry shader for sprite rendering (allows for MacOS support).


### PR DESCRIPTION
Add 5 percent threshold for opaque pixel rows.

Use max between offset and blank rows from bottom to fix inventory items floating with a lot of blank rows.

Fixes #1760 