### PR TITLE
Update ZMusicWrapper package

### DIFF
--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -120,6 +120,7 @@
     <LinkerArg Include="/opt/homebrew/opt/libvorbis/lib/libvorbis.a" />
     <LinkerArg Include="/opt/homebrew/opt/libvorbis/lib/libvorbisenc.a" />
     <LinkerArg Include="-liconv" />
+    <LinkerArg Include="-framework CoreMIDI" />
   </ItemGroup>
 
   <Target Name="HandleNativeLibraries" BeforeTargets="ResolveLockFileCopyLocalFiles">

--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="GlmSharp-netstandard" Version="0.9.8.1" />
-    <PackageReference Include="Helion.ZMusic" Version="3.0.0.3" />
+    <PackageReference Include="Helion.ZMusic" Version="3.1.3.0" />
     <PackageReference Include="NAudio.Core" Version="2.2.1" />
     <PackageReference Include="NLog" Version="6.0.0" />
     <PackageReference Include="OpenTK" Version="4.9.4" ExcludeAssets="native" />


### PR DESCRIPTION
This updates the ZMusicWrapper package to a version that includes a [post-1.3.0 sync of the upstream ZMusic repo](https://github.com/ZDoom/ZMusic/commit/d3b730795784bff3f97571446101c57c1c6ac9bc).  ZMusic seems to have updated several of the components they package, including the version of FluidSynth they embed.

It looks like they also added support for CoreMIDI as an output on MacOS, although we don't currently expose "system" MIDI outputs on our end.