### PR TITLE
frame state / randomize fix

### DIFF
--- a/Core/Dehacked/DehackedApplier.cs
+++ b/Core/Dehacked/DehackedApplier.cs
@@ -957,6 +957,9 @@ public class DehackedApplier
         {
             DehackedName = thing.Name
         };
+
+        // This wasn't an option in the original game, needs to be applied to all potential projectile spawns.
+        definition.Flags.SetRandomizeProjectile();
         definition.Properties.Height = 0;
         composer.Add(definition);
         m_dehacked.DefinitionLookup[index] = definition;

--- a/Core/Resources/Images/ArchiveImageRetriever.cs
+++ b/Core/Resources/Images/ArchiveImageRetriever.cs
@@ -260,11 +260,6 @@ public class ArchiveImageRetriever(ArchiveCollection archiveCollection, bool fin
         if (image == null)
             return null;
 
-        if (entry.Path.Name.StartsWith("MED"))
-        {
-            int lol = 1;
-        }
-
         if (entry.Namespace == ResourceNamespace.Sprites)
             SetSpriteOffset(image);
 

--- a/Core/World/Entities/Definition/Composer/DefinitionFlagApplier.cs
+++ b/Core/World/Entities/Definition/Composer/DefinitionFlagApplier.cs
@@ -123,7 +123,7 @@ public static class DefinitionFlagApplier
         if (flags.QuickToRetaliate != null)
             definition.Flags.SetQuickToRetaliate(flags.QuickToRetaliate.Value);
         if (flags.Randomize != null)
-            definition.Flags.SetRandomize(flags.Randomize.Value);
+            definition.Flags.SetRandomizeProjectile(flags.Randomize.Value);
         if (flags.Ripper != null)
             definition.Flags.SetRipper(flags.Ripper.Value);
         if (flags.Shootable != null)

--- a/Core/World/Entities/Definition/Flags/EntityFlags.cs
+++ b/Core/World/Entities/Definition/Flags/EntityFlags.cs
@@ -171,10 +171,10 @@ public struct EntityFlags
     [MethodImpl(MethodImplOptions.AggressiveInlining)] public void SetQuickToRetaliate(bool value) { if (value) SetQuickToRetaliate(); else ClearQuickToRetaliate(); }
     [MethodImpl(MethodImplOptions.AggressiveInlining)] public void ClearQuickToRetaliate() => Flags1 &= FlagValue.InvFlag30;
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)] public readonly bool Randomize() => (Flags1 & FlagValue.Flag31) != 0;
-    [MethodImpl(MethodImplOptions.AggressiveInlining)] public void SetRandomize() => Flags1 |= FlagValue.Flag31;
-    [MethodImpl(MethodImplOptions.AggressiveInlining)] public void SetRandomize(bool value) { if (value) SetRandomize(); else ClearRandomize(); }
-    [MethodImpl(MethodImplOptions.AggressiveInlining)] public void ClearRandomize() => Flags1 &= FlagValue.InvFlag31;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)] public readonly bool RandomizeProjectile() => (Flags1 & FlagValue.Flag31) != 0;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)] public void SetRandomizeProjectile() => Flags1 |= FlagValue.Flag31;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)] public void SetRandomizeProjectile(bool value) { if (value) SetRandomizeProjectile(); else ClearRandomizeProjectile(); }
+    [MethodImpl(MethodImplOptions.AggressiveInlining)] public void ClearRandomizeProjectile() => Flags1 &= FlagValue.InvFlag31;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)] public readonly bool NoTarget() => (Flags1 & FlagValue.Flag32) != 0;
     [MethodImpl(MethodImplOptions.AggressiveInlining)] public void SetNoTarget() => Flags1 |= FlagValue.Flag32;

--- a/Core/World/Entities/Definition/States/FrameState.cs
+++ b/Core/World/Entities/Definition/States/FrameState.cs
@@ -3,9 +3,9 @@ using Helion.Models;
 using Helion.Util;
 using NLog;
 using static Helion.Util.Assertion.Assert;
-using System.Collections.Generic;
 using System;
 using System.Runtime.CompilerServices;
+using System.Diagnostics;
 
 namespace Helion.World.Entities.Definition.States;
 
