### PR TITLE
default dehacked properties to zero

### DIFF
--- a/Core/Dehacked/DehackedApplier.cs
+++ b/Core/Dehacked/DehackedApplier.cs
@@ -961,6 +961,11 @@ public class DehackedApplier
         // This wasn't an option in the original game, needs to be applied to all potential projectile spawns.
         definition.Flags.SetRandomizeProjectile();
         definition.Properties.Height = 0;
+        definition.Properties.Radius = 0;
+        definition.Properties.Health = 0;
+        definition.Properties.Mass = 0;
+        definition.Properties.MonsterMovementSpeed = 0;
+        definition.Properties.MissileMovementSpeed = 0;
         composer.Add(definition);
         m_dehacked.DefinitionLookup[index] = definition;
         return definition;

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -29,6 +29,7 @@
 - Fix status bar uses ammo condition.
 - Fix BufferSubData call that could write out of bounds on GPU resulting in corrupted/missing walls.
 - Fix rendering issue with lines when changing transfer heights views.
+- Fix width, speed, and mass properties to default to zero for dehacked isntead of using default decorate values.
 
 ## Misc:
 - Use DrawArraysInstanced instead of geometry shader for sprite rendering (allows for MacOS support).

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -29,7 +29,7 @@
 - Fix status bar uses ammo condition.
 - Fix BufferSubData call that could write out of bounds on GPU resulting in corrupted/missing walls.
 - Fix rendering issue with lines when changing transfer heights views.
-- Fix width, speed, and mass properties to default to zero for dehacked isntead of using default decorate values.
+- Fix width, speed, and mass properties to default to zero for dehacked instead of using default decorate values.
 
 ## Misc:
 - Use DrawArraysInstanced instead of geometry shader for sprite rendering (allows for MacOS support).

--- a/Tests/Unit/GameAction/Dehacked/DefaultFlags.cs
+++ b/Tests/Unit/GameAction/Dehacked/DefaultFlags.cs
@@ -29,6 +29,19 @@ public class DefaultFlags
         newDef2.Flags.RandomizeProjectile().Should().BeTrue();
     }
 
+    [Fact(DisplayName = "New Dehacked thing has default properties")]
+    public void NewDehackedThingDefaultProperties()
+    {
+        var newDef = World.EntityManager.DefinitionComposer.GetByName("*deh/entity192");
+        newDef.Should().NotBeNull();
+        newDef.Properties.Height.Should().Be(0);
+        newDef.Properties.Radius.Should().Be(0);
+        newDef.Properties.Health.Should().Be(0);
+        newDef.Properties.Mass.Should().Be(0);
+        newDef.Properties.MissileMovementSpeed.Should().Be(0);
+        newDef.Properties.MonsterMovementSpeed.Should().Be(0);
+    }
+
     private static readonly string Dehacked =
 @"
 Thing 191 (NewThing)
@@ -38,5 +51,8 @@ Initial frame = 42069
 Thing 192 (NewThing with height)
 ID # = 192
 Height = 4521984
-Initial frame = 42069"";";
+Initial frame = 42069"";
+
+Thing 193 (DefaultThing)
+ID # = 193";
 }


### PR DESCRIPTION
default width, speed, and mass properties to default to zero for dehacked instead of using default decorate values.

fixes #1725 