### PR TITLE
Fix BufferSubData overflow

### DIFF
--- a/Core/Render/OpenGL/Buffer/ArrayBufferObject.cs
+++ b/Core/Render/OpenGL/Buffer/ArrayBufferObject.cs
@@ -1,4 +1,5 @@
 using System;
+using Helion.Util.Assertion;
 using OpenTK.Graphics.OpenGL;
 
 namespace Helion.Render.OpenGL.Buffer.Array;
@@ -9,6 +10,8 @@ public abstract class ArrayBufferObject<T> : BufferObject<T> where T : struct
     protected abstract BufferUsageHint Hint { get; }
 
     private IntPtr m_ptr;
+    private bool m_initialized;
+    private int m_uploadedSize;
 
     protected unsafe ArrayBufferObject(string objectLabel, int capacity = DefaultCapacity) : base(objectLabel, capacity)
     {
@@ -20,16 +23,26 @@ public abstract class ArrayBufferObject<T> : BufferObject<T> where T : struct
 
     protected override void PerformUpload()
     {
-        GL.BufferData(Target, BytesPerElement * Data.Length, Data.Data, Hint);
+        m_initialized = true;
+        m_uploadedSize = BytesPerElement * Data.Length;
+        GL.BufferData(Target, m_uploadedSize, Data.Data, Hint);
     }
 
     protected override void PerformUploadCapacity()
     {
-        GL.BufferData(Target, BytesPerElement * Data.Capacity, Data.Data, Hint);
+        m_initialized = true;
+        m_uploadedSize = BytesPerElement * Data.Capacity;
+        GL.BufferData(Target, m_uploadedSize, Data.Data, Hint);
     }
 
-    protected unsafe override void BufferSubData(int index, int length)
+    protected unsafe override bool BufferSubData(int index, int length)
     {
+        if (!Uploaded || !m_initialized)
+        {
+            Uploaded = false;
+            return false;
+        }
+
         fixed (T* buffer = &Data.Data[0])
         {
             var ptr = (IntPtr)buffer;
@@ -39,13 +52,15 @@ public abstract class ArrayBufferObject<T> : BufferObject<T> where T : struct
             {
                 m_ptr = ptr;
                 Uploaded = false;
-                return;
+                return false;
             }
 
             IntPtr offset = new(BytesPerElement * index);
             int size = BytesPerElement * length;
 
+            Assert.Precondition(m_uploadedSize >= offset + size, "Offset and size are out of bounds for the GPU");
             GL.BufferSubData(Target, offset, size, ptr + (BytesPerElement * index));
         }
+        return true;
     }
 }

--- a/Core/Render/OpenGL/Buffer/BufferObject.cs
+++ b/Core/Render/OpenGL/Buffer/BufferObject.cs
@@ -100,12 +100,22 @@ public abstract class BufferObject<T> : IDisposable where T : struct
         Uploaded = true;
     }
 
+    // Will attempt to use BufferSubData first using the underlying buffer's Length.
+    // If the underlying buffer has not been uploaded or was reallocated then it will be flagged to upload.
+    public void UploadSubDataOrSetNotUploaded(int index, int length)
+    {
+        if (!BufferSubData(index, length))
+        {
+            Uploaded = false;
+        }
+    }
+
     public void UploadSubData(int start, int length)
     {
         BufferSubData(start, length);
     }
 
-    protected abstract void BufferSubData(int start, int length);
+    protected abstract bool BufferSubData(int start, int length);
 
     public void UploadIfNeeded()
     {

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
@@ -46,7 +46,6 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
     private readonly FreeGeometryManager m_freeManager = new();
     private readonly LegacySkyRenderer m_skyRenderer;
 
-    private readonly SkyGeometryManager m_skyGeometry = new();
     private readonly LookupArray<List<Sector>?> m_transferHeightsLookup = new();
     private readonly GeometryRenderer.RenderCoverWallAction m_renderCoverWallAction;
     private readonly DynamicVertex[] m_coverWallVertices3D = new DynamicVertex[6];
@@ -81,11 +80,6 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
         m_renderTwoSidedMiddleSliceFunc = m_geometryRenderer.RenderTwoSidedMiddleSlice;
         m_renderSectorWallVertices3D = RenderSectorWallVertices3D;
         m_vanillaRender = archiveCollection.Config.Render.VanillaRender;
-    }
-
-    private static int GeometryIndexCompare(StaticGeometryData x, StaticGeometryData y)
-    {
-        return x.Index.CompareTo(y.Index);
     }
 
     private static int TransparentGeometryCompare(GeometryData x, GeometryData y)