@@ -22,6 +22,12 @@ public enum FrameStateOptions
 /// </summary>
 public struct FrameState
 {
+    private enum TickStatus
+    {
+        Continue,
+        Stop
+    }
+
     private const int InfiniteLoopLimit = 10000;
     private static readonly Logger Log = LogManager.GetCurrentClassLogger();
 
@@ -254,7 +260,7 @@ public struct FrameState
         }
     }
 
-    private void LogStackError(EntityDefinition def)
+    private readonly void LogStackError(EntityDefinition def)
     {
         string method = string.Empty;
         if (Frame.ActionFunction != null)
@@ -263,23 +269,52 @@ public struct FrameState
         Log.Error($"Stack limit reached for '{def.Name}' {method}");
     }
 
-    public void Tick(Entity entity)
+    public void TickEntity(Entity entity)
     {
-        Precondition(FrameIndex >= 0 && FrameIndex < WorldStatic.Frames.Count, "Out of range frame index for entity");
+        FrameIndexCheck();
         if (CurrentTick == -1)
             return;
 
         CurrentTick--;
         if (CurrentTick == 0)
         {
-            if (Frame.BranchType == ActorStateBranch.Stop && (Options & FrameStateOptions.DestroyOnStop) != 0)
-            {
-                WorldStatic.EntityManager.Destroy(entity);
+            if (ExecuteTick(entity) == TickStatus.Stop)
                 return;
-            }
-
-            SetFrameIndexInternal(entity, Frame.NextFrameIndex);
         }
+    }
+
+    public void TickPlayerSprite(Entity entity)
+    {
+        FrameIndexCheck();
+        if (CurrentTick == 0)
+            return;
+
+        CurrentTick--;
+        if (CurrentTick <= 0)
+        {
+            if (ExecuteTick(entity) == TickStatus.Stop)
+                return;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private TickStatus ExecuteTick(Entity entity)
+    {
+        if (Frame.BranchType == ActorStateBranch.Stop && (Options & FrameStateOptions.DestroyOnStop) != 0)
+        {
+            WorldStatic.EntityManager.Destroy(entity);
+            return TickStatus.Stop;
+        }
+
+        SetFrameIndexInternal(entity, Frame.NextFrameIndex);
+        return TickStatus.Continue;
+    }
+
+
+    [Conditional("DEBUG")]
+    private readonly void FrameIndexCheck()
+    {
+        Precondition(FrameIndex >= 0 && FrameIndex < WorldStatic.Frames.Count, "Out of range frame index for entity");
     }
 
     public FrameStateModel ToFrameStateModel()

--- a/Core/World/Entities/Entity.cs
+++ b/Core/World/Entities/Entity.cs
@@ -547,7 +547,7 @@ public partial class Entity : IDisposable, ITickable, ISoundSource, IFloorCeilin
         if (Flags.BossSpawnShot() && ReactionTime > 0)
             ReactionTime--;
 
-        FrameState.Tick(this);
+        FrameState.TickEntity(this);
 
         if (IsDisposed)
             return;
@@ -696,8 +696,7 @@ public partial class Entity : IDisposable, ITickable, ISoundSource, IFloorCeilin
     {
         if (Flags.Missile())
         {
-            // Doom will always apply randomization, force this functionality if a dehacked patch is applied
-            if (Flags.Randomize() || WorldStatic.Dehacked)
+            if (Flags.RandomizeProjectile())
                 SetRandomizeTicks();
             if (FrameState.CurrentTick < 1)
                 FrameState.SetTics(1);

--- a/Core/World/Entities/Inventories/Weapon.cs
+++ b/Core/World/Entities/Inventories/Weapon.cs
@@ -87,9 +87,9 @@ public class Weapon : InventoryItem, ITickable
         ReadyState = false;
         ReadyToFire = false;
 
-        FrameState.Tick(Owner);
+        FrameState.TickPlayerSprite(Owner);
         Owner.WeaponFlashState = true;
-        FlashState.Tick(Owner);
+        FlashState.TickPlayerSprite(Owner);
         Owner.WeaponFlashState = false;
 
         if (m_tryingToFire && ReadyToFire)

--- a/Core/World/WorldBase.cs
+++ b/Core/World/WorldBase.cs
@@ -1778,7 +1778,7 @@ public abstract partial class WorldBase : IWorld
         projectile.SetOwner(shooter);
         projectile.SetTarget(shooter);
 
-        if (projectile.Flags.Randomize())
+        if (projectile.Flags.RandomizeProjectile())
             projectile.SetRandomizeTicks();
 
         double speed = IsFastMonsters && projectile.Properties.FastSpeed > 0 ?
@@ -3338,7 +3338,7 @@ public abstract partial class WorldBase : IWorld
         if (bulletPuff)
         {
             create.Velocity.Z = 1;
-            if (create.Flags.Randomize())
+            if (create.Flags.RandomizeProjectile())
                 create.SetRandomizeTicks();
 
             // Doom would skip the initial sparking state of the bullet puff for punches

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -22,6 +22,8 @@
 - Fix A_JumpIfFlagsSet for MBF21 flags that modify entity properties. Fixes Abyssal Apocrypha MAP08 Totem of Resurrection.
 - Fix incosistensies between static/dynamic rendering paths.
 - Add better checks for sprite clipping when not using software sprite emulation. (Fixes Eye Juice Arachnotrons/Medkits floating)
+- Match frame ticking behavior differences between player and non-player states.
+- Fix dehacked not setting randomize flag. Fixes Legacy of Rust Calamity Blade firing.
 
 ## Misc:
 - Use DrawArraysInstanced instead of geometry shader for sprite rendering (allows for MacOS support).

--- a/Tests/Unit/GameAction/Dehacked/DefaultFlags.cs
+++ b/Tests/Unit/GameAction/Dehacked/DefaultFlags.cs
@@ -1,0 +1,42 @@
+﻿using FluentAssertions;
+using Helion.Resources.IWad;
+using Helion.World.Impl.SinglePlayer;
+using Xunit;
+
+namespace Helion.Tests.Unit.GameAction.Dehacked;
+
+[Collection("GameActions")]
+public class DefaultFlags
+{
+    private readonly SinglePlayerWorld World;
+
+    public DefaultFlags()
+    {
+        World = WorldAllocator.LoadMap("Resources/box.zip", "box.WAD", "MAP01", GetType().Name, (world) => { }, IWadType.Doom2,
+            dehackedPatch: Dehacked);
+    }
+
+    [Fact(DisplayName = "New Dehacked thing defaults have randomize flag")]
+    public void NewDehackedThingDefaultRandomize()
+    {
+        var newDef1 = World.EntityManager.DefinitionComposer.GetByName("*deh/entity190");
+        var newDef2 = World.EntityManager.DefinitionComposer.GetByName("*deh/entity191");
+
+        newDef1.Should().NotBeNull();
+        newDef2.Should().NotBeNull();
+
+        newDef1.Flags.RandomizeProjectile().Should().BeTrue();
+        newDef2.Flags.RandomizeProjectile().Should().BeTrue();
+    }
+
+    private static readonly string Dehacked =
+@"
+Thing 191 (NewThing)
+ID # = 191
+Initial frame = 42069
+
+Thing 192 (NewThing with height)
+ID # = 192
+Height = 4521984
+Initial frame = 42069"";";
+}

--- a/Tests/Unit/Model/EntityFlagsModelTests.cs
+++ b/Tests/Unit/Model/EntityFlagsModelTests.cs
@@ -61,7 +61,7 @@ public class EntityFlagsModelTests
         entityFlags.SetOldRadiusDmg();
         entityFlags.SetPickup();
         entityFlags.SetQuickToRetaliate();
-        entityFlags.SetRandomize();
+        entityFlags.SetRandomizeProjectile();
         entityFlags.SetRipper();
         entityFlags.SetShadow();
         entityFlags.SetShootable();
@@ -131,7 +131,7 @@ public class EntityFlagsModelTests
         entityFlags.ClearOldRadiusDmg();
         entityFlags.SetPickup();
         entityFlags.ClearQuickToRetaliate();
-        entityFlags.SetRandomize();
+        entityFlags.SetRandomizeProjectile();
         entityFlags.ClearRipper();
         entityFlags.SetShadow();
         entityFlags.ClearShootable();


### PR DESCRIPTION
Match frame ticking behavior differences between player and non-player states.

Fix dehacked not setting randomize flag. Fixes Legacy of Rust Calamity Blade firing.

fixes #1758 

This was originally broken by the fix in this [PR](https://github.com/Helion-Engine/Helion/pull/1587), but the incorrect ticking check for -1 was masking the missing forced projectile randomization for dehacked things.