### PR TITLE
Sbardef ammo fix

### DIFF
--- a/Assets/Assets/SBARDEF.lmp
+++ b/Assets/Assets/SBARDEF.lmp
@@ -119,7 +119,18 @@
               "tranmap": null,
               "translation": null,
               "translucency": false,
-              "conditions": [],
+              "conditions": [
+                {
+                  "condition": 4,
+                  "param": 0,
+                  "param2": 0
+                },
+                {
+                  "condition": 9,
+                  "param": 1,
+                  "param2": 0
+                }
+              ],
               "children": [],
               "font": "Classic Status Bar",
               "type": 4,
@@ -922,7 +933,18 @@
                     "tranmap": null,
                     "translation": null,
                     "translucency": false,
-                    "conditions": [],
+                    "conditions": [
+                      {
+                        "condition": 4,
+                        "param": 0,
+                        "param2": 0
+                      },
+                      {
+                        "condition": 9,
+                        "param": 1,
+                        "param2": 0
+                      }
+                    ],
                     "children": [],
                     "font": "Classic Status Bar",
                     "type": 4,
@@ -1656,7 +1678,7 @@
                     "type": "level_title",
                     "font": "Classic HUD",
                     "vertical": false,
-                    "duration": 4
+                    "duration": 4.0
                   }
                 }
               ]
@@ -2115,6 +2137,11 @@
                     "translucency": false,
                     "conditions": [
                       {
+                        "condition": 4,
+                        "param": 0,
+                        "param2": 0
+                      },
+                      {
                         "condition": 9,
                         "param": 1,
                         "param2": 0
@@ -2188,7 +2215,7 @@
                                 "type": "stat_totals",
                                 "font": "Boom HUD",
                                 "vertical": true,
-                                "duration": 0
+                                "duration": 0.0
                               }
                             },
                             {
@@ -2204,7 +2231,7 @@
                                 "type": "time",
                                 "font": "Boom HUD",
                                 "vertical": false,
-                                "duration": 0
+                                "duration": 0.0
                               }
                             }
                           ]
@@ -2244,7 +2271,7 @@
                           "type": "level_title",
                           "font": "Classic HUD",
                           "vertical": false,
-                          "duration": 4
+                          "duration": 4.0
                         }
                       }
                     ]
@@ -2290,7 +2317,7 @@
                                 "type": "time",
                                 "font": "Boom HUD",
                                 "vertical": false,
-                                "duration": 0
+                                "duration": 0.0
                               }
                             },
                             {
@@ -2312,7 +2339,7 @@
                                 "type": "stat_totals",
                                 "font": "Boom HUD",
                                 "vertical": false,
-                                "duration": 0
+                                "duration": 0.0
                               }
                             }
                           ],
@@ -2944,6 +2971,11 @@
                                           "condition": 4,
                                           "param": 0,
                                           "param2": 0
+                                        },
+                                        {
+                                          "condition": 9,
+                                          "param": 1,
+                                          "param2": 0
                                         }
                                       ],
                                       "children": [],
@@ -2965,6 +2997,11 @@
                                         {
                                           "condition": 5,
                                           "param": 0,
+                                          "param2": 0
+                                        },
+                                        {
+                                          "condition": 9,
+                                          "param": 1,
                                           "param2": 0
                                         }
                                       ],

--- a/Core/Dehacked/DehackedApplier.cs
+++ b/Core/Dehacked/DehackedApplier.cs
@@ -245,9 +245,9 @@ public class DehackedApplier
                 weaponDef.Properties.Weapons.AllowSwitchWithOwnedWeapon = GetWeaponByIdDefinition(dehacked, composer, weapon.AllowSwitchWithOwnedWeapon.Value);
             if (weapon.NoSwitchWithOwnedWeapon.HasValue)
                 weaponDef.Properties.Weapons.NoSwitchWithOwnedWeapon = GetWeaponByIdDefinition(dehacked, composer, weapon.NoSwitchWithOwnedWeapon.Value);