@@ -230,6 +224,8 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
         {
             var oneSided = world.Lines.Count(x => x.Back == null);
             var sidesWithTextures = world.Sides.Count(x => x.Upper.TextureHandle != 0 || x.Lower.TextureHandle != 0);
+            oneSided = 1;
+            sidesWithTextures = 1;
 
             m_coverWallGeometry = AllocateGeometryData(GeometryType.Wall, textureIndex,
                 repeat: true, addToGeometry: false, sidesWithTextures * WallVertices, overrideTexture: texture, "CoverWall Two-Sided");
@@ -617,8 +613,7 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
                 v.SurfaceOptions, v.LightLevelAdd, v.RenderOptions);
         }
 
-        staticVertices.SetLength(staticVertices.Length + vertices.Length);
-        
+        staticVertices.SetLength(staticVertices.Length + vertices.Length);        
     }
 
     private static void CopyVertices(StaticVertex[] staticVertices, Span<DynamicVertex> vertices, int index)
@@ -1398,10 +1393,9 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
         {
             var useGeometry = oneSided ? m_coverWallGeometryOneSided : m_coverWallGeometry;
             var geometryVbo = useGeometry.Pipeline.Vbo;
-            EnsureCoverWallVboCapacity(staticGeometryData, sideVertices, geometryVbo);
             var vertices = geometryVbo.Data;
-            geometryVbo.Data.EnsureCapacity(vertices.Length + sideVertices.Length);
             staticGeometryData = new(useGeometry, vertices.Length, length);
+            EnsureCoverWallVboCapacity(staticGeometryData, sideVertices, geometryVbo);
             CoverWallUtil.CopyCoverWallVertices(side, vertices.Data, sideVertices, staticGeometryData.Index, location);
             vertices.Length += length;
             m_coverWallLookup[key] = staticGeometryData;
@@ -1432,7 +1426,7 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
         else
         {
             geometryVbo.Bind();
-            geometryVbo.UploadSubData(index, length);
+            geometryVbo.UploadSubDataOrSetNotUploaded(index, length);
         }
     }
 

--- a/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
+++ b/Core/Render/OpenGL/Renderers/Legacy/World/Geometry/Static/StaticCacheGeometryRenderer.cs
@@ -224,8 +224,6 @@ public partial class StaticCacheGeometryRenderer : StyleRendererBase, IDisposabl
         {
             var oneSided = world.Lines.Count(x => x.Back == null);
             var sidesWithTextures = world.Sides.Count(x => x.Upper.TextureHandle != 0 || x.Lower.TextureHandle != 0);
-            oneSided = 1;
-            sidesWithTextures = 1;
 
             m_coverWallGeometry = AllocateGeometryData(GeometryType.Wall, textureIndex,
                 repeat: true, addToGeometry: false, sidesWithTextures * WallVertices, overrideTexture: texture, "CoverWall Two-Sided");

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -27,6 +27,7 @@
 - Fix status bars showing zero for chainsaw/fist.
 - Fix status bar weapon slot condition to correctly check against switched weapon instead of the weapon that's actively being switched to.
 - Fix status bar uses ammo condition.
+- Fix BufferSubData call that could write out of bounds on GPU resulting in corrupted/missing walls.
 
 ## Misc:
 - Use DrawArraysInstanced instead of geometry shader for sprite rendering (allows for MacOS support).


### PR DESCRIPTION
Don't call BufferSubData if the buffer is marked to be uploaded/not initialized.

Add debug assertion if BufferSubData upload would be out of bounds of what exists on the GPU.

Probably related to #1772 but it's not easily reproducible. 