-            if (weapon.AllowSwitchWithOwnedItem.HasValue && dehacked.TryGetId24PickupType(composer, weapon.AllowSwitchWithOwnedItem.Value, out var allowSwitchItemDef))
+            if (weapon.AllowSwitchWithOwnedItem.HasValue && TryGetId24PickupType(composer, weapon.AllowSwitchWithOwnedItem.Value, out var allowSwitchItemDef))
                 weaponDef.Properties.Weapons.AllowSwitchWithOwnedItem = allowSwitchItemDef;
-            if (weapon.NoSwitchWithOwnedItem.HasValue && dehacked.TryGetId24PickupType(composer, weapon.NoSwitchWithOwnedItem.Value, out var noSwitchItemDef))
+            if (weapon.NoSwitchWithOwnedItem.HasValue && TryGetId24PickupType(composer, weapon.NoSwitchWithOwnedItem.Value, out var noSwitchItemDef))
                 weaponDef.Properties.Weapons.NoSwitchWithOwnedItem = noSwitchItemDef;
         }
 
@@ -843,7 +843,7 @@ public class DehackedApplier
             return;
         }
 
-        if (!dehacked.TryGetId24PickupType(composer, pickupItemType, out var itemDef))
+        if (!TryGetId24PickupType(composer, pickupItemType, out var itemDef))
         {
             Log.Warn("Invalid item pickup type {type} for {number} {name}", pickupItemType, thing.Number, thing.Name);
             return;

--- a/Core/Dehacked/DehackedConstants.cs
+++ b/Core/Dehacked/DehackedConstants.cs
@@ -1,4 +1,3 @@
-using Helion.World.Entities.Inventories;
 using System;
 using System.Collections.Generic;
 using static Helion.World.Entities.Definition.States.EntityActionFunctions;
@@ -243,32 +242,6 @@ public partial class DehackedDefinition
         { "SHOT", "Shotgun" },
         { "SGN2", "SuperShotgun" },
     };
-
-    public readonly string[] Id24PickupLookup =
-    [
-        "",
-        "BlueCard",
-        "YellowCard",
-        "RedCard",
-        "BlueSkull",
-        "YellowSkull",
-        "RedSkull",
-        "Backpack",
-        "HealthBonus",
-        "Stimpack",
-        "Medikit",
-        "Soulsphere",
-        "Megasphere",
-        "ArmorBonus",
-        "GreenArmor",
-        "BlueArmor",
-        "Allmap",
-        "Infrared",
-        "Berserk",
-        "BlurSphere",
-        "RadSuit",
-        "InvulnerabilitySphere",
-    ];
 
     public readonly HashSet<string> SpriteNames = new(StringComparer.OrdinalIgnoreCase)
     {

--- a/Core/Dehacked/DehackedDefinition.cs
+++ b/Core/Dehacked/DehackedDefinition.cs
@@ -170,13 +170,13 @@ public partial class DehackedDefinition
     public bool GetEntityDefinition(int thingNumber, [NotNullWhen(true)] out EntityDefinition? def) =>
         DefinitionLookup.TryGetValue(thingNumber - 1, out def);
 
-    public bool TryGetId24PickupType(EntityDefinitionComposer composer, int pickupItemType, [NotNullWhen(true)] out EntityDefinition? definition)
+    public static bool TryGetId24PickupType(EntityDefinitionComposer composer, int pickupItemType, [NotNullWhen(true)] out EntityDefinition? definition)
     {
         definition = null;
-        if (pickupItemType < 0 || pickupItemType >= Id24PickupLookup.Length) 
+        if (pickupItemType < 0 || pickupItemType >= Constants.Id24PickupLookup.Length) 
             return false;
 
-        definition = composer.GetByName(Id24PickupLookup[pickupItemType]);
+        definition = composer.GetByName(Constants.Id24PickupLookup[pickupItemType]);
         if (definition == null)
             return false;
 

--- a/Core/Dehacked/Id24PickupType.cs
+++ b/Core/Dehacked/Id24PickupType.cs
@@ -24,6 +24,5 @@ public enum Id24PickupType
     Berserk,
     PartialInvisibility,
     RadiationSuit,
-    Invulnerability,
-    Count
+    Invulnerability
 }

--- a/Core/Dehacked/Id24PickupType.cs
+++ b/Core/Dehacked/Id24PickupType.cs
@@ -25,4 +25,5 @@ public enum Id24PickupType
     PartialInvisibility,
     RadiationSuit,
     Invulnerability,
+    Count
 }

--- a/Core/Layer/Worlds/StatusBar/StatusBarRenderer.cs
+++ b/Core/Layer/Worlds/StatusBar/StatusBarRenderer.cs
@@ -1154,7 +1154,7 @@ public class StatusBarRenderer
         if (!StatusBarConditionResolver.Evaluate(m_ctx, number))
             return;
 
-        int value = ResolveNumberValue(m_ctx.Player, number.Type, number.Param, out var shouldRender);
+        int value = ResolveNumberValue(m_ctx.Player, number.Type, number.Param);
 
         if (number.MaxLength > 0)
         {
@@ -1497,7 +1497,7 @@ public class StatusBarRenderer
         float sY)
     {
         m_fmtSpan.Clear();
-        m_fmtSpan.Append(ResolveNumberValue(m_ctx.Player, def.Type, def.Param, out var shouldRender));
+        m_fmtSpan.Append(ResolveNumberValue(m_ctx.Player, def.Type, def.Param));
         if (isPercent) m_fmtSpan.Append('%');
 
         Vec2F oldScale = m_scale;
@@ -1827,9 +1827,8 @@ public class StatusBarRenderer
         return result;
     }
 
-    private int ResolveNumberValue(Player player, StatusBarNumberType type, int param, out bool shouldRender)
+    private int ResolveNumberValue(Player player, StatusBarNumberType type, int param)
     {
-        shouldRender = true;
         var composer = m_archiveCollection.EntityDefinitionComposer;
         var stats = m_ctx.World.LevelStats;
 

--- a/Core/Layer/Worlds/StatusBar/StatusBarRenderer.cs
+++ b/Core/Layer/Worlds/StatusBar/StatusBarRenderer.cs
@@ -14,6 +14,7 @@ using Helion.Resources.Definitions.StatusBar;
 using Helion.Resources.Definitions.StatusBar.Enums;
 using Helion.Strings;
 using Helion.Util;
+using Helion.Util.Assertion;
 using Helion.Util.Configs.Components;
 using Helion.Util.Container;
 using Helion.World.Entities.Definition;
@@ -25,6 +26,7 @@ using Helion.World.StatusBar;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Runtime.CompilerServices;
 
 namespace Helion.Layer.Worlds.StatusBar;
@@ -122,8 +124,10 @@ public class StatusBarRenderer
             m_hudFontLookup[f.Name] = f;
 
         var composer = m_archiveCollection.EntityDefinitionComposer;
-        for (int i = 0; i < (int)Id24PickupType.Count; i++)
+        var enumCount = (int)Enum.GetValues<Id24PickupType>().Max();
+        for (int i = 0; i < enumCount; i++)
         {
+            Assert.Precondition(i < Constants.Id24PickupLookup.Length, "Id24PickupType index out of bounds of Id24PickupLookup");
             if (i >= Constants.Id24PickupLookup.Length)
                 break;
 

--- a/Core/Layer/Worlds/StatusBar/StatusBarRenderer.cs
+++ b/Core/Layer/Worlds/StatusBar/StatusBarRenderer.cs
@@ -1,3 +1,4 @@
+using Helion.Dehacked;
 using Helion.Geometry;
 using Helion.Geometry.Vectors;
 using Helion.Graphics;
@@ -14,8 +15,8 @@ using Helion.Resources.Definitions.StatusBar.Enums;
 using Helion.Strings;
 using Helion.Util;
 using Helion.Util.Configs.Components;
+using Helion.Util.Container;
 using Helion.World.Entities.Definition;
-using Helion.World.Entities.Definition.Composer;
 using Helion.World.Entities.Inventories;
 using Helion.World.Entities.Inventories.Powerups;
 using Helion.World.Entities.Players;
@@ -89,6 +90,7 @@ public class StatusBarRenderer
     private readonly List<RenderGlyph> m_glyphCache = new(256);
     private readonly Dictionary<string, StatusBarHudFontDef> m_hudFontLookup = [];
     private readonly SpanString m_lookupKeySpan = new(128);
+    private readonly LookupArray<EntityDefinition> m_id24PickupTypeLookup = new(Constants.Id24PickupLookup.Length);
 
     private readonly Func<IHudRenderContext, StatusBarHudFontDef, char, string> m_getHudFontPatch;
     private readonly Func<IHudRenderContext, StatusBarNumberFontDef, char, string> m_getFontNumberPatch;
@@ -118,6 +120,17 @@ public class StatusBarRenderer
 
         foreach (StatusBarHudFontDef f in sbarDef.HudFonts)
             m_hudFontLookup[f.Name] = f;
+
+        var composer = m_archiveCollection.EntityDefinitionComposer;
+        for (int i = 0; i < (int)Id24PickupType.Count; i++)
+        {
+            if (i >= Constants.Id24PickupLookup.Length)
+                break;
+
+            var def = composer.GetByName(Constants.Id24PickupLookup[i]);
+            if (def != null)
+                m_id24PickupTypeLookup.Set(i, def);
+        }
 
         m_getHudFontPatch = GetHudFontPatch;
         m_getFontNumberPatch = GetFontPatch;
@@ -1141,7 +1154,7 @@ public class StatusBarRenderer
         if (!StatusBarConditionResolver.Evaluate(m_ctx, number))
             return;
 
-        int value = ResolveNumberValue(m_ctx.Player, number.Type, number.Param);
+        int value = ResolveNumberValue(m_ctx.Player, number.Type, number.Param, out var shouldRender);
 
         if (number.MaxLength > 0)
         {
@@ -1484,7 +1497,7 @@ public class StatusBarRenderer
         float sY)
     {
         m_fmtSpan.Clear();
-        m_fmtSpan.Append(ResolveNumberValue(m_ctx.Player, def.Type, def.Param));
+        m_fmtSpan.Append(ResolveNumberValue(m_ctx.Player, def.Type, def.Param, out var shouldRender));
         if (isPercent) m_fmtSpan.Append('%');
 
         Vec2F oldScale = m_scale;
@@ -1814,10 +1827,11 @@ public class StatusBarRenderer
         return result;
     }
 
-    private int ResolveNumberValue(Player player, StatusBarNumberType type, int param)
+    private int ResolveNumberValue(Player player, StatusBarNumberType type, int param, out bool shouldRender)
     {
-        EntityDefinitionComposer composer = m_archiveCollection.EntityDefinitionComposer;
-        LevelStats stats = m_ctx.World.LevelStats;
+        shouldRender = true;
+        var composer = m_archiveCollection.EntityDefinitionComposer;
+        var stats = m_ctx.World.LevelStats;
 
         switch (type)
         {
@@ -1828,30 +1842,26 @@ public class StatusBarRenderer
             case StatusBarNumberType.Frags:
                 return 0;
             case StatusBarNumberType.Ammo:
-                return StatusBarConditionResolver.TryGetId24AmmoType(composer, param, out EntityDefinition? ammoDef)
-                    ? player.Inventory.Amount(ammoDef.Name)
+                return StatusBarConditionResolver.TryGetId24AmmoType(composer, param, out var ammoDef)
+                    ? GetAmount(player, ammoDef)
                     : 0;
 
             case StatusBarNumberType.AmmoSelected:
-                return player.AnimationWeapon?.Definition.Properties.Weapons.AmmoType is { } a && !string.IsNullOrEmpty(a)
-                    ? player.Inventory.Amount(a)
-                    : 0;
+                return GetAmount(player, player.Weapon?.AmmoDefinition);
 
             case StatusBarNumberType.MaxAmmo:
-                return StatusBarConditionResolver.TryGetId24AmmoType(composer, param, out EntityDefinition? maxAmmoDef)
-                    ? GetMaxAmount(player, maxAmmoDef.Name)
+                return StatusBarConditionResolver.TryGetId24AmmoType(composer, param, out var maxAmmoDef)
+                    ? GetMaxAmmoAmount(maxAmmoDef)
                     : 0;
 
             case StatusBarNumberType.AmmoWeapon:
-                return m_archiveCollection.Definitions.DehackedDefinition is { } deh &&
-                       deh.TryGetId24PickupType(composer, param, out EntityDefinition? wDef)
-                    ? player.Inventory.Amount(wDef.Properties.Weapons.AmmoType)
+                return m_id24PickupTypeLookup.TryGetValue(param, out var wDef)
+                    ? GetAmount(player, wDef.Properties.Weapons.AmmoTypeDef)
                     : 0;
 
             case StatusBarNumberType.MaxAmmoWeapon:
-                return m_archiveCollection.Definitions.DehackedDefinition is { } dehM &&
-                       dehM.TryGetId24PickupType(composer, param, out EntityDefinition? mwDef)
-                    ? GetMaxAmount(player, mwDef.Properties.Weapons.AmmoType)
+                return m_id24PickupTypeLookup.TryGetValue(param, out var mwDef)
+                    ? GetMaxAmmoAmount(mwDef.Properties.Weapons.AmmoTypeDef)
                     : 0;
 
             case StatusBarNumberType.Kills:
@@ -1905,13 +1915,22 @@ public class StatusBarRenderer
         return string.Empty;
     }
 
-    private int GetMaxAmount(Player player, string name)
+    private static int GetAmount(Player player, EntityDefinition? def)
     {
-        EntityDefinition? def = m_archiveCollection.EntityDefinitionComposer.GetByName(name);
-        if (def == null) return 0;
-        EntityDefinition baseDef = Inventory.GetBaseInventoryDefinition(def) ?? def;
-        int max = baseDef.Properties.Inventory.MaxAmount;
-        if (player.Inventory.HasItemOfClass(Inventory.BackPackBaseClassName) && baseDef.IsType(Inventory.AmmoClassName))
+        if (def == null)
+            return 0;
+
+        return player.Inventory.Amount(def);
+    }
+
+    private int GetMaxAmmoAmount(EntityDefinition? ammoDef)
+    {
+        if (ammoDef == null)
+            return 0;
+
+        var baseDef = Inventory.GetBaseInventoryDefinition(ammoDef) ?? ammoDef;
+        var max = baseDef.Properties.Inventory.MaxAmount;
+        if (m_ctx.HasBackPack && baseDef.IsAmmo)
             max = Math.Max(max, baseDef.Properties.Ammo.BackpackMaxAmount);
         return max;
     }

--- a/Core/Util/Constants.cs
+++ b/Core/Util/Constants.cs
@@ -91,6 +91,32 @@ public static class Constants
     public const string DefaultBackgroundImage = "helion-background";
     public const string Endoom = "ENDOOM";
 
+    public static readonly string[] Id24PickupLookup =
+    [
+        "",
+        "BlueCard",
+        "YellowCard",
+        "RedCard",
+        "BlueSkull",
+        "YellowSkull",
+        "RedSkull",
+        "Backpack",
+        "HealthBonus",
+        "Stimpack",
+        "Medikit",
+        "Soulsphere",
+        "Megasphere",
+        "ArmorBonus",
+        "GreenArmor",
+        "BlueArmor",
+        "Allmap",
+        "Infrared",
+        "Berserk",
+        "BlurSphere",
+        "RadSuit",
+        "InvulnerabilitySphere",
+    ];
+
     public static class MenuSounds
     {
         public const string Activate = "menu/activate";

--- a/Core/World/Entities/Definition/Composer/EntityDefinitionComposer.cs
+++ b/Core/World/Entities/Definition/Composer/EntityDefinitionComposer.cs
@@ -69,7 +69,7 @@ public class EntityDefinitionComposer
         if (m_definitionsBySpan.TryGetValue(name, out EntityDefinition? definition))
             return definition;
 
-        ActorDefinition? actorDefinition = m_archiveCollection.Definitions.Decorate[name];
+        var actorDefinition = m_archiveCollection.Definitions.Decorate[name];
         if (actorDefinition == null)
             return null;
 
@@ -90,6 +90,9 @@ public class EntityDefinitionComposer
 
         if (definition.EditorId != null)
             m_editorNumToDefinition[definition.EditorId.Value] = definition;
+
+        if (definition.Properties.Weapons.AmmoTypeDef == null && !string.IsNullOrEmpty(definition.Properties.Weapons.AmmoType))
+            definition.Properties.Weapons.AmmoTypeDef = GetByNameOrDefault(definition.Properties.Weapons.AmmoType);
 
         return definition;
     }

--- a/Core/World/Entities/Definition/EntityDefinition.cs
+++ b/Core/World/Entities/Definition/EntityDefinition.cs
@@ -4,6 +4,7 @@ using Helion.Util;
 using Helion.World.Entities.Definition.Flags;
 using Helion.World.Entities.Definition.Properties;
 using Helion.World.Entities.Definition.States;
+using Helion.World.Entities.Inventories;
 using static Helion.Util.Assertion.Assert;
 
 namespace Helion.World.Entities.Definition;
@@ -30,6 +31,7 @@ public class EntityDefinition
     public readonly EntityStates States;
     public readonly IList<string> ParentClassNames;
     public bool IsInventory;
+    public bool IsAmmo;
     public EntityType Type;
     public int? SpawnState;
     public int? MissileState;
@@ -67,6 +69,7 @@ public class EntityDefinition
         foreach (var parentClass in ParentClassNames)
             ParentClassLookup.Add(parentClass);
         IsInventory = IsType(EntityDefinitionType.Inventory);
+        IsAmmo = IsType(Inventory.AmmoClassName);
         if (ClassToType.TryGetValue(Name, out var type))
             Type = type;
     }

--- a/Core/World/Entities/Players/Player.cs
+++ b/Core/World/Entities/Players/Player.cs
@@ -1686,7 +1686,6 @@ public class Player : Entity
         if (Weapon == null)
             return;
         var weapon = Weapon.Definition.Properties.Weapons;
-        weapon.AmmoTypeDef ??= WorldStatic.World.EntityManager.DefinitionComposer.GetByName(weapon.AmmoType);
         if (weapon.AmmoTypeDef != null)
             Inventory.Add(weapon.AmmoTypeDef, amount);
     }

--- a/Core/World/StatusBar/StatusBarConditionResolver.cs
+++ b/Core/World/StatusBar/StatusBarConditionResolver.cs
@@ -276,7 +276,10 @@ public static class StatusBarConditionResolver
 
     private static bool CheckSlotSelected(Player player, int slot)
     {
-        return player.WeaponSlot == slot;
+        if (player.Weapon == null)
+            return false;
+
+        return player.Inventory.Weapons.GetWeaponSlot(player.Weapon.Definition).Slot == slot;
     }
 
     private static bool CheckItemOwned(Player player, int param, EntityDefinitionComposer composer)
@@ -547,12 +550,8 @@ public static class StatusBarConditionResolver
             def = baseDef;
 
         int max = def.Properties.Inventory.MaxAmount;
-        if (hasBackPack
-            && def.IsType(Inventory.AmmoClassName) 
-            && def.Properties.Ammo.BackpackMaxAmount > max)
-        {
+        if (hasBackPack && def.IsAmmo && def.Properties.Ammo.BackpackMaxAmount > max)
             max = def.Properties.Ammo.BackpackMaxAmount;
-        }
         return max;
     }
     

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -24,6 +24,8 @@
 - Add better checks for sprite clipping when not using software sprite emulation. (Fixes Eye Juice Arachnotrons/Medkits floating)
 - Match frame ticking behavior differences between player and non-player states.
 - Fix dehacked not setting randomize flag. Fixes Legacy of Rust Calamity Blade firing.
+- Fix status bars showing zero for chainsaw/fist.
+- Fix status bar weapon slot condition to correctly check against switched weapon instead of the weapon that's actively being switched to.
 
 ## Misc:
 - Use DrawArraysInstanced instead of geometry shader for sprite rendering (allows for MacOS support).


### PR DESCRIPTION
Fix status bars showing zero for chainsaw/fist.

Fix status bar weapon slot condition to correctly check against switched weapon instead of the weapon that's actively being switched to.

Removes constant string lookups and ammo string checks.

Removes dehacked definition dependency and builds definition lookup directly.

fixes #1751 